### PR TITLE
WIP: implementation of the Observer pattern [incomplete]

### DIFF
--- a/game/state/CMakeLists.txt
+++ b/game/state/CMakeLists.txt
@@ -78,6 +78,7 @@ set (GAMESTATE_SOURCE_FILES
 	gamestate_serialize_generated.cpp
 	gametime.cpp
 	message.cpp
+	observablelinkedmap.cpp
 	savemanager.cpp
 	
 	tilemap/collision.cpp
@@ -173,6 +174,8 @@ set (GAMESTATE_HEADER_FILES
 	gametime.h
 	gametime_facet.h
 	message.h
+	observablelinkedmap.h
+	observerlinkedmap.h
 	savemanager.h
 	stateobject.h
 	

--- a/game/state/gamestate.vcxproj
+++ b/game/state/gamestate.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="city\economyinfo.cpp" />
+    <ClCompile Include="observablelinkedmap.cpp" />
     <ClCompile Include="rules\city\ufomissionpreference.cpp" />
     <ClCompile Include="shared\agent.cpp" />
     <ClCompile Include="city\base.cpp" />
@@ -100,6 +101,8 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="city\economyinfo.h" />
+    <ClInclude Include="observablelinkedmap.h" />
+    <ClInclude Include="observerlinkedmap.h" />
     <ClInclude Include="rules\city\ufomissionpreference.h" />
     <ClInclude Include="shared\agent.h" />
     <ClInclude Include="city\base.h" />

--- a/game/state/gamestate.vcxproj.filters
+++ b/game/state/gamestate.vcxproj.filters
@@ -249,6 +249,9 @@
     <ClCompile Include="rules\city\ufomissionpreference.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="observablelinkedmap.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="gamestate.h">
@@ -507,6 +510,12 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="rules\city\ufomissionpreference.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="observablelinkedmap.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="observerlinkedmap.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/game/state/observablelinkedmap.cpp
+++ b/game/state/observablelinkedmap.cpp
@@ -1,0 +1,140 @@
+#include "game/state/observablelinkedmap.h"
+#include "game/state/observerlinkedmap.h"
+
+namespace OpenApoc
+{
+
+template <class T> ObservableLinkedMap<T>::~ObservableLinkedMap()
+{
+	for (auto &i : map)
+	{
+		fireRemoveEvent(i.second);
+	}
+	list.clear();
+	map.clear();
+}
+
+/**
+ * Get ID of the item.
+ */
+template <class T> const UString &ObservableLinkedMap<T>::getId(sp<T> item) const
+{
+	for (auto &i : map)
+	{
+		if (i.second == item)
+			return i.first;
+	}
+	return nullptr;
+}
+
+/**
+ * Get item by ID.
+ */
+template <class T> sp<T> ObservableLinkedMap<T>::getItem(const UString &id) const
+{
+	auto it = map.find(id);
+	return it == map.end() ? nullptr : it->second;
+}
+
+/**
+ * Add item to the linked map.
+ */
+template <class T> void ObservableLinkedMap<T>::addItem(const UString &id, sp<T> item)
+{
+	auto it = map.find(id);
+	if (it == map.end())
+	{
+		fireAddEvent(item);
+		list.push_back(item);
+		map.emplace(id, item);
+	}
+	else if (it->second == item)
+	{
+		fireChangeEvent(item);
+	}
+	else // found, but the item is not the same
+	{
+		removeItem(id);
+		addItem(id, item);
+	}
+}
+
+/**
+ * Remove item from the linked map.
+ */
+template <class T> void ObservableLinkedMap<T>::removeItem(const UString &id)
+{
+	auto it = map.find(id);
+	if (it != map.end())
+	{
+		fireRemoveEvent(it->second);
+		list.remove(it->second);
+		map.erase(id);
+	}
+}
+
+/**
+ * Remove item from the linked map.
+ */
+template <class T> void ObservableLinkedMap<T>::removeItem(sp<T> item)
+{
+	for (auto &i : map)
+	{
+		if (i.second == item)
+		{
+			fireRemoveEvent(i.second);
+			list.remove(i.second);
+			map.erase(i.first);
+			break;
+		}
+	}
+}
+
+/**
+ * Change item in the linked map.
+ * @param item - the item that has changed
+ */
+template <class T> void ObservableLinkedMap<T>::changeItem(sp<T> item)
+{
+	// Assume that the item exist in the map.
+	// TODO: add either a check or a conditional check of existence in the map
+	fireChangeEvent(item);
+}
+
+/**
+ * Broadcast the "add item" event.
+ * @param item - added item
+ */
+template <class T> void ObservableLinkedMap<T>::fireAddEvent(sp<T> &item)
+{
+	for (auto observer : observers)
+	{
+		static_cast<ObserverLinkedMap<T> *>(observer)->added(item);
+	}
+}
+
+/**
+ * Broadcast the "remove item" event.
+ * @param item - removed item
+ */
+template <class T> void ObservableLinkedMap<T>::fireRemoveEvent(sp<T> &item)
+{
+	for (auto observer : observers)
+	{
+		static_cast<ObserverLinkedMap<T> *>(observer)->removed(item);
+	}
+}
+
+/**
+ * Broadcast the "change item" event.
+ * @param item - changed item
+ */
+template <class T> void ObservableLinkedMap<T>::fireChangeEvent(sp<T> &item)
+{
+	for (auto observer : observers)
+	{
+		static_cast<ObserverLinkedMap<T> *>(observer)->changed(item);
+	}
+}
+
+} // namespace OpenApoc

--- a/game/state/observablelinkedmap.h
+++ b/game/state/observablelinkedmap.h
@@ -1,0 +1,59 @@
+#pragma once
+
+#include "library/observer.h"
+#include "library/sp.h"
+#include "library/strings.h"
+#include <functional>
+#include <list>
+#include <unordered_map>
+
+namespace OpenApoc
+{
+
+/**
+ * The ObservableLinkedMap contains map of items and the order of items insertion.
+ * Also the class broadcasts events for observers.
+ * The class is not multithread safe.
+ */
+template <class T> class ObservableLinkedMap : public Observable
+{
+  public:
+	ObservableLinkedMap() = default;
+	virtual ~ObservableLinkedMap();
+
+	// Get the map of items.
+	const std::unordered_map<UString, sp<T>> &getMap() const { return map; }
+	// Get the list of items.
+	const std::list<sp<T>> &getList() const { return list; }
+	// Get ID of the item.
+	const UString &getId(sp<T> item) const;
+	// Get item by ID.
+	sp<T> getItem(const UString &id) const;
+
+	// Add item to the linked map.
+	void addItem(const UString &id, sp<T> item);
+	// Remove item from the linked map.
+	void removeItem(const UString &id);
+	// Remove item from the linked map.
+	void removeItem(sp<T> item);
+	// Change item in the linked map.
+	void changeItem(sp<T> item);
+
+	// Change the order of items in the list.
+	void sort(std::function<bool(const sp<T> &a, const sp<T> &b)> comp) { list.sort(comp); }
+
+  protected:
+	// Broadcast the "add item" event.
+	void fireAddEvent(sp<T> &item);
+	// Broadcast the "remove item" event.
+	void fireRemoveEvent(sp<T> &item);
+	// Broadcast the "change item" event.
+	void fireChangeEvent(sp<T> &item);
+
+	// The map of IDs and items.
+	std::unordered_map<UString, sp<T>, UString::Hash> map;
+	// The list contains the order of items insertion.
+	std::list<sp<T>> list;
+};
+
+} // namespace OpenApoc

--- a/game/state/observerlinkedmap.h
+++ b/game/state/observerlinkedmap.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "library/observer.h"
+#include "library/sp.h"
+
+namespace OpenApoc
+{
+
+template <class T> class ObserverLinkedMap : public Observer
+{
+  public:
+	// The "added" event occurs when the item added to the linked map.
+	virtual void added(sp<T> &item) = 0;
+	// The "removed" event occurs when the item removed from the linked map.
+	virtual void removed(sp<T> &item) = 0;
+	// The "changed" event occurs when the item changed in the linked map.
+	virtual void changed(sp<T> &item) = 0;
+};
+
+} // namespace OpenApoc

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -10,11 +10,13 @@ set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package (Threads REQUIRED)
 
 set (LIBRARY_SOURCE_FILES
+	observer.cpp
 	strings.cpp
 	voxel.cpp)
 source_group(library\\sources FILES ${LIBRARY_SOURCE_FILES})
 set (LIBRARY_HEADER_FILES
 	colour.h
+	observer.h
 	rect.h
 	sp.h
 	strings.h

--- a/library/library.vcxproj
+++ b/library/library.vcxproj
@@ -21,6 +21,7 @@
   <ItemGroup>
     <ClInclude Include="colour.h" />
     <ClInclude Include="line.h" />
+    <ClInclude Include="observer.h" />
     <ClInclude Include="rect.h" />
     <ClInclude Include="resource.h" />
     <ClInclude Include="sp.h" />
@@ -32,6 +33,7 @@
     <ClInclude Include="vector_remove.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="observer.cpp" />
     <ClCompile Include="strings.cpp" />
     <ClCompile Include="voxel.cpp" />
   </ItemGroup>

--- a/library/library.vcxproj.filters
+++ b/library/library.vcxproj.filters
@@ -45,9 +45,12 @@
     <ClInclude Include="strings_format.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-	<ClInclude Include="vector_remove.h">
-	  <Filter>Header Files</Filter>
-	</ClInclude>
+    <ClInclude Include="vector_remove.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="observer.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="strings.cpp">
@@ -168,6 +171,9 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="$(MSBuildThisFileDirectory)..\..\lib\native\src\boost_thread.tss_null.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="observer.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/library/observer.cpp
+++ b/library/observer.cpp
@@ -1,0 +1,107 @@
+#include "library/observer.h"
+
+namespace OpenApoc
+{
+
+Observable::Observable(Observable &&observable)
+{
+	for (Observer *observer : observable.observers)
+	{
+		observable.detach(observer);
+		attach(observer);
+	}
+}
+
+Observable::~Observable()
+{
+	for (Observer *observer : observers)
+	{
+		detach(observer);
+	}
+}
+
+Observable &Observable::operator=(Observable &&observable)
+{
+	for (Observer *observer : observable.observers)
+	{
+		observable.detach(observer);
+		attach(observer);
+	}
+	return *this;
+}
+
+/**
+ * Add observer to the observers list.
+ * @param observer - the observer that should be added to the list.
+ */
+void Observable::attach(Observer *observer)
+{
+	observer->attached(this);
+	observers.push_back(observer);
+}
+
+/**
+ * Remove observer from the observer list.
+ * @param observer - the observer that should be removed from the list.
+ */
+void Observable::detach(Observer *observer)
+{
+	observer->detached();
+	observers.remove(observer);
+}
+
+Observer::Observer(const Observer &observer)
+{
+	if (observer.observable)
+		observer.observable->attach(this);
+}
+
+Observer::Observer(Observer &&observer)
+{
+	if (Observable *observable = observer.observable)
+	{
+		observable->detach(&observer);
+		observable->attach(this);
+	}
+}
+
+Observer::~Observer()
+{
+	if (observable)
+		observable->detach(this);
+}
+
+Observer &Observer::operator=(const Observer &observer)
+{
+	if (observer.observable)
+		observer.observable->attach(this);
+	return *this;
+}
+
+Observer &Observer::operator=(Observer &&observer)
+{
+	if (Observable *observable = observer.observable)
+	{
+		observable->detach(&observer);
+		observable->attach(this);
+	}
+	return *this;
+}
+
+/**
+ * The attached event.
+ * @param observable - that attached this observer.
+ */
+void Observer::attached(Observable *observable)
+{
+	if (this->observable)
+		this->observable->detach(this);
+	this->observable = observable;
+}
+
+/**
+ * The detached event.
+ */
+void Observer::detached() { observable = nullptr; }
+
+} // namespace OpenApoc

--- a/library/observer.h
+++ b/library/observer.h
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <list>
+
+namespace OpenApoc
+{
+
+class Observer;
+
+/**
+ * The Observable class is a part of the Observer pattern.
+ * The class broadcasts events that occurs in it.
+ */
+class Observable
+{
+  public:
+	Observable() = default;
+	Observable(Observable &&observable);
+	virtual ~Observable();
+
+	Observable &operator=(Observable &&observable);
+
+	// Add observer to the observers list.
+	virtual void attach(Observer *observer);
+	// Remove observer from the observers list.
+	virtual void detach(Observer *observer);
+
+	// Broadcasts of events implements depends on the needs of derived class.
+
+  protected:
+	// The list of observers that should receive events.
+	std::list<Observer *> observers;
+};
+
+/**
+ * The Observer class
+ * that receives events from an observable class.
+ */
+class Observer
+{
+  public:
+	Observer() = default;
+	Observer(const Observer &observer);
+	Observer(Observer &&observer);
+	virtual ~Observer();
+
+	Observer &operator=(const Observer &observer);
+	Observer &operator=(Observer &&observer);
+
+	// The "attached" event occurs when the observer attached to an observable.
+	virtual void attached(Observable *observable);
+	// The "detached" event occurs when the observer detached from the observable.
+	virtual void detached();
+
+	// Other events implements depends on the needs of derived class.
+
+  protected:
+	// A class that broadcasts events.
+	Observable *observable = nullptr;
+};
+
+} // namespace OpenApoc

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -282,6 +282,15 @@ void UString::remove(size_t offset, size_t count)
 
 bool UString::operator!=(const UString &other) const { return this->u8Str != other.u8Str; }
 
+size_t UString::Hash::operator()(const UString &str) const noexcept
+{
+	if (str.hashCode == 0)
+	{
+		str.hashCode = std::hash<std::string>{}(str.u8Str);
+	}
+	return str.hashCode;
+}
+
 UString operator+(const UString &lhs, const UString &rhs)
 {
 	UString s;

--- a/library/strings.h
+++ b/library/strings.h
@@ -14,6 +14,7 @@ class UString
 {
   private:
 	std::string u8Str;
+	mutable size_t hashCode = 0;
 
   public:
 	// ASSUMPTIONS:
@@ -83,6 +84,11 @@ class UString
 	ConstIterator end() const;
 
 	static UniChar u8Char(char c);
+
+	struct Hash
+	{
+		size_t operator()(const UString &str) const noexcept;
+	};
 };
 
 UString operator+(const UString &lhs, const UString &rhs);


### PR DESCRIPTION
The Observer pattern is a possible replacement for the StateRefMap + StateRef.

I.e. ObservableLinkedMap contains agents:
```ObservableLinkedMap<Agent> agents;```

The Lab is Observer for the agents map.
```class Lab : ObserverLinkedMap<Agent>```

If agent died (during battle or even if the agents map destroyed during the game's quitting) the lab will receive the event "removed" and remove the agent from its own list.

The vehicles horizontal list could be observer for the vehicles map.
![horizontallist_vehicles](https://user-images.githubusercontent.com/3616568/35291068-33d6c00a-007d-11e8-8753-e41817d8fe09.png)
If the player sold or buy a vehicle then the list updates automatically after receive an event. If a vehicle change its state (i.e. enter to building) then the list receives the "changed" event and changes picture of the vehicle accordingly.

The same for agents horizontal list (in battle mode too) and for the organisations list.

Main idea is forget about dereference hell of the StateRef and use the event-driven programming.
So, at this stage it is just an idea and the code is not ready for merging.

The observer.h contains the Observer and the Observable base classes.
The ObserverLinkedMap is a template of abstract class derived from the Observer.
The ObservableLinkedMap is a template class derived from the Observable.
The map is linked because the class contains hashmap and linked list to keep order of inserting.