### PR TITLE
implemented the BribeScreen

### DIFF
--- a/data/forms/city/bribe.form
+++ b/data/forms/city/bribe.form
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openapoc>
+  <form id="FORM_SCORE_SCREEN">
+    <style minwidth="640" minheight="480">
+      <position x="centre" y="centre"/>
+      <size width="640" height="480"/>
+      <graphic>
+        <image>xcom3/ufodata/dip_rift.pcx</image>
+        <position x="0" y="0"/>
+        <size width="640" height="480"/>
+      </graphic>
+      <label text="OFFER CASH SETTLEMENT">
+        <position x="113" y="0"/>
+        <size width="420" height="32"/>
+        <alignment horizontal="centre" vertical="centre"/>
+        <font>bigfont</font>
+      </label>
+      <label id="TEXT_FUNDS">
+        <position x="572" y="11"/>
+        <size width="60" height="10"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+      <label id="TEXT_DATE">
+        <position x="27" y="77"/>
+        <size width="300" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+      <label id="TEXT_RELATION">
+        <position x="27" y="102"/>
+        <size width="300" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+      <label id="TEXT_OFFER">
+        <position x="27" y="152"/>
+        <size width="400" height="30"/>
+        <alignment horizontal="left" vertical="top"/>
+        <font>smalfont</font>
+      </label>
+      <graphicbutton id="BUTTON_BRIBE">
+        <position x="602" y="40"/>
+        <size width="35" height="34"/>
+        <imagedepressed>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:78:xcom3/ufodata/base.pcx</imagedepressed>
+      </graphicbutton>
+      <graphicbutton id="BUTTON_QUIT">
+        <position x="602" y="443"/>
+        <size width="35" height="34"/>
+        <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
+      </graphicbutton>
+    </style>
+  </form>
+</openapoc>

--- a/game/state/shared/organisation.h
+++ b/game/state/shared/organisation.h
@@ -154,6 +154,10 @@ class Organisation : public StateObject
 	Relation isRelatedTo(const StateRef<Organisation> &other) const;
 	bool isPositiveTo(const StateRef<Organisation> &other) const;
 	bool isNegativeTo(const StateRef<Organisation> &other) const;
+	// Calculate the cost of a bribe.
+	int costOfBribeBy(const StateRef<Organisation> &other) const;
+	// The organisation is bribed by other org.
+	bool bribedBy(GameState &state, StateRef<Organisation> other, int bribe);
 	float getRelationTo(const StateRef<Organisation> &other) const;
 	void adjustRelationTo(GameState &state, StateRef<Organisation> other, float value);
 	std::map<StateRef<Organisation>, float> current_relations;

--- a/game/ui/CMakeLists.txt
+++ b/game/ui/CMakeLists.txt
@@ -23,6 +23,7 @@ set (GAMEUI_SOURCE_FILES
 	
 	city/basebuyscreen.cpp
 	city/baseselectscreen.cpp
+	city/bribescreen.cpp
 	city/buildingscreen.cpp
 	city/alertscreen.cpp
 	city/infiltrationscreen.cpp
@@ -86,6 +87,7 @@ set (GAMEUI_HEADER_FILES
 	
 	city/basebuyscreen.h
 	city/baseselectscreen.h
+	city/bribescreen.h
 	city/buildingscreen.h
 	city/alertscreen.h
 	city/infiltrationscreen.h

--- a/game/ui/city/bribescreen.cpp
+++ b/game/ui/city/bribescreen.cpp
@@ -1,0 +1,161 @@
+#include "game/ui/city/bribescreen.h"
+#include "forms/form.h"
+#include "forms/label.h"
+#include "forms/ui.h"
+#include "framework/event.h"
+#include "framework/framework.h"
+#include "framework/keycodes.h"
+#include "game/state/city/city.h"
+#include "game/state/gamestate.h"
+#include "game/state/shared/organisation.h"
+
+namespace OpenApoc
+{
+
+BribeScreen::BribeScreen(sp<GameState> state)
+    : Stage(), menuform(ui().getForm("city/bribe")), state(state),
+      organisation(state->current_city->cityViewSelectedOrganisation)
+{
+}
+
+BribeScreen::~BribeScreen() = default;
+
+/**
+ * Update info about deal.
+ */
+void BribeScreen::updateInfo()
+{
+	UString relationship;
+	UString offer;
+	bribe = organisation->costOfBribeBy(state->getPlayer());
+
+	switch (organisation->isRelatedTo(state->getPlayer()))
+	{
+		case Organisation::Relation::Allied:
+			relationship = ": allied with:";
+			offer =
+			    tr("X-COM is ALLIED with this organization. The relationship cannot be improved.");
+			bribe = 0;
+			break;
+
+		case Organisation::Relation::Friendly:
+			relationship = ": friendly with:";
+			offer = getOfferString(bribe, tr("ALLIED"));
+			break;
+
+		case Organisation::Relation::Neutral:
+			relationship = ": neutral towards:";
+			offer = getOfferString(bribe, tr("FRIENDLY"));
+			break;
+
+		case Organisation::Relation::Unfriendly:
+			relationship = ": unfriendly towards:";
+			offer = getOfferString(bribe, tr("NEUTRAL"));
+			break;
+
+		case Organisation::Relation::Hostile:
+			relationship = ": hostile towards:";
+			if (organisation->isRelatedTo(state->getAliens()) == Organisation::Relation::Allied)
+			{
+				offer = tr("Whilst X-COM continue to oppose our Alien friends we will remain "
+				           "hostile. Negotiations are impossible.");
+				bribe = 0;
+			}
+			else
+			{
+				offer = getOfferString(bribe, tr("UNFRIENDLY"));
+			}
+			break;
+
+		default:
+			relationship = ": Attitude unknown towards:";
+			offer = "Unconventional relations";
+			bribe = 0;
+			LogError(offer);
+	}
+
+	if (organisation->takenOver)
+	{
+		offer = tr("This organization is under Alien control.The Alien race will not enter "
+		           "negotiations with X-COM.");
+		bribe = 0;
+	}
+
+	labelFunds->setText(state->getPlayerBalance());
+	labelRelation->setText(format("%s%s X-COM", tr(organisation->name), tr(relationship)));
+	labelOffer->setText(offer);
+}
+
+/**
+ * Get the offer of a bribe.
+ * @param itWillCost - the sum of the bribe
+ * @param newRelation - text of better attitude
+ * @return - a text of the offer
+ */
+UString BribeScreen::getOfferString(int itWillCost, const UString &newAttitude) const
+{
+	return format("%s %d  %s  %s", tr("It will cost: $"), itWillCost,
+	              tr("to improve relations to:"), newAttitude);
+}
+
+void BribeScreen::begin()
+{
+	menuform->findControlTyped<Label>("TEXT_DATE")->setText(state->gameTime.getLongDateString());
+	labelFunds = menuform->findControlTyped<Label>("TEXT_FUNDS");
+	labelRelation = menuform->findControlTyped<Label>("TEXT_RELATION");
+	labelOffer = menuform->findControlTyped<Label>("TEXT_OFFER");
+
+	updateInfo();
+}
+
+void BribeScreen::pause() {}
+
+void BribeScreen::resume() {}
+
+void BribeScreen::finish() {}
+
+void BribeScreen::eventOccurred(Event *e)
+{
+	menuform->eventOccured(e);
+
+	if (e->type() == EVENT_KEY_DOWN)
+	{
+		switch (e->keyboard().KeyCode)
+		{
+			case SDLK_ESCAPE:
+			case SDLK_RETURN:
+				fw().stageQueueCommand({StageCmd::Command::POP});
+				return;
+		}
+	}
+
+	if (e->type() == EVENT_FORM_INTERACTION && e->forms().EventFlag == FormEventType::ButtonClick)
+	{
+		if (e->forms().RaisedBy->Name == "BUTTON_BRIBE")
+		{
+			if (bribe > 0)
+			{
+				organisation->bribedBy(*state, state->getPlayer(), bribe);
+				updateInfo();
+			}
+			return;
+		}
+		if (e->forms().RaisedBy->Name == "BUTTON_QUIT")
+		{
+			fw().stageQueueCommand({StageCmd::Command::POP});
+			return;
+		}
+	}
+}
+
+void BribeScreen::update() { menuform->update(); }
+
+void BribeScreen::render()
+{
+	fw().stageGetPrevious(this->shared_from_this())->render();
+	menuform->render();
+}
+
+bool BribeScreen::isTransition() { return false; }
+
+}; // namespace OpenApoc

--- a/game/ui/city/bribescreen.h
+++ b/game/ui/city/bribescreen.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include "framework/stage.h"
+#include "game/state/stateobject.h"
+#include "library/sp.h"
+
+namespace OpenApoc
+{
+
+class GameState;
+class Form;
+class Label;
+class Organisation;
+
+class BribeScreen : public Stage
+{
+  private:
+	sp<Form> menuform;
+	sp<GameState> state;
+
+	sp<Label> labelFunds;
+	sp<Label> labelRelation;
+	sp<Label> labelOffer;
+
+	StateRef<Organisation> organisation;
+	// Sum of the bribe.
+	int bribe = 0;
+
+	// Update info about deal.
+	void updateInfo();
+	// Get the offer of a bribe.
+	UString getOfferString(int itWillCost, const UString &newAttitude) const;
+
+  public:
+	BribeScreen(sp<GameState> state);
+	~BribeScreen() override;
+	// Stage control
+	void begin() override;
+	void pause() override;
+	void resume() override;
+	void finish() override;
+	void eventOccurred(Event *e) override;
+	void update() override;
+	void render() override;
+	bool isTransition() override;
+};
+
+}; // namespace OpenApoc

--- a/game/ui/gameui.vcxproj
+++ b/game/ui/gameui.vcxproj
@@ -55,6 +55,7 @@
     <ClCompile Include="city\basebuyscreen.cpp" />
     <ClCompile Include="city\basedefensescreen.cpp" />
     <ClCompile Include="city\baseselectscreen.cpp" />
+    <ClCompile Include="city\bribescreen.cpp" />
     <ClCompile Include="city\buildingscreen.cpp" />
     <ClCompile Include="city\infiltrationscreen.cpp" />
     <ClCompile Include="city\scorescreen.cpp" />
@@ -108,6 +109,7 @@
     <ClInclude Include="city\basebuyscreen.h" />
     <ClInclude Include="city\basedefensescreen.h" />
     <ClInclude Include="city\baseselectscreen.h" />
+    <ClInclude Include="city\bribescreen.h" />
     <ClInclude Include="city\buildingscreen.h" />
     <ClInclude Include="city\infiltrationscreen.h" />
     <ClInclude Include="city\scorescreen.h" />

--- a/game/ui/gameui.vcxproj.filters
+++ b/game/ui/gameui.vcxproj.filters
@@ -176,6 +176,9 @@
     <ClCompile Include="general\agentsheet.cpp" />
     <ClCompile Include="general\loadingscreen.cpp" />
     <ClCompile Include="general\vehiclesheet.cpp" />
+    <ClCompile Include="city\bribescreen.cpp">
+      <Filter>city</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="base\basescreen.h">
@@ -323,5 +326,8 @@
     <ClInclude Include="general\aequipmentsheet.h" />
     <ClInclude Include="general\agentsheet.h" />
     <ClInclude Include="general\vehiclesheet.h" />
+    <ClInclude Include="city\bribescreen.h">
+      <Filter>city</Filter>
+    </ClInclude>
   </ItemGroup>
 </Project>

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -57,6 +57,7 @@
 #include "game/ui/city/basebuyscreen.h"
 #include "game/ui/city/basedefensescreen.h"
 #include "game/ui/city/baseselectscreen.h"
+#include "game/ui/city/bribescreen.h"
 #include "game/ui/city/buildingscreen.h"
 #include "game/ui/city/infiltrationscreen.h"
 #include "game/ui/city/scorescreen.h"
@@ -1484,8 +1485,12 @@ CityView::CityView(sp<GameState> state)
 		});
 	this->uiTabs[7]
 	    ->findControl("BUTTON_BRIBE")
-	    ->addCallback(FormEventType::ButtonClick,
-	                  [this](Event *) { LogWarning("Implement bribery screen"); });
+	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
+		    if (this->state->current_city->cityViewSelectedOrganisation)
+		    {
+			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BribeScreen>(this->state)});
+		    }
+		});
 
 	auto font = ui().getFont("smallset");
 	for (int i = 0; i <= state->current_city->roadSegments.size(); i++)


### PR DESCRIPTION
- Implemented the BribeScreen.
- Since the relation is float instead of int, changed the calculation of thresholds.
`	float x = this->getRelationTo(other);`
`	if (x < -50)	{ return Relation::Hostile; }`
`	else if (x < -25)	{ return Relation::Unfriendly; }`
`	else if (x < 25)	{ return Relation::Neutral; }`
`	else if (x < 75)	{ return Relation::Friendly; }`
`	else	{ return Relation::Allied; }`
It is not exactly like vanilla, but very close. This approach allow to simplify calculations and reduce the number of bugs. Another approach is use the int relation like vanilla.

The screen:
![bribe_openapoc](https://user-images.githubusercontent.com/3616568/33905837-01fbffee-df91-11e7-9158-9069682f8577.png)
