### PR TITLE
Fix to #389 & #260

### DIFF
--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -462,6 +462,7 @@ void BuyAndSellScreen::executeOrders()
 							}
 							vehicle->die(*state, true);
 							player->balance += c->price;
+							break;
 						}
 						case TransactionControl::Type::AgentEquipmentBio:
 						{


### PR DESCRIPTION
When selling vehicles the switch was not exited and caused bugs related
to agent equipment.