### PR TITLE
Cross-compilation [incomplete]

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,13 +6,18 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
-set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 
 # check compiler
 INCLUDE(CheckCXXCompilerFlag)
 INCLUDE(CheckCCompilerFlag)
 
 set(allow_cotire ON)
+
+if(ANDROID)
+    message("Not enabling cotire for cross compilation")
+    set(allow_cotire OFF)
+endif()
 
 # Sanitize doesn't seem to work with pch on gcc
 string(TOLOWER "${CMAKE_BUILD_TYPE}" lower_build_type)
@@ -29,7 +34,7 @@ option(ENABLE_TESTS "Build some unit tests" ON)
 option(ENABLE_COTIRE "Enable Compile TIme Reducer (AKA use PCH)"
 		${allow_cotire})
 
-set(CD_PATH ${CMAKE_SOURCE_DIR}/data/cd.iso CACHE STRING "Path to cd.iso (used
+set(CD_PATH ${PROJECT_SOURCE_DIR}/data/cd.iso CACHE STRING "Path to cd.iso (used
 by test and extractor")
 
 if (NOT EXISTS ${CD_PATH})
@@ -76,7 +81,8 @@ if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments")
 endif()
 
-set(GLM_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/dependencies/glm)
+
+set(GLM_INCLUDE_DIR ${PROJECT_SOURCE_DIR}/dependencies/glm)
 MARK_AS_ADVANCED(GLM_INCLUDE_DIR)
 
 add_subdirectory(library)
@@ -87,14 +93,20 @@ add_subdirectory(game/ui)
 add_subdirectory(tools)
 add_subdirectory(dependencies)
 
-ADD_EXECUTABLE(${CMAKE_PROJECT_NAME} game/main.cpp ${sources}
-		${FRAMEWORK_SOURCES})
+# Android uses libraries instead of executables
+if (ANDROID)
+	add_library(OpenApoc SHARED game/main.cpp ${sources}
+            ${FRAMEWORK_SOURCES})
+else()
+    ADD_EXECUTABLE(OpenApoc game/main.cpp ${sources}
+	    	${FRAMEWORK_SOURCES})
+endif()
 
-target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_Library)
-target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_Framework)
-target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_Forms)
-target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_GameState)
-target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_GameUI)
+target_link_libraries(OpenApoc OpenApoc_Library)
+target_link_libraries(OpenApoc OpenApoc_Framework)
+target_link_libraries(OpenApoc OpenApoc_Forms)
+target_link_libraries(OpenApoc OpenApoc_GameState)
+target_link_libraries(OpenApoc OpenApoc_GameUI)
 
 set_property(TARGET OpenApoc PROPERTY CXX_STANDARD 11)
 set_property(TARGET OpenApoc PROPERTY CXX_STANDARD_REQUIRED ON)
@@ -110,9 +122,13 @@ INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 # apoc data copy
 SET( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
 
-install(TARGETS ${CMAKE_PROJECT_NAME}
-		RUNTIME DESTINATION bin)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}data/ DESTINATION share/OpenApoc)
+# Do not attempt to install while cross-compiling
+# FIXME: maybe applicable for *any* cross-compilation, not only Android?
+if (NOT ANDROID)
+    install(TARGETS OpenApoc
+    		RUNTIME DESTINATION bin)
+    install(DIRECTORY ${CMAKE_SOURCE_DIR}data/ DESTINATION share/OpenApoc)
+endif()
 
 if(ENABLE_TESTS)
 	enable_testing()

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -147,9 +147,12 @@ source_group(framework\\sound\\headers FILES
 list(APPEND ALL_HEADER_FILES ${SOUND_HEADER_FILES})
 
 set (RENDERER_SOURCE_FILES
-	render/gl20/ogl_2_0_renderer.cpp
 	render/gles30_v2/ogles_3_0_renderer_v2.cpp
 	render/gles30_v2/gleswrap_gles3.cpp)
+
+if (NOT ANDROID)
+    set (RENDERER_SOURCE_FILES ${RENDERER_SOURCE_FILES} render/gl20/ogl_2_0_renderer.cpp)
+endif()
 
 source_group(framework\\renderer\\sources FILES
 	${RENDERER_SOURCE_FILES})
@@ -191,8 +194,13 @@ add_library(OpenApoc_Framework STATIC
 
 set_property(TARGET OpenApoc_Framework PROPERTY CXX_STANDARD 11)
 
+set(OPENAPOC_RENDERER_LIST "GLES_3_0")
+if (NOT ANDROID)
+    set(OPENAPOC_RENDERER_LIST "${OPENAPOC_RENDERER_LIST}:GL_2_0")
+endif()
+
 target_compile_definitions(OpenApoc_Framework PUBLIC
-		"-DRENDERERS=\"GLES_3_0:GL_2_0\"")
+		"-DRENDERERS=\"${OPENAPOC_RENDERER_LIST}\"")
 
 if(APPLE)
 	target_compile_definitions(OpenApoc_Framework PRIVATE
@@ -203,7 +211,13 @@ if(APPLE)
 	# Disable libunwind use on Apple
 	SET(BACKTRACE_ON_ERROR OFF CACHE BOOL "Print backtrace on logging an error (Requires libunwind on linux, no extra dependencies on windows)" FORCE)
 else()
-	target_compile_definitions(OpenApoc_Framework PRIVATE "-DGLESWRAP_PLATFORM_GLX")
+    if(ANDROID)
+	find_library(EGL_Android EGL)
+	target_link_libraries(OpenApoc_Framework PRIVATE ${EGL_Android})
+        target_compile_definitions(OpenApoc_Framework PRIVATE "-DGLESWRAP_PLATFORM_EGL")
+    else()
+	    target_compile_definitions(OpenApoc_Framework PRIVATE "-DGLESWRAP_PLATFORM_GLX")
+	endif()
 endif()
 
 # We use boost::locale for utf conversions and boost::filesystem for
@@ -229,41 +243,49 @@ else()
 	set(BOOST_PACKAGES ${BOOST_PACKAGES} filesystem)
 	target_compile_definitions(OpenApoc_Framework PUBLIC "-DUSE_BOOST_FILESYSTEM")
 endif()
+if (ANDROID)
+    set(Boost_LIBRARIES Boost_filesystem Boost_system Boost_program_options Boost_locale)
+    target_link_libraries(OpenApoc_Framework PUBLIC ${Boost_LIBRARIES})
+else()
+    find_package(Boost REQUIRED COMPONENTS ${BOOST_PACKAGES})
+    target_link_libraries(OpenApoc_Framework PUBLIC ${Boost_LIBRARIES})
+    target_include_directories(OpenApoc_Framework PUBLIC ${Boost_INCLUDE_DIRS})
 
-find_package(Boost REQUIRED COMPONENTS ${BOOST_PACKAGES})
-target_link_libraries(OpenApoc_Framework PUBLIC ${Boost_LIBRARIES})
-target_include_directories(OpenApoc_Framework PUBLIC ${Boost_INCLUDE_DIRS})
-
-find_package(Threads)
-target_link_libraries(OpenApoc_Framework PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+    find_package(Threads)
+    target_link_libraries(OpenApoc_Framework PUBLIC ${CMAKE_THREAD_LIBS_INIT})
+endif()
 
 target_include_directories(OpenApoc_Framework PUBLIC ${GLM_INCLIDE_DIR})
 
 find_package(PkgConfig)
 
 #Require SDL2 for input/graphics/sound/pretty much everything
-pkg_check_modules(PC_SDL2 REQUIRED sdl2>=2.0)
-if (NOT PC_SDL2_FOUND)
-		message(FATAL_ERROR "sdl2 not found")
+if (ANDROID)
+    target_link_libraries(OpenApoc_Framework PUBLIC SDL2-static)
+else()
+    pkg_check_modules(PC_SDL2 REQUIRED sdl2>=2.0)
+    if (NOT PC_SDL2_FOUND)
+    		message(FATAL_ERROR "sdl2 not found")
+    endif()
+    foreach (SDL2_LIB ${PC_SDL2_LIBRARIES})
+    		message("Searching for ${SDL2_LIB} in ${PC_SDL2_LIBRARY_DIRS}")
+    		find_library(SDL2_LIBRARY_PATH-${SDL2_LIB} ${SDL2_LIB} HINTS ${PC_SDL2_LIBRARY_DIRS})
+    		if (NOT SDL2_LIBRARY_PATH-${SDL2_LIB})
+    				message(FATAL_ERROR "sdl2 library ${SDL2_LIB} not found in ${PC_SDL2_LIBRARY_DIRS}")
+		    endif()
+		    message("Found ${SDL2_LIB} at ${SDL2_LIBRARY_PATH-${SDL2_LIB}}")
+	    	target_link_libraries(OpenApoc_Framework PUBLIC ${SDL2_LIB})
+    endforeach()
+    target_include_directories(OpenApoc_Framework PUBLIC ${PC_SDL2_INCLUDE_DIRS})
 endif()
-foreach (SDL2_LIB ${PC_SDL2_LIBRARIES})
-		message("Searching for ${SDL2_LIB} in ${PC_SDL2_LIBRARY_DIRS}")
-		find_library(SDL2_LIBRARY_PATH-${SDL2_LIB} ${SDL2_LIB} HINTS ${PC_SDL2_LIBRARY_DIRS})
-		if (NOT SDL2_LIBRARY_PATH-${SDL2_LIB})
-				message(FATAL_ERROR "sdl2 library ${SDL2_LIB} not found in ${PC_SDL2_LIBRARY_DIRS}")
-		endif()
-		message("Found ${SDL2_LIB} at ${SDL2_LIBRARY_PATH-${SDL2_LIB}}")
-		target_link_libraries(OpenApoc_Framework PUBLIC ${SDL2_LIB})
-endforeach()
-target_include_directories(OpenApoc_Framework PUBLIC ${PC_SDL2_INCLUDE_DIRS})
-
 # Dialog is handled by SDL2
 if(DIALOG_ON_ERROR)
 		target_compile_definitions(OpenApoc_Framework PUBLIC -DERROR_DIALOG)
 endif()
 
 # Backtrace required libunwind
-if(BACKTRACE_ON_ERROR)
+# ...but is not available on android
+if(BACKTRACE_ON_ERROR AND NOT ANDROID)
 	pkg_check_modules(PC_UNWIND libunwind)
 	if (NOT PC_UNWIND_FOUND)
 		#Ubuntu 12.04 libunwind doesn't have a pkgconfig - try 'current' paths anyway
@@ -299,8 +321,8 @@ target_link_libraries(OpenApoc_Framework PUBLIC ${CMAKE_DL_LIBS})
 target_link_libraries(OpenApoc_Framework PUBLIC physfs-static)
 
 target_include_directories(OpenApoc_Framework PRIVATE
-		${CMAKE_SOURCE_DIR}/dependencies/physfs/src)
-target_include_directories(OpenApoc_Framework PUBLIC ${CMAKE_SOURCE_DIR})
+		${PROJECT_SOURCE_DIR}/../dependencies/physfs/src)
+target_include_directories(OpenApoc_Framework PUBLIC ${PROJECT_SOURCE_DIR})
 
 
 set_target_properties(OpenApoc_Framework PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT

--- a/framework/physfs_fs.cpp
+++ b/framework/physfs_fs.cpp
@@ -13,14 +13,7 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
-#ifdef ANDROID
-#define be16toh(x) htobe16(x)
-#define be32toh(x) htobe32(x)
-#define be64toh(x) htobe64(x)
-#define le16toh(x) htole16(x)
-#define le32toh(x) htole32(x)
-#define le64toh(x) htole64(x)
-#elif defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE)
+#if defined(_DEFAULT_SOURCE) || defined(_BSD_SOURCE)
 #include <endian.h>
 #else
 /* We assume all other platforms are little endian for now */

--- a/game/state/CMakeLists.txt
+++ b/game/state/CMakeLists.txt
@@ -172,23 +172,42 @@ add_library(OpenApoc_GameState STATIC ${GAMESTATE_SOURCE_FILES}
 target_link_libraries(OpenApoc_GameState PUBLIC OpenApoc_Library)
 target_link_libraries(OpenApoc_GameState PUBLIC OpenApoc_Framework)
 
-# This needs to be public as gamestate_serialize_generated.h needs to be in
-# the path
-target_include_directories(OpenApoc_GameState PUBLIC ${CMAKE_BINARY_DIR})
-
 set_property(TARGET OpenApoc_GameState PROPERTY CXX_STANDARD 11)
 
-add_custom_command(OUTPUT
-		gamestate_serialize_generated.h
-		gamestate_serialize_generated.cpp
-		COMMAND
-		${CMAKE_BINARY_DIR}/bin/OpenApoc_GamestateSerializeGen
-		-x ${CMAKE_SOURCE_DIR}/game/state/gamestate_serialize.xml
-		-h gamestate_serialize_generated.h
-		-o gamestate_serialize_generated.cpp
-		DEPENDS
-		${CMAKE_BINARY_DIR}/bin/OpenApoc_GamestateSerializeGen
-		${CMAKE_SOURCE_DIR}/game/state/gamestate_serialize.xml)
+# FIXME: Not just Android, but rather every time we're cross-compiling?
+if (ANDROID)
+    message("Copying generated files from ${HOST_BUILD_DIR}/game/state/gamestate_serialize_generated.* to ${CMAKE_CURRENT_BINARY_DIR}")
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy
+            ${HOST_BUILD_DIR}/game/state/gamestate_serialize_generated.cpp
+            ${CMAKE_CURRENT_BINARY_DIR}
+            )
+    execute_process(COMMAND ${CMAKE_COMMAND} -E copy
+            ${HOST_BUILD_DIR}/game/state/gamestate_serialize_generated.h
+            ${CMAKE_CURRENT_BINARY_DIR}
+            )
+    # We now need to back up two levels (because gamestate_serialize assumes specific
+    # generated state position)
+    get_filename_component(OPENAPOC_GAMESTATE_PARENT ${CMAKE_CURRENT_BINARY_DIR} DIRECTORY)
+    get_filename_component(OPENAPOC_GAMESTATE_PARENT ${OPENAPOC_GAMESTATE_PARENT} DIRECTORY)
+    target_include_directories(OpenApoc_GameState PUBLIC ${OPENAPOC_GAMESTATE_PARENT})
+else()
+    # This needs to be public as gamestate_serialize_generated.h needs to be in
+    # the path
+    target_include_directories(OpenApoc_GameState PUBLIC ${CMAKE_BINARY_DIR})
+
+    add_custom_command(OUTPUT
+    		gamestate_serialize_generated.h
+    		gamestate_serialize_generated.cpp
+    		COMMAND
+    		${CMAKE_BINARY_DIR}/bin/OpenApoc_GamestateSerializeGen
+    		-x ${CMAKE_SOURCE_DIR}/game/state/gamestate_serialize.xml
+    		-h gamestate_serialize_generated.h
+    		-o gamestate_serialize_generated.cpp
+    		DEPENDS
+    		${CMAKE_BINARY_DIR}/bin/OpenApoc_GamestateSerializeGen
+    		${CMAKE_SOURCE_DIR}/game/state/gamestate_serialize.xml)
+
+endif()
 
 set_target_properties(OpenApoc_GameState PROPERTIES COTIRE_CXX_PREFIX_HEADER_INIT
 	"gamestate_pch.h")

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -6,7 +6,9 @@ include(cotire)
 # check cmake version
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
-find_package(Boost REQUIRED COMPONENTS locale)
+if(NOT ANDROID)
+    find_package(Boost REQUIRED COMPONENTS locale)
+endif()
 
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package (Threads REQUIRED)
@@ -35,8 +37,12 @@ list(APPEND ALL_HEADER_FILES ${LIBRARY_HEADER_FILES})
 add_library(OpenApoc_Library STATIC ${LIBRARY_SOURCE_FILES}
 		${LIBRARY_HEADER_FILES})
 
-target_link_libraries(OpenApoc_Library PUBLIC ${Boost_LIBRARIES}
-		Threads::Threads)
+if (ANDROID)
+    target_link_libraries(OpenApoc_Library PUBLIC Boost_locale)
+else()
+    target_link_libraries(OpenApoc_Library PUBLIC ${Boost_LIBRARIES}
+	    	Threads::Threads)
+endif()
 
 target_include_directories(OpenApoc_Library PUBLIC ${CMAKE_SOURCE_DIR})
 target_include_directories(OpenApoc_Library PUBLIC ${GLM_INCLUDE_DIR})

--- a/tools/gamestate_serialize_gen/CMakeLists.txt
+++ b/tools/gamestate_serialize_gen/CMakeLists.txt
@@ -4,30 +4,36 @@ PROJECT(OpenApoc_GamestateSerializeGen CXX C)
 # check cmake version
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
-find_package(Boost REQUIRED COMPONENTS program_options)
+if (ANDROID)
+    # We rely on gamestate_serialize_gen being already built
+    message("Not building generator during cross compilation")
 
-set (GAMESTATESERIALIZEGEN_SOURCE_FILES
-	main.cpp)
+else()
+    find_package(Boost REQUIRED COMPONENTS program_options)
 
-source_group(gamestateserailizegen\\sources FILES ${GAMESTATESERIALIZEGEN_SOURCE_FILES})
+    set (GAMESTATESERIALIZEGEN_SOURCE_FILES
+	    main.cpp)
 
-set (GAMESTATESERIALIZEGEN_HEADER_FILES)
+    source_group(gamestateserailizegen\\sources FILES ${GAMESTATESERIALIZEGEN_SOURCE_FILES})
 
-source_group(gamestateserailizegen\\headers FILES ${GAMESTATESERIALIZEGEN_HEADER_FILES})
+    set (GAMESTATESERIALIZEGEN_HEADER_FILES)
 
-list(APPEND ALL_SOURCE_FILES ${GAMESTATESERIALIZEGEN_SOURCE_FILES})
-list(APPEND ALL_HEADER_FILES ${GAMESTATESERIALIZEGEN_HEADER_FILES})
+    source_group(gamestateserailizegen\\headers FILES ${GAMESTATESERIALIZEGEN_HEADER_FILES})
 
-add_executable(OpenApoc_GamestateSerializeGen ${GAMESTATESERIALIZEGEN_SOURCE_FILES}
-		${GAMESTATESERIALIZEGEN_HEADER_FILES})
+    list(APPEND ALL_SOURCE_FILES ${GAMESTATESERIALIZEGEN_SOURCE_FILES})
+    list(APPEND ALL_HEADER_FILES ${GAMESTATESERIALIZEGEN_HEADER_FILES})
 
-set( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
+    add_executable(OpenApoc_GamestateSerializeGen ${GAMESTATESERIALIZEGEN_SOURCE_FILES}
+    		${GAMESTATESERIALIZEGEN_HEADER_FILES})
 
-target_link_libraries(OpenApoc_GamestateSerializeGen OpenApoc_LibPugixml
-		${Boost_LIBRARIES})
+    set( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
 
-target_include_directories(OpenApoc_GamestateSerializeGen PUBLIC ${Boost_INCLUDE_DIRS})
-target_include_directories(OpenApoc_GamestateSerializeGen PUBLIC ${CMAKE_SOURCE_DIR})
+    target_link_libraries(OpenApoc_GamestateSerializeGen OpenApoc_LibPugixml
+    		${Boost_LIBRARIES})
 
-set_property(TARGET OpenApoc_GamestateSerializeGen PROPERTY CXX_STANDARD 11)
-set_property(TARGET OpenApoc_GamestateSerializeGen PROPERTY CXX_STANDARD_REQUIRED ON)
+    target_include_directories(OpenApoc_GamestateSerializeGen PUBLIC ${Boost_INCLUDE_DIRS})
+    target_include_directories(OpenApoc_GamestateSerializeGen PUBLIC ${CMAKE_SOURCE_DIR})
+
+    set_property(TARGET OpenApoc_GamestateSerializeGen PROPERTY CXX_STANDARD 11)
+    set_property(TARGET OpenApoc_GamestateSerializeGen PROPERTY CXX_STANDARD_REQUIRED ON)
+endif()


### PR DESCRIPTION
This is mostly related to the (almost forgotten) Android port. Since Android build system allows using CMake projects, I've tried to reuse the existing project files for the port. Some changes had to be made, since currently OpenApoc is not the top-level project.

There's a separate pull request for physfs submodule to resolve target name conflicts with SDL.