### PR TITLE
fix compilation for boost >= 1.66

### DIFF
--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -14,7 +14,7 @@
 #define BOOST_ALL_NO_LIB
 #include <boost/crc.hpp>
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 106800
+#if BOOST_VERSION >= 106600
 #include <boost/uuid/detail/sha1.hpp>
 #else
 #include <boost/uuid/sha1.hpp>

--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -13,7 +13,12 @@
 // symbols as part of the module that uses it
 #define BOOST_ALL_NO_LIB
 #include <boost/crc.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106800
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 #include <boost/uuid/uuid.hpp>
 
 namespace OpenApoc
@@ -213,4 +218,4 @@ bool ProviderWithChecksum::finalizeSave()
 	inner->saveDocument("checksum.xml", manifest);
 	return inner->finalizeSave();
 }
-}
+} // namespace OpenApoc

--- a/tools/gamestate_serialize_gen/main.cpp
+++ b/tools/gamestate_serialize_gen/main.cpp
@@ -11,7 +11,12 @@
 // symbols as part of the module that uses it
 #define BOOST_ALL_NO_LIB
 #include <boost/program_options.hpp>
+#include <boost/version.hpp>
+#if BOOST_VERSION >= 106800
+#include <boost/uuid/detail/sha1.hpp>
+#else
 #include <boost/uuid/sha1.hpp>
+#endif
 
 namespace po = boost::program_options;
 

--- a/tools/gamestate_serialize_gen/main.cpp
+++ b/tools/gamestate_serialize_gen/main.cpp
@@ -12,7 +12,7 @@
 #define BOOST_ALL_NO_LIB
 #include <boost/program_options.hpp>
 #include <boost/version.hpp>
-#if BOOST_VERSION >= 106800
+#if BOOST_VERSION >= 106600
 #include <boost/uuid/detail/sha1.hpp>
 #else
 #include <boost/uuid/sha1.hpp>


### PR DESCRIPTION
boost/uuid/sha1.hpp has been deprecated and moved to boost/uuid/detail/sha1.hpp