### PR TITLE
UString insert()/remove() fix

### DIFF
--- a/dependencies/libsmacker.vcxproj
+++ b/dependencies/libsmacker.vcxproj
@@ -152,6 +152,7 @@
       <PreprocessorDefinitions>WIN32;_CRT_SECURE_NO_WARNINGS;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/dependencies/lodepng.vcxproj
+++ b/dependencies/lodepng.vcxproj
@@ -143,6 +143,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/dependencies/miniz.vcxproj
+++ b/dependencies/miniz.vcxproj
@@ -20,9 +20,9 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="miniz\miniz.c" />
-	<ClCompile Include="miniz\miniz_zip.c" />
-	<ClCompile Include="miniz\miniz_tinfl.c" />
-	<ClCompile Include="miniz\miniz_tdef.c" />
+    <ClCompile Include="miniz\miniz_zip.c" />
+    <ClCompile Include="miniz\miniz_tinfl.c" />
+    <ClCompile Include="miniz\miniz_tdef.c" />
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{44A12AC1-7E09-4AF7-BAC4-A264C2F814A7}</ProjectGuid>
@@ -145,6 +145,7 @@
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/dependencies/miniz.vcxproj.filters
+++ b/dependencies/miniz.vcxproj.filters
@@ -18,5 +18,14 @@
     <ClCompile Include="miniz\miniz.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="miniz\miniz_zip.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="miniz\miniz_tinfl.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="miniz\miniz_tdef.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
 </Project>

--- a/dependencies/physfs.vcxproj
+++ b/dependencies/physfs.vcxproj
@@ -138,6 +138,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_CRT_SECURE_NO_WARNINGS;PHYSFS_SUPPORTS_ISO9660;PHYSFS_ISO9660_LOWERCASE=1;PHYSFS_ISO9660_OPENAPOC_WORKAROUND=1;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/forms/forms.vcxproj
+++ b/forms/forms.vcxproj
@@ -189,6 +189,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/framework/font.cpp
+++ b/framework/font.cpp
@@ -4,11 +4,6 @@
 #include "framework/image.h"
 #include "library/sp.h"
 
-// Disable automatic #pragma linking for boost - only enabled in msvc and that should provide boost
-// symbols as part of the module that uses it
-#define BOOST_ALL_NO_LIB
-#include <boost/locale.hpp>
-
 namespace OpenApoc
 {
 
@@ -26,12 +21,8 @@ sp<PaletteImage> BitmapFont::getString(const UString &Text)
 
 	img = mksp<PaletteImage>(Vec2<int>{width, height});
 
-	auto u8Str = Text.str();
-	auto pointString = boost::locale::conv::utf_to_utf<UniChar>(u8Str);
-
-	for (size_t i = 0; i < pointString.length(); i++)
+	for (const auto &c : Text)
 	{
-		UniChar c = pointString[i];
 		auto glyph = this->getGlyph(c);
 		PaletteImage::blit(glyph, img, {0, 0}, {pos, 0});
 		pos += glyph->size.x;
@@ -45,12 +36,10 @@ sp<PaletteImage> BitmapFont::getString(const UString &Text)
 int BitmapFont::getFontWidth(const UString &Text)
 {
 	int textlen = 0;
-	auto u8Str = Text.str();
-	auto pointString = boost::locale::conv::utf_to_utf<UniChar>(u8Str);
 
-	for (size_t i = 0; i < Text.length(); i++)
+	for (const auto &c : Text)
 	{
-		auto glyph = this->getGlyph(pointString[i]);
+		auto glyph = this->getGlyph(c);
 		textlen += glyph->size.x;
 	}
 	return textlen;

--- a/framework/framework.vcxproj
+++ b/framework/framework.vcxproj
@@ -252,6 +252,7 @@
       <PreprocessorDefinitions>WIN32;GLESWRAP_PLATFORM_WGL;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/game/OpenApoc.vcxproj
+++ b/game/OpenApoc.vcxproj
@@ -169,6 +169,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -765,7 +765,7 @@ class BattleUnit : public StateObject, public std::enable_shared_from_this<Battl
 	// Updates unit's movement
 	// Return true if retreated or destroyed and we must halt immediately
 	void updateMovement(GameState &state, unsigned int &moveTicksRemaining, bool &wasUsingLift);
-	// Updates unit's אפסרען trainsition and acquires new target אפסרען
+	// Updates unit's trainsition and acquires new target
 	void updateTurning(GameState &state, unsigned int &turnTicksRemaining,
 	                   unsigned int const handsTicksRemaining);
 	// Updates unit's displayed item (which one will draw in unit's hands on screen)
@@ -795,7 +795,7 @@ class BattleUnit : public StateObject, public std::enable_shared_from_this<Battl
 	sp<TileObjectShadow> shadowObject;
 
 	/*
-	- curr. mind state (controlled/berserk/…)
+	- curr. mind state (controlled/berserk/)
 	- ref. to psi attacker (who is controlling it/...)
 	*/
   private:

--- a/game/state/gamestate.vcxproj
+++ b/game/state/gamestate.vcxproj
@@ -355,7 +355,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/game/ui/gameui.vcxproj
+++ b/game/ui/gameui.vcxproj
@@ -289,6 +289,7 @@ gen_version_win.bat</Command>
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/game/ui/gameui.vcxproj.filters
+++ b/game/ui/gameui.vcxproj.filters
@@ -172,6 +172,10 @@
     <ClCompile Include="base\recruitscreen.cpp">
       <Filter>base</Filter>
     </ClCompile>
+    <ClCompile Include="general\aequipmentsheet.cpp" />
+    <ClCompile Include="general\agentsheet.cpp" />
+    <ClCompile Include="general\loadingscreen.cpp" />
+    <ClCompile Include="general\vehiclesheet.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="base\basescreen.h">
@@ -316,5 +320,8 @@
     <ClInclude Include="base\recruitscreen.h">
       <Filter>base</Filter>
     </ClInclude>
+    <ClInclude Include="general\aequipmentsheet.h" />
+    <ClInclude Include="general\agentsheet.h" />
+    <ClInclude Include="general\vehiclesheet.h" />
   </ItemGroup>
 </Project>

--- a/library/library.vcxproj
+++ b/library/library.vcxproj
@@ -162,6 +162,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/library/library_pch.h
+++ b/library/library_pch.h
@@ -2,8 +2,6 @@
 
 #include "dependencies/tinyformat/tinyformat.h"
 #include <algorithm>
-#include <boost/algorithm/string/predicate.hpp>
-#include <boost/locale.hpp>
 #include <cstdint>
 #include <fstream>
 #include <glm/glm.hpp>

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -6,8 +6,6 @@
 // symbols as part of the module that uses it
 #define BOOST_ALL_NO_LIB
 #include <boost/algorithm/string/predicate.hpp>
-#include <boost/locale/conversion.hpp>
-#include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/message.hpp>
 
 #ifdef DUMP_TRANSLATION_STRINGS
@@ -186,7 +184,9 @@ UString::UString(UString &&other) { this->u8Str = std::move(other.u8Str); }
 
 UString::UString(UniChar uc) : u8Str()
 {
-	u8Str = boost::locale::conv::utf_to_utf<char>(&uc, &uc + 1);
+	char buf[4];
+	auto bytes = unichar_to_utf8(uc, buf);
+	u8Str = {buf, bytes};
 }
 
 const std::string &UString::str() const { return this->u8Str; }

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -67,8 +67,6 @@ UString::UString(const std::string &str) : u8Str(str) {}
 
 UString::UString(std::string &&str) : u8Str(std::move(str)) {}
 
-UString::UString(const std::wstring &wstr) : u8Str(boost::locale::conv::utf_to_utf<char>(wstr)) {}
-
 UString::UString(const char *cstr)
 
 {
@@ -79,26 +77,9 @@ UString::UString(const char *cstr)
 	}
 }
 
-UString::UString(const wchar_t *wcstr)
-
-{
-	// We have to handle this manually as some things thought UString(nullptr) was a good idea
-	if (wcstr)
-	{
-		this->u8Str = boost::locale::conv::utf_to_utf<char>(wcstr);
-	}
-}
-
 UString::UString(const UString &) = default;
 
 UString::UString(UString &&other) { this->u8Str = std::move(other.u8Str); }
-
-UString::UString(char c) : u8Str() { u8Str = boost::locale::conv::utf_to_utf<char>(&c, &c + 1); }
-
-UString::UString(wchar_t wc) : u8Str()
-{
-	u8Str = boost::locale::conv::utf_to_utf<char>(&wc, &wc + 1);
-}
 
 UString::UString(UniChar uc) : u8Str()
 {
@@ -106,8 +87,6 @@ UString::UString(UniChar uc) : u8Str()
 }
 
 const std::string &UString::str() const { return this->u8Str; }
-
-std::wstring UString::wstr() const { return boost::locale::conv::utf_to_utf<wchar_t>(this->u8Str); }
 
 const char *UString::cStr() const { return this->u8Str.c_str(); }
 

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -1,5 +1,6 @@
 #include "library/strings.h"
 #include "library/strings_format.h"
+#include <cctype>
 #include <tuple> // used for std::ignore
 // Disable automatic #pragma linking for boost - only enabled in msvc and that should provide boost
 // symbols as part of the module that uses it
@@ -203,9 +204,33 @@ UString UString::substr(size_t offset, size_t length) const
 	return this->u8Str.substr(offset, length);
 }
 
-UString UString::toUpper() const { return boost::locale::to_upper(this->u8Str); }
+UString UString::toUpper() const
+{
+	/* Only change the case on ascii range characters (codepoint <=0x7f)
+	 * As we know the top bit is set for any bytes outside this range no matter the postion in the
+	 * utf8 stream, we can cheat a bit here */
+	UString upper_string = *this;
+	for (size_t i = 0; i < upper_string.cStrLength(); i++)
+	{
+		if ((upper_string.u8Str[i] & 0b10000000) == 0)
+			upper_string.u8Str[i] = toupper(upper_string.u8Str[i]);
+	}
+	return upper_string;
+}
 
-UString UString::toLower() const { return boost::locale::to_lower(this->u8Str); }
+UString UString::toLower() const
+{
+	/* Only change the case on ascii range characters (codepoint <=0x7f)
+	 * As we know the top bit is set for any bytes outside this range no matter the postion in the
+	 * utf8 stream, we can cheat a bit here */
+	UString lower_string = *this;
+	for (size_t i = 0; i < lower_string.cStrLength(); i++)
+	{
+		if ((lower_string.u8Str[i] & 0b10000000) == 0)
+			lower_string.u8Str[i] = tolower(lower_string.u8Str[i]);
+	}
+	return lower_string;
+}
 
 UString &UString::operator=(const UString &other) = default;
 

--- a/library/strings.h
+++ b/library/strings.h
@@ -35,7 +35,9 @@ class UString
 	const char *cStr() const;
 	size_t cStrLength() const;
 
+	/* Only changes case of ASCII-range characters */
 	UString toUpper() const;
+	/* Only changes case of ASCII-range characters */
 	UString toLower() const;
 	std::vector<UString> split(const UString &delims) const;
 	std::list<UString> splitlist(const UString &delims) const;

--- a/library/strings.h
+++ b/library/strings.h
@@ -18,16 +18,11 @@ class UString
   public:
 	// ASSUMPTIONS:
 	// All std::string/char are utf8
-	// wchar_t/std::wstring are platform-dependant unicode types
 	// All lengths/offsets are in unicode code-points (not bytes/anything)
 	UString(const std::string &str);
 	UString(std::string &&str);
-	UString(const std::wstring &wstr);
-	UString(char c);
-	UString(wchar_t wc);
 	UString(UniChar uc);
 	UString(const char *cstr);
-	UString(const wchar_t *wcstr);
 	UString(UString &&other);
 	UString();
 	~UString();
@@ -36,7 +31,6 @@ class UString
 	UString &operator=(const UString &other);
 
 	const std::string &str() const;
-	std::wstring wstr() const;
 
 	const char *cStr() const;
 	size_t cStrLength() const;
@@ -55,10 +49,7 @@ class UString
 	UString &operator+=(const UString &ustr);
 	// UString& operator+=(const std::string& str);
 	// UString& operator+=(const char* cstr);
-	// UString& operator+=(const std::wstring& wstr);
-	// UString& operator+=(const wchar_t* wcstr);
 	// UString& operator+=(const char& c);
-	// UString& operator+=(const wchar_t& wc);
 	// UString& operator+=(const UniChar& uc);
 
 	void remove(size_t offset, size_t count);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 PROJECT (OpenApoc_Tests CXX C)
 CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
 
-set (TEST_LIST test_rect test_voxel test_tilemap test_rng test_images)
+set (TEST_LIST test_rect test_voxel test_tilemap test_rng test_images
+		test_unicode)
 
 foreach(TEST ${TEST_LIST})
 		add_executable(${TEST} ${TEST}.cpp)

--- a/tests/test_images.vcxproj
+++ b/tests/test_images.vcxproj
@@ -155,6 +155,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/test_rng.vcxproj
+++ b/tests/test_rng.vcxproj
@@ -155,6 +155,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tests/test_serialize.vcxproj
+++ b/tests/test_serialize.vcxproj
@@ -122,6 +122,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/tests/test_unicode.cpp
+++ b/tests/test_unicode.cpp
@@ -1,0 +1,178 @@
+#include "framework/configfile.h"
+#include "framework/logger.h"
+#include "library/strings.h"
+
+using namespace OpenApoc;
+
+struct example_unicode
+{
+	const char *u8string;
+	std::vector<UniChar> expected_codepoints;
+
+	example_unicode(const char *str, std::vector<UniChar> codepoints)
+	    : u8string(str), expected_codepoints(codepoints){};
+
+	bool test() const
+	{
+		LogInfo("Testing string \"%s\"", u8string);
+		const auto num_codepoints = expected_codepoints.size();
+		UString string(u8string);
+		UString string2;
+		if (string.length() != num_codepoints)
+		{
+			LogError("String \"%s\" has unexpected length %zu , expected %zu", u8string,
+			         string.length(), num_codepoints);
+			return false;
+		}
+
+		std::vector<UniChar> decoded_codepoints;
+
+		for (auto c : string)
+			decoded_codepoints.push_back(c);
+
+		if (decoded_codepoints.size() != num_codepoints)
+		{
+			LogError("String \"%s\" has unexpected iterated length %zu , expected %zu", u8string,
+			         decoded_codepoints.size(), num_codepoints);
+			return false;
+		}
+
+		for (size_t i = 0; i < num_codepoints; i++)
+		{
+			if (expected_codepoints[i] != decoded_codepoints[i])
+			{
+				LogError(
+				    "String \"%s\" has unexpected codepoint at index %zu - got 0x%x expected 0x%x",
+				    u8string, i, decoded_codepoints[i], expected_codepoints[i]);
+				return false;
+			}
+			string2 += decoded_codepoints[i];
+		}
+
+		if (string != string2)
+		{
+			LogError(
+			    "String \"%s\" compared false after utf8->unichar->utf8 conversion - got \"%s\"",
+			    u8string, string2);
+
+			return false;
+		}
+
+		LogInfo("Looks good");
+
+		return true;
+	}
+};
+
+static bool test_remove(const UString &initial, const UString &expected, size_t offset,
+                        size_t count)
+{
+	UString removed = initial;
+	removed.remove(offset, count);
+	if (removed != expected)
+	{
+		LogError("\"%s\".remove(%zu, %zu) = \"%s\", expected \"%s\"", initial, offset, count,
+		         removed, expected);
+		return false;
+	}
+	return true;
+}
+
+static bool test_insert(const UString &initial, const UString &expected, size_t offset,
+                        const UString &str)
+{
+	UString inserted = initial;
+	inserted.insert(offset, str);
+	if (inserted != expected)
+	{
+		LogError("\"%s\".inserted(%zu, \"%s\") = \"%s\", expected \"%s\"", initial, offset, str,
+		         inserted, expected);
+		return false;
+	}
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+
+	const std::vector<example_unicode> examples = {
+	    {u8"£", {0xA3}},
+	    {u8"a", {0x61}},
+	    {u8"€", {0x20AC}},
+	    {u8"𐍈", {0x10348}},
+	    {u8"£a€𐍈", {0xA3, 0x61, 0x20AC, 0x10348}},
+	};
+
+	for (const auto &ex : examples)
+	{
+		if (ex.test() != true)
+			return EXIT_FAILURE;
+	}
+
+	UString example = "€UPpa91£B\"#ð𐍈";
+	UString lower_example = "€uppa91£b\"#ð𐍈";
+	UString upper_example = "€UPPA91£B\"#ð𐍈";
+
+	auto lower = example.toLower();
+	auto upper = example.toUpper();
+	if (lower != lower_example)
+	{
+		LogError("toLower(\"%s\") returned \"%s\", expected \"%s\"", example, lower, lower_example);
+		return EXIT_FAILURE;
+	}
+	if (upper != upper_example)
+	{
+		LogError("toUpper(\"%s\") returned \"%s\", expected \"%s\"", example, upper, upper_example);
+		return EXIT_FAILURE;
+	}
+
+	UString removed_example1 = "€UPpa91£\"#ð𐍈";
+	UString removed_example2 = "€UPpa91£B\"#ð";
+	UString removed_example3 = "UPpa91£B\"#ð𐍈";
+	UString removed_example4 = "€UPpa91£𐍈";
+	UString empty = "";
+
+	if (!test_remove(example, removed_example1, 8, 1))
+		return EXIT_FAILURE;
+	if (!test_remove(example, removed_example2, 12, 1))
+		return EXIT_FAILURE;
+	if (!test_remove(example, removed_example2, 12, 10))
+		return EXIT_FAILURE;
+	if (!test_remove(example, removed_example3, 0, 1))
+		return EXIT_FAILURE;
+	if (!test_remove(example, removed_example4, 8, 4))
+		return EXIT_FAILURE;
+	if (!test_remove(empty, empty, 8, 4))
+		return EXIT_FAILURE;
+	if (!test_remove(empty, empty, 0, 1))
+		return EXIT_FAILURE;
+
+	bool exception_caught = false;
+	try
+	{
+		test_insert(empty, empty, 50, "Lol");
+	}
+	catch (const std::out_of_range &ex)
+	{
+		exception_caught = true;
+	}
+	if (!exception_caught)
+	{
+		LogError("\"\".insert(50 \"Lol\") didn't throw out_of_range exception");
+		return EXIT_FAILURE;
+	}
+
+	UString insert_example1 = "Ayy€UPpa91£B\"#ð𐍈";
+	UString insert_example2 = "€UPpaÞ91£B\"#ð𐍈";
+	UString insert_example3 = "€UPpa91£B\"#ð𐍈€UPpa91£B\"#ð𐍈";
+
+	test_insert(example, insert_example1, 0, "Ayy");
+	test_insert(example, insert_example2, 5, "Þ");
+	test_insert(example, insert_example3, 13, example);
+
+	return EXIT_SUCCESS;
+}

--- a/tools/extractor.vcxproj
+++ b/tools/extractor.vcxproj
@@ -274,6 +274,7 @@
       <PreprocessorDefinitions>WIN32;NDEBUG;_CONSOLE;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tools/gamestate_serialize_gen/gamestate_serialize_gen.vcxproj
+++ b/tools/gamestate_serialize_gen/gamestate_serialize_gen.vcxproj
@@ -152,6 +152,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/tools/imagedump/imagedump.vcxproj
+++ b/tools/imagedump/imagedump.vcxproj
@@ -139,6 +139,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <SDLCheck>true</SDLCheck>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <AdditionalOptions>/bigobj /utf-8 %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
The previous insert/remove used /bytes/ for the offset, not codepoints,
causing weirdness as users (e.g. TextEdit) would end up
removing/inserting bytes within a utf8 codepoint - which would cause
invalid codings (which were probably ignored), showing as multiple
keypresses being required to delete a non-ascii character

Now, the iterator stores the offset in bytes, but as the utf8 conversion
routines let us know how many bytes each codepoint contains, we can use
that to skip/remove the correct number of bytes accordingly.

This also removes some users of boost::locale's utf conversion, wipes some headers, simplifies toUpper/toLower, and adds a test for some of the UString functions