### PR TITLE
Messages for vehicle rearmed, refuelled and not enough ammo or fuel events

### DIFF
--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -6,6 +6,7 @@
 #include "game/state/city/city.h"
 #include "game/state/city/vehicle.h"
 #include "game/state/gamestate.h"
+#include "game/state/gameevent.h"
 #include "game/state/rules/city/citycommonimagelist.h"
 #include "game/state/rules/city/vammotype.h"
 #include "game/state/rules/city/vequipmenttype.h"
@@ -138,8 +139,27 @@ void VEquipment::update(int ticks)
 	}
 }
 
+void VEquipment::noAmmoToReload(GameState &state, VEquipment *equipment) const {
+	switch (equipment->type->type) {
+	case EquipmentSlotType::VehicleEngine:
+		LogInfo("Failed to refuel engine: %s", owner->name);
+		fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughFuel, owner));
+		break;
+	case EquipmentSlotType::VehicleWeapon:
+		LogInfo("Failed to rearm weapon: %s", owner->name);
+		fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughAmmo, owner));
+		break;
+	case EquipmentSlotType::VehicleGeneral:
+		LogWarning("We should not try to reload VehicleGeneral Equipment");
+		break;
+	default:
+		break;
+	}
+}
+
 int VEquipment::reload(int ammoAvailable)
 {
+	//TODO implement proper reloading speed. Now it is instant
 	int ammoRequired = this->type->max_ammo - this->ammo;
 	int reloadAmount = std::min(ammoRequired, ammoAvailable);
 	this->ammo += reloadAmount;
@@ -161,7 +181,16 @@ bool VEquipment::reload(GameState &state, StateRef<Base> base)
 		int ammoAvailable = base->inventoryVehicleAmmo[type->ammo_type.id];
 		auto ammoSpent = reload(ammoAvailable);
 		base->inventoryVehicleAmmo[type->ammo_type.id] -= ammoSpent;
-		return ammoSpent > 0;
+		int ammoAfterReload = base->inventoryVehicleAmmo[type->ammo_type.id];
+		// If we run out of ammo/fuel
+		if (ammoAfterReload == 0 && ammoSpent > 0) {
+			noAmmoToReload(state, this);
+			return false;
+		}
+		else {
+			LogWarning("Vehicle refueled/rearmed");
+			return ammoSpent > 0;
+		}
 	}
 	else
 	{

--- a/game/state/city/vequipment.h
+++ b/game/state/city/vequipment.h
@@ -52,6 +52,8 @@ class VEquipment : public Equipment
 	bool canFire() const;
 	void update(int ticks);
 	void setReloadTime(int ticks);
+	// This sends alerts when not enough ammo to reload weapon or engine
+	void noAmmoToReload(GameState &state, VEquipment *equipment) const;
 	// Reload uses up to 'ammoAvailable' to reload the weapon. It returns the amount
 	// actually used.
 	int reload(int ammoAvailable);

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -124,9 +124,9 @@ UString GameVehicleEvent::message()
 				return tr("An illegal flyer has been detected.");
 			}
 		case GameEventType::NotEnoughAmmo:
-			return tr("Not enough ammo to rearm vehicle");
+			return format("%s %s", tr("Not enough ammo to rearm vehicle:"), vehicle->name);
 		case GameEventType::NotEnoughFuel:
-			return tr("Not enough fuel to refuel vehicle");
+			return format("%s %s", tr("Not enough fuel to refuel vehicle"), vehicle->name);
 		default:
 			LogError("Invalid vehicle event type");
 			break;

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1171,15 +1171,26 @@ void GameState::updateEndOfSecond()
 		{
 			for (auto &e : v->equipment)
 			{
-				if (e->type->type != EquipmentSlotType::VehicleWeapon || e->type->max_ammo == 0)
+				// We only can reload VehicleWeapon and VehicleEngine(?)
+				if (e->type->type != EquipmentSlotType::VehicleWeapon && e->type->type != EquipmentSlotType::VehicleEngine) //  e->type->max_ammo == 0
 				{
 					continue;
 				}
-				if (e->reload(*this, base))
-				{
-					// FIXME: Implement message vehicle rearmed / reloaded /refueled whatever
-					LogWarning(
-					    "Implement message vehicle rearmed / reloaded / refueled / whatever");
+				// Only show events for vehicles owned by current player
+				if (v->owner->name == getPlayer()->name) {
+					if (e->reload(*this, base)) {
+						switch (e->type->type) {
+						case EquipmentSlotType::VehicleEngine:
+							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleRefuelled, v));
+							break;
+						case EquipmentSlotType::VehicleWeapon:
+							fw().pushEvent(new GameVehicleEvent(GameEventType::VehicleRearmed, v));
+							break;
+						default:
+							LogInfo("Implement the remaining messages for vehicle rearmed / reloaded / refueled / whatever");
+							break;
+						}
+					}
 				}
 			}
 		}


### PR DESCRIPTION
- New notification if there is not enough ammo or fuel to refuel or
rearm the vehicle.
- Notifications when vehicle is succesfully rearmed and refuelled.