### PR TITLE
improved p[athfinding and fixes

### DIFF
--- a/data/common_patch/gamestate/ufopaedia.xml
+++ b/data/common_patch/gamestate/ufopaedia.xml
@@ -1015,7 +1015,7 @@
           </value>
         </entry>
         <entry>
-          <key>PAEDIAENTRY_HYDRO_FARM</key>
+          <key>PAEDIAENTRY_HYDRO-FARM</key>
           <value>
             <title>Hydro-Farm</title>
             <description>Open fields are unsustainable because of exposure to harmful radiation caused by the collapse of the ozone layer. The Hydro-Farms of Mega-Primus are efficient, clean and highly productive. Their controlled environments can produce any kind of vegetable or fruit, or rear any kind of animal. Unfortunately they are also quite good at nurturing the odd Alien which finds its way inside.</description>

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -96,10 +96,10 @@ void ListBox::onRender()
 	switch (ScrollOrientation)
 	{
 		case Orientation::Vertical:
-			scroller->Maximum = std::max(controlOffset.y - this->Size.y, scroller->Minimum);
+			scroller->setMaximum(std::max(controlOffset.y - this->Size.y, scroller->getMinimum()));
 			break;
 		case Orientation::Horizontal:
-			scroller->Maximum = std::max(controlOffset.x - this->Size.x, scroller->Minimum);
+			scroller->setMaximum(std::max(controlOffset.x - this->Size.x, scroller->getMinimum()));
 			break;
 	}
 	scroller->updateLargeChangeValue();

--- a/forms/scrollbar.cpp
+++ b/forms/scrollbar.cpp
@@ -31,10 +31,37 @@ bool ScrollBar::setValue(int newValue)
 	newValue = std::max(newValue, Minimum);
 	newValue = std::min(newValue, Maximum);
 	if (newValue == Value)
+	{
 		return false;
+	}
 
 	Value = newValue;
 	this->pushFormEvent(FormEventType::ScrollBarChange, nullptr);
+	setDirty();
+	return true;
+}
+
+bool ScrollBar::setMinimum(int newMininum)
+{
+	if (Minimum == newMininum)
+	{
+		return false;
+	}
+	Minimum = newMininum;
+	setValue(Value);
+	setDirty();
+	return true;
+}
+
+bool ScrollBar::setMaximum(int newMaximum)
+{
+	if (Maximum == newMaximum)
+	{
+		return false;
+	}
+	Maximum = newMaximum;
+	setValue(Value);
+	setDirty();
 	return true;
 }
 

--- a/forms/scrollbar.h
+++ b/forms/scrollbar.h
@@ -26,6 +26,9 @@ class ScrollBar : public Control
   protected:
 	void onRender() override;
 
+	int Minimum;
+	int Maximum;
+
   public:
 	enum class ScrollBarRenderStyle
 	{
@@ -35,8 +38,6 @@ class ScrollBar : public Control
 
 	ScrollBarRenderStyle RenderStyle;
 	Colour GripperColour;
-	int Minimum;
-	int Maximum;
 	int LargeChange;
 	int LargePercent;
 
@@ -49,7 +50,11 @@ class ScrollBar : public Control
 	void update() override;
 	void unloadResources() override;
 	virtual int getValue() const { return Value; }
+	virtual int getMinimum() const { return Minimum; }
+	virtual int getMaximum() const { return Maximum; }
 	virtual bool setValue(int newValue);
+	virtual bool setMinimum(int newMininum);
+	virtual bool setMaximum(int newMaximum);
 	virtual void scrollPrev(bool small = false);
 	virtual void scrollNext(bool small = false);
 

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -99,7 +99,6 @@ ConfigOptionBool autoExecuteOption("Options.Misc", "AutoExecute",
 ConfigOptionBool toolTipsOption("Options.Misc", "ToolTips",
                                 "Show tool tips when hovering over controls", true);
 
-;
 ConfigOptionBool optionPauseOnUfoSpotted("Notifications.City", "UfoSpotted", "UFO spotted", true);
 ConfigOptionBool optionPauseOnVehicleLightDamage("Notifications.City", "VehicleLightDamage",
                                                  "Vehicle lightly damaged", true);
@@ -241,6 +240,10 @@ ConfigOptionBool optionMarketRight("OpenApoc.NewFeature", "MarketOnRight",
                                    "Put market stock on the right side", true);
 ConfigOptionBool optionDGCrashingVehicles("OpenApoc.NewFeature", "CrashingDimensionGate",
                                           "Uncapable vehicles crash when entering gates", true);
+ConfigOptionBool optionFuelCrashingVehicles("OpenApoc.NewFeature", "CrashingOutOfFuel",
+                                            "Vehicles crash when out of fuel", true);
+ConfigOptionBool optionSkipTurbo("OpenApoc.NewFeature", "SkipTurboMovement",
+                                 "Skip turbo movement calculations", false);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -120,7 +120,7 @@ void Building::updateCargo(GameState &state)
 {
 	StateRef<Building> thisRef = {&state, getId(state, shared_from_this())};
 
-	// Step 01: Consume cargo with destination = this or zero count
+	// Step 01: Consume cargo with destination = this or zero count or hostile destination
 	for (auto it = cargo.begin(); it != cargo.end();)
 	{
 		if (it->count != 0 && it->destination == thisRef)
@@ -129,6 +129,11 @@ void Building::updateCargo(GameState &state)
 		}
 		if (it->count == 0)
 		{
+			it = cargo.erase(it);
+		}
+		else if (owner->isRelatedTo(it->destination->owner) == Organisation::Relation::Hostile)
+		{
+			it->seize(state, owner);
 			it = cargo.erase(it);
 		}
 		else

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -88,9 +88,9 @@ class Building : public StateObject, public std::enable_shared_from_this<Buildin
 
 	// Following members are not serialized, but rather are set in City::initMap method
 
-	Vec3<int> crewQuarters;
-	std::vector<Vec3<int>> carEntranceLocations;
-	std::vector<Vec3<int>> landingPadLocations;
+	Vec3<int> crewQuarters = {-1, -1, -1};
+	Vec3<int> carEntranceLocation = {-1, -1, -1};
+	std::set<Vec3<int>> landingPadLocations;
 	std::set<Vec3<int>> buildingParts;
 };
 

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -74,10 +74,6 @@ void City::initMap(GameState &state)
 	}
 	this->map.reset(new TileMap(this->size, VELOCITY_SCALE_CITY,
 	                            {VOXEL_X_CITY, VOXEL_Y_CITY, VOXEL_Z_CITY}, layerMap));
-	for (auto &b : this->buildings)
-	{
-		b.second->crewQuarters = {-1, -1, -1};
-	}
 	for (auto &s : this->scenery)
 	{
 		s->city = {&state, id};
@@ -91,13 +87,17 @@ void City::initMap(GameState &state)
 		}
 		if (s->type->isLandingPad)
 		{
-			s->building->landingPadLocations.push_back(s->initialPosition);
+			s->building->landingPadLocations.insert(s->initialPosition);
 		}
 		if ((s->type->connection[0] || s->type->connection[1] || s->type->connection[2] ||
 		     s->type->connection[3]) &&
 		    s->type->road_type == SceneryTileType::RoadType::Terminal)
 		{
-			s->building->carEntranceLocations.push_back(s->initialPosition);
+			if (s->building->carEntranceLocation.x != -1)
+			{
+				LogWarning("Building has multiple car entrances? %s", s->building->name);
+			}
+			s->building->carEntranceLocation = s->initialPosition;
 			// crew quarters is the closest to camera spot with vehicle access
 			if (s->initialPosition.z > s->building->crewQuarters.z ||
 			    (s->initialPosition.z == s->building->crewQuarters.z &&
@@ -122,10 +122,7 @@ void City::initMap(GameState &state)
 		{
 			LogInfo("Pad: %s", loc);
 		}
-		for (auto &loc : b.second->carEntranceLocations)
-		{
-			LogInfo("Car: %s", loc);
-		}
+		LogInfo("Car: %s", b.second->carEntranceLocation);
 		if (b.second->crewQuarters == Vec3<int>{-1, -1, -1})
 		{
 			LogWarning("Building %s has no car exit?", b.first);
@@ -573,13 +570,13 @@ void City::accuracyAlgorithmCity(GameState &state, Vec3<float> firePosition, Vec
 	target += diff;
 }
 
-void RoadSegment::notifyRoadChange(const Vec3<int> &position, bool intact)
+void RoadSegment::notifyRoadChange(const Vec3<int> &position, bool newIntact)
 {
 	for (int i = 0; i < tilePosition.size(); i++)
 	{
 		if (tilePosition.at(i) == position)
 		{
-			tileIntact.at(i) = intact;
+			tileIntact.at(i) = newIntact;
 			break;
 		}
 	}

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -46,7 +46,7 @@ class RoadSegment
 
 	// Methods
 
-	void notifyRoadChange(const Vec3<int> &position, bool intact);
+	void notifyRoadChange(const Vec3<int> &position, bool newIntact);
 	void finalizeStats();
 	bool empty() const;
 

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -371,6 +371,13 @@ class FlyingVehicleMover : public VehicleMover
 		unsigned lastTicksToTurn = 0;
 		unsigned lastTicksToMove = 0;
 
+		// This is amount of ticks (on average) per 1 tile travelled
+		// a units travels 4 speed per second in tiles, where 4 is ticks_per_sec/tick_scale
+		// so this = ticks_per_sec / (speed * ticks_per_sec / tick_scale / city_scale )
+		// which simplifies to 1 / (speed / tick_scale / city_scale)
+		// or to tick_scale * city_scale / speed
+		int ticksPerTile = TICK_SCALE * VELOCITY_SCALE_CITY.x / vehicle.getSpeed();
+
 		// Flag wether we need to update banking and direction
 		bool updateSprite = false;
 		// Move until we become idle or run out of ticks
@@ -450,14 +457,39 @@ class FlyingVehicleMover : public VehicleMover
 				vehicle.popFinishedMissions(state);
 				// Vehicle is considered idle if at goal even if there's more missions to do
 				updateIdle(state);
+				int turboTiles = state.skipTurboCalculations ? ticksToMove / ticksPerTile : 0;
+				int turboTilesBefore = turboTiles;
 				// Get new goal from mission
-				if (!vehicle.getNewGoal(state))
+				if (!vehicle.getNewGoal(state, turboTiles))
 				{
 					if (!vehicle.tileObject)
 					{
 						return;
 					}
 					break;
+				}
+				// Turbo movement
+				int turboTilesMoved = turboTilesBefore - turboTiles;
+				if (turboTilesMoved > 0)
+				{
+					// Figure out facing
+					Vec3<float> vectorToGoal = vehicle.goalPosition - vehicle.position;
+					Vec2<float> targetFacingVector = {vectorToGoal.x, vectorToGoal.y};
+					// New facing as well?
+					if (targetFacingVector.x != 0.0f || targetFacingVector.y != 0.0f)
+					{
+						targetFacingVector = glm::normalize(targetFacingVector);
+						float a1 = acosf(-targetFacingVector.y);
+						float a2 = asinf(targetFacingVector.x);
+						vehicle.goalFacing = a2 >= 0 ? a1 : M_2xPI - a1;
+					}
+					// Move and turn instantly
+					vehicle.position = vehicle.goalPosition;
+					vehicle.facing = vehicle.goalFacing;
+					vehicle.ticksToTurn = 0;
+					vehicle.angularVelocity = 0.0f;
+					updateSprite = true;
+					ticksToMove -= ticksPerTile * turboTilesMoved;
 				}
 				float speed = vehicle.getSpeed();
 				// New position goal acquired, set velocity and angles
@@ -591,6 +623,12 @@ class GroundVehicleMover : public VehicleMover
 		}
 
 		auto ticksToMove = ticks;
+		// This is amount of ticks (on average) per 1 tile travelled
+		// a units travels 4 speed per second in tiles, where 4 is ticks_per_sec/tick_scale
+		// so this = ticks_per_sec / (speed * ticks_per_sec / tick_scale / city_scale )
+		// which simplifies to 1 / (speed / tick_scale / city_scale)
+		// or to tick_scale * city_scale / speed
+		int ticksPerTile = TICK_SCALE * VELOCITY_SCALE_CITY.x / vehicle.getSpeed();
 
 		unsigned lastTicksToTurn = 0;
 		unsigned lastTicksToMove = 0;
@@ -668,14 +706,25 @@ class GroundVehicleMover : public VehicleMover
 					vehicle.popFinishedMissions(state);
 					// Vehicle is considered idle if at goal even if there's more missions to do
 					updateIdle(state);
+					int turboTiles = state.skipTurboCalculations ? ticksToMove / ticksPerTile : 0;
+					int turboTilesBefore = turboTiles;
 					// Get new goal from mission
-					if (!vehicle.getNewGoal(state))
+					if (!vehicle.getNewGoal(state, turboTiles))
 					{
 						if (!vehicle.tileObject)
 						{
 							return;
 						}
 						break;
+					}
+					// Turbo movement
+					int turboTilesMoved = turboTilesBefore - turboTiles;
+					if (turboTilesMoved > 0)
+					{
+						vehicle.position = vehicle.goalPosition;
+						vehicle.facing = vehicle.goalFacing;
+						updateSprite = true;
+						ticksToMove -= ticksPerTile * turboTilesMoved;
 					}
 				}
 				float speed = vehicle.getSpeed();
@@ -1336,13 +1385,25 @@ void Vehicle::enterBuilding(GameState &state, StateRef<Building> b)
 		this->shadowObject->removeFromMap();
 		this->shadowObject = nullptr;
 	}
-	this->position =
-	    type->isGround() ? b->carEntranceLocations.front() : b->landingPadLocations.front();
+	this->position = type->isGround() ? b->carEntranceLocation : *b->landingPadLocations.begin();
 	this->position += Vec3<float>{0.5f, 0.5f, 0.5f};
 	this->facing = 0.0f;
 	this->goalFacing = 0.0f;
 	this->ticksToTurn = 0;
 	this->angularVelocity = 0.0f;
+	// If spent some time outside then spend a unit of fuel
+	if (fuelSpentTicks > 0 && currentBuilding == homeBuilding)
+	{
+		fuelSpentTicks = 0;
+		auto engine = getEngine();
+		if (engine && engine->type->max_ammo > 0)
+		{
+			if (engine->ammo > 0)
+			{
+				engine->ammo--;
+			}
+		}
+	}
 }
 
 void Vehicle::setupMover()
@@ -1406,15 +1467,7 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 			// Base, de-equip
 			for (auto &e : equipment)
 			{
-				// FIXME: When coding manufacture and other places I had to write X = X + 1
-				// because otherwise it would not add the first item!
-				// Ensure it works here with ++ and change everywhere else
-				// where it does X = X + 1 for base inventory
-				currentBuilding->base->inventoryVehicleEquipment[e->type.id]++;
-				if (e->ammo > 0)
-				{
-					currentBuilding->base->inventoryVehicleAmmo[e->type->ammo_type.id] += e->ammo;
-				}
+				e->unequipToBase(state, currentBuilding->base);
 			}
 		}
 		else
@@ -2083,7 +2136,61 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 
 void Vehicle::updateEachSecond(GameState &state)
 {
+	// Consume fuel if out in city
+	if (tileObject && !crashed && !falling && !sliding)
+	{
+		fuelSpentTicks += FUEL_TICKS_PER_SECOND;
+		if (fuelSpentTicks > FUEL_TICKS_PER_UNIT)
+		{
+			fuelSpentTicks -= FUEL_TICKS_PER_UNIT;
+			sp<VEquipment> engine = getEngine();
+			if (engine && engine->type->max_ammo > 0)
+			{
+				if (engine->ammo > 0)
+				{
+					engine->ammo--;
+				}
+				// Low fuel
+				if (engine->ammo == 2)
+				{
+					fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleLowFuel,
+					                                    {&state, shared_from_this()}));
+				}
+				// Out of fuel, drop
+				if (engine->ammo == 0)
+				{
+					if (config().getBool("OpenApoc.NewFeature.CrashingOutOfFuel"))
+					{
+						if (owner == state.getPlayer())
+						{
+							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleNoFuel,
+							                                    {&state, shared_from_this()}));
+						}
+						if (type->isGround())
+						{
+							crash(state, nullptr);
+						}
+						else
+						{
+							startFalling(state);
+						}
+					}
+					else
+					{
+						if (owner == state.getPlayer())
+						{
+							fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleNoFuel,
+							                                          name, "", position));
+						}
+						die(state, true);
+					}
+				}
+			}
+		}
+	}
+	// Update cargo
 	updateCargo(state);
+	// Automated missions
 	if (missions.empty() && !currentBuilding && owner != state.getPlayer())
 	{
 		if (owner == state.getAliens())
@@ -2250,6 +2357,39 @@ void Vehicle::updateSprite(GameState &state)
 				shadowDirection = VehicleType::Direction::N;
 				break;
 		}
+	}
+}
+
+sp<VEquipment> Vehicle::getEngine() const
+{
+	for (auto &e : equipment)
+	{
+		if (e->type->type == EquipmentSlotType::VehicleEngine)
+		{
+			return e;
+		}
+	}
+	return nullptr;
+}
+
+bool Vehicle::hasEngine() const
+{
+	bool hasSlot = false;
+	for (auto &s : type->equipment_layout_slots)
+	{
+		if (s.type == EquipmentSlotType::VehicleEngine)
+		{
+			hasSlot = true;
+			break;
+		}
+	}
+	if (hasSlot)
+	{
+		return (bool)getEngine();
+	}
+	else
+	{
+		return true;
 	}
 }
 
@@ -2819,7 +2959,6 @@ void Vehicle::setPosition(const Vec3<float> &pos)
 	{
 		this->tileObject->setPosition(pos);
 	}
-
 	if (this->shadowObject)
 	{
 		this->shadowObject->setPosition(pos);
@@ -2834,6 +2973,16 @@ void Vehicle::setManualFirePosition(const Vec3<float> &pos)
 
 bool Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 {
+	if (!hasEngine())
+	{
+		if (owner == state.getPlayer())
+		{
+			fw().pushEvent(
+			    new GameVehicleEvent(GameEventType::VehicleNoEngine, {&state, shared_from_this()}));
+		}
+		delete mission;
+		return false;
+	}
 	bool canPlaceInFront = false;
 	switch (mission->type)
 	{
@@ -2902,6 +3051,17 @@ bool Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 
 bool Vehicle::setMission(GameState &state, VehicleMission *mission)
 {
+	if (!hasEngine())
+	{
+		if (owner == state.getPlayer())
+		{
+			fw().pushEvent(
+			    new GameVehicleEvent(GameEventType::VehicleNoEngine, {&state, shared_from_this()}));
+		}
+		delete mission;
+		return false;
+	}
+
 	bool forceClear = false;
 	switch (mission->type)
 	{
@@ -2986,7 +3146,7 @@ bool Vehicle::popFinishedMissions(GameState &state)
 	return popped;
 }
 
-bool Vehicle::getNewGoal(GameState &state)
+bool Vehicle::getNewGoal(GameState &state, int &turboTiles)
 {
 	bool popped = false;
 	bool acquired = false;
@@ -2999,7 +3159,8 @@ bool Vehicle::getNewGoal(GameState &state)
 		// Try to get new destination
 		if (!missions.empty())
 		{
-			acquired = missions.front()->getNextDestination(state, *this, goalPosition, goalFacing);
+			acquired = missions.front()->getNextDestination(state, *this, goalPosition, goalFacing,
+			                                                turboTiles);
 		}
 		// Pop finished missions if present
 		popped = popFinishedMissions(state);
@@ -3639,8 +3800,24 @@ void Cargo::refund(GameState &state, StateRef<Building> currentBuilding)
 			fw().pushEvent(
 			    new GameBaseEvent(GameEventType::CargoExpired, destination->base, originalOwner));
 		}
-		// FIXME: Return expired cargo to economy
-		LogWarning("Return expired cargo to economy");
+		switch (type)
+		{
+			case Type::Bio:
+				if (state.economy.find(id) != state.economy.end())
+				{
+					LogError("Economy found for bio item!?", id);
+				}
+				break;
+			case Type::Agent:
+			case Type::VehicleAmmo:
+			case Type::VehicleEquipment:
+				if (state.economy.find(id) != state.economy.end())
+				{
+					auto &economy = state.economy[id];
+					economy.currentStock += count / divisor;
+				}
+				break;
+		}
 	}
 	else if (currentBuilding && originalOwner == destination->owner)
 	{
@@ -3723,15 +3900,36 @@ void Cargo::arrive(GameState &state, bool &cargoArrived, bool &bioArrived, bool 
 
 void Cargo::seize(GameState &state, StateRef<Organisation> org)
 {
-	if (cost == 0)
+	switch (type)
 	{
-		// Get cost from economy if no cost
+		case Type::Bio:
+			if (state.economy.find(id) != state.economy.end())
+			{
+				LogError("Economy found for bio item!?", id);
+			}
+			break;
+		case Type::Agent:
+		case Type::VehicleAmmo:
+		case Type::VehicleEquipment:
+			if (state.economy.find(id) != state.economy.end())
+			{
+				auto &economy = state.economy[id];
+				if (cost == 0)
+				{
+					cost = economy.currentPrice;
+				}
+				economy.currentStock += count / divisor;
+			}
+			break;
 	}
 	int worth = cost * count / divisor;
-	// FIXME: Return expired cargo to economy
-	LogWarning("Implement cargo seize message, return to economy, and adjust relationship "
-	           "accordingly to worth: %d",
-	           worth);
+	// FIXME: Adjust relationship accordingly to seized cargo's worth
+	LogWarning("Adjust relationship accordingly to worth: %d", worth);
+	if (destination->owner == state.getPlayer())
+	{
+		fw().pushEvent(
+		    new GameBaseEvent(GameEventType::CargoSeized, destination->base, originalOwner));
+	}
 	clear();
 }
 

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -50,6 +50,10 @@ static const int FV_CHANCE_TO_RECOVER_VEHICLE = 66;
 static const int FV_CHANCE_TO_RECOVER_EQUIPMENT = 90;
 // How much percent is "scrapped" sold for
 static const int FV_SCRAPPED_COST_PERCENT = 25;
+// How much ticks is accumulated per second of engine usage
+static const int FUEL_TICKS_PER_SECOND = 144;
+// How much ticks is required to spend one unit of fuel
+static const int FUEL_TICKS_PER_UNIT = 40000;
 
 class Image;
 class TileObjectVehicle;
@@ -202,6 +206,7 @@ class Vehicle : public StateObject,
 	bool crashed = false;
 	bool falling = false;
 	bool sliding = false;
+	int fuelSpentTicks = 0;
 	// Cloak, increases each turn, set to 0 when firing or no cloaking device on vehicle
 	// Vehicle is cloaked when this is >= CLOAK_TICKS_REQUIRED_VEHICLE
 	unsigned int cloakTicksAccumulated = 0;
@@ -332,12 +337,16 @@ class Vehicle : public StateObject,
 	// Pops all finished missions, returns true if popped
 	bool popFinishedMissions(GameState &state);
 	// Get new goal for vehicle position or facing
-	bool getNewGoal(GameState &state);
+	bool getNewGoal(GameState &state, int &turboTiles);
 
 	void update(GameState &state, unsigned int ticks);
 	void updateEachSecond(GameState &state);
 	void updateCargo(GameState &state);
 	void updateSprite(GameState &state);
+
+	sp<VEquipment> getEngine() const;
+	// Returns true if vehicle does not require an engine
+	bool hasEngine() const;
 
 	sp<Equipment> getEquipmentAt(const Vec2<int> &position) const override;
 	const std::list<EquipmentLayoutSlot> &getSlots() const override;

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -103,8 +103,10 @@ bool FlyingVehicleTileHelper::canEnterTile(Tile *from, Tile *to, bool, bool &, f
 		return false;
 	}
 
-	// Don't allow moving underground!
-	if (fromPos.z == 0 && toPos.z == 0)
+	// We cannot move into underground tile unless we're checking if it's passable (no "from")
+	// We only enter that if we want to land into building
+	// and in that case passability is ignored anyways
+	if (from && toPos.z == 0)
 	{
 		return false;
 	}
@@ -181,11 +183,22 @@ float FlyingVehicleTileHelper::adjustCost(Vec3<int> nextPosition, int z) const
 
 float FlyingVehicleTileHelper::getDistance(Vec3<float> from, Vec3<float> to) const
 {
-	return glm::length(to - from);
+	return getDistanceStatic(from, to);
 }
 
 float FlyingVehicleTileHelper::getDistance(Vec3<float> from, Vec3<float> toStart,
                                            Vec3<float> toEnd) const
+{
+	return getDistanceStatic(from, toStart, toEnd);
+}
+
+float FlyingVehicleTileHelper::getDistanceStatic(Vec3<float> from, Vec3<float> to)
+{
+	return glm::length(to - from);
+}
+
+float FlyingVehicleTileHelper::getDistanceStatic(Vec3<float> from, Vec3<float> toStart,
+                                                 Vec3<float> toEnd)
 {
 	auto diffStart = toStart - from;
 	auto diffEnd = toEnd - from - Vec3<float>{1.0f, 1.0f, 1.0f};
@@ -320,7 +333,7 @@ Vec3<float> FlyingVehicleTileHelper::findSidestep(GameState &state, sp<TileObjec
 
 VehicleMission *VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
                                              bool allowTeleporter, bool pickNearest,
-                                             int reRouteAttempts)
+                                             int attemptsToGiveUpAfter)
 {
 	// TODO
 	// Pseudocode:
@@ -330,7 +343,7 @@ VehicleMission *VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<
 	auto *mission = new VehicleMission();
 	mission->type = MissionType::GotoLocation;
 	mission->pickNearest = pickNearest;
-	mission->reRouteAttempts = reRouteAttempts + 1;
+	mission->reRouteAttempts = attemptsToGiveUpAfter;
 	mission->allowTeleporter = allowTeleporter;
 	// Ground vehicles want to go to a closer road
 	if (v.type->type == VehicleType::Type::Road)
@@ -1000,7 +1013,7 @@ bool VehicleMission::teleportCheck(GameState &state, Vehicle &v)
 }
 
 bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float> &destPos,
-                                        float &destFacing)
+                                        float &destFacing, int &turboTiles)
 {
 	static const std::set<TileObject::Type> sceneryVehicleSet = {TileObject::Type::Scenery,
 	                                                             TileObject::Type::Vehicle};
@@ -1018,7 +1031,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 		case MissionType::Patrol:
 		case MissionType::AttackBuilding:
 		{
-			return advanceAlongPath(state, v, destPos, destFacing);
+			return advanceAlongPath(state, v, destPos, destFacing, turboTiles);
 		}
 		case MissionType::FollowVehicle:
 		{
@@ -1030,7 +1043,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 				setFollowPath(state, v);
 				if (!currentPlannedPath.empty())
 				{
-					return advanceAlongPath(state, v, destPos, destFacing);
+					return advanceAlongPath(state, v, destPos, destFacing, turboTiles);
 				}
 			}
 			return false;
@@ -1099,7 +1112,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 					}
 					if (!currentPlannedPath.empty())
 					{
-						return advanceAlongPath(state, v, destPos, destFacing);
+						return advanceAlongPath(state, v, destPos, destFacing, turboTiles);
 					}
 				}
 				else
@@ -1572,8 +1585,9 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			if (v.type->isGround())
 			{
 				// Looking for free exit
-				for (auto &exitLocation : b->carEntranceLocations)
+				do // just so we could use continue to exit
 				{
+					auto exitLocation = b->carEntranceLocation;
 					auto exitTile = map.getTile(exitLocation);
 					if (!exitTile)
 					{
@@ -1628,7 +1642,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					        leaveLocation);
 					this->currentPlannedPath = {exitLocation, exitLocation};
 					return;
-				}
+				} while (false);
 			}
 			else
 			{
@@ -1703,10 +1717,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					if (v.type->isGround())
 					{
 						auto vehiclePosition = vehicleTile->getOwningTile()->position;
-						if (std::find(targetBuilding->carEntranceLocations.begin(),
-						              targetBuilding->carEntranceLocations.end(),
-						              vehiclePosition) ==
-						    targetBuilding->carEntranceLocations.end())
+						if (vehiclePosition != targetBuilding->carEntranceLocation)
 						{
 							LogError("Vehicle at %s not inside vehicle entrance for building %s",
 							         vehiclePosition, b.id);
@@ -1816,19 +1827,12 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			{
 				if (this->currentPlannedPath.empty())
 				{
-					if (reRouteAttempts > 0)
-					{
-						reRouteAttempts--;
-						int iterationCount = getDefaultIterationCount(v);
-						iterationCount *=
-						    glm::length((Vec3<float>)targetLocation - v.position) < 33 ? 3 : 1;
-						setPathTo(state, v, targetLocation, iterationCount, true);
-					}
-					else
-					{
-						// Finall attempt, give up if fails
-						setPathTo(state, v, targetLocation, 500, true, true);
-					}
+					int iterationCount = getDefaultIterationCount(v);
+					iterationCount *=
+					    glm::length((Vec3<float>)targetLocation - v.position) < 33 ? 3 : 1;
+					iterationCount *=
+					    glm::length((Vec3<float>)targetLocation - v.position) < 11 ? 3 : 1;
+					setPathTo(state, v, targetLocation, iterationCount, true, reRouteAttempts == 0);
 				}
 			}
 			return;
@@ -1933,7 +1937,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				        "at %s",
 				        getName(), randomNearbyPos);
 				v.addMission(
-				    state, VehicleMission::gotoLocation(state, v, randomNearbyPos, false, true, 0));
+				    state, VehicleMission::gotoLocation(state, v, randomNearbyPos, false, true, 1));
 				return;
 			}
 			this->targetLocation = tile;
@@ -1966,6 +1970,10 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 		}
 		case MissionType::GotoBuilding:
 		{
+			if (isFinishedInternal(state, v))
+			{
+				return;
+			}
 			auto name = this->getName();
 			LogInfo("Vehicle mission %s checking state", name);
 			auto b = this->targetBuilding;
@@ -1989,57 +1997,35 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					return;
 				}
 			}
-			auto vehicleTile = v.tileObject;
+			// Leave building
 			if (takeOffCheck(state, v))
 			{
 				return;
 			}
 			// Actually go there
+			auto vehicleTile = v.tileObject;
 			if (v.type->isGround())
 			{
 				/* Am I already in a car depot? If so land */
 				auto position = vehicleTile->getOwningTile()->position;
-				if (std::find(targetBuilding->carEntranceLocations.begin(),
-				              targetBuilding->carEntranceLocations.end(),
-				              position) != targetBuilding->carEntranceLocations.end())
+				if (position == targetBuilding->carEntranceLocation)
 				{
 					LogInfo("Mission %s: Entering depot on entrance %s", name, position);
 					v.addMission(state, VehicleMission::land(v, b));
 					return;
 				}
-				/* I must be in the city and not in a depot - try to find the shortest path to a
-				* depot
-				* (if no successfull paths then choose the incomplete path with the lowest (cost
-				* +
-				* distance to goal)*/
-				Vec3<int> shortestPathEntrance = {0, 0, 0};
-				float shortestPathCost = std::numeric_limits<float>::max();
-
-				for (auto &dest : b->carEntranceLocations)
-				{
-					// Simply find the nearest landing pad to the current location and route to
-					// that
-					// Don't pay attention to stuff that blocks us, as things will likely move
-					// anyway...
-
-					if (position == dest)
-						continue;
-					Vec3<float> currentPosition = position;
-					Vec3<float> landingPadPosition = dest;
-
-					float distance = glm::length(currentPosition - landingPadPosition);
-
-					if (distance < shortestPathCost)
-					{
-						shortestPathCost = distance;
-						shortestPathEntrance = dest;
-					}
-				}
 
 				LogInfo("Vehicle mission %s: Pathing to entrance at %s", name,
-				        shortestPathEntrance);
-				v.addMission(state, VehicleMission::gotoLocation(state, v, shortestPathEntrance,
-				                                                 allowTeleporter, false, 10));
+				        b->carEntranceLocation);
+				v.addMission(state, VehicleMission::gotoLocation(state, v, b->carEntranceLocation,
+				                                                 allowTeleporter, false, 1));
+				// If we can't path to building then cancel
+				auto &gotoMission = v.missions.front();
+				if (gotoMission->cancelled || gotoMission->currentPlannedPath.empty() ||
+				    gotoMission->currentPlannedPath.back() == position)
+				{
+					cancelled = true;
+				}
 				return;
 			}
 			else
@@ -2064,48 +2050,79 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						return;
 					}
 				}
-				/* I must be in the air and not above a pad - try to find the shortest path to a
-				* pad
-				* (if no successfull paths then choose the incomplete path with the lowest (cost
-				* +
-				* distance to goal)*/
+				// I must be in the air and not above a pad - try to find the closest pad
 				Vec3<int> shortestPathPad = {0, 0, 0};
 				float shortestPathCost = FLT_MAX;
 
-				for (auto &dest : b->landingPadLocations)
+				for (int attempt = 1; attempt <= 2; attempt++)
 				{
-					// Simply find the nearest landing pad to the current location and route to
-					// that
-					// Don't pay attention to stuff that blocks us, as things will likely move
-					// anyway...
-
-					auto padTile = b->city->map->getTile(dest);
-					// Pad destroyed
-					if (!padTile->presentScenery || !padTile->presentScenery->type->isLandingPad)
+					// At first attempt: path to unoccupied pad
+					// At second attempt: path to any pad
+					for (auto &dest : b->landingPadLocations)
 					{
-						continue;
+						auto padTile = b->city->map->getTile(dest);
+						// Pad destroyed?
+						if (!padTile->presentScenery ||
+						    !padTile->presentScenery->type->isLandingPad)
+						{
+							continue;
+						}
+						// Pad occupied? (only on first attempt)
+						if (attempt == 1)
+						{
+							bool occupied = false;
+							for (auto &o : padTile->intersectingObjects)
+							{
+								if (o->getType() == TileObject::Type::Vehicle)
+								{
+									auto vehicle = std::static_pointer_cast<TileObjectVehicle>(o)
+									                   ->getVehicle();
+									if (!vehicle->crashed)
+									{
+										occupied = true;
+										break;
+									}
+								}
+							}
+							if (occupied)
+							{
+								continue;
+							}
+						}
+
+						// We actually want the tile above the pad itself
+						auto aboveDest = dest;
+						aboveDest.z += 1;
+						if (position == aboveDest)
+							continue;
+						Vec3<float> currentPosition = position;
+						Vec3<float> landingPadPosition = aboveDest;
+
+						float distance = glm::length(currentPosition - landingPadPosition);
+
+						if (distance < shortestPathCost)
+						{
+							shortestPathCost = distance;
+							shortestPathPad = aboveDest;
+						}
 					}
-					// We actually want the tile above the pad itself
-					auto aboveDest = dest;
-					aboveDest.z += 1;
-					if (position == aboveDest)
-						continue;
-					Vec3<float> currentPosition = position;
-					Vec3<float> landingPadPosition = aboveDest;
-
-					float distance = glm::length(currentPosition - landingPadPosition);
-
-					if (distance < shortestPathCost)
+					if (shortestPathCost != FLT_MAX)
 					{
-						shortestPathCost = distance;
-						shortestPathPad = aboveDest;
+						break;
 					}
 				}
 				if (shortestPathCost != FLT_MAX)
 				{
 					LogInfo("Vehicle mission %s: Pathing to pad at %s", name, shortestPathPad);
 					v.addMission(state, VehicleMission::gotoLocation(state, v, shortestPathPad,
-					                                                 allowTeleporter, false, 100));
+					                                                 allowTeleporter, false, 1));
+					// If we can't path to building's pad then snooze
+					auto &gotoMission = v.missions.front();
+					if (gotoMission->cancelled || gotoMission->currentPlannedPath.empty() ||
+					    gotoMission->currentPlannedPath.back() == position)
+					{
+						v.addMission(state, VehicleMission::snooze(state, v, TICKS_PER_SECOND));
+					}
 				}
 				else
 				{
@@ -2119,7 +2136,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					             VehicleMission::gotoLocation(
 					                 state, v,
 					                 v.getPreferredPosition(xPos(state.rng), yPos(state.rng)),
-					                 allowTeleporter, true));
+					                 allowTeleporter, true, 1));
 				}
 				return;
 			}
@@ -2519,6 +2536,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 void VehicleMission::setPathTo(GameState &state, Vehicle &v, Vec3<int> target, int maxIterations,
                                bool checkValidity, bool giveUpIfInvalid)
 {
+	currentPlannedPath.clear();
 	auto vehicleTile = v.tileObject;
 	if (vehicleTile)
 	{
@@ -2551,23 +2569,49 @@ void VehicleMission::setPathTo(GameState &state, Vehicle &v, Vec3<int> target, i
 		}
 
 		std::list<Vec3<int>> path;
+		float distance = 0.0f;
+		auto position = vehicleTile->getOwningTile()->position;
 		switch (v.type->type)
 		{
 			case VehicleType::Type::Road:
-				path = v.city->findShortestPath(vehicleTile->getOwningTile()->position, target,
+				path = v.city->findShortestPath(position, target,
 				                                GroundVehicleTileHelper{*v.city->map, v});
+				distance = GroundVehicleTileHelper::getDistanceStatic(position, target);
 				break;
 			case VehicleType::Type::ATV:
-				path = v.city->map->findShortestPath(vehicleTile->getOwningTile()->position, target,
-				                                     maxIterations,
+				path = v.city->map->findShortestPath(position, target, maxIterations,
 				                                     GroundVehicleTileHelper{*v.city->map, v});
+				distance = GroundVehicleTileHelper::getDistanceStatic(position, target);
 				break;
 			case VehicleType::Type::Flying:
 			case VehicleType::Type::UFO:
-				path = v.city->map->findShortestPath(vehicleTile->getOwningTile()->position, target,
-				                                     maxIterations,
+				path = v.city->map->findShortestPath(position, target, maxIterations,
 				                                     FlyingVehicleTileHelper{*v.city->map, v});
+				distance = FlyingVehicleTileHelper::getDistanceStatic(position, target);
 				break;
+		}
+
+		// Did not reach destination
+		if (path.empty() || path.back() != target)
+		{
+			// If target was close enough to reach
+			if (maxIterations > (int)distance)
+			{
+				// If told to give up - cancel mission
+				if (giveUpIfInvalid)
+				{
+					cancelled = true;
+					return;
+				}
+				// If not told to give up - subtract attempt
+				else
+				{
+					if (reRouteAttempts > 0)
+					{
+						reRouteAttempts--;
+					}
+				}
+			}
 		}
 
 		// Always start with the current position
@@ -2598,7 +2642,6 @@ void VehicleMission::setFollowPath(GameState &state, Vehicle &v)
 			     currentPlannedPath.empty()))
 			{
 				// adjust the path if target moved or planned path didn't bring us to target
-				currentPlannedPath.clear();
 				this->targetLocation = targetTile->getOwningTile()->position;
 				setPathTo(state, v, this->targetLocation, getDefaultIterationCount(v), false);
 			}
@@ -2631,7 +2674,6 @@ void VehicleMission::setFollowPath(GameState &state, Vehicle &v)
 			// Pick a random point around target
 			if (needRePath)
 			{
-				currentPlannedPath.clear();
 				targetLocation = targetTile->getOwningTile()->position;
 				targetLocation.x +=
 				    randBoundsInclusive(state.rng, -FOLLOW_BOUNDS_XY, FOLLOW_BOUNDS_XY);
@@ -2657,7 +2699,6 @@ void VehicleMission::setFollowPath(GameState &state, Vehicle &v)
 			     currentPlannedPath.empty()))
 			{
 				// adjust the path if target moved or planned path didn't bring us to target
-				currentPlannedPath.clear();
 				this->targetLocation = targetTile->getOwningTile()->position;
 				setPathTo(state, v, this->targetLocation, getDefaultIterationCount(v), false);
 			}
@@ -2672,7 +2713,6 @@ void VehicleMission::setFollowPath(GameState &state, Vehicle &v)
 			     currentPlannedPath.empty()))
 			{
 				// adjust the path if target moved or planned path didn't bring us to target
-				currentPlannedPath.clear();
 				targetLocation = v.getPreferredPosition(targetTile->getOwningTile()->position);
 				setPathTo(state, v, this->targetLocation, getDefaultIterationCount(v), false);
 			}
@@ -2681,7 +2721,7 @@ void VehicleMission::setFollowPath(GameState &state, Vehicle &v)
 }
 
 bool VehicleMission::advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> &destPos,
-                                      float &destFacing)
+                                      float &destFacing, int &turboTiles)
 {
 	if (currentPlannedPath.empty())
 	{
@@ -2750,44 +2790,72 @@ bool VehicleMission::advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> 
 	}
 
 	// See if we can make a shortcut
-	// When ordering move to vehidle already on the move, we can have a situation
-	// where going directly to 2nd step in the path is faster than going to the first
-	// In this case, we should skip unnesecary steps
-	auto it = ++currentPlannedPath.begin();
-	// Start with position after next
-	// If next position has a node and we can go directly to that node
-	// Then update current position and iterator
-	while (it != currentPlannedPath.end())
 	{
-		bool canSkip = tFrom->position == *it;
-		if (!canSkip)
+		// When ordering move to vehidle already on the move, we can have a situation
+		// where going directly to 2nd step in the path is faster than going to the first
+		// In this case, we should skip unnesecary steps
+		auto it = ++currentPlannedPath.begin();
+		// Start with position after next
+		// If next position has a node and we can go directly to that node
+		// Then update current position and iterator
+		while (it != currentPlannedPath.end())
 		{
-			bool cantSkip = std::abs(tFrom->position.x - it->x) > 1 ||
-			                std::abs(tFrom->position.y - it->y) > 1 ||
-			                std::abs(tFrom->position.z - it->z) > 1;
-			if (v.type->isGround())
+			bool canSkip = tFrom->position == *it;
+			if (!canSkip)
 			{
-				cantSkip = cantSkip ||
-				           !GroundVehicleTileHelper{tFrom->map, v}.canEnterTile(
-				               tFrom, tFrom->map.getTile(*it));
+				bool cantSkip = std::abs(tFrom->position.x - it->x) > 1 ||
+				                std::abs(tFrom->position.y - it->y) > 1 ||
+				                std::abs(tFrom->position.z - it->z) > 1;
+				if (v.type->isGround())
+				{
+					cantSkip = cantSkip ||
+					           !GroundVehicleTileHelper{tFrom->map, v}.canEnterTile(
+					               tFrom, tFrom->map.getTile(*it));
+				}
+				else
+				{
+					cantSkip = cantSkip ||
+					           !FlyingVehicleTileHelper{tFrom->map, v}.canEnterTile(
+					               tFrom, tFrom->map.getTile(*it));
+				}
+				canSkip = canSkip || !cantSkip;
 			}
-			else
+			if (!canSkip)
 			{
-				cantSkip = cantSkip ||
-				           !FlyingVehicleTileHelper{tFrom->map, v}.canEnterTile(
-				               tFrom, tFrom->map.getTile(*it));
+				break;
 			}
-			canSkip = canSkip || !cantSkip;
+
+			currentPlannedPath.pop_front();
+			pos = currentPlannedPath.front();
+			tTo = tFrom->map.getTile(pos);
+			it = ++currentPlannedPath.begin();
 		}
-		if (!canSkip)
+	}
+
+	// Advance tiles in turbo mode
+	while (turboTiles > 0 && currentPlannedPath.size() > 1)
+	{
+		auto it = ++currentPlannedPath.begin();
+		if (v.type->isGround())
 		{
-			break;
+			if (!GroundVehicleTileHelper{tFrom->map, v}.canEnterTile(tTo, tTo->map.getTile(*it)))
+			{
+				break;
+			}
+		}
+		else
+		{
+			if (!FlyingVehicleTileHelper{tFrom->map, v}.canEnterTile(tTo, tTo->map.getTile(*it)))
+			{
+				break;
+			}
 		}
 
 		currentPlannedPath.pop_front();
 		pos = currentPlannedPath.front();
+		tFrom = tTo;
 		tTo = tFrom->map.getTile(pos);
-		it = ++currentPlannedPath.begin();
+		turboTiles--;
 	}
 
 	auto sceneryTo = tTo->presentScenery;

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -57,8 +57,10 @@ class FlyingVehicleTileHelper : public CanEnterTileHelper
 	float adjustCost(Vec3<int> nextPosition, int z) const override;
 
 	float getDistance(Vec3<float> from, Vec3<float> to) const override;
-
 	float getDistance(Vec3<float> from, Vec3<float> toStart, Vec3<float> toEnd) const override;
+
+	static float getDistanceStatic(Vec3<float> from, Vec3<float> to);
+	static float getDistanceStatic(Vec3<float> from, Vec3<float> toStart, Vec3<float> toEnd);
 
 	bool canLandOnTile(Tile *to) const;
 
@@ -130,14 +132,16 @@ class VehicleMission
 	VehicleMission() = default;
 
 	// Methods used in pathfinding etc.
-	bool getNextDestination(GameState &state, Vehicle &v, Vec3<float> &destPos, float &destFacing);
+	bool getNextDestination(GameState &state, Vehicle &v, Vec3<float> &destPos, float &destFacing,
+	                        int &turboTiles);
 	void update(GameState &state, Vehicle &v, unsigned int ticks, bool finished = false);
 	bool isFinished(GameState &state, Vehicle &v, bool callUpdateIfFinished = true);
 	void start(GameState &state, Vehicle &v);
 	void setPathTo(GameState &state, Vehicle &v, Vec3<int> target, int maxIterations,
 	               bool checkValidity = true, bool giveUpIfInvalid = false);
 	void setFollowPath(GameState &state, Vehicle &v);
-	bool advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> &destPos, float &destFacing);
+	bool advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> &destPos, float &destFacing,
+	                      int &turboTiles);
 	bool isTakingOff(Vehicle &v);
 	int getDefaultIterationCount(Vehicle &v);
 	static Vec3<float> getRandomMapEdgeCoordinates(GameState &state, StateRef<City> city);
@@ -149,7 +153,7 @@ class VehicleMission
 
 	static VehicleMission *gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
 	                                    bool allowTeleporter = false, bool pickNearest = false,
-	                                    int reRouteAttempts = 20);
+	                                    int attemptsToGiveUpAfter = 20);
 	static VehicleMission *gotoPortal(GameState &state, Vehicle &v);
 	static VehicleMission *gotoPortal(GameState &state, Vehicle &v, Vec3<int> target);
 	static VehicleMission *departToSpace(GameState &state, Vehicle &v);

--- a/game/state/city/vequipment.h
+++ b/game/state/city/vequipment.h
@@ -16,6 +16,7 @@ class VWeaponType;
 class VEngineType;
 class Vehicle;
 class Projectile;
+class Base;
 
 class VEquipment : public Equipment
 {
@@ -54,6 +55,13 @@ class VEquipment : public Equipment
 	// Reload uses up to 'ammoAvailable' to reload the weapon. It returns the amount
 	// actually used.
 	int reload(int ammoAvailable);
+	// Reload from base stores, return true if reloaded
+	// Non-players reload from null base for free
+	bool reload(GameState &state, StateRef<Base> base);
+	// Subtract item from base stores and load ammo
+	void equipFromBase(GameState &state, StateRef<Base> base);
+	// Add item to base stores and unload ammo
+	void unequipToBase(GameState &state, StateRef<Base> base);
 	bool fire(GameState &state, Vec3<float> targetPosition, Vec3<float> homingPosition,
 	          StateRef<Vehicle> targetVehicle = nullptr, bool manual = false);
 	bool fire(GameState &state, Vec3<float> targetPosition,

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -90,6 +90,8 @@ UString GameVehicleEvent::message()
 			return format("%s %s", tr("Unmanned UFO recovered:"), vehicle->name);
 		case GameEventType::VehicleRecovered:
 			return format("%s %s", tr("Vehicle successfully recovered:"), vehicle->name);
+		case GameEventType::VehicleNoFuel:
+			return format("%s %s", tr("Vehicle out of fuel:"), vehicle->name);
 		case GameEventType::UfoRecoveryBegin:
 			return "";
 		case GameEventType::VehicleLightDamage:
@@ -228,21 +230,31 @@ UString GameBaseEvent::message()
 		case GameEventType::CargoExpired:
 			if (actor)
 			{
-				return tr("Cargo expired:") + " " + base->name;
-			}
-			else if (actor == base->building->owner)
-			{
-				return tr("Cargo expired:") + " " + base->name + " " + tr("Returned to base");
+				if (actor == base->building->owner)
+				{
+					return tr("Cargo expired:") + " " + base->name + " " + tr("Returned to base");
+				}
+				else
+				{
+					return tr("Cargo expired:") + " " + base->name + " " +
+					       tr("Refunded by supplier: ") + actor->name;
+				}
 			}
 			else
 			{
-				return tr("Cargo expired:") + " " + base->name + " " +
-				       tr("Refunded by supplier: ") + actor->name;
+				return tr("Cargo expired:") + " " + base->name;
 			}
+		case GameEventType::CargoSeized:
+		{
+			return tr("Cargo seized:") + " " + base->name + " " + tr("By hostile organisation: ") +
+			       actor->name;
+		}
 		case GameEventType::CargoArrived:
 			if (actor)
+			{
 				return tr("Cargo arrived:") + " " + base->name + " " + tr("Supplier: ") +
 				       actor->name;
+			}
 			else
 			{
 				return tr("Cargo arrived:") + " " + base->name;
@@ -374,6 +386,9 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 		case GameEventType::VehicleRecovered:
 			messageInner =
 			    format("%s %s", tr("Scrapped vehicle recovered in irreparable condition:"), name);
+			break;
+		case GameEventType::VehicleNoFuel:
+			messageInner = format("%s %s", tr("Vehicle out of fuel:"), name);
 			break;
 	}
 }

--- a/game/state/gameeventtypes.h
+++ b/game/state/gameeventtypes.h
@@ -15,6 +15,7 @@ enum class GameEventType
 	VehicleEscaping,
 	VehicleNoAmmo,
 	VehicleLowFuel,
+	VehicleNoFuel,
 	VehicleRepaired,
 	VehicleRearmed,
 	VehicleRefuelled,
@@ -35,6 +36,7 @@ enum class GameEventType
 	TransferArrived,
 	RecoveryArrived,
 	CargoExpired,
+	CargoSeized,
 	MissionCompletedBase,
 
 	// Something died events

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -208,6 +208,8 @@ void GameState::initState()
 	applyMods();
 	// Validate
 	validate();
+
+	skipTurboCalculations = config().getBool("OpenApoc.NewFeature.SkipTurboMovement");
 }
 
 void GameState::applyMods()
@@ -1083,21 +1085,11 @@ void GameState::updateEndOfSecond()
 				{
 					continue;
 				}
-				int ammoAvailable = std::numeric_limits<int>::max();
-				if (base)
-				{
-					ammoAvailable = base->inventoryVehicleAmmo[e->type->ammo_type.id];
-				}
-				auto ammoSpent = e->reload(ammoAvailable);
-				if (ammoSpent > 0)
+				if (e->reload(*this, base))
 				{
 					// FIXME: Implement message vehicle rearmed / reloaded /refueled whatever
 					LogWarning(
 					    "Implement message vehicle rearmed / reloaded / refueled / whatever");
-				}
-				if (base)
-				{
-					base->inventoryVehicleAmmo[e->type->ammo_type.id] -= ammoSpent;
 				}
 			}
 		}

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -238,6 +238,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 
 	// Following members are not serialized
 	bool newGame = false;
+	bool skipTurboCalculations = false;
 };
 
 }; // namespace OpenApoc

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -359,6 +359,7 @@
 		<member>falling</member>
 		<member>crashed</member>
 		<member>sliding</member>
+		<member>fuelSpentTicks</member>
 		<member>cloakTicksAccumulated</member>
 		<member>teleportTicksAccumulated</member>
 		<member>ticksAutoActionAvailable</member>

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -10,7 +10,7 @@
 #include "library/strings.h"
 
 // Uncomment to turn off org missions
-#define DEBUG_TURN_OFF_ORG_MISSIONS
+//#define DEBUG_TURN_OFF_ORG_MISSIONS
 
 namespace OpenApoc
 {

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -10,7 +10,7 @@
 #include "library/strings.h"
 
 // Uncomment to turn off org missions
-//#define DEBUG_TURN_OFF_ORG_MISSIONS
+#define DEBUG_TURN_OFF_ORG_MISSIONS
 
 namespace OpenApoc
 {

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -169,7 +169,14 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 		    Vec3<int>(destinationEnd.x < size.x ? 1 : 0, destinationEnd.y < size.y ? 1 : 0, 0);
 	}
 
-	LogInfo("Trying to route from %s to %s-%s", origin, destinationStart, destinationEnd);
+	if (destinationIsSingleTile)
+	{
+		LogInfo("Trying to route from %s to %s", origin, destinationStart);
+	}
+	else
+	{
+		LogInfo("Trying to route from %s to %s-%s", origin, destinationStart, destinationEnd);
+	}
 
 	if (!tileIsValid(origin))
 	{
@@ -399,7 +406,9 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 	}
 
 	for (auto &p : nodesToDelete)
+	{
 		delete p;
+	}
 
 	return result;
 }
@@ -831,7 +840,9 @@ std::list<int> Battle::findLosBlockPath(int origin, int destination, BattleUnitT
 	auto result = closestNodeSoFar->getPathToNode();
 
 	for (auto &p : nodesToDelete)
+	{
 		delete p;
+	}
 
 	return result;
 }
@@ -1174,10 +1185,11 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 			// Entrance intact
 			if (nextSeg.getIntactByConnectID(intoConnect))
 			{
+				auto intoTile = nextSeg.getByConnectID(intoConnect);
 				auto secondNode = new RoadSegmentNode(
-					pathToFront.size() - 1,
-					GroundVehicleTileHelper::getDistanceStatic(originSeg.getFirst(), destination),
-					startNode, originSeg.connections[0]);
+				    pathToFront.size() - 1,
+				    GroundVehicleTileHelper::getDistanceStatic(intoTile, destination), startNode,
+				    originSeg.connections[0]);
 				nodesToDelete.push_back(secondNode);
 				fringe.emplace_back(secondNode);
 			}
@@ -1194,10 +1206,11 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 			// Entrance intact
 			if (nextSeg.getIntactByConnectID(intoConnect))
 			{
+				auto intoTile = nextSeg.getByConnectID(intoConnect);
 				auto secondNode = new RoadSegmentNode(
-					pathToBack.size() - 1,
-					GroundVehicleTileHelper::getDistanceStatic(originSeg.getLast(), destination),
-					startNode, originSeg.connections[1]);
+				    pathToBack.size() - 1,
+				    GroundVehicleTileHelper::getDistanceStatic(intoTile, destination), startNode,
+				    originSeg.connections[1]);
 				nodesToDelete.push_back(secondNode);
 				fringe.emplace_back(secondNode);
 			}
@@ -1315,11 +1328,6 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 			continue;
 		}
 
-		// Which is the exit tile position for this segment
-		// - Number zero for nonroads
-		// - The opposite from entrance for roads
-		int toConnect = thisSeg.length == 1 || fromConnect == 1 ? 0 : 1;
-		auto toTile = thisSeg.getByConnectID(toConnect);
 		auto length = thisSeg.length;
 
 		// Now try every connection
@@ -1341,11 +1349,12 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 			{
 				continue;
 			}
+			auto intoTile = nextSeg.getByConnectID(intoConnect);
 
 			// Can be entered and didn't visit - add
 			auto newNode = new RoadSegmentNode(
 			    nodeToExpand->costToGetHere + length,
-			    GroundVehicleTileHelper::getDistanceStatic(toTile, destination), nodeToExpand, c);
+			    GroundVehicleTileHelper::getDistanceStatic(intoTile, destination), nodeToExpand, c);
 			nodesToDelete.push_back(newNode);
 
 			// Put node at appropriate place in the list
@@ -1372,7 +1381,9 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 
 	auto segmentPath = closestNodeSoFar->getPathToNode();
 	for (auto &p : nodesToDelete)
+	{
 		delete p;
+	}
 
 	//
 	// Part 2: Pathfinding using RoadSegment path
@@ -1407,12 +1418,17 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 	// Step 02: Path through segments
 
 	int thisID = originID;
+	int lastID = destinationID;
+	if (!segmentPath.empty())
+	{
+		lastID = segmentPath.back();
+	}
 	for (auto &segID : segmentPath)
 	{
 		auto &nextSeg = roadSegments[segID];
 		int intoConnect = nextSeg.length == 1 || nextSeg.connections[0] == thisID ? 0 : 1;
 		// If not last and not broken then path through
-		if (segID != destinationID && nextSeg.intact)
+		if (segID != lastID && nextSeg.intact)
 		{
 			auto pathThrough = nextSeg.findPathThrough(intoConnect);
 			for (auto &p : pathThrough)

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -960,6 +960,7 @@ void TransactionScreen::executeOrders()
 	}
 
 	// Step 02: Gather data about differences in stocks
+	// Map is base id to number bought/sold
 	std::map<StateRef<AEquipmentType>, std::map<int, int>> aeMap;
 	std::map<StateRef<AEquipmentType>, std::map<int, int>> bioMap;
 	std::map<StateRef<VEquipmentType>, std::map<int, int>> veMap;
@@ -1023,48 +1024,37 @@ void TransactionScreen::executeOrders()
 	// Step 03: Act according to mode
 	auto player = state->getPlayer();
 
-	// Step 03.01: If buy&sell then remove everything negative, order everything positive, adjust
-	// balance
+	// Step 03.01: If buy&sell then:
+	// - remove everything negative, order everything positive, adjust balance
+	bool needTransfer = false;
 	if (mode == Mode::BuySell)
 	{
+		// Step 03.01.01: Buy stuff
 		for (auto &e : aeMap)
 		{
 			for (auto &ae : e.second)
 			{
-				if (ae.second == 0)
+				if (ae.first == 8)
 				{
 					continue;
 				}
-				int count = ae.second *
-				            (e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1);
-				if (ae.second < 0)
-				{
-					if (count > bases[ae.first]->inventoryAgentEquipment[e.first.id])
-					{
-						bases[ae.first]->inventoryAgentEquipment[e.first.id] = 0;
-					}
-					else
-					{
-						bases[ae.first]->inventoryAgentEquipment[e.first.id] -= count;
-					}
-					int price = 0;
-					if (state->economy.find(e.first.id) == state->economy.end())
-					{
-						LogError("Economy not found for %s: How are we buying it then!?",
-						         e.first.id);
-					}
-					else
-					{
-						auto &economy = state->economy[e.first.id];
-						price = economy.currentPrice;
-						economy.currentStock -= ae.second;
-					}
-					player->balance -= ae.second * price;
-				}
 				if (ae.second > 0)
 				{
+					int count =
+					    ae.second *
+					    (e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1);
+
 					auto org = e.first->manufacturer;
-					org->purchase(*state, bases[ae.first]->building, e.first, ae.second);
+					if (org->isRelatedTo(player) != Organisation::Relation::Hostile)
+					{
+						org->purchase(*state, bases[ae.first]->building, e.first, ae.second);
+						ae.second = 0;
+					}
+					else
+					{
+						e.second[8] += ae.second;
+						needTransfer = true;
+					}
 				}
 			}
 		}
@@ -1072,9 +1062,131 @@ void TransactionScreen::executeOrders()
 		{
 			for (auto &ae : e.second)
 			{
-				if (ae.second == 0)
+				if (ae.second > 0)
+				{
+					LogError("Alien %s: How are we buying it!?", e.first.id);
+				}
+			}
+		}
+		for (auto &e : veMap)
+		{
+			for (auto &ve : e.second)
+			{
+				if (ve.first == 8)
 				{
 					continue;
+				}
+				if (ve.second > 0)
+				{
+					auto org = e.first->manufacturer;
+					if (org->isRelatedTo(player) != Organisation::Relation::Hostile)
+					{
+						org->purchase(*state, bases[ve.first]->building, e.first, ve.second);
+						ve.second = 0;
+					}
+					else
+					{
+						e.second[8] += ve.second;
+						needTransfer = true;
+					}
+				}
+			}
+		}
+		for (auto &e : vaMap)
+		{
+			for (auto &va : e.second)
+			{
+				if (va.first == 8)
+				{
+					continue;
+				}
+				if (va.second > 0)
+				{
+					auto org = e.first->manufacturer;
+					org->purchase(*state, bases[va.first]->building, e.first, va.second);
+					if (org->isRelatedTo(player) != Organisation::Relation::Hostile)
+					{
+						org->purchase(*state, bases[va.first]->building, e.first, va.second);
+						va.second = 0;
+					}
+					else
+					{
+						e.second[8] += va.second;
+						needTransfer = true;
+					}
+				}
+			}
+		}
+		for (auto &e : vtMap)
+		{
+			for (auto &vt : e.second)
+			{
+				if (vt.second > 0)
+				{
+					auto org = e.first->manufacturer;
+					org->purchase(*state, bases[vt.first]->building, e.first, vt.second);
+					if (org->isRelatedTo(player) != Organisation::Relation::Hostile)
+					{
+						org->purchase(*state, bases[vt.first]->building, e.first, vt.second);
+						vt.second = 0;
+					}
+					else
+					{
+						LogError("VehicleType %s: How the hell is being bought from a hostile org?",
+						         e.first.id);
+					}
+				}
+			}
+		}
+		// Step 03.01.02:  Sell stuff
+		for (auto &e : aeMap)
+		{
+			for (auto &ae : e.second)
+			{
+				int aeSecond = ae.second;
+				if (ae.second < 0 && e.second[8] > 0)
+				{
+					int reserve = std::min(e.second[8], -ae.second);
+					e.second[8] -= reserve;
+					aeSecond += reserve;
+				}
+				if (aeSecond < 0)
+				{
+					int count =
+					    aeSecond *
+					    (e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1);
+
+					if (-count > bases[ae.first]->inventoryAgentEquipment[e.first.id])
+					{
+						bases[ae.first]->inventoryAgentEquipment[e.first.id] = 0;
+					}
+					else
+					{
+						bases[ae.first]->inventoryAgentEquipment[e.first.id] += count;
+					}
+					int price = 0;
+					if (state->economy.find(e.first.id) == state->economy.end())
+					{
+						LogError("Economy not found for %s: How are we selling it then!?",
+						         e.first.id);
+					}
+					else
+					{
+						auto &economy = state->economy[e.first.id];
+						price = economy.currentPrice;
+						economy.currentStock -= aeSecond;
+					}
+					player->balance -= aeSecond * price;
+				}
+			}
+		}
+		for (auto &e : bioMap)
+		{
+			for (auto &ae : e.second)
+			{
+				if (ae.second < 0 && e.second[8] > 0)
+				{
+					LogError("Alien %s: How the hell is it in reserve?", e.first.id);
 				}
 				if (ae.second < 0)
 				{
@@ -1092,13 +1204,8 @@ void TransactionScreen::executeOrders()
 						price = economy.currentPrice;
 						economy.currentStock -= ae.second;
 					}
-					bases[ae.first]->inventoryAgentEquipment[e.first.id] -= ae.second;
+					bases[ae.first]->inventoryAgentEquipment[e.first.id] += ae.second;
 					player->balance -= ae.second * price;
-				}
-				if (ae.second > 0)
-				{
-					auto org = e.first->manufacturer;
-					org->purchase(*state, bases[ae.first]->building, e.first, ae.second);
 				}
 			}
 		}
@@ -1106,31 +1213,29 @@ void TransactionScreen::executeOrders()
 		{
 			for (auto &ve : e.second)
 			{
-				if (ve.second == 0)
+				int veSecond = ve.second;
+				if (ve.second < 0 && e.second[8] > 0)
 				{
-					continue;
+					int reserve = std::min(e.second[8], -ve.second);
+					e.second[8] -= reserve;
+					veSecond += reserve;
 				}
-				if (ve.second < 0)
+				if (veSecond < 0)
 				{
 					int price = 0;
 					if (state->economy.find(e.first.id) == state->economy.end())
 					{
-						LogError("Economy not found for %s: How are we buying it then!?",
+						LogError("Economy not found for %s: How are we selling it then!?",
 						         e.first.id);
 					}
 					else
 					{
 						auto &economy = state->economy[e.first.id];
 						price = economy.currentPrice;
-						economy.currentStock -= ve.second;
+						economy.currentStock -= veSecond;
 					}
-					bases[ve.first]->inventoryVehicleEquipment[e.first.id] -= ve.second;
-					player->balance -= ve.second * price;
-				}
-				if (ve.second > 0)
-				{
-					auto org = e.first->manufacturer;
-					org->purchase(*state, bases[ve.first]->building, e.first, ve.second);
+					bases[ve.first]->inventoryVehicleEquipment[e.first.id] += veSecond;
+					player->balance -= veSecond * price;
 				}
 			}
 		}
@@ -1138,11 +1243,14 @@ void TransactionScreen::executeOrders()
 		{
 			for (auto &va : e.second)
 			{
-				if (va.second == 0)
+				int vaSecond = va.second;
+				if (va.second < 0 && e.second[8] > 0)
 				{
-					continue;
+					int reserve = std::min(e.second[8], -va.second);
+					e.second[8] -= reserve;
+					vaSecond += reserve;
 				}
-				if (va.second < 0)
+				if (vaSecond < 0)
 				{
 					int price = 0;
 					if (state->economy.find(e.first.id) == state->economy.end())
@@ -1154,15 +1262,10 @@ void TransactionScreen::executeOrders()
 					{
 						auto &economy = state->economy[e.first.id];
 						price = economy.currentPrice;
-						economy.currentStock -= va.second;
+						economy.currentStock -= vaSecond;
 					}
-					bases[va.first]->inventoryVehicleAmmo[e.first.id] -= va.second;
-					player->balance -= va.second * price;
-				}
-				if (va.second > 0)
-				{
-					auto org = e.first->manufacturer;
-					org->purchase(*state, bases[va.first]->building, e.first, va.second);
+					bases[va.first]->inventoryVehicleAmmo[e.first.id] += vaSecond;
+					player->balance -= vaSecond * price;
 				}
 			}
 		}
@@ -1170,21 +1273,18 @@ void TransactionScreen::executeOrders()
 		{
 			for (auto &vt : e.second)
 			{
-				if (vt.second == 0)
+				if (vt.second < 0 && e.second[8] > 0)
 				{
-					continue;
+					LogError("VehicleType %s: How the hell is it in reserve?", e.first.id);
 				}
 				if (vt.second < 0)
 				{
 					LogError("How did we manage to sell a vehicle type!?");
 				}
-				if (vt.second > 0)
-				{
-					auto org = e.first->manufacturer;
-					org->purchase(*state, bases[vt.first]->building, e.first, vt.second);
-				}
 			}
 		}
+
+		// Step 03.01.03: Sell vehicles
 		for (auto &v : soldVehicles)
 		{
 			// Expecting sold vehicle to be parked
@@ -1202,11 +1302,10 @@ void TransactionScreen::executeOrders()
 			v.first->die(*state, true);
 			player->balance += v.second;
 		}
-		return;
 	}
 
 	// Step 03.02: If transfer then move stuff from negative to positive
-	if (mode == Mode::Transfer)
+	if (mode == Mode::Transfer || needTransfer)
 	{
 		// Agent items
 		for (auto &e : aeMap)
@@ -1215,10 +1314,6 @@ void TransactionScreen::executeOrders()
 			std::list<std::pair<int, int>> destination;
 			for (auto &ae : e.second)
 			{
-				if (ae.second == 0)
-				{
-					continue;
-				}
 				if (ae.second < 0)
 				{
 					source.emplace_back(ae.first, -ae.second);
@@ -1268,10 +1363,6 @@ void TransactionScreen::executeOrders()
 			std::list<std::pair<int, int>> destination;
 			for (auto &be : e.second)
 			{
-				if (be.second == 0)
-				{
-					continue;
-				}
 				if (be.second < 0)
 				{
 					source.emplace_back(be.first, be.second);
@@ -1315,10 +1406,6 @@ void TransactionScreen::executeOrders()
 			std::list<std::pair<int, int>> destination;
 			for (auto &ve : e.second)
 			{
-				if (ve.second == 0)
-				{
-					continue;
-				}
 				if (ve.second < 0)
 				{
 					source.emplace_back(ve.first, ve.second);
@@ -1362,10 +1449,6 @@ void TransactionScreen::executeOrders()
 			std::list<std::pair<int, int>> destination;
 			for (auto &va : e.second)
 			{
-				if (va.second == 0)
-				{
-					continue;
-				}
 				if (va.second < 0)
 				{
 					source.emplace_back(va.first, va.second);
@@ -1588,6 +1671,7 @@ void TransactionScreen::closeScreen(bool confirmed, bool forced)
 	// Step 03: Check transportation
 
 	// Step 03.01: Check transportation for purchases
+	bool purchaseTransferFound = false;
 	if (mode == Mode::BuySell)
 	{
 		bool noFerry = false;
@@ -1602,6 +1686,43 @@ void TransactionScreen::closeScreen(bool confirmed, bool forced)
 				if (linkedControls.find(c) != linkedControls.end())
 				{
 					continue;
+				}
+				// See if we transfer-bought from an org that's hostile
+				if (!purchaseTransferFound)
+				{
+					for (int i = 0; i < 7; i++)
+					{
+						if (c->initialStock[8] < c->currentStock[8])
+						{
+							StateRef<Organisation> owner;
+							switch (c->itemType)
+							{
+								case TransactionControl::Type::AgentEquipmentBio:
+								case TransactionControl::Type::AgentEquipmentCargo:
+									owner = StateRef<AEquipmentType> { state.get(), c->itemId }
+									->manufacturer;
+									break;
+								case TransactionControl::Type::VehicleEquipment:
+									owner = StateRef<VEquipmentType> { state.get(), c->itemId }
+									->manufacturer;
+									break;
+								case TransactionControl::Type::VehicleAmmo:
+									owner = StateRef<VAmmoType> { state.get(), c->itemId }
+									->manufacturer;
+									break;
+								case TransactionControl::Type::VehicleType:
+								case TransactionControl::Type::Vehicle:
+									// Vehicles need no transportation
+									break;
+							}
+							if (owner &&
+							    owner->isRelatedTo(state->getPlayer()) ==
+							        Organisation::Relation::Hostile)
+							{
+								purchaseTransferFound = true;
+							}
+						}
+					}
 				}
 				if (c->initialStock[8] > c->currentStock[8])
 				{
@@ -1711,7 +1832,8 @@ void TransactionScreen::closeScreen(bool confirmed, bool forced)
 	}
 
 	// Step 03.02: Check transportation for transfers
-	if (mode == Mode::Transfer)
+	// or for purchase-transfers
+	if (mode == Mode::Transfer || purchaseTransferFound)
 	{
 		bool transportationHostile = false;
 		bool transportationBusy = false;
@@ -1988,14 +2110,14 @@ void TransactionScreen::TransactionControl::setScrollbarValues()
 {
 	if (indexLeft == indexRight)
 	{
-		scrollBar->Minimum = 0;
-		scrollBar->Maximum = 0;
+		scrollBar->setMinimum(0);
+		scrollBar->setMaximum(0);
 		scrollBar->setValue(0);
 	}
 	else
 	{
-		scrollBar->Minimum = 0;
-		scrollBar->Maximum = currentStock[indexLeft] + currentStock[indexRight];
+		scrollBar->setMinimum(0);
+		scrollBar->setMaximum(currentStock[indexLeft] + currentStock[indexRight]);
 		scrollBar->setValue(currentStock[indexRight]);
 	}
 	updateValues();
@@ -2015,13 +2137,13 @@ void TransactionScreen::TransactionControl::setIndexRight(int index)
 
 void TransactionScreen::TransactionControl::updateValues()
 {
-	if (scrollBar->Maximum != 0)
+	if (scrollBar->getMaximum() != 0)
 	{
 		if (manufacturerHostile || manufacturerUnavailable)
 		{
 			if (indexLeft == 8)
 			{
-				if (scrollBar->getValue() > scrollBar->Maximum - initialStock[indexLeft])
+				if (scrollBar->getValue() > scrollBar->getMaximum() - initialStock[indexLeft])
 				{
 					scrollBar->setValue(initialStock[indexLeft]);
 					auto message_box = mksp<MessageBox>(
@@ -2052,7 +2174,7 @@ void TransactionScreen::TransactionControl::updateValues()
 		}
 
 		int newRight = scrollBar->getValue();
-		int newLeft = scrollBar->Maximum - scrollBar->getValue();
+		int newLeft = scrollBar->getMaximum() - scrollBar->getValue();
 		if (newRight != currentStock[indexRight] || newLeft != currentStock[indexLeft])
 		{
 			currentStock[indexRight] = newRight;
@@ -2519,8 +2641,8 @@ sp<TransactionScreen::TransactionControl> TransactionScreen::TransactionControl:
 	control->scrollBar = control->createChild<ScrollBar>();
 	control->scrollBar->Location = {102, 24};
 	control->scrollBar->Size = {147, 20};
-	control->scrollBar->Minimum = 0;
-	control->scrollBar->Maximum = 0;
+	control->scrollBar->setMinimum(0);
+	control->scrollBar->setMaximum(0);
 	// ScrollBar buttons
 	auto buttonScrollLeft = control->createChild<GraphicButton>(nullptr, scrollLeft);
 	buttonScrollLeft->Size = scrollLeft->size;

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -233,11 +233,7 @@ void VEquipScreen::eventOccurred(Event *e)
 
 			// Return the equipment to the inventory
 			this->selected->removeEquipment(equipment);
-			base->inventoryVehicleEquipment[equipment->type.id]++;
-			if (equipment->ammo > 0)
-			{
-				base->inventoryVehicleAmmo[equipment->type->ammo_type.id] += equipment->ammo;
-			}
+			equipment->unequipToBase(*state, base);
 			this->paperDoll->updateEquipment();
 
 			// Immediate action: put to the base
@@ -265,13 +261,7 @@ void VEquipScreen::eventOccurred(Event *e)
 					auto e = this->selected->addEquipment(*state, this->draggedEquipment);
 					if (e)
 					{
-						base->inventoryVehicleEquipment[draggedEquipment->id]--;
-						if (draggedEquipment->max_ammo > 0)
-						{
-							int ammoAvailable = base->inventoryVehicleAmmo[e->type->ammo_type.id];
-							auto ammoSpent = e->reload(ammoAvailable);
-							base->inventoryVehicleAmmo[e->type->ammo_type.id] -= ammoSpent;
-						}
+						e->equipFromBase(*state, base);
 						this->paperDoll->updateEquipment();
 					}
 					this->draggedEquipment = nullptr;
@@ -299,15 +289,9 @@ void VEquipScreen::eventOccurred(Event *e)
 					LogError("Trying to equip item \"%s\" with zero inventory",
 					         this->draggedEquipment->id);
 				}
-				base->inventoryVehicleEquipment[draggedEquipment->id]--;
 				auto e =
 				    this->selected->addEquipment(*state, equipmentGridPos, this->draggedEquipment);
-				if (draggedEquipment->max_ammo > 0)
-				{
-					int ammoAvailable = base->inventoryVehicleAmmo[e->type->ammo_type.id];
-					auto ammoSpent = e->reload(ammoAvailable);
-					base->inventoryVehicleAmmo[e->type->ammo_type.id] -= ammoSpent;
-				}
+				e->equipFromBase(*state, base);
 				this->paperDoll->updateEquipment();
 				// FIXME: Add ammo to equipment
 			}

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -102,6 +102,8 @@ std::list<std::pair<UString, UString>> openApocList = {
      "Any hit on hostile building provokes retaliation"},
     {"OpenApoc.NewFeature.MarketOnRight", "Put market stock on the right side"},
     {"OpenApoc.NewFeature.CrashingDimensionGate", "Uncapable vehicles crash when entering gates"},
+    {"OpenApoc.NewFeature.SkipTurboMovement", "Skip turbo movement calculations"},
+    {"OpenApoc.NewFeature.CrashingOutOfFuel", "Vehicles crash when out of fuel"},
 
     {"OpenApoc.Mod.StunHostileAction", "(M) Stunning hurts relationships"},
     {"OpenApoc.Mod.RaidHostileAction", "(M) Initiating raid hurts relationships"},
@@ -339,7 +341,7 @@ void InGameOptions::eventOccurred(Event *e)
 				return;
 			}
 			float gain =
-			    static_cast<float>(slider->getValue()) / static_cast<float>(slider->Maximum);
+			    static_cast<float>(slider->getValue()) / static_cast<float>(slider->getMaximum());
 			fw().soundBackend->setGain(SoundBackend::Gain::Global, gain);
 		}
 		else if (e->forms().RaisedBy->Name == "MUSIC_GAIN_SLIDER")
@@ -351,7 +353,7 @@ void InGameOptions::eventOccurred(Event *e)
 				return;
 			}
 			float gain =
-			    static_cast<float>(slider->getValue()) / static_cast<float>(slider->Maximum);
+			    static_cast<float>(slider->getValue()) / static_cast<float>(slider->getMaximum());
 			fw().soundBackend->setGain(SoundBackend::Gain::Music, gain);
 		}
 		else if (e->forms().RaisedBy->Name == "SAMPLE_GAIN_SLIDER")
@@ -363,7 +365,7 @@ void InGameOptions::eventOccurred(Event *e)
 				return;
 			}
 			float gain =
-			    static_cast<float>(slider->getValue()) / static_cast<float>(slider->Maximum);
+			    static_cast<float>(slider->getValue()) / static_cast<float>(slider->getMaximum());
 			fw().soundBackend->setGain(SoundBackend::Gain::Sample, gain);
 		}
 	}

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -289,8 +289,8 @@ void Skirmish::goToBattle(bool customAliens, std::map<StateRef<AgentType>, int> 
 	playerBuilding->owner = state.getPlayer();
 	playerBuilding->base = playerBase;
 	playerBuilding->city = city;
-	playerBuilding->carEntranceLocations.emplace_back(0, 0, 0);
-	playerBuilding->landingPadLocations.emplace_back(0, 0, 0);
+	playerBuilding->carEntranceLocation = {0, 0, 0};
+	playerBuilding->landingPadLocations.emplace(0, 0, 0);
 
 	playerBase->building = playerBuilding;
 	playerBase->corridors = sourceBase->corridors;

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -1253,6 +1253,7 @@ void BattleView::begin()
 
 void BattleView::resume()
 {
+	state->skipTurboCalculations = config().getBool("OpenApoc.NewFeature.SkipTurboMovement");
 	BattleTileView::resume();
 	modifierLAlt = false;
 	modifierLCtrl = false;

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1403,6 +1403,7 @@ void CityView::begin()
 void CityView::resume()
 {
 	vanillaControls = !config().getBool("OpenApoc.NewFeature.OpenApocCityControls");
+	state->skipTurboCalculations = config().getBool("OpenApoc.NewFeature.SkipTurboMovement");
 	CityTileView::resume();
 	modifierLAlt = false;
 	modifierLCtrl = false;


### PR DESCRIPTION
- improved cityscape pathfinding is implemented and seems to work
properly in all cases
- an option to skip turbo calculations is implemented and will improve
the speed at which turbo speed goes on slower machines by making craft
move immediately all the way rather than tile by tile
- craft now spends fuel and crashes when out of fuel
- craft now requires engines
- when transferring via purchase screen involving hostile org (sell on
one base buy on another), goods are now transferred instead of purchased
(which is impossible as org is hostile to you)
- cargo seized or refunded now properly goes back to economy
- proper scrollbar redraw when max/min changes