### PR TITLE
Enable GLM_FORCE_CTOR_INIT to init all glm times (e.g. vec2<>/vec3<>)…

### DIFF
--- a/library/vec.h
+++ b/library/vec.h
@@ -2,6 +2,8 @@
 
 /* GLM_GTX_transform is an experimental extension now, apparently */
 #define GLM_ENABLE_EXPERIMENTAL
+/* Force zero arg constructors to init to zeros */
+#define GLM_FORCE_CTOR_INIT
 
 #define GLM_FORCE_RADIANS
 #include <glm/vec2.hpp>


### PR DESCRIPTION
… to zeros

The recent glm update seems to have stopped doing this by default, but there's
at least one place (and likely many more) that expect this

This seems to cause issue #421