### PR TITLE
Fix equality bug when rerouting cargo from newly destroyed base

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -71,7 +71,7 @@ void Base::die(GameState &state, bool collapse)
 					// Re-route to another base
 					for (auto &b : state.player_bases)
 					{
-						if (b.second->building = building)
+						if (b.second->building == building)
 						{
 							continue;
 						}


### PR DESCRIPTION
This would have screwed up all base/building links, possibly breaking all kinds
of stuff