### PR TITLE
New feature: All units will be set to run and kneel at the beginning of combat (disabled by default)

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -244,6 +244,8 @@ ConfigOptionBool optionFuelCrashingVehicles("OpenApoc.NewFeature", "CrashingOutO
                                             "Vehicles crash when out of fuel", true);
 ConfigOptionBool optionSkipTurbo("OpenApoc.NewFeature", "SkipTurboMovement",
                                  "Skip turbo movement calculations", false);
+ConfigOptionBool optionRunAndKneel("OpenApoc.NewFeature", "RunAndKneel",
+                                   "All units run and kneel by default", false);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -1099,14 +1099,22 @@ void Battle::initialUnitSpawn(GameState &state)
 		}
 		// Stance
 		u->setBodyState(state, u->agent->type->bodyType->getFirstAllowedState());
-		if (u->current_body_state == BodyState::Kneeling ||
-		    u->current_body_state == BodyState::Prone)
+		if (config().getBool("OpenApoc.NewFeature.RunAndKneel"))
 		{
-			u->setMovementMode(MovementMode::Prone);
+			u->setKneelingMode(KneelingMode::Kneeling);
+			u->setMovementMode(MovementMode::Running);
 		}
 		else
 		{
-			u->setMovementMode(MovementMode::Walking);
+			if (u->current_body_state == BodyState::Kneeling ||
+			    u->current_body_state == BodyState::Prone)
+			{
+				u->setMovementMode(MovementMode::Prone);
+			}
+			else
+			{
+				u->setMovementMode(MovementMode::Walking);
+			}
 		}
 		// Miscellaneous
 		u->beginTurn(state);

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -104,6 +104,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.NewFeature.CrashingDimensionGate", "Uncapable vehicles crash when entering gates"},
     {"OpenApoc.NewFeature.SkipTurboMovement", "Skip turbo movement calculations"},
     {"OpenApoc.NewFeature.CrashingOutOfFuel", "Vehicles crash when out of fuel"},
+    {"OpenApoc.NewFeature.RunAndKneel", " All units run and kneel by default"},
 
     {"OpenApoc.Mod.StunHostileAction", "(M) Stunning hurts relationships"},
     {"OpenApoc.Mod.RaidHostileAction", "(M) Initiating raid hurts relationships"},


### PR DESCRIPTION
With this feature enabled you don't need to click through every unit and
set them to run and kneel.