### PR TITLE
Relicense non-library (game/* tools/* and tests/*) under GPL3+

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,9 @@
+The files under the "forms", "framework" and "library" directories are licensed under the MIT license.
+
+The All other files - the "game", "tests" and "tools" directories, are licensed under the GPL3+ license.
+
+------
+
 The MIT License (MIT)
 
 Copyright (c) 2014 Marq Watkin / Polymath Programming
@@ -19,3 +25,22 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+------
+
+The GPL3 (or later) license (GPL3+)
+
+Copyright (C) 2017 "The OpenApoc Team"
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.


### PR DESCRIPTION
As far as I can see, the only way of directly using this code is to
effectively implement an apoc clone. I don't see it being useful to pull
into other projects as library code, so I see a stricter copyleft
license as a better fit.