### PR TITLE
Make the data extraction an optional step in cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,11 +19,12 @@ string(TOLOWER "${CMAKE_BUILD_TYPE}" lower_build_type)
 
 option(LTO "Build using link-time-optimisations" OFF)
 option(ENABLE_TESTS "Build some unit tests" ON)
+option(EXTRACT_DATA "Run the data extractor as part of the default target" ON)
 
 set(CD_PATH ${CMAKE_SOURCE_DIR}/data/cd.iso CACHE STRING "Path to cd.iso (used
 by test and extractor")
 
-if (NOT EXISTS ${CD_PATH})
+if (${EXTRACT_DATA} AND NOT EXISTS ${CD_PATH})
 		message(FATAL_ERROR "CD_PATH \"${CD_PATH}\" points at non-existant file")
 endif()
 

--- a/tools/extractors/CMakeLists.txt
+++ b/tools/extractors/CMakeLists.txt
@@ -899,4 +899,8 @@ add_extractor(EXTRACTOR_TARGET_LIST "battle_map_sectors"
 	"data/maps/57ufo7_01"
 	"data/maps/58ufo8_01")
 
+if ($EXTRACT_DATA)
 add_custom_target(extract-data ALL DEPENDS ${EXTRACTOR_TARGET_LIST})
+else()
+add_custom_target(extract-data DEPENDS ${EXTRACTOR_TARGET_LIST})
+endif()

--- a/tools/extractors/CMakeLists.txt
+++ b/tools/extractors/CMakeLists.txt
@@ -899,7 +899,9 @@ add_extractor(EXTRACTOR_TARGET_LIST "battle_map_sectors"
 	"data/maps/57ufo7_01"
 	"data/maps/58ufo8_01")
 
-if ($EXTRACT_DATA)
+option(EXTRACT_DATA "Run the data extractor as part of the default target" ON)
+
+if (${EXTRACT_DATA})
 add_custom_target(extract-data ALL DEPENDS ${EXTRACTOR_TARGET_LIST})
 else()
 add_custom_target(extract-data DEPENDS ${EXTRACTOR_TARGET_LIST})


### PR DESCRIPTION
If you set the cmake var EXTRACT_DATA to off (default on), it no longer causes
the data extractor to be run as part of the default build. This means CD_PATH
would no longer need to point to a valid file, for example.

The extraction step can still be run with the 'extract-data' target - make sure
this is run before trying to run the game or any tests!