### PR TITLE
Remove some (unnecessary) sp<> wrappers in the serializer

### DIFF
--- a/framework/serialization/serialize.h
+++ b/framework/serialization/serialize.h
@@ -7,27 +7,24 @@
 
 namespace OpenApoc
 {
-class SerializationNode : public std::enable_shared_from_this<SerializationNode>
+class SerializationNode
 {
   public:
-	sp<SerializationNode> virtual addNode(const UString &name, const UString &value = "") = 0;
-	sp<SerializationNode> virtual addSection(const UString &name) = 0;
+	virtual SerializationNode *addNode(const UString &name, const UString &value = "") = 0;
+	virtual SerializationNode *addSection(const UString &name) = 0;
 
 	// Opt versions may return nullptr (they're 'optional'), Req gets throw an exception if
 	// missing
-	sp<SerializationNode> virtual getNodeReq(const UString &name);
-	sp<SerializationNode> virtual getNodeOpt(const UString &name) = 0;
-	sp<SerializationNode> virtual getNextSiblingReq(const UString &name);
-	sp<SerializationNode> virtual getNextSiblingOpt(const UString &name) = 0;
-	sp<SerializationNode> virtual getSectionReq(const UString &name);
-	sp<SerializationNode> virtual getSectionOpt(const UString &name) = 0;
+	virtual SerializationNode *getNodeReq(const UString &name);
+	virtual SerializationNode *getNodeOpt(const UString &name) = 0;
+	virtual SerializationNode *getNextSiblingReq(const UString &name);
+	virtual SerializationNode *getNextSiblingOpt(const UString &name) = 0;
+	virtual SerializationNode *getSectionReq(const UString &name);
+	virtual SerializationNode *getSectionOpt(const UString &name) = 0;
 
-	sp<SerializationNode> getNode(const UString &name) { return this->getNodeOpt(name); }
-	sp<SerializationNode> getNextSibling(const UString &name)
-	{
-		return this->getNextSiblingOpt(name);
-	}
-	sp<SerializationNode> getSection(const UString &name) { return this->getSectionOpt(name); }
+	SerializationNode *getNode(const UString &name) { return this->getNodeOpt(name); }
+	SerializationNode *getNextSibling(const UString &name) { return this->getNextSiblingOpt(name); }
+	SerializationNode *getSection(const UString &name) { return this->getSectionOpt(name); }
 
 	virtual UString getName() = 0;
 	virtual void setName(const UString &str) = 0;
@@ -68,21 +65,20 @@ class SerializationNode : public std::enable_shared_from_this<SerializationNode>
 class SerializationArchive
 {
   public:
-	static sp<SerializationArchive> createArchive();
-	static sp<SerializationArchive> readArchive(const UString &path);
+	static up<SerializationArchive> createArchive();
+	static up<SerializationArchive> readArchive(const UString &path);
 
-	sp<SerializationNode> virtual newRoot(const UString &prefix, const UString &name) = 0;
-	sp<SerializationNode> virtual getRoot(const UString &prefix, const UString &name) = 0;
-	bool virtual write(const UString &path, bool pack = true, bool pretty = false) = 0;
+	virtual SerializationNode *newRoot(const UString &prefix, const UString &name) = 0;
+	virtual SerializationNode *getRoot(const UString &prefix, const UString &name) = 0;
+	virtual bool write(const UString &path, bool pack = true, bool pretty = false) = 0;
 	virtual ~SerializationArchive() = default;
 };
 
 class SerializationException : public std::runtime_error
 {
   public:
-	sp<SerializationNode> node;
-	SerializationException(const UString &description, sp<SerializationNode> node)
-	    : std::runtime_error(description.cStr()), node(node)
+	SerializationException(const UString &description, SerializationNode *node)
+	    : std::runtime_error(UString(description + " " + node->getFullPath()).cStr())
 	{
 	}
 };

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -178,10 +178,10 @@ class GameState : public std::enable_shared_from_this<GameState>
 	bool saveGame(const UString &path, bool pack = true, bool pretty = false);
 
 	// serializes gamestate to archive
-	bool serialize(sp<SerializationArchive> archive) const;
+	bool serialize(SerializationArchive *archive) const;
 
 	// deserializes gamestate from archive
-	bool deserialize(const sp<SerializationArchive> archive);
+	bool deserialize(SerializationArchive *archive);
 
 	// Called on a newly started Game to setup initial state that isn't serialized in (random
 	// vehicle positions etc.) - it is not called

--- a/game/state/gamestate_serialize.cpp
+++ b/game/state/gamestate_serialize.cpp
@@ -27,63 +27,63 @@
 namespace OpenApoc
 {
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, UString &str)
+void serializeIn(const GameState *, SerializationNode *node, UString &str)
 {
 	if (!node)
 		return;
 	str = node->getValue();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, unsigned int &val)
+void serializeIn(const GameState *, SerializationNode *node, unsigned int &val)
 {
 	if (!node)
 		return;
 	val = node->getValueUInt();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, unsigned char &val)
+void serializeIn(const GameState *, SerializationNode *node, unsigned char &val)
 {
 	if (!node)
 		return;
 	val = node->getValueUChar();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, float &val)
+void serializeIn(const GameState *, SerializationNode *node, float &val)
 {
 	if (!node)
 		return;
 	val = node->getValueFloat();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, int &val)
+void serializeIn(const GameState *, SerializationNode *node, int &val)
 {
 	if (!node)
 		return;
 	val = node->getValueInt();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, uint64_t &val)
+void serializeIn(const GameState *, SerializationNode *node, uint64_t &val)
 {
 	if (!node)
 		return;
 	val = node->getValueUInt64();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, bool &val)
+void serializeIn(const GameState *, SerializationNode *node, bool &val)
 {
 	if (!node)
 		return;
 	val = node->getValueBool();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<LazyImage> &ptr)
+void serializeIn(const GameState *, SerializationNode *node, sp<LazyImage> &ptr)
 {
 	if (!node)
 		return;
 	ptr = std::static_pointer_cast<LazyImage>(fw().data->loadImage(node->getValue(), true));
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<Image> &ptr)
+void serializeIn(const GameState *, SerializationNode *node, sp<Image> &ptr)
 {
 	if (!node)
 		return;
@@ -91,28 +91,28 @@ void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<Image>
 }
 
 // std::vector<bool> is special
-void serializeIn(const GameState *, const sp<SerializationNode> &node, std::vector<bool> &vector)
+void serializeIn(const GameState *, SerializationNode *node, std::vector<bool> &vector)
 {
 	if (!node)
 		return;
 	vector = node->getValueBoolVector();
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<VoxelSlice> &ptr)
+void serializeIn(const GameState *, SerializationNode *node, sp<VoxelSlice> &ptr)
 {
 	if (!node)
 		return;
 	ptr = fw().data->loadVoxelSlice(node->getValue());
 }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<Sample> &ptr)
+void serializeIn(const GameState *, SerializationNode *node, sp<Sample> &ptr)
 {
 	if (!node)
 		return;
 	ptr = fw().data->loadSample(node->getValue());
 }
 
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, VoxelMap &map)
+void serializeIn(const GameState *state, SerializationNode *node, VoxelMap &map)
 {
 	if (!node)
 		return;
@@ -120,7 +120,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, Voxe
 	serializeIn(state, node->getNode("slices"), map.slices);
 }
 
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, Colour &c)
+void serializeIn(const GameState *state, SerializationNode *node, Colour &c)
 {
 	if (!node)
 		return;
@@ -130,8 +130,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, Colo
 	serializeIn(state, node->getNode("a"), c.a);
 }
 
-void serializeIn(const GameState *state, const sp<SerializationNode> &node,
-                 Xorshift128Plus<uint32_t> &t)
+void serializeIn(const GameState *state, SerializationNode *node, Xorshift128Plus<uint32_t> &t)
 {
 	if (!node)
 		return;
@@ -142,44 +141,39 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node,
 	t.setState(s);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const UString &string, const UString &)
+void serializeOut(SerializationNode *node, const UString &string, const UString &)
 {
 	node->setValue(string);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const unsigned int &val, const unsigned int &)
+void serializeOut(SerializationNode *node, const unsigned int &val, const unsigned int &)
 {
 	node->setValueUInt(val);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const unsigned char &val,
-                  const unsigned char &)
+void serializeOut(SerializationNode *node, const unsigned char &val, const unsigned char &)
 {
 	node->setValueUChar(val);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const float &val, const float &)
+void serializeOut(SerializationNode *node, const float &val, const float &)
 {
 	node->setValueFloat(val);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const int &val, const int &)
-{
-	node->setValueInt(val);
-}
+void serializeOut(SerializationNode *node, const int &val, const int &) { node->setValueInt(val); }
 
-void serializeOut(const sp<SerializationNode> &node, const uint64_t &val, const uint64_t &)
+void serializeOut(SerializationNode *node, const uint64_t &val, const uint64_t &)
 {
 	node->setValueUInt64(val);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const bool &val, const bool &)
+void serializeOut(SerializationNode *node, const bool &val, const bool &)
 {
 	node->setValueBool(val);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const sp<LazyImage> &ptr,
-                  const sp<LazyImage> &)
+void serializeOut(SerializationNode *node, const sp<LazyImage> &ptr, const sp<LazyImage> &)
 {
 	if (ptr != nullptr)
 	{
@@ -187,7 +181,7 @@ void serializeOut(const sp<SerializationNode> &node, const sp<LazyImage> &ptr,
 	}
 }
 
-void serializeOut(const sp<SerializationNode> &node, const sp<Image> &ptr, const sp<Image> &)
+void serializeOut(SerializationNode *node, const sp<Image> &ptr, const sp<Image> &)
 {
 	if (ptr != nullptr)
 	{
@@ -195,8 +189,7 @@ void serializeOut(const sp<SerializationNode> &node, const sp<Image> &ptr, const
 	}
 }
 
-void serializeOut(const sp<SerializationNode> &node, const sp<VoxelSlice> &ptr,
-                  const sp<VoxelSlice> &)
+void serializeOut(SerializationNode *node, const sp<VoxelSlice> &ptr, const sp<VoxelSlice> &)
 {
 	if (ptr)
 	{
@@ -204,7 +197,7 @@ void serializeOut(const sp<SerializationNode> &node, const sp<VoxelSlice> &ptr,
 	}
 }
 
-void serializeOut(const sp<SerializationNode> &node, const sp<Sample> &ptr, const sp<Sample> &)
+void serializeOut(SerializationNode *node, const sp<Sample> &ptr, const sp<Sample> &)
 {
 	if (ptr)
 	{
@@ -212,19 +205,19 @@ void serializeOut(const sp<SerializationNode> &node, const sp<Sample> &ptr, cons
 	}
 }
 
-void serializeOut(const sp<SerializationNode> &node, const std::vector<bool> &vector,
+void serializeOut(SerializationNode *node, const std::vector<bool> &vector,
                   const std::vector<bool> &)
 {
 	node->setValueBoolVector(vector);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const VoxelMap &map, const VoxelMap &ref)
+void serializeOut(SerializationNode *node, const VoxelMap &map, const VoxelMap &ref)
 {
 	serializeOut(node->addNode("size"), map.size, ref.size);
 	serializeOut(node->addNode("slices"), map.slices, ref.slices);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const Colour &c, const Colour &ref)
+void serializeOut(SerializationNode *node, const Colour &c, const Colour &ref)
 {
 	serializeOut(node->addNode("r"), c.r, ref.r);
 	serializeOut(node->addNode("g"), c.g, ref.g);
@@ -232,7 +225,7 @@ void serializeOut(const sp<SerializationNode> &node, const Colour &c, const Colo
 	serializeOut(node->addNode("a"), c.a, ref.a);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const Xorshift128Plus<uint32_t> &t,
+void serializeOut(SerializationNode *node, const Xorshift128Plus<uint32_t> &t,
                   const Xorshift128Plus<uint32_t> &ref)
 {
 	if (!node)
@@ -246,7 +239,7 @@ void serializeOut(const sp<SerializationNode> &node, const Xorshift128Plus<uint3
 	serializeOut(node->addNode("s1"), s[1], sr[1]);
 }
 
-void serializeIn(const GameState *state, sp<SerializationNode> node, sp<UnitAI> &ai)
+void serializeIn(const GameState *state, SerializationNode *node, sp<UnitAI> &ai)
 {
 	if (!node)
 		return;
@@ -293,7 +286,7 @@ void serializeIn(const GameState *state, sp<SerializationNode> node, sp<UnitAI> 
 	}
 }
 
-void serializeIn(const GameState *state, sp<SerializationNode> node, sp<TacticalAI> &ai)
+void serializeIn(const GameState *state, SerializationNode *node, sp<TacticalAI> &ai)
 {
 	if (!node)
 		return;
@@ -312,7 +305,7 @@ void serializeIn(const GameState *state, sp<SerializationNode> node, sp<Tactical
 	}
 }
 
-void serializeOut(sp<SerializationNode> node, const sp<UnitAI> &ptr, const sp<UnitAI> &ref)
+void serializeOut(SerializationNode *node, const sp<UnitAI> &ptr, const sp<UnitAI> &ref)
 {
 	if (ptr)
 	{
@@ -401,7 +394,7 @@ bool operator==(const UnitAI &a, const UnitAI &b)
 }
 bool operator!=(const UnitAI &a, const UnitAI &b) { return !(a == b); }
 
-void serializeOut(sp<SerializationNode> node, const sp<TacticalAI> &ptr, const sp<TacticalAI> &ref)
+void serializeOut(SerializationNode *node, const sp<TacticalAI> &ptr, const sp<TacticalAI> &ref)
 {
 	if (ptr)
 	{
@@ -442,7 +435,7 @@ bool GameState::saveGame(const UString &path, bool pack, bool pretty)
 {
 	TRACE_FN_ARGS1("path", path);
 	auto archive = SerializationArchive::createArchive();
-	if (serialize(archive))
+	if (serialize(archive.get()))
 	{
 		archive->write(path, pack, pretty);
 		return true;
@@ -461,10 +454,10 @@ bool GameState::loadGame(const UString &path)
 		return false;
 	}
 
-	return deserialize(archive);
+	return deserialize(archive.get());
 }
 
-bool GameState::serialize(sp<SerializationArchive> archive) const
+bool GameState::serialize(SerializationArchive *archive) const
 {
 	try
 	{
@@ -475,13 +468,13 @@ bool GameState::serialize(sp<SerializationArchive> archive) const
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
 }
 
-bool GameState::deserialize(const sp<SerializationArchive> archive)
+bool GameState::deserialize(SerializationArchive *archive)
 {
 	try
 	{
@@ -489,13 +482,13 @@ bool GameState::deserialize(const sp<SerializationArchive> archive)
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
 }
 
-static bool serialize(const BattleMapTileset &tileSet, sp<SerializationArchive> archive)
+static bool serialize(const BattleMapTileset &tileSet, SerializationArchive *archive)
 {
 	try
 	{
@@ -504,14 +497,14 @@ static bool serialize(const BattleMapTileset &tileSet, sp<SerializationArchive> 
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
 }
 
 static bool deserialize(BattleMapTileset &tileSet, const GameState &state,
-                        const sp<SerializationArchive> archive)
+                        SerializationArchive *archive)
 {
 	try
 	{
@@ -519,7 +512,7 @@ static bool deserialize(BattleMapTileset &tileSet, const GameState &state,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
@@ -529,7 +522,7 @@ bool BattleMapTileset::saveTileset(const UString &path, bool pack, bool pretty)
 {
 	TRACE_FN_ARGS1("path", path);
 	auto archive = SerializationArchive::createArchive();
-	if (serialize(*this, archive))
+	if (serialize(*this, archive.get()))
 	{
 		archive->write(path, pack, pretty);
 		return true;
@@ -548,10 +541,10 @@ bool BattleMapTileset::loadTileset(GameState &state, const UString &path)
 		return false;
 	}
 
-	return deserialize(*this, state, archive);
+	return deserialize(*this, state, archive.get());
 }
 
-static bool serialize(const BattleUnitImagePack &imagePack, sp<SerializationArchive> archive)
+static bool serialize(const BattleUnitImagePack &imagePack, SerializationArchive *archive)
 {
 	try
 	{
@@ -560,14 +553,14 @@ static bool serialize(const BattleUnitImagePack &imagePack, sp<SerializationArch
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
 }
 
 static bool deserialize(BattleUnitImagePack &imagePack, const GameState &state,
-                        const sp<SerializationArchive> archive)
+                        SerializationArchive *archive)
 {
 	try
 	{
@@ -575,7 +568,7 @@ static bool deserialize(BattleUnitImagePack &imagePack, const GameState &state,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
@@ -585,7 +578,7 @@ bool BattleUnitImagePack::saveImagePack(const UString &path, bool pack, bool pre
 {
 	TRACE_FN_ARGS1("path", path);
 	auto archive = SerializationArchive::createArchive();
-	if (serialize(*this, archive))
+	if (serialize(*this, archive.get()))
 	{
 		archive->write(path, pack, pretty);
 		return true;
@@ -604,11 +597,10 @@ bool BattleUnitImagePack::loadImagePack(GameState &state, const UString &path)
 		return false;
 	}
 
-	return deserialize(*this, state, archive);
+	return deserialize(*this, state, archive.get());
 }
 
-static bool serialize(const BattleUnitAnimationPack &animationPack,
-                      sp<SerializationArchive> archive)
+static bool serialize(const BattleUnitAnimationPack &animationPack, SerializationArchive *archive)
 {
 	try
 	{
@@ -617,14 +609,14 @@ static bool serialize(const BattleUnitAnimationPack &animationPack,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
 }
 
 static bool deserialize(BattleUnitAnimationPack &animationPack, const GameState &state,
-                        const sp<SerializationArchive> archive)
+                        SerializationArchive *archive)
 {
 	try
 	{
@@ -632,7 +624,7 @@ static bool deserialize(BattleUnitAnimationPack &animationPack, const GameState 
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
@@ -642,7 +634,7 @@ bool BattleUnitAnimationPack::saveAnimationPack(const UString &path, bool pack, 
 {
 	TRACE_FN_ARGS1("path", path);
 	auto archive = SerializationArchive::createArchive();
-	if (serialize(*this, archive))
+	if (serialize(*this, archive.get()))
 	{
 		archive->write(path, pack, pretty);
 		return true;
@@ -661,10 +653,10 @@ bool BattleUnitAnimationPack::loadAnimationPack(GameState &state, const UString 
 		return false;
 	}
 
-	return deserialize(*this, state, archive);
+	return deserialize(*this, state, archive.get());
 }
 
-static bool serialize(const BattleMapSectorTiles &mapSector, sp<SerializationArchive> archive)
+static bool serialize(const BattleMapSectorTiles &mapSector, SerializationArchive *archive)
 {
 	try
 	{
@@ -673,14 +665,14 @@ static bool serialize(const BattleMapSectorTiles &mapSector, sp<SerializationArc
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
 }
 
 static bool deserialize(BattleMapSectorTiles &mapSector, const GameState &state,
-                        const sp<SerializationArchive> archive)
+                        SerializationArchive *archive)
 {
 	try
 	{
@@ -688,7 +680,7 @@ static bool deserialize(BattleMapSectorTiles &mapSector, const GameState &state,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\" at %s", e.what(), e.node->getFullPath());
+		LogError("Serialization failed: \"%s\"", e.what());
 		return false;
 	}
 	return true;
@@ -698,7 +690,7 @@ bool BattleMapSectorTiles::saveSector(const UString &path, bool pack, bool prett
 {
 	TRACE_FN_ARGS1("path", path);
 	auto archive = SerializationArchive::createArchive();
-	if (serialize(*this, archive))
+	if (serialize(*this, archive.get()))
 	{
 		archive->write(path, pack, pretty);
 		return true;
@@ -717,7 +709,7 @@ bool BattleMapSectorTiles::loadSector(GameState &state, const UString &path)
 		return false;
 	}
 
-	return deserialize(*this, state, archive);
+	return deserialize(*this, state, archive.get());
 }
 
 } // namespace OpenApoc

--- a/game/state/gamestate_serialize.h
+++ b/game/state/gamestate_serialize.h
@@ -121,33 +121,31 @@ template <typename T> bool operator==(const sp<T> &a, const sp<T> &b)
 
 template <typename T> bool operator!=(const sp<T> &a, const sp<T> &b) { return !(a == b); }
 
-void serializeIn(const GameState *, const sp<SerializationNode> &node, UString &str);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, unsigned int &val);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, unsigned char &val);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, float &val);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, int &val);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, uint64_t &val);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, bool &val);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<LazyImage> &ptr);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<Image> &ptr);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, std::vector<bool> &vector);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<VoxelSlice> &ptr);
-void serializeIn(const GameState *, const sp<SerializationNode> &node, sp<Sample> &ptr);
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, VoxelMap &map);
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, Colour &c);
-void serializeIn(const GameState *state, const sp<SerializationNode> &node,
-                 Xorshift128Plus<uint32_t> &t);
+void serializeIn(const GameState *, SerializationNode *node, UString &str);
+void serializeIn(const GameState *, SerializationNode *node, unsigned int &val);
+void serializeIn(const GameState *, SerializationNode *node, unsigned char &val);
+void serializeIn(const GameState *, SerializationNode *node, float &val);
+void serializeIn(const GameState *, SerializationNode *node, int &val);
+void serializeIn(const GameState *, SerializationNode *node, uint64_t &val);
+void serializeIn(const GameState *, SerializationNode *node, bool &val);
+void serializeIn(const GameState *, SerializationNode *node, sp<LazyImage> &ptr);
+void serializeIn(const GameState *, SerializationNode *node, sp<Image> &ptr);
+void serializeIn(const GameState *, SerializationNode *node, std::vector<bool> &vector);
+void serializeIn(const GameState *, SerializationNode *node, sp<VoxelSlice> &ptr);
+void serializeIn(const GameState *, SerializationNode *node, sp<Sample> &ptr);
+void serializeIn(const GameState *state, SerializationNode *node, VoxelMap &map);
+void serializeIn(const GameState *state, SerializationNode *node, Colour &c);
+void serializeIn(const GameState *state, SerializationNode *node, Xorshift128Plus<uint32_t> &t);
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, StateRef<T> &ref)
+void serializeIn(const GameState *state, SerializationNode *node, StateRef<T> &ref)
 {
 	if (!node)
 		return;
 	ref = StateRef<T>{state, node->getValue()};
 }
 
-template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, up<T> &ptr)
+template <typename T> void serializeIn(const GameState *state, SerializationNode *node, up<T> &ptr)
 {
 	if (!node)
 		return;
@@ -158,8 +156,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, up<T
 	serializeIn(state, node, *ptr);
 }
 
-template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, sp<T> &ptr)
+template <typename T> void serializeIn(const GameState *state, SerializationNode *node, sp<T> &ptr)
 {
 	if (!node)
 		return;
@@ -171,7 +168,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, sp<T
 }
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, Vec3<T> &val)
+void serializeIn(const GameState *state, SerializationNode *node, Vec3<T> &val)
 {
 	if (!node)
 		return;
@@ -181,7 +178,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, Vec3
 }
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, Vec2<T> &val)
+void serializeIn(const GameState *state, SerializationNode *node, Vec2<T> &val)
 {
 	if (!node)
 		return;
@@ -190,7 +187,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, Vec2
 }
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, Rect<T> &val)
+void serializeIn(const GameState *state, SerializationNode *node, Rect<T> &val)
 {
 	if (!node)
 		return;
@@ -199,7 +196,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, Rect
 }
 
 template <typename T>
-void serializeIn(const GameState *, const sp<SerializationNode> &node, T &val,
+void serializeIn(const GameState *, SerializationNode *node, T &val,
                  const std::map<T, UString> &valueMap)
 {
 	if (!node)
@@ -218,8 +215,7 @@ void serializeIn(const GameState *, const sp<SerializationNode> &node, T &val,
 }
 
 template <typename Key, typename Value>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node,
-                 std::map<Key, Value> &map)
+void serializeIn(const GameState *state, SerializationNode *node, std::map<Key, Value> &map)
 {
 	if (!node)
 		return;
@@ -236,7 +232,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node,
 }
 
 template <typename Value>
-void serializeInSectionMap(const GameState *state, const sp<SerializationNode> &node,
+void serializeInSectionMap(const GameState *state, SerializationNode *node,
                            std::map<UString, Value> &map)
 {
 	if (!node)
@@ -254,8 +250,8 @@ void serializeInSectionMap(const GameState *state, const sp<SerializationNode> &
 }
 
 template <typename Key, typename Value>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node,
-                 std::map<Key, Value> &map, const std::map<Key, UString> &keyMap)
+void serializeIn(const GameState *state, SerializationNode *node, std::map<Key, Value> &map,
+                 const std::map<Key, UString> &keyMap)
 {
 	if (!node)
 		return;
@@ -272,7 +268,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node,
 }
 
 template <typename A, typename B>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, std::pair<A, B> &pair)
+void serializeIn(const GameState *state, SerializationNode *node, std::pair<A, B> &pair)
 {
 	if (!node)
 		return;
@@ -281,7 +277,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, std:
 }
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, std::list<T> &list)
+void serializeIn(const GameState *state, SerializationNode *node, std::list<T> &list)
 {
 	if (!node)
 		return;
@@ -295,7 +291,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, std:
 }
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, std::vector<T> &vector)
+void serializeIn(const GameState *state, SerializationNode *node, std::vector<T> &vector)
 {
 	if (!node)
 		return;
@@ -317,7 +313,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, std:
 // std::vector<bool> is special
 
 template <typename T>
-void serializeIn(const GameState *state, const sp<SerializationNode> &node, std::set<T> &set)
+void serializeIn(const GameState *state, SerializationNode *node, std::set<T> &set)
 {
 	if (!node)
 		return;
@@ -332,7 +328,7 @@ void serializeIn(const GameState *state, const sp<SerializationNode> &node, std:
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const T &val, const T &,
+void serializeOut(SerializationNode *node, const T &val, const T &,
                   const std::map<T, UString> &valueMap)
 {
 	auto it = valueMap.find(val);
@@ -343,30 +339,26 @@ void serializeOut(const sp<SerializationNode> &node, const T &val, const T &,
 	node->setValue(it->second);
 }
 
-void serializeOut(const sp<SerializationNode> &node, const UString &str, const UString &ref);
-void serializeOut(const sp<SerializationNode> &node, const unsigned int &val,
-                  const unsigned int &ref);
-void serializeOut(const sp<SerializationNode> &node, const unsigned char &val,
-                  const unsigned char &ref);
-void serializeOut(const sp<SerializationNode> &node, const float &val, const float &ref);
-void serializeOut(const sp<SerializationNode> &node, const int &val, const int &ref);
-void serializeOut(const sp<SerializationNode> &node, const uint64_t &val, const uint64_t &ref);
-void serializeOut(const sp<SerializationNode> &node, const bool &val, const bool &ref);
-void serializeOut(const sp<SerializationNode> &node, const sp<LazyImage> &ptr,
-                  const sp<LazyImage> &ref);
-void serializeOut(const sp<SerializationNode> &node, const sp<Image> &ptr, const sp<Image> &ref);
-void serializeOut(const sp<SerializationNode> &node, const std::vector<bool> &vector,
+void serializeOut(SerializationNode *node, const UString &str, const UString &ref);
+void serializeOut(SerializationNode *node, const unsigned int &val, const unsigned int &ref);
+void serializeOut(SerializationNode *node, const unsigned char &val, const unsigned char &ref);
+void serializeOut(SerializationNode *node, const float &val, const float &ref);
+void serializeOut(SerializationNode *node, const int &val, const int &ref);
+void serializeOut(SerializationNode *node, const uint64_t &val, const uint64_t &ref);
+void serializeOut(SerializationNode *node, const bool &val, const bool &ref);
+void serializeOut(SerializationNode *node, const sp<LazyImage> &ptr, const sp<LazyImage> &ref);
+void serializeOut(SerializationNode *node, const sp<Image> &ptr, const sp<Image> &ref);
+void serializeOut(SerializationNode *node, const std::vector<bool> &vector,
                   const std::vector<bool> &ref);
-void serializeOut(const sp<SerializationNode> &node, const sp<VoxelSlice> &ptr,
-                  const sp<VoxelSlice> &ref);
-void serializeOut(const sp<SerializationNode> &node, const sp<Sample> &ptr, const sp<Sample> &ref);
-void serializeOut(const sp<SerializationNode> &node, const VoxelMap &map, const VoxelMap &ref);
-void serializeOut(const sp<SerializationNode> &node, const Colour &c, const Colour &ref);
-void serializeOut(const sp<SerializationNode> &node, const Xorshift128Plus<uint32_t> &t,
+void serializeOut(SerializationNode *node, const sp<VoxelSlice> &ptr, const sp<VoxelSlice> &ref);
+void serializeOut(SerializationNode *node, const sp<Sample> &ptr, const sp<Sample> &ref);
+void serializeOut(SerializationNode *node, const VoxelMap &map, const VoxelMap &ref);
+void serializeOut(SerializationNode *node, const Colour &c, const Colour &ref);
+void serializeOut(SerializationNode *node, const Xorshift128Plus<uint32_t> &t,
                   const Xorshift128Plus<uint32_t> &ref);
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const StateRef<T> &val, const StateRef<T> &)
+void serializeOut(SerializationNode *node, const StateRef<T> &val, const StateRef<T> &)
 {
 	// node->setValue("") causes an extra unnecessary <tag></tag> instead of <tag />
 	if (val.id != "")
@@ -374,7 +366,7 @@ void serializeOut(const sp<SerializationNode> &node, const StateRef<T> &val, con
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const Vec3<T> &val, const Vec3<T> &ref)
+void serializeOut(SerializationNode *node, const Vec3<T> &val, const Vec3<T> &ref)
 {
 	serializeOut(node->addNode("x"), val.x, ref.x);
 	serializeOut(node->addNode("y"), val.y, ref.y);
@@ -382,21 +374,20 @@ void serializeOut(const sp<SerializationNode> &node, const Vec3<T> &val, const V
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const Vec2<T> &val, const Vec2<T> &ref)
+void serializeOut(SerializationNode *node, const Vec2<T> &val, const Vec2<T> &ref)
 {
 	serializeOut(node->addNode("x"), val.x, ref.x);
 	serializeOut(node->addNode("y"), val.y, ref.y);
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const Rect<T> &val, const Rect<T> &ref)
+void serializeOut(SerializationNode *node, const Rect<T> &val, const Rect<T> &ref)
 {
 	serializeOut(node->addNode("p0"), val.p0, ref.p0);
 	serializeOut(node->addNode("p1"), val.p1, ref.p1);
 }
 
-template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const up<T> &ptr, const up<T> &ref)
+template <typename T> void serializeOut(SerializationNode *node, const up<T> &ptr, const up<T> &ref)
 {
 	if (ptr)
 	{
@@ -410,8 +401,7 @@ void serializeOut(const sp<SerializationNode> &node, const up<T> &ptr, const up<
 	}
 }
 
-template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const sp<T> &ptr, const sp<T> &ref)
+template <typename T> void serializeOut(SerializationNode *node, const sp<T> &ptr, const sp<T> &ref)
 {
 	if (ptr)
 	{
@@ -426,7 +416,7 @@ void serializeOut(const sp<SerializationNode> &node, const sp<T> &ptr, const sp<
 }
 
 template <typename Key, typename Value>
-void serializeOut(const sp<SerializationNode> &node, const std::map<Key, Value> &map,
+void serializeOut(SerializationNode *node, const std::map<Key, Value> &map,
                   const std::map<Key, Value> &ref)
 {
 	Key defaultKey;
@@ -457,8 +447,7 @@ void serializeOut(const sp<SerializationNode> &node, const std::map<Key, Value> 
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const StateRefMap<T> &map,
-                  const StateRefMap<T> &ref)
+void serializeOut(SerializationNode *node, const StateRefMap<T> &map, const StateRefMap<T> &ref)
 {
 	UString defaultKey;
 	sp<T> defaultValue;
@@ -488,7 +477,7 @@ void serializeOut(const sp<SerializationNode> &node, const StateRefMap<T> &map,
 }
 
 template <typename Value>
-void serializeOutSectionMap(const sp<SerializationNode> &node, const std::map<UString, Value> &map,
+void serializeOutSectionMap(SerializationNode *node, const std::map<UString, Value> &map,
                             const std::map<UString, Value> &ref)
 {
 	UString defaultKey;
@@ -519,7 +508,7 @@ void serializeOutSectionMap(const sp<SerializationNode> &node, const std::map<US
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const std::set<T> &set, const std::set<T> &)
+void serializeOut(SerializationNode *node, const std::set<T> &set, const std::set<T> &)
 {
 	T defaultRef;
 	for (const auto &entry : set)
@@ -529,15 +518,14 @@ void serializeOut(const sp<SerializationNode> &node, const std::set<T> &set, con
 }
 
 template <typename A, typename B>
-void serializeOut(const sp<SerializationNode> &node, const std::pair<A, B> &pair,
-                  const std::pair<A, B> &ref)
+void serializeOut(SerializationNode *node, const std::pair<A, B> &pair, const std::pair<A, B> &ref)
 {
 	serializeOut(node->addNode("first"), pair.first, ref.first);
 	serializeOut(node->addNode("second"), pair.second, ref.second);
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const std::list<T> &list, const std::list<T> &)
+void serializeOut(SerializationNode *node, const std::list<T> &list, const std::list<T> &)
 {
 	T defaultRef;
 	for (auto &entry : list)
@@ -547,8 +535,7 @@ void serializeOut(const sp<SerializationNode> &node, const std::list<T> &list, c
 }
 
 template <typename T>
-void serializeOut(const sp<SerializationNode> &node, const std::vector<T> &vector,
-                  const std::vector<T> &)
+void serializeOut(SerializationNode *node, const std::vector<T> &vector, const std::vector<T> &)
 {
 	T defaultRef;
 	for (auto &entry : vector)
@@ -560,14 +547,14 @@ void serializeOut(const sp<SerializationNode> &node, const std::vector<T> &vecto
 	serializeOut(node->addNode("sizeHint"), sizeHint, sizeHintDefault);
 }
 
-void serializeIn(const GameState *, sp<SerializationNode> node, sp<UnitAI> &ai);
-void serializeIn(const GameState *, sp<SerializationNode> node, sp<TacticalAI> &ai);
+void serializeIn(const GameState *, SerializationNode *node, sp<UnitAI> &ai);
+void serializeIn(const GameState *, SerializationNode *node, sp<TacticalAI> &ai);
 
-void serializeOut(sp<SerializationNode> node, const sp<UnitAI> &ptr, const sp<UnitAI> &ref);
+void serializeOut(SerializationNode *node, const sp<UnitAI> &ptr, const sp<UnitAI> &ref);
 bool operator==(const UnitAI &a, const UnitAI &b);
 bool operator!=(const UnitAI &a, const UnitAI &b);
 
-void serializeOut(sp<SerializationNode> node, const sp<TacticalAI> &ptr, const sp<TacticalAI> &ref);
+void serializeOut(SerializationNode *node, const sp<TacticalAI> &ptr, const sp<TacticalAI> &ref);
 bool operator==(const TacticalAI &a, const TacticalAI &b);
 bool operator!=(const TacticalAI &a, const TacticalAI &b);
 

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -37,9 +37,9 @@ class SaveMetadata
 	SaveMetadata(const SaveMetadata &metdata, time_t creationDate, const sp<GameState> gameState);
 
 	/* Deserialize given manifest document	*/
-	bool deserializeManifest(const sp<SerializationArchive> archive, const UString &saveFileName);
+	bool deserializeManifest(SerializationArchive *archive, const UString &saveFileName);
 
-	bool serializeManifest(const sp<SerializationArchive> archive) const;
+	bool serializeManifest(SerializationArchive *archive) const;
 
 	/* Creation date of save file (unix epoch)	*/
 	time_t getCreationDate() const;

--- a/tools/gamestate_serialize_gen/main.cpp
+++ b/tools/gamestate_serialize_gen/main.cpp
@@ -226,10 +226,10 @@ void writeHeader(std::ofstream &out, const StateDefinition &state)
 	{
 		if (object.external == false)
 			continue;
-		out << "void serializeIn(const GameState *, sp<SerializationNode> node, " << object.name
+		out << "void serializeIn(const GameState *, SerializationNode* node, " << object.name
 		    << " &obj);\n";
-		out << "void serializeOut(sp<SerializationNode> node, const " << object.name
-		    << " &obj, const " << object.name << " &ref);\n";
+		out << "void serializeOut(SerializationNode* node, const " << object.name << " &obj, const "
+		    << object.name << " &ref);\n";
 		out << "bool operator==(const " << object.name << " &a, const " << object.name << " &b);\n";
 		out << "bool operator!=(const " << object.name << " &a, const " << object.name
 		    << " &b);\n\n";
@@ -239,9 +239,9 @@ void writeHeader(std::ofstream &out, const StateDefinition &state)
 	{
 		if (e.external == false)
 			continue;
-		out << "void serializeIn(const GameState *, sp<SerializationNode> node, " << e.name
+		out << "void serializeIn(const GameState *, SerializationNode* node, " << e.name
 		    << " &val);\n";
-		out << "void serializeOut(sp<SerializationNode> node, const " << e.name << " &val, const "
+		out << "void serializeOut(SerializationNode* node, const " << e.name << " &val, const "
 		    << e.name << " &ref);\n";
 	}
 
@@ -261,9 +261,9 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 	{
 		if (object.external == true)
 			continue;
-		out << "inline void serializeIn(const GameState *, sp<SerializationNode> node, "
-		    << object.name << " &obj);\n";
-		out << "inline void serializeOut(sp<SerializationNode> node, const " << object.name
+		out << "inline void serializeIn(const GameState *, SerializationNode* node, " << object.name
+		    << " &obj);\n";
+		out << "inline void serializeOut(SerializationNode* node, const " << object.name
 		    << " &obj, const " << object.name << " &ref);\n";
 		out << "inline bool operator==(const " << object.name << " &a, const " << object.name
 		    << " &b);\n";
@@ -275,17 +275,17 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 	{
 		if (e.external == true)
 			continue;
-		out << "inline void serializeIn(const GameState *, sp<SerializationNode> node, " << e.name
+		out << "inline void serializeIn(const GameState *, SerializationNode* node, " << e.name
 		    << " &val);\n";
-		out << "inline void serializeOut(sp<SerializationNode> node, const " << e.name
+		out << "inline void serializeOut(SerializationNode* node, const " << e.name
 		    << " &val, const " << e.name << " &ref);\n";
 	}
 	for (auto &object : state.objects)
 	{
 		if (object.external == false)
 			out << "inline\n";
-		out << "void serializeIn(const GameState *state, sp<SerializationNode> node, "
-		    << object.name << " &obj)\n{\n";
+		out << "void serializeIn(const GameState *state, SerializationNode* node, " << object.name
+		    << " &obj)\n{\n";
 
 		out << "\tif (!node) return;\n";
 
@@ -316,8 +316,8 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 
 		if (object.external == false)
 			out << "inline\n";
-		out << "void serializeOut(sp<SerializationNode> node, const " << object.name
-		    << " &obj, const " << object.name << " &ref)\n{\n";
+		out << "void serializeOut(SerializationNode* node, const " << object.name << " &obj, const "
+		    << object.name << " &ref)\n{\n";
 
 		for (auto &member : object.members)
 		{
@@ -375,7 +375,7 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 	{
 		if (e.external == false)
 			out << "inline\n";
-		out << "void serializeIn(const GameState *state, sp<SerializationNode> node, " << e.name
+		out << "void serializeIn(const GameState *state, SerializationNode* node, " << e.name
 		    << " &val)\n{\n"
 		    << "\tstatic const std::map<" << e.name << ", UString> valueMap = {\n";
 		for (auto &value : e.values)
@@ -389,7 +389,7 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 
 		if (e.external == false)
 			out << "inline\n";
-		out << "void serializeOut(sp<SerializationNode> node, const " << e.name << " &val, const "
+		out << "void serializeOut(SerializationNode* node, const " << e.name << " &val, const "
 		    << e.name << " &ref)\n{\n"
 		    << "\tstatic const std::map<" << e.name << ", UString> valueMap = {\n";
 		for (auto &value : e.values)


### PR DESCRIPTION
The lifetimes of these objects is known, so there's no need for shared
ownership.

Might make things a little faster if we're doing doing lots of atomic
refcounting...