### PR TITLE
Fix when entering battle with empty autocannon #383

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3531,7 +3531,7 @@ void Battle::loadImagePacks(GameState &state)
 				if (imagePacks.find(packName) == imagePacks.end())
 					imagePacks.insert(packName);
 			}
-			if (!brainsuckerFound && ae->getPayloadType()->damage_type &&
+			if (!brainsuckerFound && ae->getPayloadType() && ae->getPayloadType()->damage_type &&
 			    ae->getPayloadType()->damage_type->effectType ==
 			        DamageType::EffectType::Brainsucker)
 			{
@@ -3647,7 +3647,7 @@ void Battle::loadAnimationPacks(GameState &state)
 		{
 			for (auto &e : u.second->agent->equipment)
 			{
-				if (e->getPayloadType()->damage_type &&
+				if (e->getPayloadType() && e->getPayloadType()->damage_type &&
 				    e->getPayloadType()->damage_type->effectType ==
 				        DamageType::EffectType::Brainsucker)
 				{


### PR DESCRIPTION
There is no payloadType for empty autocannon so we can't get damage_type
of weapon.