### PR TITLE
fixed currentAgent and currentVehicle selection

### DIFF
--- a/game/ui/city/alertscreen.cpp
+++ b/game/ui/city/alertscreen.cpp
@@ -93,19 +93,22 @@ void AlertScreen::eventOccurred(Event *e)
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_EQUIPAGENT")
 		{
-			fw().stageQueueCommand(
-			    {StageCmd::Command::PUSH,
-			     mksp<AEquipScreen>(this->state, agentAssignment->currentAgent)});
+			if (agentAssignment->currentAgent)
+			{
+				fw().stageQueueCommand(
+				    {StageCmd::Command::PUSH,
+				     mksp<AEquipScreen>(this->state, agentAssignment->currentAgent)});
+			}
 			return;
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_EQUIPVEHICLE")
 		{
-			auto equipScreen = mksp<VEquipScreen>(this->state);
 			if (agentAssignment->currentVehicle)
 			{
+				auto equipScreen = mksp<VEquipScreen>(this->state);
 				equipScreen->setSelectedVehicle(agentAssignment->currentVehicle);
+				fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
 			}
-			fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
 			return;
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_QUIT")

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -231,19 +231,22 @@ void BuildingScreen::eventOccurred(Event *e)
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_EQUIPAGENT")
 		{
-			fw().stageQueueCommand(
-			    {StageCmd::Command::PUSH,
-			     mksp<AEquipScreen>(this->state, agentAssignment->currentAgent)});
+			if (agentAssignment->currentAgent)
+			{
+				fw().stageQueueCommand(
+				    {StageCmd::Command::PUSH,
+				     mksp<AEquipScreen>(this->state, agentAssignment->currentAgent)});
+			}
 			return;
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_EQUIPVEHICLE")
 		{
-			auto equipScreen = mksp<VEquipScreen>(this->state);
 			if (agentAssignment->currentVehicle)
 			{
+				auto equipScreen = mksp<VEquipScreen>(this->state);
 				equipScreen->setSelectedVehicle(agentAssignment->currentVehicle);
+				fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
 			}
-			fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
 			return;
 		}
 	}

--- a/game/ui/components/agentassignment.cpp
+++ b/game/ui/components/agentassignment.cpp
@@ -79,10 +79,13 @@ void AgentAssignment::init(sp<Form> form, Vec2<int> location, Vec2<int> size)
 			return select;
 
 		auto agent = c->getData<Agent>();
+		if (agent)
+		{
+			this->currentAgent = agent;
+		}
 		auto icon = c->findControl(ControlGenerator::AGENT_ICON_NAME);
 		if (agent && icon && c->isPointInsideControlBounds(e, icon))
 		{
-			this->currentAgent = agent;
 			this->isDragged = false;
 			fw().stageQueueCommand(
 			    {StageCmd::Command::PUSH, mksp<AEquipScreen>(this->state, agent)});
@@ -267,6 +270,15 @@ void AgentAssignment::updateLocation()
 				}
 			}
 		}
+	}
+
+	if (!vehicles.empty())
+	{
+		currentVehicle = vehicles.front();
+	}
+	if (!agents.empty())
+	{
+		currentAgent = agents.front();
 	}
 
 	/* Create tree.

--- a/game/ui/components/locationscreen.cpp
+++ b/game/ui/components/locationscreen.cpp
@@ -106,16 +106,22 @@ void LocationScreen::eventOccurred(Event *e)
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_EQUIPAGENT")
 		{
-			fw().stageQueueCommand(
-			    {StageCmd::Command::PUSH,
-			     mksp<AEquipScreen>(this->state, agentAssignment->currentAgent)});
+			if (agentAssignment->currentAgent)
+			{
+				fw().stageQueueCommand(
+				    {StageCmd::Command::PUSH,
+				     mksp<AEquipScreen>(this->state, agentAssignment->currentAgent)});
+			}
 			return;
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_EQUIPVEHICLE")
 		{
-			auto equipScreen = mksp<VEquipScreen>(this->state);
-			equipScreen->setSelectedVehicle(agentAssignment->currentVehicle);
-			fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
+			if (agentAssignment->currentVehicle)
+			{
+				auto equipScreen = mksp<VEquipScreen>(this->state);
+				equipScreen->setSelectedVehicle(agentAssignment->currentVehicle);
+				fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
+			}
 			return;
 		}
 	}


### PR DESCRIPTION
fixed the first issue from #291 

> First issue i had is a crash when i tried to outfit a vehicle.
> You click on the icon with the vehicle and the + sign at the UI menu at the bottom and from that screen click on the top right vehicle with the missile and it crashes.