### PR TITLE
refactoring Agentassignment

### DIFF
--- a/data/forms/city/agentassignment.form
+++ b/data/forms/city/agentassignment.form
@@ -35,19 +35,19 @@
     </graphicbutton>
     <multilistbox id="AGENT_SELECT_BOX" scrollbarid="AGENT_SELECT_SCROLL">
         <position x="16" y="32"/>
-        <size width="228" height="328"/>
+        <size width="506" height="328"/>
         <item size="0" spacing="2"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
         <selcolour r="128" g="180" b="255" a="255"/>
     </multilistbox>
 
-	<multilistbox id="VEHICLE_SELECT_BOX"> <!--scrollbarid="AGENT_SELECT_SCROLL"-->
+	<!--multilistbox id="VEHICLE_SELECT_BOX">
         <position x="271" y="32"/>
         <size width="228" height="328"/>
         <item size="0" spacing="2"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
         <selcolour r="128" g="180" b="255" a="255"/>
-    </multilistbox>
+    </multilistbox-->
 
     <multilistbox id="DRAGGED_AGENT_BOX">
         <item size="0" spacing="2"/>

--- a/data/forms/city/agentassignment.form
+++ b/data/forms/city/agentassignment.form
@@ -36,21 +36,21 @@
     <multilistbox id="AGENT_SELECT_BOX" scrollbarid="AGENT_SELECT_SCROLL">
         <position x="16" y="32"/>
         <size width="228" height="328"/>
-        <item size="0" spacing="0"/>
+        <item size="0" spacing="2"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
         <selcolour r="128" g="180" b="255" a="255"/>
     </multilistbox>
 
 	<multilistbox id="VEHICLE_SELECT_BOX"> <!--scrollbarid="AGENT_SELECT_SCROLL"-->
-        <position x="291" y="32"/>
+        <position x="271" y="32"/>
         <size width="228" height="328"/>
-        <item size="0" spacing="0"/>
+        <item size="0" spacing="2"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
         <selcolour r="128" g="180" b="255" a="255"/>
     </multilistbox>
 
     <multilistbox id="DRAGGED_AGENT_BOX">
-        <item size="0" spacing="0"/>
+        <item size="0" spacing="2"/>
     </multilistbox>
     </style>
   </form>

--- a/data/forms/city/agentassignment.form
+++ b/data/forms/city/agentassignment.form
@@ -3,7 +3,7 @@
   <form id="FORM_AGENT_ASSIGNMENT">
     <style minwidth="529" minheight="373">
       <size width="529" height="373"/>
-	
+
 	<label text="This form is a temporary stub____________">
         <position x="0" y="0"/>
         <size width="529" height="373"/>
@@ -23,7 +23,7 @@
         <alignment horizontal="centre" vertical="centre"/>
         <font>smalfont</font>
     </label>
-	  
+
 	<scroll id="AGENT_SELECT_SCROLL">
         <position x="503" y="27"/>
         <size width="26" height="320"/>
@@ -45,16 +45,20 @@
         <size width="228" height="328"/>
         <item size="0" spacing="0"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
-        <selcolour r="0" g="0" b="255" a="255"/>
+        <selcolour r="128" g="180" b="255" a="255"/>
     </multilistbox>
-	  
-	<listbox id="VEHICLE_SELECT_BOX" >
+
+	<multilistbox id="VEHICLE_SELECT_BOX"> <!--scrollbarid="AGENT_SELECT_SCROLL"-->
         <position x="291" y="32"/>
-        <size width="203" height="328"/>
+        <size width="228" height="328"/>
         <item size="0" spacing="0"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
-        <selcolour r="0" g="255" b="0" a="255"/>
-    </listbox>
+        <selcolour r="128" g="180" b="255" a="255"/>
+    </multilistbox>
+
+    <multilistbox id="DRAGGED_AGENT_BOX">
+        <item size="0" spacing="0"/>
+    </multilistbox>
     </style>
   </form>
 </openapoc>

--- a/data/forms/city/agentassignment.form
+++ b/data/forms/city/agentassignment.form
@@ -4,13 +4,6 @@
     <style minwidth="529" minheight="373">
       <size width="529" height="373"/>
 
-	<label text="This form is a temporary stub____________">
-        <position x="0" y="0"/>
-        <size width="529" height="373"/>
-        <alignment horizontal="right" vertical="bottom"/>
-        <font>smalfont</font>
-    </label>
-
 	<label text="Unassigned Agents">
         <position x="45" y="3"/>
         <size width="167" height="15"/>

--- a/data/forms/city/agentassignment.form
+++ b/data/forms/city/agentassignment.form
@@ -28,13 +28,6 @@
         <position x="503" y="27"/>
         <size width="26" height="320"/>
     </scroll>
-    <listbox id="AGENT_SELECT_BOX" scrollbarid="AGENT_SELECT_SCROLL">
-        <position x="16" y="32"/>
-        <size width="228" height="328"/>
-        <item size="0" spacing="0"/>
-        <hovercolour r="255" g="255" b="255" a="255"/>
-        <selcolour r="0" g="255" b="0" a="255"/>
-    </listbox>
     <graphicbutton id="AGENT_SCROLL_UP" scrollprev="AGENT_SELECT_SCROLL">
         <position x="505" y="3"/>
         <size width="22" height="21"/>
@@ -47,6 +40,13 @@
         <image/>
         <imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
     </graphicbutton>
+    <multilistbox id="AGENT_SELECT_BOX" scrollbarid="AGENT_SELECT_SCROLL">
+        <position x="16" y="32"/>
+        <size width="228" height="328"/>
+        <item size="0" spacing="0"/>
+        <hovercolour r="255" g="255" b="255" a="255"/>
+        <selcolour r="0" g="0" b="255" a="255"/>
+    </multilistbox>
 	  
 	<listbox id="VEHICLE_SELECT_BOX" >
         <position x="291" y="32"/>

--- a/forms/CMakeLists.txt
+++ b/forms/CMakeLists.txt
@@ -17,6 +17,7 @@ set (FORMS_SOURCE_FILES
 	graphic.cpp
 	label.cpp
 	listbox.cpp
+	multilistbox.cpp
 	radiobutton.cpp
 	scrollbar.cpp
 	textbutton.cpp
@@ -36,6 +37,7 @@ set (FORMS_HEADER_FILES
 	graphic.h
 	label.h
 	listbox.h
+	multilistbox.h
 	radiobutton.h
 	scrollbar.h
 	textbutton.h

--- a/forms/checkbox.cpp
+++ b/forms/checkbox.cpp
@@ -56,6 +56,8 @@ void CheckBox::eventOccured(Event *e)
 
 void CheckBox::onRender()
 {
+	Control::onRender();
+
 	sp<Image> useimage;
 
 	useimage = (Checked ? imagechecked : imageunchecked);

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -19,7 +19,7 @@ Control::Control(bool takesFocus)
     : mouseInside(false), mouseDepressed(false), resolvedLocation(0, 0), Visible(true),
       Name("Control"), Location(0, 0), Size(0, 0), SelectionSize(0, 0),
       BackgroundColour(0, 0, 0, 0), takesFocus(takesFocus), showBounds(false), Enabled(true),
-      canCopy(true)
+      canCopy(true), funcUpdate(nullptr)
 {
 }
 
@@ -343,6 +343,11 @@ void Control::postRender()
 
 void Control::update()
 {
+	if (funcUpdate)
+	{
+		funcUpdate(shared_from_this());
+	}
+
 	for (auto ctrlidx = Controls.begin(); ctrlidx != Controls.end(); ctrlidx++)
 	{
 		auto c = *ctrlidx;
@@ -689,6 +694,22 @@ sp<Control> Control::findControl(UString ID) const
 			return childControl;
 	}
 	return nullptr;
+}
+
+bool Control::replaceChildByName(sp<Control> ctrl)
+{
+	for (auto it = Controls.begin(); it != Controls.end(); ++it)
+	{
+		if ((*it)->Name == ctrl->Name)
+		{
+			Controls.erase(it);
+			ctrl->setParent(shared_from_this());
+			setDirty();
+			return true;
+		}
+	}
+
+	return false;
 }
 
 sp<Control> Control::getParent() const { return owningControl.lock(); }
@@ -1044,7 +1065,5 @@ void Control::setVisible(bool value)
 		this->setDirty();
 	}
 }
-
-bool Control::isVisible() const { return this->Visible; }
 
 }; // namespace OpenApoc

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -17,8 +17,9 @@ namespace OpenApoc
 
 Control::Control(bool takesFocus)
     : mouseInside(false), mouseDepressed(false), resolvedLocation(0, 0), Visible(true),
-      Name("Control"), Location(0, 0), Size(0, 0), SelectionSize(0, 0), BackgroundColour(0, 0, 0, 0),
-      takesFocus(takesFocus), showBounds(false), Enabled(true), canCopy(true)
+      Name("Control"), Location(0, 0), Size(0, 0), SelectionSize(0, 0),
+      BackgroundColour(0, 0, 0, 0), takesFocus(takesFocus), showBounds(false), Enabled(true),
+      canCopy(true)
 {
 }
 
@@ -68,10 +69,11 @@ void Control::resolveLocation()
 
 bool Control::isPointInsideControlBounds(int x, int y) const
 {
-	const Vec2<int>& Size = (SelectionSize.x == 0 || SelectionSize.y == 0) ? this->Size : SelectionSize;
+	const Vec2<int> &Size =
+	    (SelectionSize.x == 0 || SelectionSize.y == 0) ? this->Size : SelectionSize;
 
-	return x >= resolvedLocation.x && x < resolvedLocation.x + Size.x &&
-		   y >= resolvedLocation.y && y < resolvedLocation.y + Size.y;
+	return x >= resolvedLocation.x && x < resolvedLocation.x + Size.x && y >= resolvedLocation.y &&
+	       y < resolvedLocation.y + Size.y;
 }
 
 bool Control::isPointInsideControlBounds(Event *e, sp<Control> c) const
@@ -81,12 +83,13 @@ bool Control::isPointInsideControlBounds(Event *e, sp<Control> c) const
 		return false;
 	}
 
-	const Vec2<int>& Size = (c->SelectionSize.x == 0 || c->SelectionSize.y == 0) ? c->Size : c->SelectionSize;
+	const Vec2<int> &Size =
+	    (c->SelectionSize.x == 0 || c->SelectionSize.y == 0) ? c->Size : c->SelectionSize;
 	int eventX = e->forms().MouseInfo.X + e->forms().RaisedBy->resolvedLocation.x;
 	int eventY = e->forms().MouseInfo.Y + e->forms().RaisedBy->resolvedLocation.y;
 
 	return eventX >= c->resolvedLocation.x && eventX < c->resolvedLocation.x + Size.x &&
-		   eventY >= c->resolvedLocation.y && eventY < c->resolvedLocation.y + Size.y;
+	       eventY >= c->resolvedLocation.y && eventY < c->resolvedLocation.y + Size.y;
 }
 
 void Control::eventOccured(Event *e)
@@ -320,10 +323,7 @@ void Control::preRender()
 	// Any operations other than graphical.
 }
 
-void Control::onRender()
-{
-	fw().renderer->clear(BackgroundColour);
-}
+void Control::onRender() { fw().renderer->clear(BackgroundColour); }
 
 void Control::postRender()
 {
@@ -870,6 +870,7 @@ void Control::copyControlData(sp<Control> CopyOf)
 	CopyOf->Name = this->Name;
 	CopyOf->Location = this->Location;
 	CopyOf->Size = this->Size;
+	CopyOf->SelectionSize = this->SelectionSize;
 	CopyOf->BackgroundColour = this->BackgroundColour;
 	CopyOf->takesFocus = this->takesFocus;
 	CopyOf->showBounds = this->showBounds;

--- a/forms/control.h
+++ b/forms/control.h
@@ -35,6 +35,9 @@ class Control : public std::enable_shared_from_this<Control>
 
 	// Configures children of element after it was configured, see ConfigureFromXML
 	void configureChildrenFromXml(pugi::xml_node *parent);
+	// The function will be called during update of the control.
+	// arg - this control
+	std::function<void(sp<Control>)> funcUpdate;
 
 	bool dirty = true;
 
@@ -66,7 +69,6 @@ class Control : public std::enable_shared_from_this<Control>
 
 	void triggerEventCallbacks(FormsEvent *e);
 
-	void setDirty();
 	bool isDirty() const { return dirty; }
 
 	bool Visible;
@@ -102,9 +104,11 @@ class Control : public std::enable_shared_from_this<Control>
 
 	sp<Control> operator[](int Index) const;
 	sp<Control> findControl(UString ID) const;
+	bool replaceChildByName(sp<Control> ctrl);
 
+	void setDirty();
 	void setVisible(bool value);
-	bool isVisible() const;
+	bool isVisible() const { return Visible; };
 
 	template <typename T> sp<T> findControlTyped(const UString &name) const
 	{
@@ -160,6 +164,8 @@ class Control : public std::enable_shared_from_this<Control>
 
 	// Simulate mouse click on control
 	virtual bool click();
+	// Setter for funcUpdate
+	void setFuncUpdate(std::function<void(sp<Control>)> func) { funcUpdate = func; }
 };
 
 }; // namespace OpenApoc

--- a/forms/control.h
+++ b/forms/control.h
@@ -52,7 +52,8 @@ class Control : public std::enable_shared_from_this<Control>
 	virtual bool isFocused() const;
 
 	void resolveLocation();
-	bool isPointInsideControlBounds(int x, int y);
+	bool isPointInsideControlBounds(int x, int y) const;
+	bool isPointInsideControlBounds(Event * e, sp<Control> c) const;
 
 	// Loads control and all subcontrols from xml
 	void configureFromXml(pugi::xml_node *node);
@@ -66,13 +67,18 @@ class Control : public std::enable_shared_from_this<Control>
 	void triggerEventCallbacks(FormsEvent *e);
 
 	void setDirty();
+	bool isDirty() const { return dirty; }
 
 	bool Visible;
 
-  public:
+public:
 	UString Name;
+	// Relative location.
 	Vec2<int> Location;
+	// Size of the control.
 	Vec2<int> Size;
+	// Which area size will be selected.
+	Vec2<int> SelectionSize;
 	Colour BackgroundColour;
 	bool takesFocus;
 	bool showBounds;

--- a/forms/control.h
+++ b/forms/control.h
@@ -56,7 +56,6 @@ class Control : public std::enable_shared_from_this<Control>
 
 	void resolveLocation();
 	bool isPointInsideControlBounds(int x, int y) const;
-	bool isPointInsideControlBounds(Event *e, sp<Control> c) const;
 
 	// Loads control and all subcontrols from xml
 	void configureFromXml(pugi::xml_node *node);
@@ -152,6 +151,7 @@ class Control : public std::enable_shared_from_this<Control>
 	void setData(sp<void> Data) { data = Data; }
 
 	bool eventIsWithin(const Event *e) const;
+	bool isPointInsideControlBounds(Event *e, sp<Control> c) const;
 
 	template <typename T, typename... Args> sp<T> createChild(Args &&... args)
 	{

--- a/forms/control.h
+++ b/forms/control.h
@@ -35,9 +35,9 @@ class Control : public std::enable_shared_from_this<Control>
 
 	// Configures children of element after it was configured, see ConfigureFromXML
 	void configureChildrenFromXml(pugi::xml_node *parent);
-	// The function will be called during update of the control.
+	// The function will be called during pre-rendering of the control.
 	// arg - this control
-	std::function<void(sp<Control>)> funcUpdate;
+	std::function<void(sp<Control>)> funcPreRender;
 
 	bool dirty = true;
 
@@ -48,7 +48,6 @@ class Control : public std::enable_shared_from_this<Control>
 	bool mouseDepressed;
 	Vec2<int> resolvedLocation;
 
-	virtual void preRender();
 	virtual void postRender();
 	virtual void onRender();
 
@@ -97,6 +96,8 @@ class Control : public std::enable_shared_from_this<Control>
 	virtual ~Control();
 
 	virtual void eventOccured(Event *e);
+	// Used if controls require computations before rendering.
+	void preRender();
 	void render();
 	virtual void update();
 	virtual void unloadResources();
@@ -164,8 +165,8 @@ class Control : public std::enable_shared_from_this<Control>
 
 	// Simulate mouse click on control
 	virtual bool click();
-	// Setter for funcUpdate
-	void setFuncUpdate(std::function<void(sp<Control>)> func) { funcUpdate = func; }
+	// Setter for funcPreRender
+	void setFuncPreRender(std::function<void(sp<Control>)> func) { funcPreRender = func; }
 };
 
 }; // namespace OpenApoc

--- a/forms/control.h
+++ b/forms/control.h
@@ -53,7 +53,7 @@ class Control : public std::enable_shared_from_this<Control>
 
 	void resolveLocation();
 	bool isPointInsideControlBounds(int x, int y) const;
-	bool isPointInsideControlBounds(Event * e, sp<Control> c) const;
+	bool isPointInsideControlBounds(Event *e, sp<Control> c) const;
 
 	// Loads control and all subcontrols from xml
 	void configureFromXml(pugi::xml_node *node);
@@ -71,7 +71,7 @@ class Control : public std::enable_shared_from_this<Control>
 
 	bool Visible;
 
-public:
+  public:
 	UString Name;
 	// Relative location.
 	Vec2<int> Location;

--- a/forms/form.cpp
+++ b/forms/form.cpp
@@ -33,7 +33,7 @@ void Form::readFormStyle(pugi::xml_node *node)
 
 void Form::eventOccured(Event *e) { Control::eventOccured(e); }
 
-void Form::onRender() {}
+void Form::onRender() { Control::onRender(); }
 
 void Form::update()
 {

--- a/forms/forms.h
+++ b/forms/forms.h
@@ -8,6 +8,7 @@
 #include "forms/graphicbutton.h"
 #include "forms/label.h"
 #include "forms/listbox.h"
+#include "forms/multilistbox.h"
 #include "forms/radiobutton.h"
 #include "forms/scrollbar.h"
 #include "forms/textbutton.h"

--- a/forms/forms.vcxproj
+++ b/forms/forms.vcxproj
@@ -26,6 +26,7 @@
     <ClCompile Include="graphicbutton.cpp" />
     <ClCompile Include="label.cpp" />
     <ClCompile Include="listbox.cpp" />
+    <ClCompile Include="multilistbox.cpp" />
     <ClCompile Include="radiobutton.cpp" />
     <ClCompile Include="scrollbar.cpp" />
     <ClCompile Include="textbutton.cpp" />
@@ -44,6 +45,7 @@
     <ClInclude Include="graphicbutton.h" />
     <ClInclude Include="label.h" />
     <ClInclude Include="listbox.h" />
+    <ClInclude Include="multilistbox.h" />
     <ClInclude Include="radiobutton.h" />
     <ClInclude Include="scrollbar.h" />
     <ClInclude Include="textbutton.h" />

--- a/forms/forms.vcxproj.filters
+++ b/forms/forms.vcxproj.filters
@@ -15,6 +15,7 @@
     <ClCompile Include="textedit.cpp" />
     <ClCompile Include="ticker.cpp" />
     <ClCompile Include="tristatebox.cpp" />
+    <ClCompile Include="multilistbox.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="checkbox.h" />
@@ -33,6 +34,7 @@
     <ClInclude Include="ticker.h" />
     <ClInclude Include="tristatebox.h" />
     <ClInclude Include="ui.h" />
+    <ClInclude Include="multilistbox.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/forms/graphic.cpp
+++ b/forms/graphic.cpp
@@ -22,6 +22,8 @@ void Graphic::eventOccured(Event *e) { Control::eventOccured(e); }
 
 void Graphic::onRender()
 {
+	Control::onRender();
+
 	if (!image)
 	{
 		return;

--- a/forms/graphicbutton.cpp
+++ b/forms/graphicbutton.cpp
@@ -66,6 +66,8 @@ void GraphicButton::eventOccured(Event *e)
 
 void GraphicButton::onRender()
 {
+	Control::onRender();
+
 	sp<Image> useimage;
 
 	if (image)

--- a/forms/label.cpp
+++ b/forms/label.cpp
@@ -27,6 +27,8 @@ void Label::eventOccured(Event *e) { Control::eventOccured(e); }
 
 void Label::onRender()
 {
+	Control::onRender();
+
 	int xpos;
 	int ypos;
 	std::list<UString> lines = font->wordWrapText(text, Size.x);

--- a/forms/multilistbox.h
+++ b/forms/multilistbox.h
@@ -46,7 +46,6 @@ class MultilistBox : public Control
 	std::function<void(sp<Control>)> funcSelectionItemRender;
 
   protected:
-	void preRender() override;
 	void onRender() override;
 	void postRender() override;
 

--- a/forms/multilistbox.h
+++ b/forms/multilistbox.h
@@ -36,7 +36,8 @@ class MultilistBox : public Control
 	// Additional operations during the selection action.
 	// arg1 - child control
 	// arg2 - selection (true) or deselection (false) operation
-	std::function<void(sp<Control>, bool)> funcHandleSelection;
+	// return - item should be selected (true/false)
+	std::function<bool(Event *, sp<Control>, bool)> funcHandleSelection;
 	// Render the "hover" effect.
 	// arg - child control
 	std::function<void(sp<Control>)> funcHoverItemRender;
@@ -74,7 +75,7 @@ class MultilistBox : public Control
 	// Setter for the isVisibleItem function.
 	void setFuncIsVisibleItem(std::function<bool(sp<Control>)> func);
 	// Setter for the funcHandleSelection function.
-	void setFuncHandleSelection(std::function<void(sp<Control>, bool)> func);
+	void setFuncHandleSelection(std::function<bool(Event *, sp<Control>, bool)> func);
 	// Setter for the funcHoverItemRender function.
 	void setFuncHoverItemRender(std::function<void(sp<Control>)> func);
 	// Setter for the funcSelectionItemRender function.

--- a/forms/multilistbox.h
+++ b/forms/multilistbox.h
@@ -1,0 +1,90 @@
+#pragma once
+#include "listbox.h"
+
+namespace OpenApoc
+{
+
+class MultilistBox : public Control
+{
+public:
+	MultilistBox();
+	MultilistBox(sp<ScrollBar> ExternalScrollBar);
+	~MultilistBox() override;
+
+private:
+	sp<Control> hovered;
+	std::vector<sp<Control>> selected;
+	Vec2<int> scrollOffset = { 0, 0 };
+	
+protected:
+	void preRender() override;
+	void onRender() override;
+	void postRender() override;
+
+public:
+	//
+	sp<ScrollBar> scroller;
+	int ItemSize, ItemSpacing;
+	Orientation ListOrientation, ScrollOrientation;
+	Colour HoverColour, SelectedColour;
+	// Image to use instead of frame for hover
+	sp<Image> HoverImage;
+	// Image to use instead of frame for selection
+	sp<Image> SelectedImage;
+	bool AlwaysEmitSelectionEvents;
+
+
+	void eventOccured(Event *e) override;
+	void update() override;
+	void unloadResources() override;
+
+	void setSelected(sp<Control> c);
+	std::vector<sp<Control>> getSelectedItems();
+	sp<Control> getHoveredItem();
+
+	void clear();
+	void addItem(sp<Control> Item);
+	void replaceItem(sp<Control> Item);
+	sp<Control> removeItem(sp<Control> Item);
+	sp<Control> removeItem(int Index);
+	sp<Control> operator[](int Index);
+
+	sp<Control> copyTo(sp<Control> CopyParent) override;
+	void configureSelfFromXml(pugi::xml_node *node) override;
+
+	template <typename T> sp<T> getHoveredData() const
+	{
+		if (hovered != nullptr)
+		{
+			return hovered->getData<T>();
+		}
+		return nullptr;
+	}
+
+	template <typename T> sp<T> getSelectedData() const
+	{
+		if (selected != nullptr)
+		{
+			return selected->getData<T>();
+		}
+		return nullptr;
+	}
+
+	template <typename T> sp<Control> removeByData(const sp<T> data)
+	{
+		this->setDirty();
+		sp<Control> Item;
+		for (auto i = Controls.begin(); i != Controls.end(); i++)
+		{
+			if ((*i)->getData<T>() == data)
+			{
+				Item = *i;
+				break;
+			}
+		}
+		return removeItem(Item);
+	}
+};
+
+}
+

--- a/forms/multilistbox.h
+++ b/forms/multilistbox.h
@@ -20,11 +20,29 @@ class MultilistBox : public Control
 	~MultilistBox() override;
 
   private:
-	sp<Control> hovered;
-	sp<Control> selected;
+	// Hovered Item.
+	sp<Control> hoveredItem;
+	// Selected Item during selection action.
+	sp<Control> selectedItem;
+	// The set of selected Controls.
 	std::set<sp<Control>> selectedSet;
 	Vec2<int> scrollOffset = {0, 0};
-	bool selection;
+	// Execution of selection action.
+	bool selectionAction;
+	// Strategy func which implements the decision about visibility/invisibility of certain Item.
+	// arg - child control
+	// TODO: move to the Control class
+	std::function<bool(sp<Control>)> isVisibleItem;
+	// Additional operations during the selection action.
+	// arg1 - child control
+	// arg2 - selection (true) or deselection (false) operation
+	std::function<void(sp<Control>, bool)> funcHandleSelection;
+	// Render the "hover" effect.
+	// arg - child control
+	std::function<void(sp<Control>)> funcHoverItemRender;
+	// Render the "selection" effect.
+	// arg - child control
+	std::function<void(sp<Control>)> funcSelectionItemRender;
 
   protected:
 	void preRender() override;
@@ -36,10 +54,6 @@ class MultilistBox : public Control
 	int ItemSize, ItemSpacing;
 	Orientation ListOrientation, ScrollOrientation;
 	Colour HoverColour, SelectedColour;
-	// Image to use instead of frame for hover
-	sp<Image> HoverImage;
-	// Image to use instead of frame for selection
-	sp<Image> SelectedImage;
 
 	void eventOccured(Event *e) override;
 	void update() override;
@@ -47,9 +61,24 @@ class MultilistBox : public Control
 
 	// Set selection status for Item.
 	void setSelected(sp<Control> Item, bool select);
-	// Get controls that have been selected.
+	// Select all items.
+	void selectAll();
+	// Deselect all selected items.
+	void clearSelection();
+	// Get vector of controls (whith preservation of order) that have been selected.
 	std::vector<sp<Control>> getSelectedItems() const;
-	sp<Control> getHoveredItem();
+	// Get set of controls that have been selected.
+	std::set<sp<Control>> &getSelectedSet() { return selectedSet; }
+	// Get hovered control.
+	sp<Control> getHoveredItem() const { return hoveredItem; }
+	// Setter for the isVisibleItem function.
+	void setFuncIsVisibleItem(std::function<bool(sp<Control>)> func);
+	// Setter for the funcHandleSelection function.
+	void setFuncHandleSelection(std::function<void(sp<Control>, bool)> func);
+	// Setter for the funcHoverItemRender function.
+	void setFuncHoverItemRender(std::function<void(sp<Control>)> func);
+	// Setter for the funcSelectionItemRender function.
+	void setFuncSelectionItemRender(std::function<void(sp<Control>)> func);
 
 	void clear();
 	void addItem(sp<Control> Item);
@@ -63,21 +92,12 @@ class MultilistBox : public Control
 
 	template <typename T> sp<T> getHoveredData() const
 	{
-		if (hovered != nullptr)
+		if (hoveredItem != nullptr)
 		{
-			return hovered->getData<T>();
+			return hoveredItem->getData<T>();
 		}
 		return nullptr;
 	}
-
-	// template <typename T> sp<T> getSelectedData() const
-	//{
-	//	if (selected != nullptr)
-	//	{
-	//		return selected->getData<T>();
-	//	}
-	//	return nullptr;
-	//}
 
 	template <typename T> sp<Control> removeByData(const sp<T> data)
 	{

--- a/forms/multilistbox.h
+++ b/forms/multilistbox.h
@@ -1,28 +1,37 @@
 #pragma once
-#include "listbox.h"
+#include "forms/control.h"
+#include "forms/forms_enums.h"
+#include "library/colour.h"
+#include "library/sp.h"
+
+#include <set>
 
 namespace OpenApoc
 {
 
+class ScrollBar;
+class Image;
+
 class MultilistBox : public Control
 {
-public:
+  public:
 	MultilistBox();
 	MultilistBox(sp<ScrollBar> ExternalScrollBar);
 	~MultilistBox() override;
 
-private:
+  private:
 	sp<Control> hovered;
-	std::vector<sp<Control>> selected;
-	Vec2<int> scrollOffset = { 0, 0 };
-	
-protected:
+	sp<Control> selected;
+	std::set<sp<Control>> selectedSet;
+	Vec2<int> scrollOffset = {0, 0};
+	bool selection;
+
+  protected:
 	void preRender() override;
 	void onRender() override;
 	void postRender() override;
 
-public:
-	//
+  public:
 	sp<ScrollBar> scroller;
 	int ItemSize, ItemSpacing;
 	Orientation ListOrientation, ScrollOrientation;
@@ -31,15 +40,15 @@ public:
 	sp<Image> HoverImage;
 	// Image to use instead of frame for selection
 	sp<Image> SelectedImage;
-	bool AlwaysEmitSelectionEvents;
-
 
 	void eventOccured(Event *e) override;
 	void update() override;
 	void unloadResources() override;
 
-	void setSelected(sp<Control> c);
-	std::vector<sp<Control>> getSelectedItems();
+	// Set selection status for Item.
+	void setSelected(sp<Control> Item, bool select);
+	// Get controls that have been selected.
+	std::vector<sp<Control>> getSelectedItems() const;
 	sp<Control> getHoveredItem();
 
 	void clear();
@@ -61,14 +70,14 @@ public:
 		return nullptr;
 	}
 
-	template <typename T> sp<T> getSelectedData() const
-	{
-		if (selected != nullptr)
-		{
-			return selected->getData<T>();
-		}
-		return nullptr;
-	}
+	// template <typename T> sp<T> getSelectedData() const
+	//{
+	//	if (selected != nullptr)
+	//	{
+	//		return selected->getData<T>();
+	//	}
+	//	return nullptr;
+	//}
 
 	template <typename T> sp<Control> removeByData(const sp<T> data)
 	{
@@ -85,6 +94,4 @@ public:
 		return removeItem(Item);
 	}
 };
-
 }
-

--- a/forms/scrollbar.cpp
+++ b/forms/scrollbar.cpp
@@ -132,6 +132,8 @@ void ScrollBar::eventOccured(Event *e)
 
 void ScrollBar::onRender()
 {
+	Control::onRender();
+
 	// LoadResources();
 	if (Minimum == Maximum)
 		return;

--- a/forms/textbutton.cpp
+++ b/forms/textbutton.cpp
@@ -45,6 +45,8 @@ void TextButton::eventOccured(Event *e)
 
 void TextButton::onRender()
 {
+	Control::onRender();
+
 	if (label->getParent() == nullptr)
 	{
 		label->setParent(shared_from_this());

--- a/forms/textedit.cpp
+++ b/forms/textedit.cpp
@@ -160,6 +160,8 @@ void TextEdit::eventOccured(Event *e)
 
 void TextEdit::onRender()
 {
+	Control::onRender();
+
 	int xpos = align(TextHAlign, Size.x, font->getFontWidth(text));
 	int ypos = align(TextVAlign, Size.y, font->getFontHeight());
 

--- a/forms/ticker.cpp
+++ b/forms/ticker.cpp
@@ -26,6 +26,8 @@ void Ticker::eventOccured(Event *e) { Control::eventOccured(e); }
 
 void Ticker::onRender()
 {
+	Control::onRender();
+
 	int xpos;
 	int ypos;
 	if (!animating)

--- a/forms/tristatebox.cpp
+++ b/forms/tristatebox.cpp
@@ -55,6 +55,8 @@ void TriStateBox::eventOccured(Event *e)
 
 void TriStateBox::onRender()
 {
+	Control::onRender();
+
 	sp<Image> useimage;
 
 	switch (State)

--- a/game/OpenApoc.vcxproj.user
+++ b/game/OpenApoc.vcxproj.user
@@ -21,6 +21,6 @@
     <LocalDebuggerCommandArguments>--Game.SkipIntro=true</LocalDebuggerCommandArguments>
   </PropertyGroup>
   <PropertyGroup>
-    <ShowAllFiles>true</ShowAllFiles>
+    <ShowAllFiles>false</ShowAllFiles>
   </PropertyGroup>
 </Project>

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -2736,6 +2736,8 @@ int TransactionScreen::TransactionControl::getPriceDelta() const
 
 void TransactionScreen::TransactionControl::onRender()
 {
+	Control::onRender();
+
 	static Vec2<int> bgLeftPos = {0, 2};
 	static Vec2<int> bgRightPos = {172, 2};
 	static Vec2<int> ammoPos = {4, 2};

--- a/game/ui/city/alertscreen.cpp
+++ b/game/ui/city/alertscreen.cpp
@@ -121,6 +121,7 @@ void AlertScreen::update() { menuform->update(); }
 void AlertScreen::render()
 {
 	fw().stageGetPrevious(this->shared_from_this())->render();
+	menuform->preRender();
 	menuform->render();
 }
 

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -254,6 +254,7 @@ void BuildingScreen::update() { menuform->update(); }
 void BuildingScreen::render()
 {
 	fw().stageGetPrevious(this->shared_from_this())->render();
+	menuform->preRender();
 	menuform->render();
 }
 

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -112,25 +112,14 @@ void BuildingScreen::eventOccurred(Event *e)
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}
-			// FIXME: Implement selecting agents that will do the mission
-			LogWarning("Implement selecting agents that will do the mission");
-			std::list<StateRef<Agent>> agents;
+
+			std::list<StateRef<Agent>> agents(agentAssignment->getSelectedAgents());
 			StateRef<Vehicle> vehicle;
 			if (agentAssignment->currentVehicle)
 			{
 				vehicle = {state.get(), Vehicle::getId(*state, agentAssignment->currentVehicle)};
-				for (auto &a : agentAssignment->currentVehicle->currentAgents)
-				{
-					agents.push_back(a);
-				}
 			}
-			else
-			{
-				for (auto &a : agentAssignment->agents)
-				{
-					agents.emplace_back(state.get(), a);
-				}
-			}
+
 			if (agents.empty())
 			{
 				fw().stageQueueCommand(

--- a/game/ui/components/agentassignment.cpp
+++ b/game/ui/components/agentassignment.cpp
@@ -5,6 +5,7 @@
 #include "forms/graphic.h"
 #include "forms/label.h"
 #include "forms/listbox.h"
+#include "forms/multilistbox.h"
 #include "forms/ui.h"
 #include "framework/data.h"
 #include "framework/event.h"
@@ -15,6 +16,7 @@
 #include "game/state/city/vehicle.h"
 #include "game/state/gamestate.h"
 #include "game/state/shared/agent.h"
+#include "game/state/shared/organisation.h"
 #include "game/ui/components/controlgenerator.h"
 #include <cmath>
 
@@ -29,43 +31,43 @@ void AgentAssignment::init(sp<Form> form, Vec2<int> location, Vec2<int> size)
 	Location = location;
 	Size = size;
 
-	auto agentList = findControlTyped<ListBox>("AGENT_SELECT_BOX");
-	agentList->addCallback(FormEventType::ListBoxChangeSelected, [this](FormsEvent *e) {
-		auto list = std::static_pointer_cast<ListBox>(e->forms().RaisedBy);
-		auto agent = list->getSelectedData<Agent>();
-		if (!agent)
-		{
-			LogError("No agent in selected data");
-			return;
-		}
-		this->currentAgent = agent;
-		if (currentVehicle)
-		{
-			if (currentAgent->currentVehicle != currentVehicle &&
-			    (currentAgent->currentBuilding == currentVehicle->currentBuilding ||
-			     currentAgent->currentVehicle->currentBuilding ==
-			         currentVehicle->currentBuilding) &&
-			    currentVehicle->getMaxPassengers() > currentVehicle->getPassengers())
-			{
-				auto oldVehicle = currentAgent->currentVehicle;
-				currentAgent->enterVehicle(*this->state, {this->state.get(), currentVehicle});
-				updateControl(currentAgent);
-				updateControl(currentVehicle);
-				if (oldVehicle)
-				{
-					updateControl(oldVehicle);
-				}
-			}
-		}
-		else if (currentAgent->currentVehicle && currentAgent->currentVehicle->currentBuilding)
-		{
-			auto oldVehicle = currentAgent->currentVehicle;
-			currentAgent->enterBuilding(*this->state,
-			                            currentAgent->currentVehicle->currentBuilding);
-			updateControl(currentAgent);
-			updateControl(oldVehicle);
-		}
-	});
+	//auto agentList = findControlTyped<MultilistBox>("AGENT_SELECT_BOX");
+	//agentList->addCallback(FormEventType::ListBoxChangeSelected, [this](FormsEvent *e) {
+	//	auto list = std::static_pointer_cast<ListBox>(e->forms().RaisedBy);
+	//	auto agent = list->getSelectedData<Agent>();
+	//	if (!agent)
+	//	{
+	//		LogError("No agent in selected data");
+	//		return;
+	//	}
+	//	this->currentAgent = agent;
+	//	if (currentVehicle)
+	//	{
+	//		if (currentAgent->currentVehicle != currentVehicle &&
+	//		    (currentAgent->currentBuilding == currentVehicle->currentBuilding ||
+	//		     currentAgent->currentVehicle->currentBuilding ==
+	//		         currentVehicle->currentBuilding) &&
+	//		    currentVehicle->getMaxPassengers() > currentVehicle->getPassengers())
+	//		{
+	//			auto oldVehicle = currentAgent->currentVehicle;
+	//			currentAgent->enterVehicle(*this->state, {this->state.get(), currentVehicle});
+	//			updateControl(currentAgent);
+	//			updateControl(currentVehicle);
+	//			if (oldVehicle)
+	//			{
+	//				updateControl(oldVehicle);
+	//			}
+	//		}
+	//	}
+	//	else if (currentAgent->currentVehicle && currentAgent->currentVehicle->currentBuilding)
+	//	{
+	//		auto oldVehicle = currentAgent->currentVehicle;
+	//		currentAgent->enterBuilding(*this->state,
+	//		                            currentAgent->currentVehicle->currentBuilding);
+	//		updateControl(currentAgent);
+	//		updateControl(oldVehicle);
+	//	}
+	//});
 	auto vehicleList = findControlTyped<ListBox>("VEHICLE_SELECT_BOX");
 	vehicleList->addCallback(FormEventType::ListBoxChangeSelected, [this](FormsEvent *e) {
 		auto list = std::static_pointer_cast<ListBox>(e->forms().RaisedBy);
@@ -194,20 +196,57 @@ void AgentAssignment::updateLocation()
 		}
 	}
 
-	auto agentList = findControlTyped<ListBox>("AGENT_SELECT_BOX");
-	agentList->clear();
-	agentList->AlwaysEmitSelectionEvents = true;
+	auto baseList = findControlTyped<MultilistBox>("AGENT_SELECT_BOX");
+	//baseList->SelectionSize = { 10, 10 };
+	baseList->clear();
+	//agentList->AlwaysEmitSelectionEvents = true;
 	auto owner = state->getPlayer();
+	auto ownerControl1 = ControlGenerator::createOrganisationControl(*state, owner);
+	ownerControl1->SelectionSize = { 80, 24 }; //ownerControl1->Size;
+	//ownerControl1->Size = { 150, 250 };
+	auto ownerControl2 = ControlGenerator::createOrganisationControl(*state, owner);
+	ownerControl2->SelectionSize = { 80, 24 }; //ownerControl2->Size;
+	//ownerControl2->Size = { 150, 210 };
+
+	baseList->addItem(ownerControl1);
+	baseList->addItem(ownerControl2);
+
+	auto agentList = ownerControl1->createChild<MultilistBox>();
+	agentList->Name = "agentList";
+	agentList->Location = { 20, ownerControl1->Size.y };
+	agentList->HoverColour = Colour(200, 255, 255, 255);
+	agentList->addCallback(FormEventType::ListBoxChangeHover, [](FormsEvent *e) {});
+	//agentList->SelectionSize = { 100, 30 };
+
 	for (auto &agent : agents)
 	{
-		auto agentControl = ControlGenerator::createAgentControl(*state, agent);
-		agentControl->Size = {agentList->Size.x, ControlGenerator::getFontHeight(*state) * 2};
+		auto agentControl = ControlGenerator::createLargeAgentControl(*state, agent);
+		agentControl->SelectionSize = { 120, 32 };
+		//agentControl->Size = {agentList->Size.x, ControlGenerator::getFontHeight(*state) * 2};
 		agentList->addItem(agentControl);
-		if (agent == currentAgent)
-		{
-			agentList->setSelected(agentControl);
-		}
+		//if (agent == currentAgent)
+		//{
+		//	agentList->setSelected(agentControl);
+		//}
 	}
+	auto vehicleList2 = ownerControl2->createChild<MultilistBox>();
+	vehicleList2->Name = "vehicleList2";
+	vehicleList2->Location = { 20, ownerControl2->Size.y };
+	vehicleList2->HoverColour = Colour(255, 200, 255, 255);
+	//vehicleList2->SelectionSize = { 102, 30 };
+	for (auto &vehicle : vehicles)
+	{
+		auto vehicleControl = ControlGenerator::createVehicleControl(*state, vehicle);
+		vehicleControl->SelectionSize = { 122, 30 };
+		//vehicleControl->Size = { vehicleList->Size.x, ControlGenerator::getFontHeight(*state) * 2 };
+		vehicleList2->addItem(vehicleControl);
+		//if (vehicle == currentVehicle)
+		//{
+		//	vehicleList2->setSelected(vehicleControl);
+		//}
+	}
+
+
 
 	auto vehicleList = findControlTyped<ListBox>("VEHICLE_SELECT_BOX");
 	vehicleList->clear();
@@ -231,7 +270,7 @@ void AgentAssignment::updateLocation()
 
 void AgentAssignment::updateControl(sp<Agent> agent)
 {
-	auto agentList = findControlTyped<ListBox>("AGENT_SELECT_BOX");
+	auto agentList = findControlTyped<MultilistBox>("AGENT_SELECT_BOX");
 	auto agentControl = ControlGenerator::createAgentControl(*state, agent);
 	agentControl->Size = {agentList->Size.x, ControlGenerator::getFontHeight(*state) * 2};
 	agentList->replaceItem(agentControl);

--- a/game/ui/components/agentassignment.h
+++ b/game/ui/components/agentassignment.h
@@ -24,6 +24,9 @@ class AgentAssignment : public Form
 	sp<Building> building;
 	sp<GameState> state;
 
+	Colour HoverColour, SelectedColour;
+	Vec2<int> renderOffset{32, 0};
+
 	// List of dragged agents.
 	sp<MultilistBox> draggedList;
 	// The agents MultilistBox which selected agents was taken from.
@@ -37,11 +40,15 @@ class AgentAssignment : public Form
 	// Update the agent's icon
 	std::function<void(sp<Control>)> funcAgentUpdate;
 	// Select/deselect individual agent
-	std::function<void(sp<Control>, bool)> funcHandleAgentSelection;
+	std::function<bool(Event *, sp<Control>, bool)> funcHandleAgentSelection;
 	// Select/deselect agents inside vehicle
-	std::function<void(sp<Control>, bool)> funcHandleVehicleSelection;
+	std::function<bool(Event *, sp<Control>, bool)> funcHandleVehicleSelection;
 	// Select/deselect agents inside building
-	std::function<void(sp<Control>, bool)> funcHandleBuildingSelection;
+	std::function<bool(Event *, sp<Control>, bool)> funcHandleBuildingSelection;
+	// Selection render
+	std::function<void(sp<Control>)> funcSelectionItemRender;
+	// Hover render
+	std::function<void(sp<Control>)> funcHoverItemRender;
 
 	void addAgentsToList(sp<MultilistBox> list, const int listOffset);
 

--- a/game/ui/components/agentassignment.h
+++ b/game/ui/components/agentassignment.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "forms/form.h"
+#include "game/state/stateobject.h"
 #include <array>
 #include <set>
 
@@ -25,20 +26,38 @@ class AgentAssignment : public Form
 
 	// List of dragged agents.
 	sp<MultilistBox> draggedList;
-	// Cache of vehile's controls.
-	std::vector<sp<Control>> vehicleList;
-	// Cache of agent's lists.
-	std::vector<sp<MultilistBox>> agentGroupList;
 	// The agents MultilistBox which selected agents was taken from.
 	sp<MultilistBox> sourceRaisedBy;
-	// For handle the mouse's drag&drop sensibility.
-	int positionX = 0, positionY = 0;
+	// Handle the mouse's drag&drop sensibility.
+	int positionX = 0, positionY = 0, insensibility = 5 * 5;
 	// State of dragged action.
 	bool isDragged = false;
+	// Update the vehicle's icon
+	std::function<void(sp<Control>)> funcVehicleUpdate;
+	// Update the agent's icon
+	std::function<void(sp<Control>)> funcAgentUpdate;
+	// Select/deselect individual agent
+	std::function<void(sp<Control>, bool)> funcHandleAgentSelection;
+	// Select/deselect agents inside vehicle
+	std::function<void(sp<Control>, bool)> funcHandleVehicleSelection;
+	// Select/deselect agents inside building
+	std::function<void(sp<Control>, bool)> funcHandleBuildingSelection;
+
+	void addAgentsToList(sp<MultilistBox> list, const int listOffset);
+
+	void addVehiclesToList(sp<MultilistBox> list, const int listOffset);
+
+	void addBuildingsToList(sp<MultilistBox> list, const int listOffset);
 
   public:
+	static const UString LEFT_LIST_NAME;
+	static const UString RIGHT_LIST_NAME;
+	static const UString AGENT_LIST_NAME;
+	static const UString VEHICLE_LIST_NAME;
+
 	std::list<sp<Agent>> agents;
 	std::list<sp<Vehicle>> vehicles;
+	std::list<sp<Building>> buildings;
 
 	sp<Agent> currentAgent;
 	sp<Vehicle> currentVehicle;
@@ -47,14 +66,17 @@ class AgentAssignment : public Form
 
 	void init(sp<Form> form, Vec2<int> location, Vec2<int> size);
 
+	// Call when selected agent.
 	void setLocation(sp<Agent> agent);
+	// Call when selected vehicle.
 	void setLocation(sp<Vehicle> vehicle);
+	// Call when selected building.
 	void setLocation(sp<Building> building);
+	// Call when the alien incident happens.
 	void setLocation();
 	void updateLocation();
-
-	void updateControl(sp<Agent> agent);
-	void updateControl(sp<Vehicle> vehicle);
+	// Get selected agents with preservation of order.
+	std::list<StateRef<Agent>> getSelectedAgents() const;
 
 	void eventOccured(Event *e) override;
 	void update() override;

--- a/game/ui/components/agentassignment.h
+++ b/game/ui/components/agentassignment.h
@@ -43,8 +43,6 @@ class AgentAssignment : public Form
 	std::function<bool(Event *, sp<Control>, bool)> funcHandleAgentSelection;
 	// Select/deselect agents inside vehicle
 	std::function<bool(Event *, sp<Control>, bool)> funcHandleVehicleSelection;
-	// Select/deselect agents inside building
-	std::function<bool(Event *, sp<Control>, bool)> funcHandleBuildingSelection;
 	// Selection render
 	std::function<void(sp<Control>)> funcSelectionItemRender;
 	// Hover render
@@ -54,11 +52,10 @@ class AgentAssignment : public Form
 
 	void addVehiclesToList(sp<MultilistBox> list, const int listOffset);
 
-	void addBuildingsToList(sp<MultilistBox> list, const int listOffset);
+	void addBuildingToRightList(sp<Building> building, sp<MultilistBox> list, const int listOffset);
 
   public:
-	static const UString LEFT_LIST_NAME;
-	static const UString RIGHT_LIST_NAME;
+	static const UString AGENT_SELECT_BOX;
 	static const UString AGENT_LIST_NAME;
 	static const UString VEHICLE_LIST_NAME;
 
@@ -84,6 +81,8 @@ class AgentAssignment : public Form
 	void updateLocation();
 	// Get selected agents with preservation of order.
 	std::list<StateRef<Agent>> getSelectedAgents() const;
+	// Get selected vehicles with preservation of order.
+	std::list<StateRef<Vehicle>> getSelectedVehicles() const;
 
 	void eventOccured(Event *e) override;
 	void update() override;

--- a/game/ui/components/agentassignment.h
+++ b/game/ui/components/agentassignment.h
@@ -13,6 +13,7 @@ class Vehicle;
 class GameState;
 class BitmapFont;
 class Image;
+class MultilistBox;
 
 class AgentAssignment : public Form
 {
@@ -21,6 +22,19 @@ class AgentAssignment : public Form
 	sp<Vehicle> vehicle;
 	sp<Building> building;
 	sp<GameState> state;
+
+	// List of dragged agents.
+	sp<MultilistBox> draggedList;
+	// Cache of vehile's controls.
+	std::vector<sp<Control>> vehicleList;
+	// Cache of agent's lists.
+	std::vector<sp<MultilistBox>> agentGroupList;
+	// The agents MultilistBox which selected agents was taken from.
+	sp<MultilistBox> sourceRaisedBy;
+	// For handle the mouse's drag&drop sensibility.
+	int positionX = 0, positionY = 0;
+	// State of dragged action.
+	bool isDragged = false;
 
   public:
 	std::list<sp<Agent>> agents;
@@ -42,6 +56,7 @@ class AgentAssignment : public Form
 	void updateControl(sp<Agent> agent);
 	void updateControl(sp<Vehicle> vehicle);
 
+	void eventOccured(Event *e) override;
 	void update() override;
 };
 

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -219,6 +219,22 @@ sp<Control> ControlGenerator::createVehicleControl(GameState &state, sp<Vehicle>
 	return createVehicleControl(state, info);
 }
 
+sp<Control> ControlGenerator::createVehicleLargeControl(GameState &state, sp<Vehicle> v)
+{
+	const int controlLength = 140, controlHeight = 30, iconLenght = 40;
+
+	auto info = createVehicleInfo(state, v);
+
+	sp<Control> control = createVehicleControl(state, info);
+	control->Size = {controlLength, controlHeight};
+
+	auto nameLabel = control->createChild<Label>(info.vehicle->name, singleton.labelFont);
+	nameLabel->Size = {controlLength - iconLenght, singleton.labelFont->getFontHeight()};
+	nameLabel->Location = {iconLenght, (control->Size.y - nameLabel->Size.y) / 2};
+
+	return control;
+}
+
 AgentInfo ControlGenerator::createAgentInfo(GameState &state, sp<Agent> a,
                                             UnitSelectionState forcedSelectionState, bool forceFade)
 {

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -234,14 +234,14 @@ sp<Control> ControlGenerator::createVehicleControl(GameState &state, sp<Vehicle>
 
 sp<Control> ControlGenerator::createVehicleAssignmentControl(GameState &state, sp<Vehicle> vehicle)
 {
-	const int controlLength = 200, controlHeight = 30, iconLenght = 40;
+	const int controlLength = 200, controlHeight = 24, iconLenght = 40;
 
 	auto control = mksp<Control>();
 	control->Size = control->SelectionSize = {controlLength, controlHeight};
 	control->setData(vehicle);
 
 	auto icon = createVehicleIcon(state, vehicle);
-	icon->Location = {4, 3};
+	icon->Size = {iconLenght, controlHeight};
 	icon->setParent(control);
 
 	auto nameLabel = control->createChild<Label>(vehicle->name, singleton.labelFont);
@@ -282,7 +282,7 @@ sp<Control> ControlGenerator::createBuildingAssignmentControl(GameState &state,
 
 sp<Control> ControlGenerator::createAgentAssignmentControl(GameState &state, sp<Agent> agent)
 {
-	const int controlLength = 200, controlHeight = 30, iconLenght = 40;
+	const int controlLength = 200, controlHeight = 24, iconLenght = 40;
 
 	if (!singleton.initialised)
 	{
@@ -295,7 +295,7 @@ sp<Control> ControlGenerator::createAgentAssignmentControl(GameState &state, sp<
 	control->Name = "AGENT_PORTRAIT";
 
 	auto icon = createAgentIcon(state, agent, UnitSelectionState::Unselected, false);
-	icon->Location = {4, 3};
+	icon->Size = {iconLenght, controlHeight};
 	icon->setParent(control);
 
 	auto nameLabel = control->createChild<Label>(agent->name, singleton.labelFont);

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -69,6 +69,8 @@ class ControlGenerator
 	static VehicleTileInfo createVehicleInfo(GameState &state, sp<Vehicle> v);
 	static sp<Control> createVehicleControl(GameState &state, const VehicleTileInfo &info);
 	static sp<Control> createVehicleControl(GameState &state, sp<Vehicle> v);
+	// Vehicle control with name
+	static sp<Control> createVehicleLargeControl(GameState &state, sp<Vehicle> v);
 
 	static AgentInfo
 	createAgentInfo(GameState &state, sp<Agent> a,

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -69,6 +69,8 @@ class ControlGenerator
   public:
 	static const UString VEHICLE_ICON_NAME;
 	static const UString AGENT_ICON_NAME;
+	static const UString LEFT_LIST_NAME;
+	static const UString RIGHT_LIST_NAME;
 
 	// Icon of vehicle
 	static sp<Control> createVehicleIcon(GameState &state, sp<Vehicle> vehicle);
@@ -107,6 +109,8 @@ class ControlGenerator
 	                        bool forceFade = false, bool labMode = false);
 	// Create lab icon control with quantity label.
 	static sp<Control> createLabControl(sp<GameState> state, sp<Facility> facility);
+	// Control containing two MultilistBox for assignment state
+	static sp<Control> createDoubleListControl(const int controlLength);
 
 	static OrganisationInfo createOrganisationInfo(GameState &state, sp<Organisation> org);
 	static sp<Control> createOrganisationControl(GameState &state, const OrganisationInfo &info);

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -9,6 +9,7 @@ namespace OpenApoc
 
 class Vehicle;
 class Agent;
+class Building;
 class GameState;
 class VehicleTileInfo;
 class AgentInfo;
@@ -66,16 +67,32 @@ class ControlGenerator
 	std::vector<sp<Image>> purchaseControlParts;
 
   public:
+	static const UString VEHICLE_ICON_NAME;
+	static const UString AGENT_ICON_NAME;
+
+	// Icon of vehicle
+	static sp<Control> createVehicleIcon(GameState &state, sp<Vehicle> vehicle);
+
 	static VehicleTileInfo createVehicleInfo(GameState &state, sp<Vehicle> v);
 	static sp<Control> createVehicleControl(GameState &state, const VehicleTileInfo &info);
 	static sp<Control> createVehicleControl(GameState &state, sp<Vehicle> v);
 	// Vehicle control with name
-	static sp<Control> createVehicleLargeControl(GameState &state, sp<Vehicle> v);
+	static sp<Control> createVehicleAssignmentControl(GameState &state, sp<Vehicle> vehicle);
+	// Building control for assignment
+	static sp<Control> createBuildingAssignmentControl(GameState &state, sp<Building> building);
+	// Agent control for assignment state
+	static sp<Control> createAgentAssignmentControl(GameState &state, sp<Agent> agent);
+	// Icon of agent
+	static sp<Control>
+	createAgentIcon(GameState &state, sp<Agent> agent,
+	                UnitSelectionState forcedSelectionState = UnitSelectionState::NA,
+	                bool forceFade = false);
 
 	static AgentInfo
 	createAgentInfo(GameState &state, sp<Agent> a,
 	                UnitSelectionState forcedSelectionState = UnitSelectionState::NA,
 	                bool forceFade = false);
+	static CityUnitState getCityUnitState(sp<Agent> agent);
 	static void fillAgentControl(GameState &state, sp<Graphic> baseControl, const AgentInfo &info);
 	static sp<Control> createAgentControl(GameState &state, const AgentInfo &info);
 	static sp<Control>

--- a/game/ui/components/equipscreen.cpp
+++ b/game/ui/components/equipscreen.cpp
@@ -99,6 +99,8 @@ static const EquipmentLayoutSlot *getSlotAtPosition(Vec2<int> pos,
 
 void EquipmentPaperDoll::onRender()
 {
+	Control::onRender();
+
 	if (!object)
 	{
 		return;

--- a/game/ui/components/locationscreen.cpp
+++ b/game/ui/components/locationscreen.cpp
@@ -126,6 +126,7 @@ void LocationScreen::update() { menuform->update(); }
 void LocationScreen::render()
 {
 	fw().stageGetPrevious(this->shared_from_this())->render();
+	menuform->preRender();
 	menuform->render();
 }
 


### PR DESCRIPTION
UPDATED

Changes:
1. Added the MultilistBox class.
- extends the Control class.
- allow to multiselect items.
- allow to build hierarchical trees. Hierarchical "hover" and "select" can works too.
- uses strategy pattern for "hover" and "select" rendering.
- uses strategy pattern to make a decision about visible/invisible items.
- uses strategy pattern for behaviour during selection actions.
- can be use either with ScrollBar or without ScrollBar.
- works only for vertical orientation (yet).
2. Several changes in the Control class.
- added SelectionSize to the Control class. It's an area which can be hovered and selected. The old Size is the area where the Control rendered. In most cases they're the same but not for the MultilistBox.
- changed meaning of the Control::preRender(). From now this method implements any operations other than graphical. It should call before the render() method if used controls which should adjust theyself just before rendering. I.e. if controls resize because of other controls.
- uses strategy pattern for ~~Control::update()~~ Control::preRender() performing.
3. Refactored the AgentAssignment.
- added drag&drop transfering between base and vehicle lists.
- generates the selected agents list for Raid and Extermination actions.
- generates the selected vehicle list (will be used for the Alert screen);
- click on agent's icons starts the agent's equip screen;
- click on vehicle's icons starts the vehicles screen.

Disadvantages:
1. Buildings icons is not vanilla. I don't know which image resources should be used.
2. ~~The right tree without scroll bar and not syncronised with the left tree.~~
3. The "Raid" action could not be started because cannot to load some image item.

Pictures (outdated):
1. Xcom base (has been opened by the agent button)

![assignment10_base](https://user-images.githubusercontent.com/3616568/32690490-a5495206-c708-11e7-8419-a250f4d1db5d.png)

2. On the fly (has been opened by the vehicle button)

![assignment11_fly](https://user-images.githubusercontent.com/3616568/32690507-ecf275ba-c708-11e7-8165-027be57678a8.png)

3. Ready for raid (has been opened by the click on a building)

![assignment12_raid](https://user-images.githubusercontent.com/3616568/32690509-f6047162-c708-11e7-8020-bdbc789550b8.png)


Outdated pictures:
1. Multiselection

![assignment1_select](https://user-images.githubusercontent.com/3616568/32457872-91d778b8-c33b-11e7-9b26-2bb1e95ec49b.png)

2. Drag

![assignment2_move](https://user-images.githubusercontent.com/3616568/32457911-a9b6dcd0-c33b-11e7-8b58-d7f96c7ea961.png)

3. Drop

![assignment3_drop](https://user-images.githubusercontent.com/3616568/32457943-bf539b50-c33b-11e7-8a7f-4ebc3278897b.png)

4. Agents assigned to vehicle

![assignment4_hover1](https://user-images.githubusercontent.com/3616568/32457992-ea5e7ca2-c33b-11e7-944c-37f631db183a.png)

5. New selection

![assignment5_new_selection](https://user-images.githubusercontent.com/3616568/32458020-06357188-c33c-11e7-8d23-a8aec8d32381.png)

6. Drag to another vehicle

![assignment6_move2](https://user-images.githubusercontent.com/3616568/32458050-267ef2de-c33c-11e7-957a-74b881d924e5.png)

7. Drop and agents assigned to another vehicle

![assignment7_drop2](https://user-images.githubusercontent.com/3616568/32458111-577e399e-c33c-11e7-8b8c-69119798fd79.png)
