### PR TITLE
cityview controls, building improv, city update

### DIFF
--- a/README_HOTKEYS.txt
+++ b/README_HOTKEYS.txt
@@ -71,6 +71,7 @@ Cityscape Keyboard:
 Cityscape Debug:
 - Debug hotkeys are always active
 - [Ctrl] + [Alt] + [Shift] + [Left Click] destroys scenery
+- [Ctrl] + [Alt] + [Shift] + [Right Click] destroys whole buildings
 - [R] repairs all buildings
 - [U] spawns three crashed UFOs
 - [F4] show aliens in buildings on strategy map

--- a/README_HOTKEYS.txt
+++ b/README_HOTKEYS.txt
@@ -23,28 +23,37 @@ General Hotkeys:
 - [M] Show Log
 - [Home] Zoom to last event
 
+Cityscape Vanilla Controls Note
+* Vanilla city controls were not very consistent and quite limited. For starters, right-clicking mouse in city moved map, while in battle, it didn't. There were no ways to quickly open frequently used screens (namely equipment, location, base screens) without clicking their buttons, and when using Alt/Shift hotkeys, they acted as if you clicked a corresponding button, meaning that if you missed your selection mode changed.
+* Instead, OpenApoc introduces a new, consistent control scheme, which is explained in the next two sections
+* For those who prefer to still use the vanilla control scheme, there is a feature to disable in the options menu called "Improved city control scheme". When disabled, vanilla control scheme will apply:
+- Right click will move screen to cursor
+- Alt+LMB will order vehicle attack
+- Shift+LMB will order moving to building
+- Left-clicking on building will always open building screen
+- No mouse controls introduced by OpenApoc will function
+
 Cityscape Mouse:
 * [Ctrl] when giving order that includes moving, forces Agents to move on foot (never call a taxi), as well as allows Vehicles and Agents manual use of teleporter
-* [Alt] Opens object's ufopaedia screens
-* [Shift] Opens object's management screens
+* [Alt] Opens ufopaedia
+* [Alt/Shift] + [Click] orders vehicles directly, Alt+Shift targets buildings and Shift targets vehicles or locations, while left click is aggressive and right is non-aggressive
 - [Alt] + [Left Click] Opens ufopaedia screen for the object (vehicle type, building function or who fired the missile)
 - [Alt] + [Right Click] Opens ufopaedia screen for object's owner (be that vehicle or building)
-- [Shift] + [Left Click] 
-  - Equipment screen for vehicles
-  - Base screen for building that contains a base
-  - Base buy screen for non-owned building that house a base
-  - Building screen for other buildings
-- [Shift] + [Right Click] 
-  - Location screens for vehicles
-  - Building screen for buildings
+- [Alt] + [Shift] + [Left Click] Order Attack Building
+- [Alt] + [Shift] + [Right Click] Order Goto Building
+- [Shift] + [Left Click] Order Attack Vehicle
+- [Shift] + [Right Click] Order Follow Vehicle / Goto Location
 - [Left Click]
   - Issues orders
-  - Open building screen
-- [Right Click]
-  - Issues orders
   - Base screen for building that contains a base
   - Base buy screen for non-owned building that house a base
-  - Building screen for other buildings
+- [Right Click]
+  - Building screen for buildings
+
+Cityscape Mouse Clicks on Vehicle / Agent icons:
+- [Shift] + [Right Click] Open Location Screen
+- [Ctrl] + [Shift] + [Right Click] Open Equipment Screen
+- [Alt] + [Shift] + [Right Click] Open Equipment Screen
 
 Cityscape Mouse Unit Selection:
 * [Ctrl] makes selection additive
@@ -54,9 +63,10 @@ Cityscape Mouse Unit Selection:
   - Add Agent/Vehicle to selection and make it first in the list
 - [Right Click]
   - Remove Agent/Vehicle from selection
-
+  
 Cityscape Keyboard:
-- ... (none yet)
+- [0],[1]...[5] control time 
+- [N] Manual control (if using vanilla scheme then [M] is the manual control key and there is no way to open message log, as per vanilla)
 
 Cityscape Debug:
 - Debug hotkeys are always active
@@ -80,6 +90,16 @@ Cityscape Debug:
   - For roads, switch between showing only tiles marked as "road", or to also include tiles marked with road direction
   - For hills, switch between showing only tiles marked as "road", or to also include tiles marked with hill direction
  
+Vehicle Equipment:
+- [Shift] makes item auto-equip into first available slot, or auto-remove to base stores
+ 
+Agent Equipment:
+* Usual selection controls apply, with option to de-select with right click as well
+- [Shift] makes item auto-equip into first available slot, or auto-remove to base stores / ground
+- [Ctrl] makes you remove clip when clicking on weapon
+- [1]...[0] applies equipment template to every selected agent
+- [Ctrl] + [1]...[0] remembers current agent's equipment set as a template
+
 Battlescape Mouse:
 * [Alt] When giving moving orders, makes unit keep facing to the target (making unit strafe or move backwards)
 		When firing at a tile, makes the shot aim at the ground of the tile, rather than at unit's level

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -35,6 +35,8 @@ after_build:
 - del data\cd.iso.xz
 - xcopy /E data OpenApoc-%OPENAPOC_VERSION%\data\
 - copy portable.txt OpenApoc-%OPENAPOC_VERSION%\
+- copy README.md OpenApoc-%OPENAPOC_VERSION%\
+- copy README_HOTKEYS.txt OpenApoc-%OPENAPOC_VERSION%\
 - 7z a %OPENAPOC_FILENAME% OpenApoc-%OPENAPOC_VERSION%
 - copy bin\%PLATFORM%\%CONFIGURATION%\*.pdb OpenApoc-%OPENAPOC_VERSION%\
 - 7z a %OPENAPOC_DEBUG_FILENAME% OpenApoc-%OPENAPOC_VERSION%\*.pdb

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,8 @@ after_build:
 - del data\cd.iso.xz
 - xcopy /E data OpenApoc-%OPENAPOC_VERSION%\data\
 - copy portable.txt OpenApoc-%OPENAPOC_VERSION%\
+- copy README.md OpenApoc-%OPENAPOC_VERSION%\
+- copy README_HOTKEYS.txt OpenApoc-%OPENAPOC_VERSION%\
 - 7z a %OPENAPOC_FILENAME% OpenApoc-%OPENAPOC_VERSION%
 - copy bin\%PLATFORM%\%CONFIGURATION%\*.pdb OpenApoc-%OPENAPOC_VERSION%\
 - 7z a %OPENAPOC_DEBUG_FILENAME% OpenApoc-%OPENAPOC_VERSION%\*.pdb

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -232,6 +232,9 @@ ConfigOptionBool optionAllowBuildingLootDeposit("OpenApoc.NewFeature", "AllowBui
 ConfigOptionBool optionArmoredRoads("OpenApoc.NewFeature", "ArmoredRoads", "Armored roads", true);
 ConfigOptionBool optionVanillaCityControls("OpenApoc.NewFeature", "OpenApocCityControls",
                                            "Improved city control scheme", true);
+ConfigOptionBool optionCollapseRaidedBuilding("OpenApoc.NewFeature", "CollapseRaidedBuilding",
+                                              "Successful raid collapses building", true);
+
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);
 ConfigOptionBool optionRaidHostileAction("OpenApoc.Mod", "RaidHostileAction",

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -229,7 +229,13 @@ ConfigOptionBool optionAllowNearbyVehicleLootPickup("OpenApoc.NewFeature",
                                                     "Allow nearby vehicles to pick up loot", true);
 ConfigOptionBool optionAllowBuildingLootDeposit("OpenApoc.NewFeature", "AllowBuildingLootDeposit",
                                                 "Allow loot to be stashed in the building", true);
-ConfigOptionBool optionArmoredRoads("OpenApoc.NewFeature", "ArmoredRoads", "Armored roads", false);
+ConfigOptionBool optionArmoredRoads("OpenApoc.NewFeature", "ArmoredRoads", "Armored roads", true);
+ConfigOptionBool optionVanillaCityControls("OpenApoc.NewFeature", "OpenApocCityControls",
+                                           "Improved city control scheme", true);
+ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
+                                         "Stunning hurts relationships", false);
+ConfigOptionBool optionRaidHostileAction("OpenApoc.Mod", "RaidHostileAction",
+                                         "Initiating raid hurts relationships", false);
 ConfigOptionBool optionBSKLauncherSound("OpenApoc.Mod", "BSKLauncherSound",
                                         "(MOD) Original Brainsucker Launcher SFX", true);
 ConfigOptionBool optionInvulnerableRoads("OpenApoc.Mod", "InvulnerableRoads",

--- a/game/state/agent.h
+++ b/game/state/agent.h
@@ -362,22 +362,23 @@ class Agent : public StateObject,
 
 	std::list<up<AgentMission>> missions;
 	std::list<sp<AEquipment>> equipment;
-	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type,
+	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> equipmentType,
 	                     EquipmentSlotType &slotType) const;
-	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> type) const;
+	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> equipmentType) const;
 	Vec2<int> findFirstSlotByType(EquipmentSlotType slotType,
-	                              StateRef<AEquipmentType> type = nullptr);
+	                              StateRef<AEquipmentType> equipmentType = nullptr);
+	Vec2<int> findFirstSlot(StateRef<AEquipmentType> equipmentType = nullptr);
 	// Add equipment by type to the first available slot of any type
-	sp<AEquipment> addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
+	sp<AEquipment> addEquipmentByType(GameState &state, StateRef<AEquipmentType> equipmentType,
 	                                  bool allowFailure);
 	// Add equipment to the first available slot of a specific type
-	sp<AEquipment> addEquipmentByType(GameState &state, StateRef<AEquipmentType> type,
+	sp<AEquipment> addEquipmentByType(GameState &state, StateRef<AEquipmentType> equipmentType,
 	                                  EquipmentSlotType slotType, bool allowFailure);
 	// Add equipment by type to a specific position
 	sp<AEquipment> addEquipmentByType(GameState &state, Vec2<int> pos,
-	                                  StateRef<AEquipmentType> type);
+	                                  StateRef<AEquipmentType> equipmentType);
 	// Add equipment as ammo
-	sp<AEquipment> addEquipmentAsAmmoByType(StateRef<AEquipmentType> type);
+	sp<AEquipment> addEquipmentAsAmmoByType(StateRef<AEquipmentType> equipmentType);
 
 	// Add equipment to the first available slot of a specific type
 	void addEquipment(GameState &state, sp<AEquipment> object, EquipmentSlotType slotType);
@@ -397,12 +398,17 @@ class Agent : public StateObject,
 	// Replaces all missions with provided mission, returns true if successful
 	bool setMission(GameState &state, AgentMission *mission);
 
+	// Pops all finished missions, returns true if popped
+	bool popFinishedMissions(GameState &state);
+	// Get new goal for vehicle position or facing
+	bool getNewGoal(GameState &state);
+
 	void die(GameState &state, bool silent = false);
 	bool isDead() const;
 
 	// Update agent in city
 	void update(GameState &state, unsigned ticks);
-	void updateFiveSeconds(GameState &state);
+	void updateEachSecond(GameState &state);
 	void updateDaily(GameState &state);
 	void updateMovement(GameState &state, unsigned ticks);
 
@@ -415,10 +421,10 @@ class Agent : public StateObject,
 	StateRef<AEquipmentType>
 	getDominantItemInHands(GameState &state,
 	                       StateRef<AEquipmentType> itemLastFired = nullptr) const;
-	sp<AEquipment> getFirstItemInSlot(EquipmentSlotType type, bool lazy = true) const;
+	sp<AEquipment> getFirstItemInSlot(EquipmentSlotType equipmentSlotType, bool lazy = true) const;
 	sp<AEquipment> getFirstShield(GameState &state) const;
-	sp<AEquipment> getFirstItemByType(StateRef<AEquipmentType> type) const;
-	sp<AEquipment> getFirstItemByType(AEquipmentType::Type type) const;
+	sp<AEquipment> getFirstItemByType(StateRef<AEquipmentType> equipmentType) const;
+	sp<AEquipment> getFirstItemByType(AEquipmentType::Type itemType) const;
 
 	StateRef<BattleUnitImagePack> getImagePack(BodyPart bodyPart) const;
 

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3143,6 +3143,10 @@ void Battle::exitBattle(GameState &state)
 				state.eventFromBattle = GameEventType::MissionCompletedBuildingAlien;
 				StateRef<Building>(&state, state.current_battle->mission_location_id)
 				    ->collapse(state);
+				for (auto v : returningVehicles)
+				{
+					v->addMission(state, VehicleMission::snooze(state, *v, 3 * TICKS_PER_SECOND));
+				}
 			}
 			break;
 		}
@@ -3170,6 +3174,16 @@ void Battle::exitBattle(GameState &state)
 		case Battle::MissionType::RaidHumans:
 		{
 			state.eventFromBattle = GameEventType::MissionCompletedBuildingRaid;
+			if (state.current_battle->playerWon &&
+			    config().getBool("OpenApoc.NewFeature.CollapseRaidedBuilding"))
+			{
+				StateRef<Building>(&state, state.current_battle->mission_location_id)
+				    ->collapse(state);
+				for (auto v : returningVehicles)
+				{
+					v->addMission(state, VehicleMission::snooze(state, *v, 3 * TICKS_PER_SECOND));
+				}
+			}
 			break;
 		}
 		case Battle::MissionType::UfoRecovery:

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2600,9 +2600,7 @@ void Battle::finishBattle(GameState &state)
 		// Send home if not on vehicle
 		if (!u.second->agent->currentVehicle && !state.current_battle->skirmish)
 		{
-			u.second->agent->setMission(
-			    state, AgentMission::gotoBuilding(state, *u.second->agent,
-			                                      u.second->agent->homeBuilding, false, false));
+			u.second->agent->setMission(state, AgentMission::gotoBuilding(state, *u.second->agent));
 		}
 	}
 
@@ -2989,13 +2987,71 @@ void Battle::exitBattle(GameState &state)
 		}
 	}
 
-	// Check cargo limits
+	// List of bio-containment leftover loot
+	std::map<StateRef<AEquipmentType>, int> leftoverBioLoot;
+	// List of cargo bay leftover loot
+	std::map<StateRef<AEquipmentType>, int> leftoverCargoLoot;
+
+	// Check cargo limits (this can move loot into leftover loot)
 	if (config().getBool("OpenApoc.NewFeature.EnforceCargoLimits"))
 	{
 		LogWarning("Implement feature: Enforce containment limits");
+
+		// FIXME: Implement enforce cargo limits
+		// Basically here we should open a window where we offer to leave behind
+		// loot that won't fit combined cargo capacity and alien capacity of player craft
+		// That loot is moved to leftover loot
 	}
 
-	// Load cargo into vehicles
+	// If player has no vehicles all loot goes to leftover loot
+	if (playerVehicles.empty())
+	{
+		for (auto &e : state.current_battle->cargoLoot)
+		{
+			leftoverCargoLoot[e.first] = e.second;
+		}
+		state.current_battle->cargoLoot.clear();
+		for (auto &e : state.current_battle->bioLoot)
+		{
+			leftoverBioLoot[e.first] = e.second;
+		}
+		state.current_battle->bioLoot.clear();
+	}
+
+	// Bio loot remaining?
+	if (!leftoverBioLoot.empty())
+	{
+		// Bio loot is wasted if can't be loaded on player craft
+	}
+
+	// Cargo loot remaining?
+	if (leftoverCargoLoot.empty())
+	{
+		if (config().getBool("OpenApoc.NewFeature.AllowBuildingLootDeposit"))
+		{
+			if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
+			{
+				// Still cant't do anything if we're recovering UFO
+			}
+			else
+			{
+				// Deposit loot into building, call for pickup
+				StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+				auto homeBuilding =
+				    playerVehicles.empty() ? nullptr : playerVehicles.front()->homeBuilding;
+				if (!homeBuilding)
+				{
+					homeBuilding = state.player_bases.begin()->second->building;
+				}
+				for (auto &e : leftoverCargoLoot)
+				{
+					location->cargo.emplace_back(state, e.first, e.second, nullptr, homeBuilding);
+				}
+			}
+		}
+	}
+
+	// Load cargo/bio into vehicles
 	if (!playerVehicles.empty())
 	{
 		// Go through every loot position
@@ -3066,46 +3122,13 @@ void Battle::exitBattle(GameState &state)
 		}
 	}
 
-	// Bio loot remaining?
-	if (!state.current_battle->bioLoot.empty())
-	{
-		// Bio loot is wasted if can't be loaded on player craft
-	}
-
-	// Cargo loot remaining?
-	if (!state.current_battle->cargoLoot.empty())
-	{
-		if (config().getBool("OpenApoc.NewFeature.AllowBuildingLootDeposit"))
-		{
-			if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
-			{
-				// Still cant't do anything if we're recovering UFO
-			}
-			else
-			{
-				// Deposit loot into building, call for pickup
-				StateRef<Building> location = {&state, state.current_battle->mission_location_id};
-				auto homeBuilding =
-				    playerVehicles.empty() ? nullptr : playerVehicles.front()->homeBuilding;
-				if (!homeBuilding)
-				{
-					homeBuilding = state.player_bases.begin()->second->building;
-				}
-				for (auto &e : state.current_battle->cargoLoot)
-				{
-					location->cargo.emplace_back(state, e.first, e.second, nullptr, homeBuilding);
-				}
-			}
-		}
-	}
-
 	// Give player vehicle a null cargo just so it comes back to base once
 	for (auto v : returningVehicles)
 	{
 		v->cargo.emplace_front(
 		    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0,
 		    nullptr, v->homeBuilding);
-		v->setMission(state, VehicleMission::gotoBuilding(state, *v, v->homeBuilding));
+		v->setMission(state, VehicleMission::gotoBuilding(state, *v));
 		v->addMission(state, VehicleMission::offerService(state, *v), true);
 	}
 

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -713,7 +713,7 @@ class BattleUnit : public StateObject, public std::enable_shared_from_this<Battl
 	// Try to make unit rise (may fail if other unit stands on top)
 	void tryToRiseUp(GameState &state);
 	// Process unit becoming unconscious
-	void fallUnconscious(GameState &state);
+	void fallUnconscious(GameState &state, StateRef<BattleUnit> attacker = nullptr);
 	// Process unit dying
 	void die(GameState &state, StateRef<BattleUnit> attacker = nullptr, bool violently = true);
 

--- a/game/state/city/agentmission.h
+++ b/game/state/city/agentmission.h
@@ -67,7 +67,10 @@ class AgentMission
 	bool advanceAlongPath(GameState &state, Agent &a, Vec3<float> &destPos);
 
 	// Methods to create new missions
-	static AgentMission *gotoBuilding(GameState &state, Agent &a, StateRef<Building> target,
+
+	// With no building goes home, allowTaxi auto set to true for non-soldiers
+	static AgentMission *gotoBuilding(GameState &state, Agent &a,
+	                                  StateRef<Building> target = nullptr,
 	                                  bool allowTeleporter = false, bool allowTaxi = false);
 	static AgentMission *awaitPickup(GameState &state, Agent &a, StateRef<Building> target);
 	static AgentMission *snooze(GameState &state, Agent &a, unsigned int ticks);

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -819,6 +819,28 @@ void Building::alienGrowth(GameState &state)
 	detected = detected && hasAliens();
 }
 
+void Building::underAttack(GameState &state, StateRef<Organisation> attacker)
+{
+	if (owner->isRelatedTo(attacker) == Organisation::Relation::Hostile)
+	{
+		std::list<StateRef<Vehicle>> toLaunch;
+		for (auto v : currentVehicles)
+		{
+			toLaunch.push_back(v);
+		}
+		for (auto v : toLaunch)
+		{
+			v->setMission(state, VehicleMission::patrol(state, *v, true, 5));
+		}
+		if (timeOfLastAttackEvent + TICKS_ATTACK_EVENT_TIMEOUT < state.gameTime.getTicks())
+		{
+			timeOfLastAttackEvent = state.gameTime.getTicks();
+			fw().pushEvent(new GameBuildingEvent(GameEventType::BuildingAttacked,
+			                                     {&state, shared_from_this()}, attacker));
+		}
+	}
+}
+
 void Building::collapse(GameState &state) { LogWarning("Collpase the whole building!"); }
 
 } // namespace OpenApoc

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -4,6 +4,7 @@
 #include "game/state/base/base.h"
 #include "game/state/city/agentmission.h"
 #include "game/state/city/city.h"
+#include "game/state/city/scenery.h"
 #include "game/state/city/vehicle.h"
 #include "game/state/city/vehiclemission.h"
 #include "game/state/gameevent.h"
@@ -841,6 +842,21 @@ void Building::underAttack(GameState &state, StateRef<Organisation> attacker)
 	}
 }
 
-void Building::collapse(GameState &state) { LogWarning("Collpase the whole building!"); }
+void Building::collapse(GameState &state)
+{
+	std::list<sp<Scenery>> sceneryToCollapse;
+	for (auto &p : buildingParts)
+	{
+		auto tile = city->map->getTile(p);
+		if (tile->presentScenery)
+		{
+			sceneryToCollapse.push_back(tile->presentScenery);
+		}
+	}
+	for (auto &s : sceneryToCollapse)
+	{
+		s->collapse(state);
+	}
+}
 
 } // namespace OpenApoc

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -81,6 +81,7 @@ class Building : public StateObject, public std::enable_shared_from_this<Buildin
 	Vec3<int> crewQuarters;
 	std::vector<Vec3<int>> carEntranceLocations;
 	std::vector<Vec3<int>> landingPadLocations;
+	std::set<Vec3<int>> buildingParts;
 };
 
 }; // namespace OpenApoc

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -17,6 +17,8 @@ static const unsigned int TICKS_PER_DETECTION_ATTEMPT[5] = {
     70 * TICKS_PER_MINUTE, 80 * TICKS_PER_MINUTE, 85 * TICKS_PER_MINUTE, 95 * TICKS_PER_MINUTE,
     110 * TICKS_PER_MINUTE};
 static const unsigned int TICKS_DETECTION_TIMEOUT = 6 * TICKS_PER_HOUR;
+// How frequently building attack events are emitted
+static const unsigned int TICKS_ATTACK_EVENT_TIMEOUT = TICKS_PER_HOUR;
 
 class BuildingDef;
 class Agent;
@@ -59,6 +61,7 @@ class Building : public StateObject, public std::enable_shared_from_this<Buildin
 	std::set<StateRef<Agent>> currentAgents;
 	std::list<Cargo> cargo;
 
+	uint64_t timeOfLastAttackEvent = 0;
 	unsigned ticksDetectionTimeOut = 0;
 	unsigned ticksDetectionAttemptAccumulated = 0;
 	bool detected = false;
@@ -68,6 +71,8 @@ class Building : public StateObject, public std::enable_shared_from_this<Buildin
 	void updateCargo(GameState &state);
 	void detect(GameState &state, bool forced = false);
 	void alienGrowth(GameState &state);
+
+	void underAttack(GameState &state, StateRef<Organisation> attacker);
 
 	void collapse(GameState &state);
 

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -209,13 +209,13 @@ void City::update(GameState &state, unsigned int ticks)
 				case TileObject::Type::Vehicle:
 				{
 					auto vehicle = std::static_pointer_cast<TileObjectVehicle>(c.obj)->getVehicle();
-					displayDoodad = vehicle->handleCollision(state, c, playSound);
+					displayDoodad = !vehicle->handleCollision(state, c, playSound);
 					break;
 				}
 				case TileObject::Type::Scenery:
 				{
 					auto sceneryTile = std::static_pointer_cast<TileObjectScenery>(c.obj);
-					displayDoodad = sceneryTile->getOwner()->handleCollision(state, c);
+					displayDoodad = !sceneryTile->getOwner()->handleCollision(state, c);
 					playSound = displayDoodad;
 					break;
 				}
@@ -308,7 +308,7 @@ void City::updateInfiltration(GameState &state)
 
 void City::initialSceneryLinkUp()
 {
-	LogWarning("Begun scenery parts link up!");
+	LogWarning("Begun scenery link up!");
 	auto &mapref = *map;
 
 	for (auto &s : this->scenery)
@@ -369,7 +369,7 @@ void City::initialSceneryLinkUp()
 		}
 	}
 
-	mapref.updateAllBattlescapeInfo();
+	mapref.updateAllCityInfo();
 	LogWarning("Link up finished!");
 }
 

--- a/game/state/city/projectile.cpp
+++ b/game/state/city/projectile.cpp
@@ -19,19 +19,21 @@ namespace OpenApoc
 {
 
 Projectile::Projectile(Type type, StateRef<Vehicle> firer, StateRef<Vehicle> target,
-                       Vec3<float> position, Vec3<float> velocity, int turnRate,
-                       unsigned int lifetime, int damage, unsigned int delay,
+                       Vec3<float> targetPosition, Vec3<float> position, Vec3<float> velocity,
+                       int turnRate, unsigned int lifetime, int damage, unsigned int delay,
                        unsigned int tail_length, std::list<sp<Image>> projectile_sprites,
                        sp<Sample> impactSfx, StateRef<DoodadType> doodadType, sp<VoxelMap> voxelMap)
     : type(type), position(position), velocity(velocity), turnRate(turnRate), age(0),
       lifetime(lifetime), damage(damage), delay_ticks_remaining(delay), firerVehicle(firer),
-      firerPosition(firer->position), trackedVehicle(target), previousPosition(position),
-      spritePositions({position}), tail_length(tail_length), projectile_sprites(projectile_sprites),
-      sprite_distance(1.0f / TILE_Y_CITY), voxelMap(voxelMap), impactSfx(impactSfx),
-      doodadType(doodadType), velocityScale(VELOCITY_SCALE_CITY)
+      firerPosition(firer->position), trackedVehicle(target), targetPosition(targetPosition),
+      previousPosition(position), spritePositions({position}), tail_length(tail_length),
+      projectile_sprites(projectile_sprites), sprite_distance(1.0f / TILE_Y_CITY),
+      voxelMap(voxelMap), impactSfx(impactSfx), doodadType(doodadType),
+      velocityScale(VELOCITY_SCALE_CITY)
 {
-	// 36 / (velocity length) = enough ticks to pass 1 whole tile
-	ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(velocity / velocityScale)) + 1;
+	// enough ticks to pass 1 tile diagonally and some more since vehicles can move quite quickly
+	ownerInvulnerableTicks =
+	    (int)ceilf(1.33f * 1.5f * (float)TICK_SCALE / glm::length(velocity / velocityScale)) + 1;
 	if (target)
 		trackedObject = target->tileObject;
 }
@@ -50,8 +52,9 @@ Projectile::Projectile(Type type, StateRef<BattleUnit> firer, StateRef<BattleUni
       sprite_distance(1.0f / TILE_Y_BATTLE), voxelMap(voxelMap), impactSfx(impactSfx),
       doodadType(doodadType), damageType(damageType), velocityScale(VELOCITY_SCALE_BATTLE)
 {
-	// 36 / (velocity length) = enough ticks to pass 1 whole tile
-	ownerInvulnerableTicks = (int)ceilf(36.0f / glm::length(velocity / velocityScale)) + 1;
+	// enough ticks to pass 1 tile diagonally
+	ownerInvulnerableTicks =
+	    (int)ceilf(1.5f * (float)TICK_SCALE / glm::length(velocity / velocityScale)) + 1;
 	if (target)
 		trackedObject = target->tileObject;
 }

--- a/game/state/city/projectile.h
+++ b/game/state/city/projectile.h
@@ -49,9 +49,9 @@ class Projectile : public std::enable_shared_from_this<Projectile>
 	// Beams have a width & tail length
 	// FIXME: Make this a non-constant colour?
 	// FIXME: Width is currently just used for drawing - TODO What is "collision" size of beams?
-	Projectile(Type type, StateRef<Vehicle> firer, StateRef<Vehicle> target, Vec3<float> position,
-	           Vec3<float> velocity, int turnRate, unsigned int lifetime, int damage,
-	           unsigned int delay, unsigned int tail_length,
+	Projectile(Type type, StateRef<Vehicle> firer, StateRef<Vehicle> target,
+	           Vec3<float> targetPosition, Vec3<float> position, Vec3<float> velocity, int turnRate,
+	           unsigned int lifetime, int damage, unsigned int delay, unsigned int tail_length,
 	           std::list<sp<Image>> projectile_sprites, sp<Sample> impactSfx,
 	           StateRef<DoodadType> doodadType, sp<VoxelMap> voxelMap = nullptr);
 	Projectile(Type type, StateRef<BattleUnit> firer, StateRef<BattleUnit> target,

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -773,7 +773,7 @@ void Scenery::setPosition(const Vec3<float> &pos)
 bool Scenery::handleCollision(GameState &state, Collision &c)
 {
 	// Adjust relationships
-	if (building && c.projectile->firerVehicle)
+	if (!type->commonProperty && building && c.projectile->firerVehicle)
 	{
 		auto attackerOrg = c.projectile->firerVehicle->owner;
 		auto ourOrg = building->owner;
@@ -996,6 +996,10 @@ void Scenery::die(GameState &state, bool forced)
 		}
 		this->tileObject->removeFromMap();
 		this->tileObject.reset();
+		if (building)
+		{
+			building->buildingParts.erase(initialPosition);
+		}
 	}
 }
 
@@ -1029,6 +1033,10 @@ void Scenery::collapse(GameState &state)
 	}
 	ceaseBeingSupported();
 	ceaseSupportProvision();
+	if (building)
+	{
+		building->buildingParts.erase(initialPosition);
+	}
 }
 
 void Scenery::update(GameState &state, unsigned int ticks)
@@ -1220,6 +1228,10 @@ void Scenery::repair(GameState &state)
 		this->overlayDoodad =
 		    mksp<Doodad>(this->getPosition(), type->imageOffset, false, 1, type->overlaySprite);
 		map.addObjectToMap(this->overlayDoodad);
+	}
+	if (building && !type->commonProperty)
+	{
+		building->buildingParts.insert(initialPosition);
 	}
 	map.clearPathCaches();
 }

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -156,10 +156,26 @@ class FlyingVehicleMover : public VehicleMover
 	// Vehicle is considered idle whenever it's at goal in its tile, even if it has missions to do
 	void updateIdle(GameState &state)
 	{
-		if (vehicle.crashed || vehicle.falling)
+		// Crashed/falling/sliding aren't doing anything
+		if (vehicle.crashed || vehicle.falling || vehicle.sliding)
 		{
 			return;
 		}
+		// Vehicles on take off mission don't do anything
+		if (!vehicle.missions.empty())
+		{
+			if (vehicle.missions.front()->type == VehicleMission::MissionType::TakeOff ||
+			    vehicle.missions.front()->type == VehicleMission::MissionType::Land)
+			{
+				return;
+			}
+		}
+		// Vehicles below ground don't do anything
+		if (vehicle.position.z < 2.0f)
+		{
+			return;
+		}
+		// Don't idle every frame
 		if (vehicle.ticksAutoActionAvailable > state.gameTime.getTicks())
 		{
 			return;
@@ -175,7 +191,7 @@ class FlyingVehicleMover : public VehicleMover
 			vehicle.carriedVehicle.clear();
 		}
 
-		// Step 02: Try to move to preferred height if no mission
+		// Step 02: Try to move to preferred altitude if no mission
 		if (vehicle.missions.empty() && (int)vehicle.position.z != (int)vehicle.altitude)
 		{
 			auto targetPos = vehicle.position;
@@ -491,6 +507,7 @@ class FlyingVehicleMover : public VehicleMover
 			// Request new goal
 			if (vehicle.position == vehicle.goalPosition && vehicle.facing == vehicle.goalFacing)
 			{
+				// Need to pop before checking idle
 				vehicle.popFinishedMissions(state);
 				// Vehicle is considered idle if at goal even if there's more missions to do
 				updateIdle(state);
@@ -708,6 +725,7 @@ class GroundVehicleMover : public VehicleMover
 				}
 				else
 				{
+					// Need to pop before checking idle
 					vehicle.popFinishedMissions(state);
 					// Vehicle is considered idle if at goal even if there's more missions to do
 					updateIdle(state);
@@ -923,15 +941,8 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 				switch (atvMode)
 				{
 					case SceneryTileType::WalkMode::Into:
-						if (newPosition.z - floorf(newPosition.z) >=
-						    (tile->presentScenery->type->isHill ? 0.5f : 0.05f))
-						{
-							tryPlowThrough = false;
-						}
-						break;
 					case SceneryTileType::WalkMode::Onto:
-						if (newPosition.z - floorf(newPosition.z) >=
-						    (float)tile->presentScenery->type->height / 15.0f)
+						if (newPosition.z >= tile->getRestingPosition(false, true).z)
 						{
 							tryPlowThrough = false;
 						}
@@ -942,8 +953,7 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 							// Only try to plow through high Nones once
 							tryPlowThrough = newTile;
 						}
-						else if (newPosition.z - floorf(newPosition.z) >=
-						         (float)tile->presentScenery->type->height / 15.0f)
+						else if (newPosition.z >= tile->getRestingPosition(false, true).z)
 						{
 							tryPlowThrough = false;
 						}
@@ -1031,7 +1041,8 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 		vehicle.setPosition(newPosition);
 
 		// See if we've landed
-		auto presentScenery = vehicle.tileObject->getOwningTile()->presentScenery;
+		tile = vehicle.tileObject->getOwningTile();
+		auto presentScenery = tile->presentScenery;
 		if (presentScenery)
 		{
 			auto atvMode = presentScenery->type->getATVMode();
@@ -1039,18 +1050,9 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 			{
 				case SceneryTileType::WalkMode::None:
 				case SceneryTileType::WalkMode::Onto:
-				{
-					if (newPosition.z - floorf(newPosition.z) <
-					    (float)presentScenery->type->height / 15.0f)
-					{
-						vehicle.falling = false;
-					}
-					break;
-				}
 				case SceneryTileType::WalkMode::Into:
 				{
-					if (newPosition.z - floorf(newPosition.z) <
-					    (presentScenery->type->isHill ? 0.5f : 0.05f))
+					if (newPosition.z < tile->getRestingPosition(false, true).z)
 					{
 						vehicle.falling = false;
 					}
@@ -1075,24 +1077,7 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 				}
 				// Move to resting position in the tile
 				Vec3<float> newGoal = (Vec3<int>)newPosition;
-				switch (atvMode)
-				{
-					case SceneryTileType::WalkMode::None:
-					case SceneryTileType::WalkMode::Onto:
-						newGoal += Vec3<float>{0.5f, 0.5f,
-						                       (float)presentScenery->type->height / 15.0f - 0.01f};
-						break;
-					case SceneryTileType::WalkMode::Into:
-						if (presentScenery->type->isHill)
-						{
-							newGoal += Vec3<float>{0.5f, 0.5f, 0.5f};
-						}
-						else
-						{
-							newGoal += Vec3<float>{0.5f, 0.5f, 0.05f};
-						}
-						break;
-				}
+				newGoal.z = tile->getRestingPosition(false, true).z;
 				vehicle.goalWaypoints.push_back(newGoal);
 				newPosition.z = newGoal.z;
 				// Translate Z velocity into XY velocity
@@ -1107,11 +1092,16 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 				vehicle.setPosition(newPosition);
 				vehicle.goalPosition = vehicle.position;
 				vehicle.angularVelocity /= 2.0f;
-				// Flying vehicle or fell into an unpassable tile -> start sliding and eventually
-				// crash
+				// Start sliding and eventually crash if:
+				// - Flying vehicle
+				// - Ground vehicle fell into an unpassable tile
+				// - Ground vehicle fell into a tile which has different resting height and vehicle
+				// height
+				//   (which is something like a tunnel or terminus at base)
 				if (!vehicle.type->isGround() || atvMode == SceneryTileType::WalkMode::None ||
 				    (vehicle.type->type == VehicleType::Type::Road &&
-				     presentScenery->type->tile_type != SceneryTileType::TileType::Road))
+				     presentScenery->type->tile_type != SceneryTileType::TileType::Road) ||
+				    vehicle.position.z != tile->getRestingPosition(false, true).z)
 				{
 					vehicle.sliding = true;
 					vehicle.goalWaypoints.clear();
@@ -1813,16 +1803,6 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 	}
 	popFinishedMissions(state);
 
-	if (this->type->type == VehicleType::Type::UFO && this->missions.empty())
-	{
-		auto alien_city = state.cities["CITYMAP_ALIEN"];
-		// Make UFOs patrol their city if we're looking at it
-		if (this->city == alien_city && state.current_city == this->city)
-		{
-			this->missions.emplace_back(VehicleMission::patrol(state, *this));
-		}
-	}
-
 	int maxShield = this->getMaxShield();
 	if (maxShield)
 	{
@@ -1853,39 +1833,74 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 			nextFrame(ticks);
 		}
 
-		bool has_active_weapon = false;
-		bool has_active_pd = false;
-		Vec2<int> arc = {0, 0};
-		Vec2<int> arcPD = {0, 0};
-		for (auto &equipment : this->equipment)
+		// Vehicles that are taking off or landing don't attempt to fire
+		bool attemptFire = true;
+		if (!type->isGround() && !missions.empty())
 		{
-			if (equipment->type->type != EquipmentSlotType::VehicleWeapon)
-				continue;
-			equipment->update(ticks);
-			if (!crashed && !falling && this->attackMode != Vehicle::AttackMode::Evasive &&
-			    equipment->canFire())
+			if (missions.front()->type == VehicleMission::MissionType::TakeOff ||
+			    missions.front()->type == VehicleMission::MissionType::Land)
 			{
-				has_active_weapon = true;
-				if (arc.x < equipment->type->firing_arc_1)
+				attemptFire = false;
+			}
+		}
+		if (attemptFire)
+		{
+			bool has_active_weapon = false;
+			bool has_active_pd = false;
+			Vec2<int> arc = {0, 0};
+			Vec2<int> arcPD = {0, 0};
+			for (auto &equipment : this->equipment)
+			{
+				if (equipment->type->type != EquipmentSlotType::VehicleWeapon)
+					continue;
+				equipment->update(ticks);
+				if (!crashed && !falling && this->attackMode != Vehicle::AttackMode::Evasive &&
+				    equipment->canFire())
 				{
-					// FIXME: Are vertical firing arcs actually working in vanilla? I think not..
-					arc = {equipment->type->firing_arc_1, 8};
+					has_active_weapon = true;
+					if (arc.x < equipment->type->firing_arc_1)
+					{
+						// FIXME: Are vertical firing arcs actually working in vanilla? I think
+						// not..
+						arc = {equipment->type->firing_arc_1, 8};
+					}
+					has_active_pd = equipment->type->point_defence;
+					if (has_active_pd && arcPD.x < equipment->type->firing_arc_1)
+					{
+						// FIXME: Are vertical firing arcs actually working in vanilla? I think
+						// not..
+						arcPD = {equipment->type->firing_arc_1, 8};
+					}
 				}
-				has_active_pd = equipment->type->point_defence;
-				if (has_active_pd && arcPD.x < equipment->type->firing_arc_1)
+			}
+
+			if (has_active_weapon)
+			{
+				// First fire where told to manually
+				if (manualFire)
 				{
-					// FIXME: Are vertical firing arcs actually working in vanilla? I think not..
-					arcPD = {equipment->type->firing_arc_1, 8};
+					fireWeaponsManual(state, arc);
+				}
+				// Try firing point defense weapons
+				else if (!has_active_pd || !fireWeaponsPointDefense(state, arcPD))
+				{
+					// Fire normal weapons
+					fireWeaponsNormal(state, arc);
 				}
 			}
 		}
+	}
+	manualFire = false;
+}
 
-		// First try firing point defense weapons
-		if (has_active_weapon && (!has_active_pd || !firePointDefenseWeapons(state, arcPD)))
-		{
-			// Fire normal weapons
-			fireNormalWeapons(state, arc);
-		}
+void Vehicle::updateEachSecond(GameState &state)
+{
+	updateCargo(state);
+	if (missions.empty() && !currentBuilding && owner != state.getPlayer())
+	{
+		setMission(state,
+		           owner == state.getAliens() ? VehicleMission::patrol(state, *this)
+		                                      : VehicleMission::gotoBuilding(state, *this));
 	}
 }
 
@@ -2169,7 +2184,7 @@ sp<TileObjectVehicle> Vehicle::findClosestEnemy(GameState &state, sp<TileObjectV
 			/* Can't fire at yourself */
 			continue;
 		}
-		if (otherVehicle->crashed)
+		if (otherVehicle->crashed || otherVehicle->falling || otherVehicle->sliding)
 		{
 			// Can't fire at crashed vehicles
 			continue;
@@ -2268,18 +2283,18 @@ sp<TileObjectProjectile> Vehicle::findClosestHostileMissile(GameState &state,
 	return closestEnemy;
 }
 
-bool Vehicle::firePointDefenseWeapons(GameState &state, Vec2<int> arc)
+bool Vehicle::fireWeaponsPointDefense(GameState &state, Vec2<int> arc)
 {
 	// Find something to shoot at!
 	sp<TileObjectProjectile> missile = findClosestHostileMissile(state, tileObject, arc);
 	if (missile)
 	{
-		return attackTarget(state, tileObject, missile);
+		return attackTarget(state, missile);
 	}
 	return false;
 }
 
-void Vehicle::fireNormalWeapons(GameState &state, Vec2<int> arc)
+void Vehicle::fireWeaponsNormal(GameState &state, Vec2<int> arc)
 {
 	// Find something to shoot at!
 	sp<TileObjectVehicle> enemy;
@@ -2298,11 +2313,16 @@ void Vehicle::fireNormalWeapons(GameState &state, Vec2<int> arc)
 
 	if (enemy)
 	{
-		attackTarget(state, tileObject, enemy);
+		attackTarget(state, enemy);
 	}
 }
-void Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
-                           sp<TileObjectVehicle> enemyTile)
+
+void Vehicle::fireWeaponsManual(GameState &state, Vec2<int> arc)
+{
+	attackTarget(state, manualFirePosition);
+}
+
+void Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> enemyTile)
 {
 	static const std::set<TileObject::Type> scenerySet = {TileObject::Type::Scenery,
 	                                                      TileObject::Type::Vehicle};
@@ -2364,8 +2384,8 @@ void Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
 		for (int i = 0; i < 2; i++)
 		{
 			bool hitSomethingBad = false;
-			auto hitObject = vehicleTile->map.findCollision(firePosition, targetPosAdjusted,
-			                                                scenerySet, tileObject);
+			auto hitObject = tileObject->map.findCollision(firePosition, targetPosAdjusted,
+			                                               scenerySet, tileObject);
 			if (hitObject)
 			{
 				if (hitObject.obj->getType() == TileObject::Type::Vehicle)
@@ -2406,8 +2426,7 @@ void Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
 	return;
 }
 
-bool Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
-                           sp<TileObjectProjectile> enemyTile)
+bool Vehicle::attackTarget(GameState &state, sp<TileObjectProjectile> enemyTile)
 {
 	static const std::set<TileObject::Type> scenerySet = {TileObject::Type::Scenery,
 	                                                      TileObject::Type::Vehicle};
@@ -2474,8 +2493,8 @@ bool Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
 		for (int i = 0; i < 2; i++)
 		{
 			bool hitSomethingBad = false;
-			auto hitObject = vehicleTile->map.findCollision(firePosition, targetPosAdjusted,
-			                                                scenerySet, tileObject);
+			auto hitObject = tileObject->map.findCollision(firePosition, targetPosAdjusted,
+			                                               scenerySet, tileObject);
 			if (hitObject)
 			{
 				if (hitObject.obj->getType() == TileObject::Type::Vehicle)
@@ -2514,6 +2533,60 @@ bool Vehicle::attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
 	return false;
 }
 
+void Vehicle::attackTarget(GameState &state, Vec3<float> target)
+{
+	auto firePosition = getMuzzleLocation();
+	auto distanceTiles = glm::length(position - target);
+
+	auto distanceVoxels = this->tileObject->getDistanceTo(target);
+
+	for (auto &eq : this->equipment)
+	{
+		// Not a weapon
+		if (eq->type->type != EquipmentSlotType::VehicleWeapon)
+		{
+			continue;
+		}
+		// Out of ammo or on cooldown
+		if (eq->canFire() == false)
+		{
+			continue;
+		}
+		// Out of range
+		if (distanceVoxels > eq->getRange())
+		{
+			continue;
+		}
+		// Check firing arc
+		if (eq->type->firing_arc_1 < 8 || eq->type->firing_arc_2 < 8)
+		{
+			Vec2<int> arc = {eq->type->firing_arc_1, 8};
+			auto facing = type->directionToVector(direction);
+			auto vecToTarget = target - position;
+			float angleXY = glm::angle(glm::normalize(Vec2<float>{facing.x, facing.y}),
+			                           glm::normalize(Vec2<float>{vecToTarget.x, vecToTarget.y}));
+			float vecToTargetXY =
+			    sqrtf(vecToTarget.x * vecToTarget.x + vecToTarget.y * vecToTarget.y);
+			float angleZ = glm::angle(Vec2<float>{1.0f, 0.0f},
+			                          glm::normalize(Vec2<float>{vecToTargetXY, vecToTarget.z}));
+			if (angleXY > (float)arc.x * (float)M_PI / 8.0f ||
+			    angleZ > (float)arc.y * (float)M_PI / 8.0f)
+			{
+				continue;
+			}
+		}
+
+		// Cancel cloak
+		cloakTicksAccumulated = 0;
+
+		// Fire
+		eq->fire(state, target);
+		return;
+	}
+
+	return;
+}
+
 float Vehicle::getFiringRange() const
 {
 	float range = 0;
@@ -2546,6 +2619,12 @@ void Vehicle::setPosition(const Vec3<float> &pos)
 	{
 		this->shadowObject->setPosition(pos);
 	}
+}
+
+void Vehicle::setManualFirePosition(const Vec3<float> &pos)
+{
+	manualFirePosition = pos;
+	manualFire = true;
 }
 
 bool Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
@@ -2656,7 +2735,6 @@ bool Vehicle::getNewGoal(GameState &state)
 {
 	bool popped = false;
 	bool acquired = false;
-	Vec3<float> nextGoal;
 	// Pop finished missions if present
 	popped = popFinishedMissions(state);
 	do
@@ -3002,7 +3080,8 @@ bool Vehicle::canAddEquipment(Vec2<int> pos, StateRef<VEquipmentType> type) cons
 	return true;
 }
 
-void Vehicle::addEquipment(GameState &state, Vec2<int> pos, StateRef<VEquipmentType> type)
+sp<VEquipment> Vehicle::addEquipment(GameState &state, Vec2<int> pos,
+                                     StateRef<VEquipmentType> equipmentType)
 {
 	// We can't check this here, as some of the non-buyable vehicles have insane initial equipment
 	// layouts
@@ -3026,47 +3105,70 @@ void Vehicle::addEquipment(GameState &state, Vec2<int> pos, StateRef<VEquipmentT
 	// If this was not within a slow fail
 	if (!slotFound)
 	{
-		LogError("Equipping \"%s\" on \"%s\" at %s failed: No valid slot", type->name, this->name,
-		         pos);
-		return;
+		LogError("Equipping \"%s\" on \"%s\" at %s failed: No valid slot", equipmentType->name,
+		         this->name, pos);
+		return nullptr;
 	}
 
-	switch (type->type)
+	switch (equipmentType->type)
 	{
 		case EquipmentSlotType::VehicleEngine:
 		{
 			auto engine = mksp<VEquipment>();
-			engine->type = type;
+			engine->type = equipmentType;
 			this->equipment.emplace_back(engine);
 			engine->equippedPosition = slotOrigin;
-			LogInfo("Equipped \"%s\" with engine \"%s\"", this->name, type->name);
-			break;
+			LogInfo("Equipped \"%s\" with engine \"%s\"", this->name, equipmentType->name);
+			return engine;
 		}
 		case EquipmentSlotType::VehicleWeapon:
 		{
 			auto thisRef = StateRef<Vehicle>(&state, shared_from_this());
 			auto weapon = mksp<VEquipment>();
-			weapon->type = type;
+			weapon->type = equipmentType;
 			weapon->owner = thisRef;
-			weapon->ammo = type->max_ammo;
+			weapon->ammo = equipmentType->max_ammo;
 			this->equipment.emplace_back(weapon);
 			weapon->equippedPosition = slotOrigin;
-			LogInfo("Equipped \"%s\" with weapon \"%s\"", this->name, type->name);
-			break;
+			LogInfo("Equipped \"%s\" with weapon \"%s\"", this->name, equipmentType->name);
+			return weapon;
 		}
 		case EquipmentSlotType::VehicleGeneral:
 		{
 			auto equipment = mksp<VEquipment>();
-			equipment->type = type;
-			LogInfo("Equipped \"%s\" with general equipment \"%s\"", this->name, type->name);
+			equipment->type = equipmentType;
+			LogInfo("Equipped \"%s\" with general equipment \"%s\"", this->name,
+			        equipmentType->name);
 			equipment->equippedPosition = slotOrigin;
 			this->equipment.emplace_back(equipment);
-			break;
+			return equipment;
 		}
 		default:
-			LogError("Equipment \"%s\" for \"%s\" at pos (%d,%d} has invalid type", type->name,
-			         this->name, pos.x, pos.y);
+			LogError("Equipment \"%s\" for \"%s\" at pos (%d,%d} has invalid type",
+			         equipmentType->name, this->name, pos.x, pos.y);
+			return nullptr;
 	}
+}
+
+sp<VEquipment> Vehicle::addEquipment(GameState &state, StateRef<VEquipmentType> equipmentType)
+{
+	Vec2<int> pos;
+	bool slotFound = false;
+	for (auto &slot : type->equipment_layout_slots)
+	{
+		if (canAddEquipment(slot.bounds.p0, equipmentType))
+		{
+			pos = slot.bounds.p0;
+			slotFound = true;
+			break;
+		}
+	}
+	if (!slotFound)
+	{
+		return nullptr;
+	}
+
+	return addEquipment(state, pos, equipmentType);
 }
 
 void Vehicle::removeEquipment(sp<VEquipment> object)

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -236,7 +236,9 @@ class Vehicle : public StateObject,
 	bool isDead() const;
 
 	bool canAddEquipment(Vec2<int> pos, StateRef<VEquipmentType> type) const;
-	void addEquipment(GameState &state, Vec2<int> pos, StateRef<VEquipmentType> type);
+	sp<VEquipment> addEquipment(GameState &state, Vec2<int> pos,
+	                            StateRef<VEquipmentType> equipmentType);
+	sp<VEquipment> addEquipment(GameState &state, StateRef<VEquipmentType> equipmentType);
 	void removeEquipment(sp<VEquipment> object);
 
 	bool applyDamage(GameState &state, int damage, float armour);
@@ -248,12 +250,12 @@ class Vehicle : public StateObject,
 	sp<TileObjectProjectile> findClosestHostileMissile(GameState &state,
 	                                                   sp<TileObjectVehicle> vehicleTile,
 	                                                   Vec2<int> arc = {8, 8});
-	bool firePointDefenseWeapons(GameState &state, Vec2<int> arc = {8, 8});
-	void fireNormalWeapons(GameState &state, Vec2<int> arc = {8, 8});
-	void attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
-	                  sp<TileObjectVehicle> enemyTile);
-	bool attackTarget(GameState &state, sp<TileObjectVehicle> vehicleTile,
-	                  sp<TileObjectProjectile> enemyTile);
+	bool fireWeaponsPointDefense(GameState &state, Vec2<int> arc = {8, 8});
+	void fireWeaponsNormal(GameState &state, Vec2<int> arc = {8, 8});
+	void fireWeaponsManual(GameState &state, Vec2<int> arc = {8, 8});
+	void attackTarget(GameState &state, sp<TileObjectVehicle> enemyTile);
+	bool attackTarget(GameState &state, sp<TileObjectProjectile> enemyTile);
+	void attackTarget(GameState &state, Vec3<float> target);
 	float getFiringRange() const;
 
 	Vec3<float> getMuzzleLocation() const;
@@ -295,6 +297,8 @@ class Vehicle : public StateObject,
 
 	void setPosition(const Vec3<float> &pos);
 
+	void setManualFirePosition(const Vec3<float> &pos);
+
 	// Adds mission to list of missions, returns true if successful
 	bool addMission(GameState &state, VehicleMission *mission, bool toBack = false);
 	// Replaces all missions with provided mission, returns true if successful
@@ -306,6 +310,7 @@ class Vehicle : public StateObject,
 	bool getNewGoal(GameState &state);
 
 	void update(GameState &state, unsigned int ticks);
+	void updateEachSecond(GameState &state);
 	void updateCargo(GameState &state);
 	void updateSprite(GameState &state);
 
@@ -323,6 +328,12 @@ class Vehicle : public StateObject,
 	// Following members are not serialized, but rather are set in initCity method
 
 	sp<std::vector<sp<Image>>> strategyImages;
+
+	// Following members are not serialized, since there is no need
+
+  private:
+	Vec3<float> manualFirePosition = {0.0f, 0.0f, 0.0f};
+	bool manualFire = false;
 };
 
 }; // namespace OpenApoc

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -303,6 +303,7 @@ class Vehicle : public StateObject,
 	bool addMission(GameState &state, VehicleMission *mission, bool toBack = false);
 	// Replaces all missions with provided mission, returns true if successful
 	bool setMission(GameState &state, VehicleMission *mission);
+	bool clearMissions(GameState &state, bool forced = false);
 
 	// Pops all finished missions, returns true if popped
 	bool popFinishedMissions(GameState &state);

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -32,8 +32,7 @@ namespace
 {
 // Add {0.5,0.5,0.5} to make it route to the center of the tile
 static const Vec3<float> offsetFlying{0.5f, 0.5f, 0.5f};
-static const Vec3<float> offsetLandInto{0.5f, 0.5f, 0.05f};
-static const Vec3<float> offsetLandOnto{0.5f, 0.5f, 0.95f};
+static const Vec3<float> offsetLandInto{0.5f, 0.5f, 0.01f};
 static const Vec3<float> offsetLaunch{0.5f, 0.5f, -1.0f};
 }
 
@@ -383,7 +382,7 @@ VehicleMission *VehicleMission::gotoPortal(GameState &, Vehicle &, Vec3<int> tar
 	return mission;
 }
 
-VehicleMission *VehicleMission::gotoBuilding(GameState &, Vehicle &, StateRef<Building> target,
+VehicleMission *VehicleMission::gotoBuilding(GameState &, Vehicle &v, StateRef<Building> target,
                                              bool allowTeleporter)
 {
 	// TODO
@@ -402,7 +401,7 @@ VehicleMission *VehicleMission::gotoBuilding(GameState &, Vehicle &, StateRef<Bu
 	//  queue(Land)
 	auto *mission = new VehicleMission();
 	mission->type = MissionType::GotoBuilding;
-	mission->targetBuilding = target;
+	mission->targetBuilding = target ? target : v.homeBuilding;
 	mission->allowTeleporter = allowTeleporter;
 	return mission;
 }
@@ -423,6 +422,15 @@ VehicleMission *VehicleMission::attackVehicle(GameState &, Vehicle &, StateRef<V
 	mission->type = MissionType::AttackVehicle;
 	mission->targetVehicle = target;
 	mission->attackCrashed = target->crashed;
+	return mission;
+}
+
+VehicleMission *VehicleMission::attackBuilding(GameState &state, Vehicle &v,
+                                               StateRef<Building> target)
+{
+	auto *mission = new VehicleMission();
+	mission->type = MissionType::AttackBuilding;
+	mission->targetBuilding = target;
 	return mission;
 }
 
@@ -489,11 +497,12 @@ VehicleMission *VehicleMission::crashLand(GameState &, Vehicle &)
 	return mission;
 }
 
-VehicleMission *VehicleMission::patrol(GameState &, Vehicle &, unsigned int counter)
+VehicleMission *VehicleMission::patrol(GameState &, Vehicle &, bool home, unsigned int counter)
 {
 	auto *mission = new VehicleMission();
 	mission->type = MissionType::Patrol;
 	mission->missionCounter = counter;
+	mission->patrolHome = home;
 	return mission;
 }
 
@@ -943,23 +952,11 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 		case MissionType::GotoLocation: // Fall-through
 		case MissionType::Crash:
 		case MissionType::Land:
+		case MissionType::Patrol:
+		case MissionType::AttackBuilding:
 		{
 			return advanceAlongPath(state, v, destPos, destFacing);
 		}
-		case MissionType::Patrol:
-			if (!advanceAlongPath(state, v, destPos, destFacing))
-			{
-				if (missionCounter == 0)
-				{
-					return false;
-				}
-
-				missionCounter--;
-				std::uniform_int_distribution<int> xyPos(25, 115);
-				setPathTo(state, v, {xyPos(state.rng), xyPos(state.rng), v.altitude},
-				          getDefaultIterationCount(v));
-			}
-			return false;
 		case MissionType::AttackVehicle:
 		case MissionType::FollowVehicle:
 		{
@@ -1164,6 +1161,10 @@ void VehicleMission::update(GameState &state, Vehicle &v, unsigned int ticks, bo
 		// Pick attack target
 		case MissionType::Patrol:
 		{
+			if (finished)
+			{
+				return;
+			}
 			float range = v.getFiringRange();
 			if (v.tileObject && range > 0)
 			{
@@ -1171,6 +1172,7 @@ void VehicleMission::update(GameState &state, Vehicle &v, unsigned int ticks, bo
 				if (enemy)
 				{
 					StateRef<Vehicle> vehicleRef(&state, enemy->getVehicle());
+					currentPlannedPath.clear();
 					v.addMission(state, VehicleMission::attackVehicle(state, v, vehicleRef));
 				}
 			}
@@ -1237,6 +1239,7 @@ void VehicleMission::update(GameState &state, Vehicle &v, unsigned int ticks, bo
 		case MissionType::RestartNextMission:
 		case MissionType::TakeOff:
 		case MissionType::RecoverVehicle:
+		case MissionType::AttackBuilding:
 			return;
 		case MissionType::SelfDestruct:
 			if (finished)
@@ -1350,6 +1353,9 @@ bool VehicleMission::isFinishedInternal(GameState &, Vehicle &v)
 		case MissionType::RestartNextMission:
 		case MissionType::Teleport:
 			return true;
+		// For now there's no known way to finish AttackBuilding
+		case MissionType::AttackBuilding:
+			return false;
 		default:
 			LogWarning("TODO: Implement isFinishedInternal");
 			return false;
@@ -1445,35 +1451,34 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				// Looking for free exit
 				for (auto &exitLocation : b->carEntranceLocations)
 				{
-					auto entTile = map.getTile(exitLocation);
-					if (!entTile)
+					auto exitTile = map.getTile(exitLocation);
+					if (!exitTile)
 					{
 						LogError("Invalid entrance location %s - outside map?", exitLocation.x);
 						continue;
 					}
-					auto scenery = entTile->presentScenery;
+					auto scenery = exitTile->presentScenery;
 					if (!scenery)
 					{
 						LogInfo("Tried exit %s - destroyed", exitLocation);
 						continue;
 					}
-					bool padIsBusy = false;
-					for (auto &obj : entTile->ownedObjects)
+					bool exitIsBusy = false;
+					for (auto &obj : exitTile->ownedObjects)
 					{
 						if (obj->getType() == TileObject::Type::Vehicle)
 						{
-							padIsBusy = true;
+							exitIsBusy = true;
 							break;
 						}
 					}
-					if (padIsBusy)
+					if (exitIsBusy)
 					{
 						continue;
 					}
 					LogInfo("Launching vehicle from building \"%s\" at exit %s", b.id,
 					        exitLocation);
-					Vec3<float> leaveLocation = exitLocation;
-					leaveLocation += offsetLandInto;
+					Vec3<float> leaveLocation = exitTile->getRestingPosition();
 					float facing = 0.0f;
 					if (scenery->type->connection[0])
 					{
@@ -1508,6 +1513,11 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				for (auto &padLocation : b->landingPadLocations)
 				{
 					auto padTile = map.getTile(padLocation);
+					// Pad destroyed
+					if (!padTile->presentScenery || !padTile->presentScenery->type->isLandingPad)
+					{
+						continue;
+					}
 					auto abovePadLocation = padLocation;
 					abovePadLocation.z += 1;
 					auto tileAbovePad = map.getTile(abovePadLocation);
@@ -1548,21 +1558,6 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			v.addMission(state, snooze(state, v, TICKS_PER_SECOND / 2));
 			return;
 		}
-		case MissionType::SelfDestruct:
-			if (v.smokeDoodad)
-			{
-				LogError("Restarting self destruct?");
-			}
-			else
-			{
-				v.smokeDoodad = v.city->placeDoodad({&state, "DOODAD_13_SMOKE_FUME"},
-				                                    v.position + Vec3<float>{0.0f, 0.0f, 0.25f});
-			}
-			return;
-		case MissionType::RestartNextMission:
-		case MissionType::Snooze:
-			// No setup
-			return;
 		case MissionType::Land:
 		{
 			auto b = this->targetBuilding;
@@ -1695,9 +1690,67 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			}
 			return;
 		}
+		case MissionType::Patrol:
+		{
+			if (isFinishedInternal(state, v))
+			{
+				return;
+			}
+			if (takeOffCheck(state, v))
+			{
+				return;
+			}
+			else
+			{
+				if (this->currentPlannedPath.empty())
+				{
+					if (missionCounter == 0)
+					{
+						return;
+					}
+					missionCounter--;
+
+					if (patrolHome)
+					{
+						std::uniform_int_distribution<int> xPos(v.homeBuilding->bounds.p0.x - 2,
+						                                        v.homeBuilding->bounds.p1.x + 2);
+						std::uniform_int_distribution<int> yPos(v.homeBuilding->bounds.p0.y - 2,
+						                                        v.homeBuilding->bounds.p1.y + 2);
+						setPathTo(state, v, {xPos(state.rng), yPos(state.rng), v.altitude},
+						          getDefaultIterationCount(v));
+					}
+					else
+					{
+						std::uniform_int_distribution<int> xyPos(25, 115);
+						setPathTo(state, v, {xyPos(state.rng), xyPos(state.rng), v.altitude},
+						          getDefaultIterationCount(v));
+					}
+				}
+			}
+			return;
+		}
+		case MissionType::AttackBuilding:
+		{
+			if (takeOffCheck(state, v))
+			{
+				return;
+			}
+			else
+			{
+				if (this->currentPlannedPath.empty())
+				{
+					std::uniform_int_distribution<int> xPos(targetBuilding->bounds.p0.x - 2,
+					                                        targetBuilding->bounds.p1.x + 2);
+					std::uniform_int_distribution<int> yPos(targetBuilding->bounds.p0.y - 2,
+					                                        targetBuilding->bounds.p1.y + 2);
+					setPathTo(state, v, {xPos(state.rng), yPos(state.rng), v.altitude},
+					          getDefaultIterationCount(v));
+				}
+			}
+			return;
+		}
 		case MissionType::Crash:
 		{
-			// Ground can't crash (yet)
 			if (v.type->type != VehicleType::Type::UFO)
 			{
 				LogError("Only UFOs can crash, how did we end up starting this?");
@@ -1732,11 +1785,6 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			}
 			this->targetLocation = tile;
 			setPathTo(state, v, tile, getDefaultIterationCount(v));
-			return;
-		}
-		case MissionType::Patrol:
-		{
-			takeOffCheck(state, v);
 			return;
 		}
 		case MissionType::FollowVehicle:
@@ -1854,6 +1902,12 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				LogInfo("Vehicle mission %s: at position %s", name, position);
 				for (auto &padLocation : b->landingPadLocations)
 				{
+					auto padTile = b->city->map->getTile(padLocation);
+					// Pad destroyed
+					if (!padTile->presentScenery || !padTile->presentScenery->type->isLandingPad)
+					{
+						continue;
+					}
 					auto abovePadLocation = padLocation;
 					abovePadLocation.z += 1;
 					if (abovePadLocation == position)
@@ -1869,7 +1923,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				* +
 				* distance to goal)*/
 				Vec3<int> shortestPathPad = {0, 0, 0};
-				float shortestPathCost = std::numeric_limits<float>::max();
+				float shortestPathCost = FLT_MAX;
 
 				for (auto &dest : b->landingPadLocations)
 				{
@@ -1878,6 +1932,12 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					// Don't pay attention to stuff that blocks us, as things will likely move
 					// anyway...
 
+					auto padTile = b->city->map->getTile(dest);
+					// Pad destroyed
+					if (!padTile->presentScenery || !padTile->presentScenery->type->isLandingPad)
+					{
+						continue;
+					}
 					// We actually want the tile above the pad itself
 					auto aboveDest = dest;
 					aboveDest.z += 1;
@@ -1894,10 +1954,25 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						shortestPathPad = aboveDest;
 					}
 				}
-
-				LogInfo("Vehicle mission %s: Pathing to pad at %s", name, shortestPathPad);
-				v.addMission(state, VehicleMission::gotoLocation(state, v, shortestPathPad,
-				                                                 allowTeleporter, false, 100));
+				if (shortestPathCost != FLT_MAX)
+				{
+					LogInfo("Vehicle mission %s: Pathing to pad at %s", name, shortestPathPad);
+					v.addMission(state, VehicleMission::gotoLocation(state, v, shortestPathPad,
+					                                                 allowTeleporter, false, 100));
+				}
+				else
+				{
+					LogInfo("Vehicle mission %s: No pads, pathing to random location near building",
+					        name);
+					std::uniform_int_distribution<int> xPos(targetBuilding->bounds.p0.x - 2,
+					                                        targetBuilding->bounds.p1.x + 2);
+					std::uniform_int_distribution<int> yPos(targetBuilding->bounds.p0.y - 2,
+					                                        targetBuilding->bounds.p1.y + 2);
+					v.addMission(state,
+					             VehicleMission::gotoLocation(
+					                 state, v, {xPos(state.rng), yPos(state.rng), v.altitude},
+					                 allowTeleporter, true));
+				}
 				return;
 			}
 		}
@@ -2048,8 +2123,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						missionCounter++;
 						if (v.homeBuilding)
 						{
-							v.addMission(state,
-							             VehicleMission::gotoBuilding(state, v, v.homeBuilding));
+							v.addMission(state, VehicleMission::gotoBuilding(state, v));
 							if (v.owner != state.getPlayer())
 							{
 								v.addMission(state,
@@ -2216,8 +2290,23 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					return;
 			}
 		}
+		case MissionType::SelfDestruct:
+			if (v.smokeDoodad)
+			{
+				LogError("Restarting self destruct?");
+			}
+			else
+			{
+				v.smokeDoodad = v.city->placeDoodad({&state, "DOODAD_13_SMOKE_FUME"},
+				                                    v.position + Vec3<float>{0.0f, 0.0f, 0.25f});
+			}
+			return;
+		case MissionType::RestartNextMission:
+		case MissionType::Snooze:
+			// No setup
+			return;
 		default:
-			LogWarning("TODO: Implement start");
+			LogError("TODO: Implement start %s", getName());
 			return;
 	}
 }
@@ -2296,13 +2385,28 @@ bool VehicleMission::advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> 
 	// Land/TakeOff mission does not check for collision or path skips
 	if (type == MissionType::Land)
 	{
-		destPos = Vec3<float>{pos.x, pos.y, pos.z} + offsetLandInto;
+		if (v.type->isGround())
+		{
+			destPos = v.city->map->getTile(pos)->getRestingPosition();
+		}
+		else
+		{
+			destPos = pos;
+			destPos += offsetLandInto;
+		}
 		return true;
 	}
 	if (type == MissionType::TakeOff)
 	{
-		destPos =
-		    Vec3<float>{pos.x, pos.y, pos.z} + (v.type->isGround() ? offsetLandInto : offsetFlying);
+		if (v.type->isGround())
+		{
+			destPos = v.city->map->getTile(pos)->getRestingPosition();
+		}
+		else
+		{
+			destPos = pos;
+			destPos += offsetFlying;
+		}
 		return true;
 	}
 
@@ -2372,56 +2476,24 @@ bool VehicleMission::advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> 
 		it = ++currentPlannedPath.begin();
 	}
 
-	destPos = Vec3<float>{pos.x, pos.y, pos.z};
-
-	Vec3<float> offset = offsetFlying;
 	auto sceneryTo = tTo->presentScenery;
-	switch (v.type->type)
+	if (v.type->isGround())
 	{
-		case VehicleType::Type::Road:
-		{
-			if (!sceneryTo)
-			{
-				LogError("Ground vehicle going into no scenery at %s?", pos);
-				return true;
-			}
-			if (!sceneryTo->type->isHill)
-			{
-				offset = offsetLandInto;
-			}
-			break;
-		}
-		case VehicleType::Type::ATV:
-		{
-			if (!sceneryTo)
-			{
-				LogError("Ground vehicle going into no scenery at %s?", pos);
-				return true;
-			}
-			if (!sceneryTo->type->isHill)
-			{
-				// Expecting to not meet a none here!
-				if (sceneryTo->type->getATVMode() == SceneryTileType::WalkMode::Into)
-				{
-					offset = offsetLandInto;
-				}
-				else
-				{
-					offset = {0.5f, 0.5f, (float)sceneryTo->type->height / 15.0f - 0.01f};
-				}
-			}
-			break;
-		}
-		case VehicleType::Type::Flying:
-		case VehicleType::Type::UFO:
-			// If there's a scenery there then we must be rescuing, go to the top
-			if (sceneryTo)
-			{
-				offset = offsetLandOnto;
-			}
-			break;
+		destPos = tTo->getRestingPosition();
 	}
-	destPos += offset;
+	else
+	{
+		// If there's a scenery there then we must be rescuing, go to the top
+		if (sceneryTo)
+		{
+			destPos = tTo->getRestingPosition(false, true);
+		}
+		else
+		{
+			destPos = pos;
+			destPos += offsetFlying;
+		}
+	}
 
 	return true;
 }
@@ -2617,8 +2689,9 @@ bool GroundVehicleTileHelper::canEnterTile(Tile *from, Tile *to, bool, bool &, f
 		{
 			return false;
 		}
-		// If moving to an "onto" tile must have clear above
-		if (sceneryTo->type->getATVMode() == SceneryTileType::WalkMode::Onto)
+		// If moving to an "onto" tile must have clear above (unless road)
+		if (sceneryTo->type->getATVMode() == SceneryTileType::WalkMode::Onto &&
+		    sceneryTo->type->tile_type != SceneryTileType::TileType::Road)
 		{
 			auto checkedPos = (Vec3<int>)sceneryTo->currentPosition + Vec3<int>(0, 0, 1);
 			if (map.tileIsValid(checkedPos))

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -1712,10 +1712,10 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 
 					if (patrolHome)
 					{
-						std::uniform_int_distribution<int> xPos(v.homeBuilding->bounds.p0.x - 2,
-						                                        v.homeBuilding->bounds.p1.x + 2);
-						std::uniform_int_distribution<int> yPos(v.homeBuilding->bounds.p0.y - 2,
-						                                        v.homeBuilding->bounds.p1.y + 2);
+						std::uniform_int_distribution<int> xPos(v.homeBuilding->bounds.p0.x - 5,
+						                                        v.homeBuilding->bounds.p1.x + 5);
+						std::uniform_int_distribution<int> yPos(v.homeBuilding->bounds.p0.y - 5,
+						                                        v.homeBuilding->bounds.p1.y + 5);
 						setPathTo(state, v, {xPos(state.rng), yPos(state.rng), v.altitude},
 						          getDefaultIterationCount(v));
 					}
@@ -1739,10 +1739,10 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			{
 				if (this->currentPlannedPath.empty())
 				{
-					std::uniform_int_distribution<int> xPos(targetBuilding->bounds.p0.x - 2,
-					                                        targetBuilding->bounds.p1.x + 2);
-					std::uniform_int_distribution<int> yPos(targetBuilding->bounds.p0.y - 2,
-					                                        targetBuilding->bounds.p1.y + 2);
+					std::uniform_int_distribution<int> xPos(targetBuilding->bounds.p0.x - 5,
+					                                        targetBuilding->bounds.p1.x + 5);
+					std::uniform_int_distribution<int> yPos(targetBuilding->bounds.p0.y - 5,
+					                                        targetBuilding->bounds.p1.y + 5);
 					setPathTo(state, v, {xPos(state.rng), yPos(state.rng), v.altitude},
 					          getDefaultIterationCount(v));
 				}
@@ -1847,7 +1847,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			{
 				return;
 			}
-
+			// Actually go there
 			if (v.type->isGround())
 			{
 				/* Am I already in a car depot? If so land */
@@ -1985,7 +1985,9 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				return;
 			}
 			// Target not crashed or dead or already rescued
-			if (!targetVehicle || !targetVehicle->crashed || targetVehicle->carriedByVehicle)
+			if (!targetVehicle ||
+			    (!targetVehicle->crashed && !targetVehicle->sliding && !targetVehicle->falling) ||
+			    targetVehicle->carriedByVehicle)
 			{
 				cancelled = true;
 				return;
@@ -2048,7 +2050,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 								                        state, v, targetVehicle->homeBuilding));
 								v.carriedVehicle = target;
 								target->carriedByVehicle = thisRef;
-								target->missions.clear();
+								target->clearMissions(state, true);
 								if (target->smokeDoodad)
 								{
 									target->smokeDoodad->remove(state);

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -132,17 +132,21 @@ class VehicleMission
 	int getDefaultIterationCount(Vehicle &v);
 
 	// Methods to create new missions
+
 	static VehicleMission *gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
 	                                    bool allowTeleporter = false, bool pickNearest = false,
 	                                    int reRouteAttempts = 20);
 	static VehicleMission *gotoPortal(GameState &state, Vehicle &v);
 	static VehicleMission *gotoPortal(GameState &state, Vehicle &v, Vec3<int> target);
-	static VehicleMission *gotoBuilding(GameState &state, Vehicle &v, StateRef<Building> target,
+	// With now building goes home
+	static VehicleMission *gotoBuilding(GameState &state, Vehicle &v,
+	                                    StateRef<Building> target = nullptr,
 	                                    bool allowTeleporter = false);
 	static VehicleMission *infiltrateOrSubvertBuilding(GameState &state, Vehicle &v,
 	                                                   StateRef<Building> target,
 	                                                   bool subvert = false);
 	static VehicleMission *attackVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
+	static VehicleMission *attackBuilding(GameState &state, Vehicle &v, StateRef<Building> target);
 	static VehicleMission *followVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission *recoverVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission *offerService(GameState &state, Vehicle &v,
@@ -151,7 +155,8 @@ class VehicleMission
 	static VehicleMission *selfDestruct(GameState &state, Vehicle &v);
 	static VehicleMission *restartNextMission(GameState &state, Vehicle &v);
 	static VehicleMission *crashLand(GameState &state, Vehicle &v);
-	static VehicleMission *patrol(GameState &state, Vehicle &v, unsigned int counter = 10);
+	static VehicleMission *patrol(GameState &state, Vehicle &v, bool home = false,
+	                              unsigned int counter = 10);
 	static VehicleMission *teleport(GameState &state, Vehicle &v, Vec3<int> target = {-1, -1, -1});
 	UString getName();
 
@@ -186,6 +191,8 @@ class VehicleMission
 	int reRouteAttempts = 0;
 	// GotoLocation - should it pick nearest point or random point if destination unreachable
 	bool pickNearest = false;
+	// Patrol - should patrol around home building only
+	bool patrolHome = false;
 	// GotoLocation - picked nearest (allows finishing mission without reaching destination)
 	bool pickedNearest = false;
 	// GotoBuilding AttackBuilding Land Infiltrate

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -72,7 +72,6 @@ void VEquipment::fire(GameState &state, Vec3<float> targetPosition, StateRef<Veh
 
 	auto fromScaled = vehicleMuzzle * VELOCITY_SCALE_CITY;
 	auto toScaled = targetPosition * VELOCITY_SCALE_CITY;
-	// FIXME: Account for target's cloak!
 	City::accuracyAlgorithmCity(state, fromScaled, toScaled, type->accuracy + owner->getAccuracy(),
 	                            targetVehicle && targetVehicle->hasCloak());
 
@@ -85,7 +84,8 @@ void VEquipment::fire(GameState &state, Vec3<float> targetPosition, StateRef<Veh
 	{
 		auto projectile = mksp<Projectile>(
 		    type->guided ? Projectile::Type::Missile : Projectile::Type::Beam, owner, targetVehicle,
-		    vehicleMuzzle, velocity, type->turn_rate, type->ttl * TICKS_MULTIPLIER, type->damage,
+		    targetPosition, vehicleMuzzle, velocity, type->turn_rate, type->ttl * TICKS_MULTIPLIER,
+		    type->damage,
 		    /*delay*/ 0, type->tail_size, type->projectile_sprites, type->impact_sfx,
 		    type->explosion_graphic,
 		    type->guided ? state.city_common_image_list->projectileVoxelMap : nullptr);

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -203,6 +203,9 @@ UString GameBuildingEvent::message()
 			return format("%s %s", tr("X-COM returning from mission at:"), building->name);
 		case GameEventType::MissionCompletedBuildingRaid:
 			return format("%s %s", tr("X-COM returning from raid at:"), building->name);
+		case GameEventType::BuildingAttacked:
+			return format("%s %s %s %s", tr("Building under attack :"), building->name,
+			              tr("Attacked by:"), actor->name);
 		case GameEventType::AlienSpotted:
 			return tr("Live Alien spotted.");
 		case GameEventType::CargoExpiresSoon:
@@ -283,8 +286,9 @@ GameBaseEvent::GameBaseEvent(GameEventType type, StateRef<Base> base, StateRef<O
 {
 }
 
-GameBuildingEvent::GameBuildingEvent(GameEventType type, StateRef<Building> building)
-    : GameEvent(type), building(building)
+GameBuildingEvent::GameBuildingEvent(GameEventType type, StateRef<Building> building,
+                                     StateRef<Organisation> actor)
+    : GameEvent(type), building(building), actor(actor)
 {
 }
 

--- a/game/state/gameevent.h
+++ b/game/state/gameevent.h
@@ -63,8 +63,10 @@ class GameBuildingEvent : public GameEvent
 {
   public:
 	StateRef<Building> building;
+	StateRef<Organisation> actor;
 
-	GameBuildingEvent(GameEventType type, StateRef<Building> building);
+	GameBuildingEvent(GameEventType type, StateRef<Building> building,
+	                  StateRef<Organisation> actor = nullptr);
 	~GameBuildingEvent() override = default;
 	UString message() override;
 };

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -117,7 +117,9 @@ void GameState::initState()
 	// FIXME: reseed rng when game starts
 
 	if (current_battle)
+	{
 		current_battle->initBattle(*this);
+	}
 
 	for (auto &c : this->cities)
 	{
@@ -131,6 +133,11 @@ void GameState::initState()
 				if (building->bounds.within(pos2d))
 				{
 					s->building = {this, building};
+					if (s->isAlive() && !s->type->commonProperty)
+					{
+						s->building->buildingParts.insert(s->initialPosition);
+					}
+					break;
 				}
 			}
 		}

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -391,8 +391,8 @@ void GameState::validateScenery()
 			if (sc.second->getATVMode() == SceneryTileType::WalkMode::Onto &&
 			    sc.second->height == 0)
 			{
-				LogError("City %s Scenery %s has no height and WalkMode::Onto? Missing voxelmap?",
-				         c.first, sc.first);
+				/*LogError("City %s Scenery %s has no height and WalkMode::Onto? Missing voxelmap?",
+				         c.first, sc.first);*/
 			}
 		}
 	}
@@ -405,7 +405,7 @@ void GameState::fillOrgStartingProperty()
 	for (auto &o : this->organisations)
 	{
 		o.second->updateVehicleAgentPark(*this);
-		for (auto &m : o.second->missions)
+		for (auto &m : o.second->missions[{this, "CITYMAP_HUMAN"}])
 		{
 			m.next += TICKS_PER_HOUR * 12 + randBoundsInclusive(rng, (uint64_t)0,
 			                                                    m.pattern.maxIntervalRepeat -
@@ -679,11 +679,9 @@ void GameState::update(unsigned int ticks)
 		}
 
 		Trace::start("GameState::update::cities");
-		for (auto &c : this->cities)
-		{
-			c.second->update(*this, ticks);
-		}
+		current_city->update(*this, ticks);
 		Trace::end("GameState::update::cities");
+
 		Trace::start("GameState::update::organisations");
 		for (auto &o : this->organisations)
 		{
@@ -694,20 +692,27 @@ void GameState::update(unsigned int ticks)
 		Trace::start("GameState::update::vehicles");
 		for (auto &v : this->vehicles)
 		{
-			v.second->update(*this, ticks);
+			if (v.second->city == current_city)
+			{
+				v.second->update(*this, ticks);
+			}
 		}
 		Trace::end("GameState::update::vehicles");
+
 		Trace::start("GameState::update::agents");
 		for (auto &a : this->agents)
 		{
-			a.second->update(*this, ticks);
+			if (a.second->city == current_city)
+			{
+				a.second->update(*this, ticks);
+			}
 		}
 		Trace::end("GameState::update::agents");
 
 		gameTime.addTicks(ticks);
-		if (gameTime.fiveSecondsPassed())
+		if (gameTime.secondPassed())
 		{
-			this->updateEndOfFiveSeconds();
+			this->updateEndOfSecond();
 		}
 		if (gameTime.fiveMinutesPassed())
 		{
@@ -729,26 +734,32 @@ void GameState::update(unsigned int ticks)
 	}
 }
 
-void GameState::updateEndOfFiveSeconds()
+void GameState::updateEndOfSecond()
 {
-	Trace::start("GameState::updateEndOfFiveSeconds::buildings");
+	Trace::start("GameState::updateEachSecond::buildings");
 	for (auto &b : current_city->buildings)
 	{
 		b.second->updateCargo(*this);
 	}
-	Trace::end("GameState::updateEndOfFiveSeconds::buildings");
-	Trace::start("GameState::updateEndOfFiveSeconds::vehicles");
+	Trace::end("GameState::updateEachSecond::buildings");
+	Trace::start("GameState::updateEachSecond::vehicles");
 	for (auto &v : vehicles)
 	{
-		v.second->updateCargo(*this);
+		if (v.second->city == current_city)
+		{
+			v.second->updateEachSecond(*this);
+		}
 	}
-	Trace::end("GameState::updateEndOfFiveSeconds::vehicles");
-	Trace::start("GameState::updateEndOfFiveSeconds::agents");
+	Trace::end("GameState::updateEachSecond::vehicles");
+	Trace::start("GameState::updateEachSecond::agents");
 	for (auto &a : this->agents)
 	{
-		a.second->updateFiveSeconds(*this);
+		if (a.second->city == current_city)
+		{
+			a.second->updateEachSecond(*this);
+		}
 	}
-	Trace::end("GameState::updateEndOfFiveSeconds::agents");
+	Trace::end("GameState::updateEachSecond::agents");
 }
 
 void GameState::updateEndOfFiveMinutes()
@@ -904,7 +915,6 @@ void GameState::updateEndOfWeek()
 
 					auto v = city->placeVehicle(*this, {this, (*vehicleType).first}, alienOrg,
 					                            {xyPos(rng), xyPos(rng), city->map->size.z - 1});
-					v->missions.emplace_front(VehicleMission::patrol(*this, *v));
 				}
 			}
 		}

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -193,7 +193,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 	void updateBeforeBattle();
 	void upateAfterBattle();
 
-	void updateEndOfFiveSeconds();
+	void updateEndOfSecond();
 	void updateEndOfFiveMinutes();
 	void updateEndOfHour();
 	void updateEndOfDay();

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -980,6 +980,7 @@
 		<member>height</member>
 		<member>overlayHeight</member>
 		<member>basement</member>
+		<member>commonProperty</member>
 		<member>isHill</member>
 	</object>
 	<object>

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -373,6 +373,7 @@
 		<member>allowTeleporter</member>
 		<member>reRouteAttempts</member>
 		<member>pickNearest</member>
+		<member>patrolHome</member>
 		<member>pickedNearest</member>
 		<member>targetBuilding</member>
 		<member>targetVehicle</member>
@@ -936,6 +937,7 @@
 		<member>ticksDetectionTimeOut</member>
 		<member>ticksDetectionAttemptAccumulated</member>
 		<member>detected</member>
+		<member>timeOfLastAttackEvent</member>
 	</object>
 	<object>
 		<name>UFOIncursion</name>
@@ -976,6 +978,8 @@
 		<member>mass</member>
 		<member>strength</member>
 		<member>height</member>
+		<member>overlayHeight</member>
+		<member>basement</member>
 		<member>isHill</member>
 	</object>
 	<object>

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -150,7 +150,7 @@ unsigned int GameTime::getMinutes() const { return getPtime(this->ticks).time_of
 
 uint64_t GameTime::getTicks() const { return ticks; }
 
-bool GameTime::fiveSecondsPassed() const { return fiveSecondsPassedFlag; }
+bool GameTime::secondPassed() const { return secondPassedFlag; }
 
 bool GameTime::fiveMinutesPassed() const { return fiveMinutesPassedFlag; }
 
@@ -162,7 +162,7 @@ bool GameTime::weekPassed() const { return weekPassedFlag; }
 
 void GameTime::clearFlags()
 {
-	fiveSecondsPassedFlag = false;
+	secondPassedFlag = false;
 	fiveMinutesPassedFlag = false;
 	hourPassedFlag = false;
 	dayPassedFlag = false;
@@ -172,11 +172,11 @@ void GameTime::clearFlags()
 void GameTime::addTicks(uint64_t ticks)
 {
 	this->ticks += ticks;
-	uint64_t fiveSecondsTicks = this->ticks % (5 * TICKS_PER_SECOND);
+	uint64_t secondTicks = this->ticks % (TICKS_PER_SECOND);
 	uint64_t fiveMinutesTicks = this->ticks % (5 * TICKS_PER_MINUTE);
 	if (fiveMinutesTicks < ticks)
 	{
-		fiveSecondsPassedFlag = true;
+		secondPassedFlag = true;
 		fiveMinutesPassedFlag = true;
 		uint64_t hourTicks = this->ticks % TICKS_PER_HOUR;
 		if (hourTicks < ticks)
@@ -196,9 +196,9 @@ void GameTime::addTicks(uint64_t ticks)
 	}
 	else
 	{
-		if (fiveSecondsTicks < ticks)
+		if (secondTicks < ticks)
 		{
-			fiveSecondsPassedFlag = true;
+			secondPassedFlag = true;
 		}
 	}
 }

--- a/game/state/gametime.h
+++ b/game/state/gametime.h
@@ -17,7 +17,7 @@ static const unsigned TURBO_TICKS = 5 * 60 * TICKS_PER_SECOND;
 class GameTime
 {
   private:
-	bool fiveSecondsPassedFlag = false;
+	bool secondPassedFlag = false;
 	bool fiveMinutesPassedFlag = false;
 	bool hourPassedFlag = false;
 	bool dayPassedFlag = false;
@@ -55,8 +55,8 @@ class GameTime
 	// returns formatted date in format d m, y
 	UString getShortDateString() const;
 
-	// set at end of each 5 seconds
-	bool fiveSecondsPassed() const;
+	// set at end of each second
+	bool secondPassed() const;
 
 	// set at end of each 5 minutes
 	bool fiveMinutesPassed() const;

--- a/game/state/organisation.cpp
+++ b/game/state/organisation.cpp
@@ -203,7 +203,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	           building.id, buyer.id);
 	auto v = building->city->placeVehicle(state, vehicle, buyer->owner, building);
 	v->homeBuilding = buyer;
-	v->setMission(state, VehicleMission::gotoBuilding(state, *v, v->homeBuilding));
+	v->setMission(state, VehicleMission::gotoBuilding(state, *v));
 	// FIXME: Economy
 	auto owner = buyer->owner;
 	owner->balance -= count * 1;
@@ -218,7 +218,7 @@ void Organisation::updateMissions(GameState &state)
 	{
 		return;
 	}
-	for (auto &m : missions)
+	for (auto &m : missions[state.current_city])
 	{
 		if (m.next < state.gameTime.getTicks())
 		{
@@ -267,9 +267,7 @@ void Organisation::updateMissions(GameState &state)
 					    state,
 					    VehicleMission::recoverVehicle(state, *rescueTransport, {&state, v.first}));
 					rescueTransport->addMission(
-					    state, VehicleMission::gotoBuilding(state, *rescueTransport,
-					                                        rescueTransport->homeBuilding),
-					    true);
+					    state, VehicleMission::gotoBuilding(state, *rescueTransport), true);
 					break;
 				}
 			}
@@ -303,9 +301,7 @@ void Organisation::updateMissions(GameState &state)
 					    state,
 					    VehicleMission::recoverVehicle(state, *rescueTransport, {&state, v.first}));
 					rescueTransport->addMission(
-					    state, VehicleMission::gotoBuilding(state, *rescueTransport,
-					                                        rescueTransport->homeBuilding),
-					    true);
+					    state, VehicleMission::gotoBuilding(state, *rescueTransport), true);
 					break;
 				}
 			}
@@ -354,6 +350,7 @@ void Organisation::updateHirableAgents(GameState &state)
 		auto a = state.agent_generator.createAgent(state, {&state, id},
 		                                           setRandomiser(state.rng, hirableTypes));
 		a->homeBuilding = hireeLocation;
+		a->city = hireeLocation->city;
 		a->enterBuilding(state, hireeLocation);
 	}
 }

--- a/game/state/organisation.h
+++ b/game/state/organisation.h
@@ -22,6 +22,7 @@ class VehicleType;
 class Building;
 class AgentType;
 class VEquipmentType;
+class City;
 class AEquipmentType;
 class VAmmoType;
 class GameState;
@@ -62,7 +63,7 @@ class Organisation : public StateObject
 			OwnedOrOther,
 			Other,
 			ArriveFromSpace,
-			DepartToSpace
+			DepartToSpace,
 		};
 		uint64_t minIntervalRepeat = 0;
 		uint64_t maxIntervalRepeat = 0;
@@ -113,7 +114,7 @@ class Organisation : public StateObject
 
 	StateRef<UfopaediaEntry> ufopaedia_entry;
 
-	std::list<Mission> missions;
+	std::map<StateRef<City>, std::list<Mission>> missions;
 	std::map<StateRef<VehicleType>, int> vehiclePark;
 	bool providesTransportationServices = false;
 	int minHireePool = 0;

--- a/game/state/rules/scenery_tile_type.h
+++ b/game/state/rules/scenery_tile_type.h
@@ -69,6 +69,8 @@ class SceneryTileType : public StateObject
 	// Max value 16
 	int overlayHeight = 0;
 	bool basement = false;
+	// Does not receive attacks and is not considered hostile action if receives stray shots
+	bool commonProperty = false;
 
 	// instead of road_level_change; should be enough for now
 	bool isHill = false;

--- a/game/state/rules/scenery_tile_type.h
+++ b/game/state/rules/scenery_tile_type.h
@@ -64,8 +64,11 @@ class SceneryTileType : public StateObject
 	int value = 0;
 	int mass = 0;
 	int strength = 0;
-	// Max value 15
+	// Max value 16
 	int height = 0;
+	// Max value 16
+	int overlayHeight = 0;
+	bool basement = false;
 
 	// instead of road_level_change; should be enough for now
 	bool isHill = false;

--- a/game/state/tileview/tile.h
+++ b/game/state/tileview/tile.h
@@ -91,9 +91,12 @@ class Tile
 
 	// Vars
 
-	// Height, 0-0.975, of the tile's ground and feature's height
+	// Height, in battle its 0-0.975, of the tile's ground and feature's height (height / 40)
+	//         in city its 0-0.999, of the tile's scenery height (height / 16.1)
 	// Height cannot be 1 as that is equal to 0.000 on the tile below
 	float height = 0.0f;
+	// Same but for city overlays
+	float overlayHeight = 0.0f;
 	// Movement cost through the tile's ground (or feature)
 	int movementCostIn = 4;
 	// Movement cost to walk on the level above this, if next level is empty and this height is
@@ -153,7 +156,7 @@ class Tile
 	// Returns items that can be collected by standing in this tile)
 	std::list<sp<BattleItem>> getItems();
 	// Returns resting position for items and units in the tile
-	Vec3<float> getRestingPosition(bool large = false);
+	Vec3<float> getRestingPosition(bool large = false, bool overlay = false);
 	// Returns the object that provides support (resting position) for items
 	sp<BattleMapPart> getItemSupportingObject();
 	// Returns if the tile is passable (including side tiles for large)

--- a/game/state/tileview/tileobject_scenery.cpp
+++ b/game/state/tileview/tileobject_scenery.cpp
@@ -142,7 +142,7 @@ void TileObjectScenery::addToDrawnTiles(Tile *tile)
 		// Map parts are drawn in the topmost tile their head pops into
 		// Otherwise, they can only be drawn in it if it's their owner tile
 		if (maxCoords.z * 1000 + maxCoords.x + maxCoords.y < z * 1000 + x + y &&
-		    sc->currentPosition.z + (float)sc->type->height / 15.1f >= (float)z)
+		    sc->currentPosition.z + (float)sc->type->height / 16.1f >= (float)z)
 		{
 			tile = intersectingTile;
 			maxCoords = {x, y, z};

--- a/game/state/tileview/tileobject_vehicle.cpp
+++ b/game/state/tileview/tileobject_vehicle.cpp
@@ -187,9 +187,18 @@ Vec3<float> TileObjectVehicle::getVoxelCentrePosition() const
 
 	// Simple version:
 	auto objPos = this->getCenter();
-	return Vec3<float>(objPos.x, objPos.y,
-	                   objPos.z - getVoxelOffset().z +
-	                       (float)getVehicle()->type->height / 2.0f / 16.0f);
+	auto v = getVehicle();
+	if (v->crashed)
+	{
+		// Fire at crashed's top
+		return Vec3<float>(objPos.x, objPos.y,
+		                   objPos.z - getVoxelOffset().z + (float)v->type->height / 1.0f / 16.0f);
+	}
+	else
+	{
+		return Vec3<float>(objPos.x, objPos.y,
+		                   objPos.z - getVoxelOffset().z + (float)v->type->height / 2.0f / 16.0f);
+	}
 }
 
 sp<VoxelMap> TileObjectVehicle::getVoxelMap(Vec3<int> mapIndex, bool los) const

--- a/game/ui/base/aequipscreen.h
+++ b/game/ui/base/aequipscreen.h
@@ -85,6 +85,8 @@ class AEquipScreen : public Stage
 
 	bool modifierLCtrl = false;
 	bool modifierRCtrl = false;
+	bool modifierLShift = false;
+	bool modifierRShift = false;
 
 	// Checks wether agent should be displayed in the agent list
 	bool checkAgent(sp<Agent> agent, sp<Organisation> owner);
@@ -124,6 +126,7 @@ class AEquipScreen : public Stage
 	bool tryPickUpItem(sp<AEquipmentType> item);
 	void pickUpItem(sp<AEquipment> item);
 	bool tryPlaceItem(sp<Agent> agent, Vec2<int> slotPos, bool *insufficientTU = nullptr);
+	bool tryPlaceItem(sp<Agent> agent, bool toAgent, bool *insufficientTU = nullptr);
 
 	void processTemplate(int idx, bool remember);
 
@@ -150,6 +153,10 @@ class AEquipScreen : public Stage
 	void update() override;
 	void render() override;
 	bool isTransition() override;
+
+	void handleItemPickup(Vec2<int> mousePos);
+	void handleItemPlacement(Vec2<int> mousePos);
+	void handleItemPlacement(bool toAgent);
 
 	void selectAgent(sp<Agent> agent, bool inverse = false, bool additive = false);
 

--- a/game/ui/base/vequipscreen.h
+++ b/game/ui/base/vequipscreen.h
@@ -52,6 +52,9 @@ class VEquipScreen : public Stage
 
 	sp<GameState> state;
 
+	bool modifierLShift = false;
+	bool modifierRShift = false;
+
   public:
 	VEquipScreen(sp<GameState> state);
 	~VEquipScreen() override;

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -102,8 +102,7 @@ void BaseBuyScreen::eventOccurred(Event *e)
 							if (v.second->currentBuilding == base->building)
 							{
 								v.second->setMission(
-								    *state, VehicleMission::gotoBuilding(*state, *v.second,
-								                                         v.second->homeBuilding));
+								    *state, VehicleMission::gotoBuilding(*state, *v.second));
 							}
 						}
 						else
@@ -115,8 +114,7 @@ void BaseBuyScreen::eventOccurred(Event *e)
 					         v.second->owner != state->getPlayer())
 					{
 						v.second->setMission(*state,
-						                     VehicleMission::gotoBuilding(*state, *v.second,
-						                                                  v.second->homeBuilding));
+						                     VehicleMission::gotoBuilding(*state, *v.second));
 					}
 				}
 				for (auto &a : state->agents)
@@ -128,9 +126,8 @@ void BaseBuyScreen::eventOccurred(Event *e)
 							a.second->homeBuilding = newBuilding;
 							if (a.second->currentBuilding == base->building)
 							{
-								a.second->setMission(
-								    *state, AgentMission::gotoBuilding(*state, *a.second,
-								                                       a.second->homeBuilding));
+								a.second->setMission(*state,
+								                     AgentMission::gotoBuilding(*state, *a.second));
 							}
 						}
 						else
@@ -141,9 +138,7 @@ void BaseBuyScreen::eventOccurred(Event *e)
 					else if (a.second->currentBuilding == base->building &&
 					         a.second->owner != state->getPlayer())
 					{
-						a.second->setMission(
-						    *state,
-						    AgentMission::gotoBuilding(*state, *a.second, a.second->homeBuilding));
+						a.second->setMission(*state, AgentMission::gotoBuilding(*state, *a.second));
 					}
 				}
 				base->name = "Base " + Strings::fromInteger(state->player_bases.size() + 1);

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -3,6 +3,7 @@
 #include "forms/graphic.h"
 #include "forms/label.h"
 #include "forms/ui.h"
+#include "framework/configfile.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/keycodes.h"
@@ -208,6 +209,10 @@ void BuildingScreen::eventOccurred(Event *e)
 						         tr("You have not found any hostile forces in this building."),
 						         MessageBox::ButtonOptions::Ok)});
 						return;
+					}
+					if (config().getBool("OpenApoc.Mod.RaidHostileAction"))
+					{
+						building->owner->adjustRelationTo(*state, state->getPlayer(), -200.0f);
 					}
 					bool inBuilding = true;
 					bool raid = true;

--- a/game/ui/city/cityview.cpp
+++ b/game/ui/city/cityview.cpp
@@ -659,7 +659,7 @@ void CityView::orderAttack(StateRef<Vehicle> vehicle, bool forced)
 		{
 			if (v && v->owner == this->state->getPlayer() && v != vehicle)
 			{
-				if (forced || !vehicle->crashed)
+				if (forced || (!vehicle->crashed && !vehicle->falling && !vehicle->sliding))
 				{
 					if (vehicle->owner == state->getPlayer() &&
 					    !config().getBool("OpenApoc.NewFeature.AllowAttackingOwnedVehicles"))
@@ -984,7 +984,7 @@ CityView::CityView(sp<GameState> state)
 		    {
 			    if (v && v->owner == this->state->getPlayer())
 			    {
-				    setSelectionState(CitySelectionState::GotoLocation);
+				    setSelectionState(CitySelectionState::AttackBuilding);
 				    break;
 			    }
 		    }
@@ -2008,7 +2008,14 @@ bool CityView::handleMouseDown(Event *e)
 
 					if (modifierLAlt && modifierLCtrl && modifierLShift)
 					{
-						scenery->die(*state);
+						if (building && buttonPressed == Event::MouseButton::Right)
+						{
+							building->collapse(*state);
+						}
+						else
+						{
+							scenery->die(*state);
+						}
 						return true;
 					}
 					break;

--- a/game/ui/city/cityview.cpp
+++ b/game/ui/city/cityview.cpp
@@ -111,7 +111,56 @@ std::shared_future<void> loadBattleVehicle(sp<GameState> state, StateRef<Vehicle
 bool CityView::handleClickedBuilding(StateRef<Building> building, bool rightClick,
                                      CitySelectionState selState)
 {
-	// Alt opens info screens
+	if (vanillaControls)
+	{
+		switch (selState)
+		{
+			case CitySelectionState::Normal:
+			{
+				// Location (building) screen
+				fw().stageQueueCommand(
+				    {StageCmd::Command::PUSH, mksp<BuildingScreen>(this->state, building)});
+				return true;
+			}
+			case CitySelectionState::AttackBuilding:
+			{
+				orderAttack(building);
+				setSelectionState(CitySelectionState::Normal);
+				return true;
+			}
+			case CitySelectionState::GotoBuilding:
+			{
+				orderMove(building, modifierRCtrl || modifierLCtrl);
+				setSelectionState(CitySelectionState::Normal);
+				return true;
+			}
+			case CitySelectionState::AttackVehicle:
+			case CitySelectionState::GotoLocation:
+			case CitySelectionState::ManualControl:
+				break;
+		}
+		return false;
+	}
+
+	// [Alt] + [Shift] gives bulding orders (left = attack, right = move)
+	if ((modifierLShift || modifierRShift) && (modifierLAlt || modifierRAlt))
+	{
+		if (rightClick)
+		{
+			orderMove(building, modifierRCtrl || modifierLCtrl);
+		}
+		else
+		{
+			orderAttack(building);
+		}
+		return true;
+	}
+	// [Shift] pass through to a scenery click
+	if (modifierLShift || modifierRShift)
+	{
+		return false;
+	}
+	// [Alt] opens ufopaedia screens
 	if (modifierLAlt || modifierRAlt)
 	{
 		StateRef<UfopaediaEntry> ufopaediaEntry;
@@ -126,47 +175,20 @@ bool CityView::handleClickedBuilding(StateRef<Building> building, bool rightClic
 		tryOpenUfopaediaEntry(ufopaediaEntry);
 		return true;
 	}
-	// If shift then we show object's info screen
-	if (modifierLShift || modifierRShift)
-	{
-		if (rightClick)
-		{
-			// Building screen
-			fw().stageQueueCommand(
-			    {StageCmd::Command::PUSH, mksp<BuildingScreen>(this->state, building)});
-		}
-		else
-		{
-			if (building->base)
-			{
-				// Base screen
-				state->current_base = building->base;
-				this->uiTabs[0]
-				    ->findControlTyped<Label>("TEXT_BASE_NAME")
-				    ->setText(this->state->current_base->name);
-				fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BaseScreen>(this->state)});
-			}
-			else if (building->base_layout && building->owner == state->getGovernment())
-			{
-				// Base buy screen
-				fw().stageQueueCommand(
-				    {StageCmd::Command::PUSH, mksp<BaseBuyScreen>(state, building)});
-			}
-			else
-			{
-				// Building screen
-				fw().stageQueueCommand(
-				    {StageCmd::Command::PUSH, mksp<BuildingScreen>(this->state, building)});
-			}
-		}
-		return true;
-	}
+	// No modifiers
 	switch (selState)
 	{
 		case CitySelectionState::Normal:
 		{
 			if (rightClick)
 			{
+				// Location (building) screen
+				fw().stageQueueCommand(
+				    {StageCmd::Command::PUSH, mksp<BuildingScreen>(this->state, building)});
+			}
+			else
+			{
+				// Base / buy screen
 				if (building->base)
 				{
 					// Base screen
@@ -184,17 +206,11 @@ bool CityView::handleClickedBuilding(StateRef<Building> building, bool rightClic
 					    {StageCmd::Command::PUSH, mksp<BaseBuyScreen>(state, building)});
 				}
 			}
-			else
-			{
-				// Building screen for any building
-				fw().stageQueueCommand(
-				    {StageCmd::Command::PUSH, mksp<BuildingScreen>(this->state, building)});
-			}
 			return true;
 		}
 		case CitySelectionState::AttackBuilding:
 		{
-			orderAttack(StateRef<Building>{state.get(), Building::getId(*state, building)});
+			orderAttack(building);
 			setSelectionState(CitySelectionState::Normal);
 			return true;
 		}
@@ -204,6 +220,10 @@ bool CityView::handleClickedBuilding(StateRef<Building> building, bool rightClic
 			setSelectionState(CitySelectionState::Normal);
 			return true;
 		}
+		case CitySelectionState::AttackVehicle:
+		case CitySelectionState::GotoLocation:
+		case CitySelectionState::ManualControl:
+			break;
 	}
 	return false;
 }
@@ -211,7 +231,44 @@ bool CityView::handleClickedBuilding(StateRef<Building> building, bool rightClic
 bool CityView::handleClickedVehicle(StateRef<Vehicle> vehicle, bool rightClick,
                                     CitySelectionState selState)
 {
-	// Alt opens info screens
+	if (vanillaControls)
+	{
+		switch (selState)
+		{
+			case CitySelectionState::Normal:
+			{
+				orderSelect(vehicle, rightClick, modifierLCtrl || modifierRCtrl);
+				break;
+			}
+			case CitySelectionState::AttackVehicle:
+			{
+				orderAttack(vehicle, modifierLCtrl || modifierRCtrl);
+				setSelectionState(CitySelectionState::Normal);
+				break;
+			}
+		}
+		return true;
+	}
+
+	// [Alt] + [Shift] gives bulding orders (therefore do nothing)
+	if ((modifierLShift || modifierRShift) && (modifierLAlt || modifierRAlt))
+	{
+		return false;
+	}
+	// [Shift] gives attack order on left click and move on right click
+	if (modifierLShift || modifierRShift)
+	{
+		if (rightClick)
+		{
+			orderFollow(vehicle);
+		}
+		else
+		{
+			orderAttack(vehicle, modifierLCtrl || modifierRCtrl);
+		}
+		return true;
+	}
+	// [Alt] opens info screens
 	if (modifierLAlt || modifierRAlt)
 	{
 		StateRef<UfopaediaEntry> ufopaediaEntry;
@@ -226,45 +283,33 @@ bool CityView::handleClickedVehicle(StateRef<Vehicle> vehicle, bool rightClick,
 		tryOpenUfopaediaEntry(ufopaediaEntry);
 		return true;
 	}
-	// If shift then we show object's info screen
-	if (modifierLShift || modifierRShift)
-	{
-		if (rightClick)
-		{
-			if (vehicle->owner == state->player)
-			{
-				// Location screen
-				fw().stageQueueCommand(
-				    {StageCmd::Command::PUSH, mksp<LocationScreen>(this->state, vehicle)});
-			}
-		}
-		else
-		{
-			if (vehicle->owner == state->player)
-			{
-				// Equipscreen for owner vehicles
-				auto equipScreen = mksp<VEquipScreen>(this->state);
-				equipScreen->setSelectedVehicle(vehicle);
-				fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
-			}
-		}
-		return true;
-	}
 	switch (selState)
 	{
+		case CitySelectionState::ManualControl:
+		{
+			if (rightClick)
+			{
+				orderFollow(vehicle);
+			}
+			else
+			{
+				orderFire(vehicle->position);
+			}
+			return true;
+		}
 		case CitySelectionState::Normal:
 		{
 			orderSelect(vehicle, rightClick, modifierLCtrl || modifierRCtrl);
-			break;
+			return true;
 		}
 		case CitySelectionState::AttackVehicle:
 		{
 			orderAttack(vehicle, modifierLCtrl || modifierRCtrl);
 			setSelectionState(CitySelectionState::Normal);
-			break;
+			return true;
 		}
 	}
-	return true;
+	return false;
 }
 
 bool CityView::handleClickedAgent(StateRef<Agent> agent, bool rightClick,
@@ -277,6 +322,10 @@ bool CityView::handleClickedAgent(StateRef<Agent> agent, bool rightClick,
 bool CityView::handleClickedProjectile(sp<Projectile> projectile, bool rightClick,
                                        CitySelectionState selState)
 {
+	if (vanillaControls)
+	{
+		return false;
+	}
 	if (modifierLAlt || modifierRAlt)
 	{
 		if (rightClick)
@@ -284,6 +333,27 @@ bool CityView::handleClickedProjectile(sp<Projectile> projectile, bool rightClic
 			tryOpenUfopaediaEntry(projectile->firerVehicle->owner->ufopaedia_entry);
 			return true;
 		}
+	}
+	switch (selState)
+	{
+		case CitySelectionState::ManualControl:
+		{
+			if (rightClick)
+			{
+				orderMove(projectile->position, modifierRCtrl || modifierLCtrl);
+			}
+			else
+			{
+				orderFire(projectile->position);
+			}
+			return true;
+		}
+		case CitySelectionState::AttackBuilding:
+		case CitySelectionState::AttackVehicle:
+		case CitySelectionState::GotoBuilding:
+		case CitySelectionState::GotoLocation:
+		case CitySelectionState::Normal:
+			break;
 	}
 	return false;
 }
@@ -566,6 +636,21 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 	LogWarning("FIX Implement agent select controls for psi and phys train");
 }
 
+void CityView::orderFire(Vec3<float> position)
+{
+	if (activeTab == uiTabs[1])
+	{
+		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		{
+			if (v && v->owner == this->state->getPlayer())
+			{
+				v->setManualFirePosition(position);
+			}
+		}
+		return;
+	}
+}
+
 void CityView::orderAttack(StateRef<Vehicle> vehicle, bool forced)
 {
 	if (activeTab == uiTabs[1])
@@ -617,6 +702,21 @@ void CityView::orderAttack(StateRef<Vehicle> vehicle, bool forced)
 	}
 }
 
+void CityView::orderFollow(StateRef<Vehicle> vehicle)
+{
+	if (activeTab == uiTabs[1])
+	{
+		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		{
+			if (v && v->owner == this->state->getPlayer() && v != vehicle)
+			{
+				v->setMission(*state, VehicleMission::followVehicle(*this->state, *v, vehicle));
+			}
+		}
+		return;
+	}
+}
+
 void CityView::orderAttack(StateRef<Building> building)
 {
 	if (activeTab == uiTabs[1])
@@ -625,9 +725,7 @@ void CityView::orderAttack(StateRef<Building> building)
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
-				// TODO: Attack building mission
-				LogWarning("IMPLEMENT: Vehicle \"%s\" attack building \"%s\"", v->name,
-				           building->name);
+				v->setMission(*state, VehicleMission::attackBuilding(*this->state, *v, building));
 			}
 		}
 	}
@@ -1014,6 +1112,7 @@ CityView::~CityView() = default;
 
 void CityView::begin()
 {
+	vanillaControls = !config().getBool("OpenApoc.NewFeature.OpenApocCityControls");
 	CityTileView::begin();
 	if (state->newGame)
 	{
@@ -1025,6 +1124,7 @@ void CityView::begin()
 
 void CityView::resume()
 {
+	vanillaControls = !config().getBool("OpenApoc.NewFeature.OpenApocCityControls");
 	CityTileView::resume();
 	modifierLAlt = false;
 	modifierLCtrl = false;
@@ -1323,6 +1423,33 @@ void CityView::update()
 				{
 					control = ControlGenerator::createVehicleControl(*state, info);
 					control->addCallback(FormEventType::MouseDown, [this, vehicle](FormsEvent *e) {
+						if (!this->vanillaControls)
+						{
+							if (Event::isPressed(e->forms().MouseInfo.Button,
+							                     Event::MouseButton::Right))
+							{
+								// [Alt/Ctrl] + [Shift] opens equipment
+								if ((modifierLShift || modifierRShift) &&
+								    (modifierLAlt || modifierRAlt || modifierLCtrl ||
+								     modifierRCtrl))
+								{
+									// Equipscreen for owner vehicles
+									auto equipScreen = mksp<VEquipScreen>(this->state);
+									equipScreen->setSelectedVehicle(vehicle);
+									fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
+									return;
+								}
+								// [Shift] opens location
+								if (modifierLShift || modifierRShift)
+								{
+									// Location screen
+									fw().stageQueueCommand(
+									    {StageCmd::Command::PUSH,
+									     mksp<LocationScreen>(this->state, vehicle)});
+									return;
+								}
+							}
+						}
 						handleClickedVehicle(
 						    StateRef<Vehicle>{state.get(), Vehicle::getId(*state, vehicle)},
 						    Event::isPressed(e->forms().MouseInfo.Button,
@@ -1374,6 +1501,33 @@ void CityView::update()
 				{
 					control = ControlGenerator::createAgentControl(*state, info);
 					control->addCallback(FormEventType::MouseDown, [this, agent](FormsEvent *e) {
+						if (!this->vanillaControls)
+						{
+							if (Event::isPressed(e->forms().MouseInfo.Button,
+							                     Event::MouseButton::Right))
+							{
+								// [Alt/Ctrl] + [Shift] opens equipment
+								if ((modifierLShift || modifierRShift) &&
+								    (modifierLAlt || modifierRAlt || modifierLCtrl ||
+								     modifierRCtrl))
+								{
+									// Equipscreen for owner vehicles
+									auto equipScreen = mksp<AEquipScreen>(this->state, agent);
+									fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
+									return;
+								}
+								// [Shift] opens location
+								if (modifierLShift || modifierRShift)
+								{
+									// Location screen
+									fw().stageQueueCommand(
+									    {StageCmd::Command::PUSH,
+									     mksp<LocationScreen>(this->state, agent)});
+									return;
+								}
+							}
+						}
+
 						handleClickedAgent(
 						    StateRef<Agent>{state.get(), Agent::getId(*state, agent)},
 						    Event::isPressed(e->forms().MouseInfo.Button,
@@ -1658,13 +1812,43 @@ bool CityView::handleKeyDown(Event *e)
 					setUpdateSpeed(this->lastSpeed);
 				return true;
 			case SDLK_m:
+				if (vanillaControls)
+				{
+					setSelectionState(CitySelectionState::ManualControl);
+					return true;
+				}
 				baseForm->findControl("BUTTON_SHOW_LOG")->click();
 				return true;
+			case SDLK_n:
+				if (!vanillaControls)
+				{
+					setSelectionState(CitySelectionState::ManualControl);
+					return true;
+				}
+				break;
 			case SDLK_HOME:
 				baseForm->findControl("BUTTON_ZOOM_EVENT")->click();
 				return true;
 			case SDLK_c:
 				baseForm->findControl("BUTTON_FOLLOW_AGENT")->click();
+				return true;
+			case SDLK_0:
+				setUpdateSpeed(CityUpdateSpeed::Pause);
+				return true;
+			case SDLK_1:
+				setUpdateSpeed(CityUpdateSpeed::Speed1);
+				return true;
+			case SDLK_2:
+				setUpdateSpeed(CityUpdateSpeed::Speed2);
+				return true;
+			case SDLK_3:
+				setUpdateSpeed(CityUpdateSpeed::Speed3);
+				return true;
+			case SDLK_4:
+				setUpdateSpeed(CityUpdateSpeed::Speed4);
+				return true;
+			case SDLK_5:
+				setUpdateSpeed(CityUpdateSpeed::Speed5);
 				return true;
 		}
 	}
@@ -1699,7 +1883,8 @@ bool CityView::handleKeyUp(Event *e)
 
 bool CityView::handleMouseDown(Event *e)
 {
-	if (Event::isPressed(e->mouse().Button, Event::MouseButton::Middle))
+	if (Event::isPressed(e->mouse().Button, Event::MouseButton::Middle) ||
+	    (Event::isPressed(e->mouse().Button, Event::MouseButton::Right) && vanillaControls))
 	{
 		Vec2<float> screenOffset = {this->getScreenOffset().x, this->getScreenOffset().y};
 		auto clickTile =
@@ -1713,6 +1898,21 @@ bool CityView::handleMouseDown(Event *e)
 		auto buttonPressed = Event::isPressed(e->mouse().Button, Event::MouseButton::Left)
 		                         ? Event::MouseButton::Left
 		                         : Event::MouseButton::Right;
+
+		if (vanillaControls)
+		{
+			if (buttonPressed == Event::MouseButton::Left)
+			{
+				if (modifierLAlt || modifierRAlt)
+				{
+					setSelectionState(CitySelectionState::AttackVehicle);
+				}
+				else if (modifierLShift || modifierRShift)
+				{
+					setSelectionState(CitySelectionState::GotoBuilding);
+				}
+			}
+		}
 
 		// If a click has not been handled by a form it's in the map. See if we intersect with
 		// anything
@@ -1854,18 +2054,21 @@ bool CityView::handleMouseDown(Event *e)
 				}
 			}
 			// Try to handle clicks on objects
+			// Click on vehicle
 			if (vehicle && handleClickedVehicle(
 			                   StateRef<Vehicle>{state.get(), Vehicle::getId(*state, vehicle)},
 			                   buttonPressed == Event::MouseButton::Right, selectionState))
 			{
 				return true;
 			}
+			// Click on building
 			if (building &&
 			    handleClickedBuilding(building, buttonPressed == Event::MouseButton::Right,
 			                          selectionState))
 			{
 				return true;
 			}
+			// Click on projectile
 			if (projectile &&
 			    handleClickedProjectile(projectile, buttonPressed == Event::MouseButton::Right,
 			                            selectionState))
@@ -1875,12 +2078,33 @@ bool CityView::handleMouseDown(Event *e)
 			// Otherwise proceed as normal
 			switch (selectionState)
 			{
+				case CitySelectionState::ManualControl:
+				{
+					if (buttonPressed == Event::MouseButton::Right)
+					{
+						orderMove(position, modifierRCtrl || modifierLCtrl);
+					}
+					else
+					{
+						orderFire(position);
+					}
+					break;
+				}
 				case CitySelectionState::GotoLocation:
 				{
 					// We always have a position if we came this far
 					{
 						orderMove(position, modifierRCtrl || modifierLCtrl);
 						setSelectionState(CitySelectionState::Normal);
+					}
+					break;
+				}
+				case CitySelectionState::Normal:
+				{
+					if (buttonPressed == Event::MouseButton::Right &&
+					    (modifierRShift || modifierLShift))
+					{
+						orderMove(position, modifierRCtrl || modifierLCtrl);
 					}
 					break;
 				}
@@ -1981,8 +2205,7 @@ bool CityView::handleGameStateEvent(Event *e)
 			gameRecoveryEvent->vehicle->die(*state, nullptr, true);
 			// Return to base
 			gameRecoveryEvent->actor->setMission(
-			    *state, VehicleMission::gotoBuilding(*state, *gameRecoveryEvent->actor,
-			                                         gameRecoveryEvent->actor->homeBuilding));
+			    *state, VehicleMission::gotoBuilding(*state, *gameRecoveryEvent->actor));
 			break;
 		}
 		case GameEventType::AlienSpotted:
@@ -2211,6 +2434,7 @@ void CityView::updateSelectedUnits()
 {
 	auto o = state->getPlayer();
 	bool foundOwned = false;
+	bool foundOwnedVehicle = false;
 	// Vehicles
 	{
 		auto it = state->current_city->cityViewSelectedVehicles.begin();
@@ -2226,6 +2450,7 @@ void CityView::updateSelectedUnits()
 				if (v->owner == o)
 				{
 					foundOwned = true;
+					foundOwnedVehicle = true;
 				}
 				it++;
 			}
@@ -2252,6 +2477,14 @@ void CityView::updateSelectedUnits()
 		}
 	}
 	if (!foundOwned && selectionState != CitySelectionState::Normal)
+	{
+		setSelectionState(CitySelectionState::Normal);
+	}
+	if (activeTab != uiTabs[1])
+	{
+		foundOwnedVehicle = false;
+	}
+	if (!foundOwnedVehicle && selectionState == CitySelectionState::ManualControl)
 	{
 		setSelectionState(CitySelectionState::Normal);
 	}
@@ -2355,6 +2588,12 @@ void CityView::setSelectionState(CitySelectionState selectionState)
 		{
 			overlayTab->findControlTyped<Label>("TEXT")->setText(
 			    tr("Click on destination map point for selected vehicle"));
+			overlayTab->setVisible(true);
+			break;
+		}
+		case CitySelectionState::ManualControl:
+		{
+			overlayTab->findControlTyped<Label>("TEXT")->setText(tr("Manual control"));
 			overlayTab->setVisible(true);
 			break;
 		}

--- a/game/ui/city/cityview.h
+++ b/game/ui/city/cityview.h
@@ -41,6 +41,7 @@ enum class CitySelectionState
 	GotoLocation,
 	AttackVehicle,
 	AttackBuilding,
+	ManualControl
 };
 
 class CityView : public CityTileView
@@ -69,6 +70,8 @@ class CityView : public CityTileView
 	bool modifierRAlt = false;
 	bool modifierLCtrl = false;
 	bool modifierRCtrl = false;
+
+	bool vanillaControls = false;
 
 	sp<Palette> day_palette;
 	sp<Palette> twilight_palette;
@@ -103,7 +106,9 @@ class CityView : public CityTileView
 	void orderMove(StateRef<Building> building, bool alternative);
 	void orderSelect(StateRef<Vehicle> vehicle, bool inverse, bool additive);
 	void orderSelect(StateRef<Agent> agent, bool inverse, bool additive);
+	void orderFire(Vec3<float> position);
 	void orderAttack(StateRef<Vehicle> vehicle, bool forced);
+	void orderFollow(StateRef<Vehicle> vehicle);
 	void orderAttack(StateRef<Building> building);
 
   public:

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -97,6 +97,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.NewFeature.ArmoredRoads", "Armored roads (20 armor value)"},
     {"OpenApoc.NewFeature.CrashingGroundVehicles", "Unsupported ground vehicles crash"},
     {"OpenApoc.NewFeature.OpenApocCityControls", "Improved city control scheme"},
+    {"OpenApoc.NewFeature.CollapseRaidedBuilding", "Successful raid collapses building"},
     {"OpenApoc.Mod.StunHostileAction", "(M) Stunning hurts relationships"},
     {"OpenApoc.Mod.RaidHostileAction", "(M) Initiating raid hurts relationships"},
     {"OpenApoc.Mod.CrashingVehicles", "(M) Vehicles crash on low HP"},

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -94,12 +94,16 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.NewFeature.EnforceCargoLimits", "(N) Enforce vehicle cargo limits"},
     {"OpenApoc.NewFeature.AllowNearbyVehicleLootPickup", "Allow nearby vehicles to pick up loot"},
     {"OpenApoc.NewFeature.AllowBuildingLootDeposit", "Allow loot to be stashed in the building"},
-    {"OpenApoc.NewFeature.ArmoredRoads", "Armored roads"},
+    {"OpenApoc.NewFeature.ArmoredRoads", "Armored roads (20 armor value)"},
     {"OpenApoc.NewFeature.CrashingGroundVehicles", "Unsupported ground vehicles crash"},
+    {"OpenApoc.NewFeature.OpenApocCityControls", "Improved city control scheme"},
+    {"OpenApoc.Mod.StunHostileAction", "(M) Stunning hurts relationships"},
+    {"OpenApoc.Mod.RaidHostileAction", "(M) Initiating raid hurts relationships"},
     {"OpenApoc.Mod.CrashingVehicles", "(M) Vehicles crash on low HP"},
     {"OpenApoc.Mod.InvulnerableRoads", "(M) Invulnerable roads"},
     {"OpenApoc.Mod.ATVTank", "(M) Griffon becomes All-Terrain"},
     {"OpenApoc.Mod.BSKLauncherSound", "(M) Original Brainsucker Launcher SFX"},
+
 };
 
 std::vector<UString> listNames = {"Message Toggles", "OpenApoc Features"};

--- a/tools/extractors/extract_city_map.cpp
+++ b/tools/extractors/extract_city_map.cpp
@@ -94,15 +94,15 @@ void InitialGameStateExtractor::extractCityMap(GameState &state, UString fileNam
 	// Fixing buggy city
 	if (fileName == "citymap1")
 	{
-		city->initial_tiles[Vec3<int>{50, 109, 4}] = {&state, "CITYTILE_CITYMAP_78"};
+		city->initial_tiles[Vec3<int>{50, 109, 4}] = {&state, "CITYTILE_CITYMAP_83"};
 	}
 	if (fileName == "citymap2")
 	{
-		// Erase two bugs
 		city->initial_tiles.erase(Vec3<int>{47, 86, 4});
 		city->initial_tiles.erase(Vec3<int>{45, 98, 6});
 		city->initial_tiles.erase(Vec3<int>{69, 80, 4});
 		city->initial_tiles.erase(Vec3<int>{77, 80, 4});
+		city->initial_tiles[Vec3<int>{44, 71, 4}] = {&state, "CITYTILE_CITYMAP_82"};
 	}
 	if (fileName == "citymap3")
 	{

--- a/tools/extractors/extract_city_scenery.cpp
+++ b/tools/extractors/extract_city_scenery.cpp
@@ -197,6 +197,8 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 			tile->walk_mode = SceneryTileType::WalkMode::Onto;
 		}
 
+		tile->commonProperty = i < 134 || i > 936;
+
 		if (entry.damagedtile_idx)
 		{
 			tile->damagedTile = {&state, format("%s%s%u", SceneryTileType::getPrefix(), tilePrefix,

--- a/tools/extractors/extract_organisations.cpp
+++ b/tools/extractors/extract_organisations.cpp
@@ -231,22 +231,24 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 			                                                Organisation::Relation::Neutral};
 			std::set<Organisation::Relation> UnfriendlyMinus = {Organisation::Relation::Unfriendly,
 			                                                    Organisation::Relation::Hostile};
+
+			auto &missions = o->missions[{&state, "CITYMAP_HUMAN"}];
 			// Agents
-			/*o->missions.emplace_back(m, 7 * m, 13 * m, 1, 1, std::set<StateRef<VehicleType>>{{}},
+			/*missions.emplace_back(m, 7 * m, 13 * m, 1, 1, std::set<StateRef<VehicleType>>{{}},
 			                         Organisation::MissionPattern::Target::Other);*/
 			switch (vdata.vehiclePark)
 			{
 				// Government
 				case 0:
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 3 * m, 7 * m, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_RESCUE_TRANSPORT"}},
 					    Organisation::MissionPattern::Target::OwnedOrOther);
-					o->missions.emplace_back(0, 3 * m, 7 * m, 1, 1,
-					                         std::set<StateRef<VehicleType>>{
-					                             {&state, "VEHICLETYPE_CONSTRUCTION_VEHICLE"}},
-					                         Organisation::MissionPattern::Target::OwnedOrOther);
-					o->missions.emplace_back(
+					missions.emplace_back(0, 3 * m, 7 * m, 1, 1,
+					                      std::set<StateRef<VehicleType>>{
+					                          {&state, "VEHICLETYPE_CONSTRUCTION_VEHICLE"}},
+					                      Organisation::MissionPattern::Target::OwnedOrOther);
+					missions.emplace_back(
 					    0, 2 * m, 4 * m, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_CIVILIAN_CAR"},
 					                                    {&state, "VEHICLETYPE_BLAZER_TURBO_BIKE"}},
@@ -254,19 +256,19 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 					break;
 				// Transtellar
 				case 3:
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 30 * s, 90 * s, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_SPACE_LINER"}},
 					    Organisation::MissionPattern::Target::DepartToSpace);
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 30 * s, 90 * s, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_SPACE_LINER"}},
 					    Organisation::MissionPattern::Target::ArriveFromSpace);
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 5 * m, 11 * m, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_AUTOTRANS"}},
 					    Organisation::MissionPattern::Target::Other, NeutralPlus);
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 5 * m, 11 * m, 1, 3,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_AIRRANS"}},
 					    Organisation::MissionPattern::Target::Other, NeutralPlus);
@@ -278,7 +280,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 				case 6:
 				case 10:
 				case 20:
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 15 * m, 25 * m, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_CIVILIAN_CAR"},
 					                                    {&state, "VEHICLETYPE_BLAZER_TURBO_BIKE"}},
@@ -286,7 +288,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 					break;
 				// Sirius
 				case 30:
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 7 * m, 13 * m, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_CIVILIAN_CAR"},
 					                                    {&state, "VEHICLETYPE_BLAZER_TURBO_BIKE"}},
@@ -294,7 +296,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 					break;
 				// Crime
 				case 60:
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    5 * m, 11 * m, 19 * m, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_CIVILIAN_CAR"},
 					                                    {&state, "VEHICLETYPE_BLAZER_TURBO_BIKE"}},
@@ -302,15 +304,15 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 					break;
 				// Police
 				case 55:
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    0, 20 * s, 40 * s, 1, 1,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_POLICE_CAR"}},
 					    Organisation::MissionPattern::Target::Owned);
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    5 * m, 13 * m, 17 * m, 3, 5,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_POLICE_CAR"}},
 					    Organisation::MissionPattern::Target::Owned);
-					o->missions.emplace_back(
+					missions.emplace_back(
 					    3 * m, 30 * m, 90 * m, 3, 5,
 					    std::set<StateRef<VehicleType>>{{&state, "VEHICLETYPE_POLICE_CAR"}},
 					    Organisation::MissionPattern::Target::Other, UnfriendlyMinus);


### PR DESCRIPTION
- attack building mission
- building selection frame for goto/attack
- proper patrol mission
- craft scrambles when building is under attack
- building under attack event
- cityview vanilla controls
- improved cityview apoc controls
- cityview time hotkeys
- manual vehicle controls
- handling destroyed land pads
- fixed vehicles firing when landing/taking off
- fixed vehicles dodging when landing/taking off
- fixed vehicles overwriting orders when landing/taking off
- fixed vehicles disregarding LOF when firing
- fixed some crashed/falling vehicle bugs
- in agent and vehicle equip screen you can use shift+click auto-equip (or de-equip)
- proper height extraction and usage for scenery
- building collapse (test by shiflt-alt-ctrl-right click)
- building collapse when raid succeeds option
- vehicles should no longer hit themselves
- vehicles should no longer have problems attacking crashed vehicles