### PR TITLE
Fix bug when selling vehicle equipment or ammo

### DIFF
--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -192,7 +192,6 @@ bool VEquipment::reload(GameState &state, StateRef<Base> base)
 		}
 		else
 		{
-			LogWarning("Vehicle refueled/rearmed");
 			return ammoSpent > 0;
 		}
 	}

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -5,8 +5,8 @@
 #include "game/state/city/base.h"
 #include "game/state/city/city.h"
 #include "game/state/city/vehicle.h"
-#include "game/state/gamestate.h"
 #include "game/state/gameevent.h"
+#include "game/state/gamestate.h"
 #include "game/state/rules/city/citycommonimagelist.h"
 #include "game/state/rules/city/vammotype.h"
 #include "game/state/rules/city/vequipmenttype.h"
@@ -139,27 +139,29 @@ void VEquipment::update(int ticks)
 	}
 }
 
-void VEquipment::noAmmoToReload(GameState &state, VEquipment *equipment) const {
-	switch (equipment->type->type) {
-	case EquipmentSlotType::VehicleEngine:
-		LogInfo("Failed to refuel engine: %s", owner->name);
-		fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughFuel, owner));
-		break;
-	case EquipmentSlotType::VehicleWeapon:
-		LogInfo("Failed to rearm weapon: %s", owner->name);
-		fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughAmmo, owner));
-		break;
-	case EquipmentSlotType::VehicleGeneral:
-		LogWarning("We should not try to reload VehicleGeneral Equipment");
-		break;
-	default:
-		break;
+void VEquipment::noAmmoToReload(GameState &state, VEquipment *equipment) const
+{
+	switch (equipment->type->type)
+	{
+		case EquipmentSlotType::VehicleEngine:
+			LogInfo("Failed to refuel engine: %s", owner->name);
+			fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughFuel, owner));
+			break;
+		case EquipmentSlotType::VehicleWeapon:
+			LogInfo("Failed to rearm weapon: %s", owner->name);
+			fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughAmmo, owner));
+			break;
+		case EquipmentSlotType::VehicleGeneral:
+			LogWarning("We should not try to reload VehicleGeneral Equipment");
+			break;
+		default:
+			break;
 	}
 }
 
 int VEquipment::reload(int ammoAvailable)
 {
-	//TODO implement proper reloading speed. Now it is instant
+	// TODO implement proper reloading speed. Now it is instant
 	int ammoRequired = this->type->max_ammo - this->ammo;
 	int reloadAmount = std::min(ammoRequired, ammoAvailable);
 	this->ammo += reloadAmount;
@@ -183,11 +185,13 @@ bool VEquipment::reload(GameState &state, StateRef<Base> base)
 		base->inventoryVehicleAmmo[type->ammo_type.id] -= ammoSpent;
 		int ammoAfterReload = base->inventoryVehicleAmmo[type->ammo_type.id];
 		// If we run out of ammo/fuel
-		if (ammoAfterReload == 0 && ammoSpent > 0) {
+		if (ammoAfterReload == 0 && ammoSpent > 0)
+		{
 			noAmmoToReload(state, this);
 			return false;
 		}
-		else {
+		else
+		{
 			LogWarning("Vehicle refueled/rearmed");
 			return ammoSpent > 0;
 		}

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -139,7 +139,7 @@ void VEquipment::update(int ticks)
 	}
 }
 
-void VEquipment::noAmmoToReload(GameState &state, VEquipment *equipment) const
+void VEquipment::noAmmoToReload(const GameState &state, const VEquipment *equipment) const
 {
 	switch (equipment->type->type)
 	{

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -6,6 +6,7 @@
 #include "game/state/city/city.h"
 #include "game/state/city/vehicle.h"
 #include "game/state/gamestate.h"
+#include "game/state/gameevent.h"
 #include "game/state/rules/city/citycommonimagelist.h"
 #include "game/state/rules/city/vammotype.h"
 #include "game/state/rules/city/vequipmenttype.h"
@@ -138,8 +139,27 @@ void VEquipment::update(int ticks)
 	}
 }
 
+void VEquipment::noAmmoToReload(GameState &state, VEquipment *equipment) const {
+	switch (equipment->type->type) {
+	case EquipmentSlotType::VehicleEngine:
+		LogInfo("Failed to refuel engine: %s", owner->name);
+		fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughFuel, owner));
+		break;
+	case EquipmentSlotType::VehicleWeapon:
+		LogInfo("Failed to rearm weapon: %s", owner->name);
+		fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughAmmo, owner));
+		break;
+	case EquipmentSlotType::VehicleGeneral:
+		LogWarning("We should not try to reload VehicleGeneral Equipment");
+		break;
+	default:
+		break;
+	}
+}
+
 int VEquipment::reload(int ammoAvailable)
 {
+	//TODO implement proper reloading speed. Now it is instant
 	int ammoRequired = this->type->max_ammo - this->ammo;
 	int reloadAmount = std::min(ammoRequired, ammoAvailable);
 	this->ammo += reloadAmount;
@@ -161,7 +181,16 @@ bool VEquipment::reload(GameState &state, StateRef<Base> base)
 		int ammoAvailable = base->inventoryVehicleAmmo[type->ammo_type.id];
 		auto ammoSpent = reload(ammoAvailable);
 		base->inventoryVehicleAmmo[type->ammo_type.id] -= ammoSpent;
-		return ammoSpent > 0;
+		int ammoAfterReload = base->inventoryVehicleAmmo[type->ammo_type.id];
+		// If we run out of ammo/fuel
+		if (ammoAfterReload == 0 && ammoSpent > 0) {
+			noAmmoToReload(state, this);
+			return false;
+		}
+		else {
+			LogWarning("Vehicle refueled/rearmed");
+			return ammoSpent > 0;
+		}
 	}
 	else
 	{

--- a/game/state/city/vequipment.h
+++ b/game/state/city/vequipment.h
@@ -53,7 +53,7 @@ class VEquipment : public Equipment
 	void update(int ticks);
 	void setReloadTime(int ticks);
 	// This sends alerts when not enough ammo to reload weapon or engine
-	void noAmmoToReload(GameState &state, VEquipment *equipment) const;
+	void noAmmoToReload(const GameState &state, const VEquipment *equipment) const;
 	// Reload uses up to 'ammoAvailable' to reload the weapon. It returns the amount
 	// actually used.
 	int reload(int ammoAvailable);

--- a/game/state/city/vequipment.h
+++ b/game/state/city/vequipment.h
@@ -52,6 +52,8 @@ class VEquipment : public Equipment
 	bool canFire() const;
 	void update(int ticks);
 	void setReloadTime(int ticks);
+	// This sends alerts when not enough ammo to reload weapon or engine
+	void noAmmoToReload(GameState &state, VEquipment *equipment) const;
 	// Reload uses up to 'ammoAvailable' to reload the weapon. It returns the amount
 	// actually used.
 	int reload(int ammoAvailable);

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -124,9 +124,9 @@ UString GameVehicleEvent::message()
 				return tr("An illegal flyer has been detected.");
 			}
 		case GameEventType::NotEnoughAmmo:
-			return tr("Not enough ammo to rearm vehicle");
+			return format("%s %s", tr("Not enough ammo to rearm vehicle:"), vehicle->name);
 		case GameEventType::NotEnoughFuel:
-			return tr("Not enough fuel to refuel vehicle");
+			return format("%s %s", tr("Not enough fuel to refuel vehicle"), vehicle->name);
 		default:
 			LogError("Invalid vehicle event type");
 			break;

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1171,15 +1171,26 @@ void GameState::updateEndOfSecond()
 		{
 			for (auto &e : v->equipment)
 			{
-				if (e->type->type != EquipmentSlotType::VehicleWeapon || e->type->max_ammo == 0)
+				// We only can reload VehicleWeapon and VehicleEngine(?)
+				if (e->type->type != EquipmentSlotType::VehicleWeapon && e->type->type != EquipmentSlotType::VehicleEngine) //  e->type->max_ammo == 0
 				{
 					continue;
 				}
-				if (e->reload(*this, base))
-				{
-					// FIXME: Implement message vehicle rearmed / reloaded /refueled whatever
-					LogWarning(
-					    "Implement message vehicle rearmed / reloaded / refueled / whatever");
+				// Only show events for vehicles owned by current player
+				if (v->owner->name == getPlayer()->name) {
+					if (e->reload(*this, base)) {
+						switch (e->type->type) {
+						case EquipmentSlotType::VehicleEngine:
+							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleRefuelled, v));
+							break;
+						case EquipmentSlotType::VehicleWeapon:
+							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleRearmed, v));
+							break;
+						default:
+							LogInfo("Implement the remaining messages for vehicle rearmed / reloaded / refueled / whatever");
+							break;
+						}
+					}
 				}
 			}
 		}

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1172,23 +1172,30 @@ void GameState::updateEndOfSecond()
 			for (auto &e : v->equipment)
 			{
 				// We only can reload VehicleWeapon and VehicleEngine(?)
-				if (e->type->type != EquipmentSlotType::VehicleWeapon && e->type->type != EquipmentSlotType::VehicleEngine) //  e->type->max_ammo == 0
+				if (e->type->type != EquipmentSlotType::VehicleWeapon &&
+				    e->type->type != EquipmentSlotType::VehicleEngine) //  e->type->max_ammo == 0
 				{
 					continue;
 				}
 				// Only show events for vehicles owned by current player
-				if (v->owner->name == getPlayer()->name) {
-					if (e->reload(*this, base)) {
-						switch (e->type->type) {
-						case EquipmentSlotType::VehicleEngine:
-							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleRefuelled, v));
-							break;
-						case EquipmentSlotType::VehicleWeapon:
-							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleRearmed, v));
-							break;
-						default:
-							LogInfo("Implement the remaining messages for vehicle rearmed / reloaded / refueled / whatever");
-							break;
+				if (v->owner->name == getPlayer()->name)
+				{
+					if (e->reload(*this, base))
+					{
+						switch (e->type->type)
+						{
+							case EquipmentSlotType::VehicleEngine:
+								fw().pushEvent(
+								    new GameVehicleEvent(GameEventType::VehicleRefuelled, v));
+								break;
+							case EquipmentSlotType::VehicleWeapon:
+								fw().pushEvent(
+								    new GameVehicleEvent(GameEventType::VehicleRearmed, v));
+								break;
+							default:
+								LogInfo("Implement the remaining messages for vehicle rearmed / "
+								        "reloaded / refueled / whatever");
+								break;
 						}
 					}
 				}

--- a/game/state/rules/city/vammotype.cpp
+++ b/game/state/rules/city/vammotype.cpp
@@ -6,7 +6,7 @@ namespace OpenApoc
 
 const UString &VAmmoType::getPrefix()
 {
-	static UString prefix = "VEQUIPMENTAMMOTYPE_";
+	static UString prefix = "VAMMOTYPE_";
 	return prefix;
 }
 

--- a/game/state/rules/city/vammotype.cpp
+++ b/game/state/rules/city/vammotype.cpp
@@ -6,7 +6,7 @@ namespace OpenApoc
 
 const UString &VAmmoType::getPrefix()
 {
-	static UString prefix = "VAMMOTYPE_";
+	static UString prefix = "VEQUIPMENTAMMOTYPE_";
 	return prefix;
 }
 

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -485,14 +485,14 @@ void BuyAndSellScreen::executeOrders()
 						{
 							economy.currentStock += order;
 							player->balance += order * economy.currentPrice;
-							b.second->inventoryAgentEquipment[c->itemId] -= order;
+							b.second->inventoryVehicleAmmo[c->itemId] -= order;
 							break;
 						}
 						case TransactionControl::Type::VehicleEquipment:
 						{
 							economy.currentStock += order;
 							player->balance += order * economy.currentPrice;
-							b.second->inventoryAgentEquipment[c->itemId] -= order;
+							b.second->inventoryVehicleEquipment[c->itemId] -= order;
 							break;
 						}
 						case TransactionControl::Type::VehicleType:


### PR DESCRIPTION
Fixed typo in buy and sell screen.

Related to:
No aequipement type matching ID "VEQUIPMENTTYPE_BOLTER_4000_LASER_GUN"
#353

Selling vehicle equipment/ammo resulted in selling non existing agent
equipment and ammo.