### PR TITLE
Deleting abstract classes without virtual destructors is undefined

### DIFF
--- a/framework/stage.h
+++ b/framework/stage.h
@@ -63,4 +63,7 @@ class Stage
 				*Boolean* Indicates if stage should be considered as a transition stage
     */
     virtual bool IsTransition() = 0;
+
+	/* Need a virtual destructor to correctly call any subclass descructors */
+    virtual ~Stage(){};
 };

--- a/shaders/shader.h
+++ b/shaders/shader.h
@@ -15,4 +15,5 @@ class Shader
 {
 	public:
 		virtual void Apply( ALLEGRO_BITMAP* Target ) = 0;
+		virtual ~Shader(){};
 };


### PR DESCRIPTION
Deleting abstract classes without virtual destructor is undefined, according to gcc warnings.

Fix this by having a trivial virtual destructor defined for Stage and Shader classes.
