### PR TITLE
fixed mission timers

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -36,6 +36,21 @@ namespace
 static const Vec3<float> offsetFlying{0.5f, 0.5f, 0.5f};
 static const Vec3<float> offsetLandInto{0.5f, 0.5f, 0.01f};
 static const Vec3<float> offsetLaunch{0.5f, 0.5f, -1.0f};
+
+// Self-destruct timer for UFOs.
+// division /5 because need to round to 5 mins
+// TODO: find a way how to extract from the game data
+static const std::map<UString, std::pair<unsigned, unsigned>> selfDestructTimer = {
+    {"VEHICLETYPE_ALIEN_PROBE", {10 / 5 * TICKS_PER_MINUTE, 90 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_SCOUT", {10 / 5 * TICKS_PER_MINUTE, 90 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_TRANSPORTER", {15 / 5 * TICKS_PER_MINUTE, 120 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_FAST_ATTACK_SHIP", {15 / 5 * TICKS_PER_MINUTE, 120 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_DESTROYER", {15 / 5 * TICKS_PER_MINUTE, 120 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_ASSAULT_SHIP", {15 / 5 * TICKS_PER_MINUTE, 180 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_BOMBER", {10 / 5 * TICKS_PER_MINUTE, 120 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_ESCORT", {15 / 5 * TICKS_PER_MINUTE, 120 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_BATTLESHIP", {60 / 5 * TICKS_PER_MINUTE, 240 / 5 * TICKS_PER_MINUTE}},
+    {"VEHICLETYPE_ALIEN_MOTHERSHIP", {60 / 5 * TICKS_PER_MINUTE, 240 / 5 * TICKS_PER_MINUTE}}};
 }
 
 FlyingVehicleTileHelper::FlyingVehicleTileHelper(TileMap &map, Vehicle &v)
@@ -518,9 +533,16 @@ VehicleMission *VehicleMission::snooze(GameState &, Vehicle &, unsigned int snoo
 
 VehicleMission *VehicleMission::selfDestruct(GameState &state, Vehicle &v)
 {
+	unsigned timer = TICKS_PER_HOUR;
+	auto timerUFO = selfDestructTimer.find(v.type.id);
+	if (timerUFO != selfDestructTimer.cend())
+	{
+		timer = 5 * std::uniform_int_distribution<unsigned>(timerUFO->second.first,
+		                                                    timerUFO->second.second)(state.rng);
+	}
 	auto *mission = new VehicleMission();
 	mission->type = MissionType::SelfDestruct;
-	mission->timeToSnooze = SELF_DESTRUCT_TIMER;
+	mission->timeToSnooze = timer;
 	return mission;
 }
 

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -14,7 +14,6 @@ namespace OpenApoc
 {
 
 static const int TELEPORTER_SPREAD = 10;
-static const int SELF_DESTRUCT_TIMER = 12 * TICKS_PER_HOUR;
 static const int DIMENSION_GATE_DELAY = TICKS_PER_SECOND / 2;
 static const int FOLLOW_BOUNDS_XY = 4;
 static const int FOLLOW_BOUNDS_Z = 1;


### PR DESCRIPTION
partially fixed the issue #339 "Destroyed buildings often trap vehicles in their basement causing performance issues and eventual CTD."
- if really impossible to leave a building, then next attempt will be after 30 min.
- the self-destruct timer for UFO was hardcoded as described by @FilmBoy84 #339
- the self-destruct timer for vehicles decreased to 1 hour.