### PR TITLE
set correct initial equipment for vehicles

### DIFF
--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -662,8 +662,8 @@ sp<Doodad> City::placeDoodad(StateRef<DoodadType> type, Vec3<float> position)
 	return doodad;
 }
 
-sp<Vehicle> City::placeVehicle(GameState &state, StateRef<VehicleType> type,
-                               StateRef<Organisation> owner)
+sp<Vehicle> City::createVehicle(GameState &state, StateRef<VehicleType> type,
+                                StateRef<Organisation> owner)
 {
 	auto v = mksp<Vehicle>();
 	v->type = type;
@@ -680,8 +680,28 @@ sp<Vehicle> City::placeVehicle(GameState &state, StateRef<VehicleType> type,
 	UString vID = Vehicle::generateObjectID(state);
 	state.vehicles[vID] = v;
 
-	v->equipDefaultEquipment(state);
+	return v;
+}
+sp<Vehicle> City::createVehicle(GameState &state, StateRef<VehicleType> type,
+                                StateRef<Organisation> owner, StateRef<Building> building)
+{
+	if (building->city.id != id)
+	{
+		LogError("Adding vehicle to a building in a different city?");
+		return nullptr;
+	}
+	auto v = createVehicle(state, type, owner);
 
+	v->enterBuilding(state, building);
+
+	return v;
+}
+
+sp<Vehicle> City::placeVehicle(GameState &state, StateRef<VehicleType> type,
+                               StateRef<Organisation> owner)
+{
+	auto v = createVehicle(state, type, owner);
+	v->equipDefaultEquipment(state);
 	return v;
 }
 

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -133,6 +133,10 @@ class City : public StateObject, public std::enable_shared_from_this<City>
 	void initialSceneryLinkUp();
 
 	sp<Doodad> placeDoodad(StateRef<DoodadType> type, Vec3<float> position);
+	sp<Vehicle> createVehicle(GameState &state, StateRef<VehicleType> type,
+	                          StateRef<Organisation> owner);
+	sp<Vehicle> createVehicle(GameState &state, StateRef<VehicleType> type,
+	                          StateRef<Organisation> owner, StateRef<Building> building);
 	sp<Vehicle> placeVehicle(GameState &state, StateRef<VehicleType> type,
 	                         StateRef<Organisation> owner);
 	sp<Vehicle> placeVehicle(GameState &state, StateRef<VehicleType> type,

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -663,10 +663,11 @@ void GameState::fillPlayerStartingProperty()
 	}*/
 	for (auto &pair : this->initial_vehicles)
 	{
-		for (int i = 0; i < pair.second; i++)
+		auto v = current_city->createVehicle(*this, pair.first, this->getPlayer(), {this, bld});
+		v->homeBuilding = v->currentBuilding;
+		for (auto &eq : pair.second)
 		{
-			auto v = current_city->placeVehicle(*this, pair.first, this->getPlayer(), {this, bld});
-			v->homeBuilding = v->currentBuilding;
+			v->addEquipment(*this, eq);
 		}
 	}
 	// Give the player initial vehicle equipment

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -116,7 +116,8 @@ class GameState : public std::enable_shared_from_this<GameState>
 	std::map<AgentType::Role, unsigned> initial_agents;
 	std::map<UString, unsigned> initial_facilities;
 	std::list<std::list<StateRef<AEquipmentType>>> initial_agent_equipment;
-	std::list<std::pair<StateRef<VehicleType>, int>> initial_vehicles;
+	std::list<std::pair<StateRef<VehicleType>, std::list<StateRef<VEquipmentType>>>>
+	    initial_vehicles;
 	std::list<std::pair<StateRef<VEquipmentType>, int>> initial_vehicle_equipment;
 	std::list<std::pair<StateRef<VAmmoType>, int>> initial_vehicle_ammo;
 	std::map<UString, int> initial_base_agent_equipment;

--- a/tools/extractors/extract_vehicles.cpp
+++ b/tools/extractors/extract_vehicles.cpp
@@ -125,12 +125,33 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 {
 	// Initial stuff
 	state.initial_vehicles.emplace_back(
-	    StateRef<VehicleType>{&state, "VEHICLETYPE_VALKYRIE_INTERCEPTOR"}, 1);
-	state.initial_vehicles.emplace_back(StateRef<VehicleType>{&state, "VEHICLETYPE_STORMDOG"}, 1);
+	    StateRef<VehicleType>{&state, "VEHICLETYPE_VALKYRIE_INTERCEPTOR"},
+	    std::list<StateRef<VEquipmentType>>{
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_LANCER_7000_LASER_GUN"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_JANITOR_MISSILE_ARRAY"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_PASSENGER_MODULE"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_CARGO_MODULE"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_SD_TURBO"}});
 	state.initial_vehicles.emplace_back(
-	    StateRef<VehicleType>{&state, "VEHICLETYPE_PHOENIX_HOVERCAR"}, 2);
-	state.initial_vehicles.emplace_back(StateRef<VehicleType>{&state, "VEHICLETYPE_WOLFHOUND_APC"},
-	                                    1);
+	    StateRef<VehicleType>{&state, "VEHICLETYPE_STORMDOG"},
+	    std::list<StateRef<VEquipmentType>>{
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_AIRGUARD_ANTI-AIR_CANNON"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_METRO_ROADGRAV"}});
+	for (int i = 0; i < 2; ++i)
+	{
+		state.initial_vehicles.emplace_back(
+		    StateRef<VehicleType>{&state, "VEHICLETYPE_PHOENIX_HOVERCAR"},
+		    std::list<StateRef<VEquipmentType>>{
+		        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_BOLTER_4000_LASER_GUN"},
+		        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_JANITOR_MISSILE_ARRAY"},
+		        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_SD_SPORTS"}});
+	}
+	state.initial_vehicles.emplace_back(
+	    StateRef<VehicleType>{&state, "VEHICLETYPE_WOLFHOUND_APC"},
+	    std::list<StateRef<VEquipmentType>>{
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_CARGO_MODULE"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_GLM_ARRAY"},
+	        StateRef<VEquipmentType>{&state, "VEQUIPMENTTYPE_METRO_POWERGRAV"}});
 
 	auto &data = this->ufo2p;
 	LogInfo("Number of vehicle strings: %zu", data.vehicle_names->readStrings.size());


### PR DESCRIPTION
Now all the initial equipment for vehicles must be defined explicitly. Don't assume that the initial equipment is the same as the vehicle's default.
See issue #254