### PR TITLE
Fix config file write in portable mode

### DIFF
--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -203,7 +203,8 @@ class ConfigFileImpl
 			std::string str = configPathString.str();
 			fs::path configPath(str);
 			auto dir = configPath.parent_path();
-			fs::create_directories(dir);
+			if (!dir.empty())
+				fs::create_directories(dir);
 			std::ofstream outFile(configPath.string());
 			if (!outFile)
 			{


### PR DESCRIPTION
Some std::filesystem implementations (e.g. GCC7) don't like trying to
create a directory for an empty path, which was happening for portable
mode. This stopped the config file being written.