### PR TITLE
fixed destructor of GameState

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -83,8 +83,11 @@ GameState::~GameState()
 		for (auto &f : b.second->facilities)
 		{
 			if (f->lab)
-				f->lab->current_project = "";
-			f->lab = "";
+			{
+				f->lab->assigned_agents.clear();
+				f->lab->current_project.clear();
+				f->lab.clear();
+			}
 		}
 		b.second->building.clear();
 	}


### PR DESCRIPTION
fixed issue described in #260 
![tumblr_inline_mmr7u5q6481qz4rgp](https://user-images.githubusercontent.com/33913088/33565974-89b5aa24-d916-11e7-926a-bf6d8df868c5.png)

When quit game the destructor of Lab calls to agents from list, but agents already destroyed.
Simplest way is to clear the Lab's agents list in the GameState destructor.