### PR TITLE
refactor algorithm to populate vehicle equipment controls

### DIFF
--- a/forms/transactioncontrol.h
+++ b/forms/transactioncontrol.h
@@ -114,7 +114,7 @@ class TransactionControl : public Control
 
   protected:
 	// Link
-	std::list<sp<TransactionControl>> linked;
+	sp<std::list<wp<TransactionControl>>> linked;
 	bool suspendUpdates = false;
 
 	// Subcontrols
@@ -151,8 +151,7 @@ class TransactionControl : public Control
 	void setIndexLeft(int index);
 	void setIndexRight(int index);
 	void updateValues();
-	void link(sp<TransactionControl> control);
-	const std::list<sp<TransactionControl>> &getLinked() const;
+	const decltype(linked) &getLinked() const;
 
 	// Transferring/Buying/selling agent equipment and ammo
 	// Transferring agents
@@ -184,6 +183,8 @@ class TransactionControl : public Control
 	                                            bool manufacturerUnavailable, int price,
 	                                            int storeSpace, std::vector<int> &initialStock,
 	                                            int indexLeft, int indexRight);
+
+	static void link(sp<TransactionControl> c1, sp<TransactionControl> c2);
 
 	void setupCallbacks();
 

--- a/game/ui/base/aliencontainmentscreen.cpp
+++ b/game/ui/base/aliencontainmentscreen.cpp
@@ -77,9 +77,12 @@ void AlienContainmentScreen::closeScreen()
 				}
 				i++;
 			}
-			for (auto &l : c->getLinked())
+			if (c->getLinked())
 			{
-				linkedControls.insert(l);
+				for (auto &l : *c->getLinked())
+				{
+					linkedControls.insert(l.lock());
+				}
 			}
 		}
 

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -141,9 +141,12 @@ void BuyAndSellScreen::closeScreen()
 					}
 					i++;
 				}
-				for (auto &l : c->getLinked())
+				if (c->getLinked())
 				{
-					linkedControls.insert(l);
+					for (auto &l : *c->getLinked())
+					{
+						linkedControls.insert(l.lock());
+					}
 				}
 			}
 		}
@@ -220,9 +223,12 @@ void BuyAndSellScreen::closeScreen()
 							break;
 					}
 				}
-				for (auto &l : c->getLinked())
+				if (c->getLinked())
 				{
-					linkedControls.insert(l);
+					for (auto &l : *c->getLinked())
+					{
+						linkedControls.insert(l.lock());
+					}
 				}
 			}
 		}
@@ -555,9 +561,12 @@ void BuyAndSellScreen::executeOrders()
 					}
 				}
 			}
-			for (auto &l : c->getLinked())
+			if (c->getLinked())
 			{
-				linkedControls.insert(l);
+				for (auto &l : *c->getLinked())
+				{
+					linkedControls.insert(l.lock());
+				}
 			}
 		}
 	}

--- a/game/ui/base/transactionscreen.h
+++ b/game/ui/base/transactionscreen.h
@@ -115,6 +115,9 @@ class TransactionScreen : public BaseStage
 	// Initialisation the mini view for the second base.
 	virtual void initViewSecondBase();
 
+	sp<TransactionControl> findControlById(Type type, const UString &itemId);
+	sp<TransactionControl> findControlById(const UString &itemId);
+
   public:
 	TransactionScreen(sp<GameState> state, bool forceLimits = false);
 

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -275,9 +275,12 @@ void TransferScreen::closeScreen()
 					}
 					i++;
 				}
-				for (auto &l : c->getLinked())
+				if (c->getLinked())
 				{
-					linkedControls.insert(l);
+					for (auto &l : *c->getLinked())
+					{
+						linkedControls.insert(l.lock());
+					}
 				}
 			}
 		}
@@ -530,9 +533,12 @@ void TransferScreen::executeOrders()
 					}
 				}
 			}
-			for (auto &l : c->getLinked())
+			if (c->getLinked())
 			{
-				linkedControls.insert(l);
+				for (auto &l : *c->getLinked())
+				{
+					linkedControls.insert(l.lock());
+				}
 			}
 		}
 	}
@@ -612,9 +618,12 @@ void TransferScreen::executeOrders()
 					}
 				}
 			}
-			for (auto &l : c->getLinked())
+			if (c->getLinked())
 			{
-				linkedControls.insert(l);
+				for (auto &l : *c->getLinked())
+				{
+					linkedControls.insert(l.lock());
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Made the algorithm to populate the vehicle equipment screen simpler (should fix #362)
Transaction controls are now linked through a shared list of weak pointers which should be more efficient. The previous solution was to keep a list of shared ptrs to every linked node per node, thus creating a mesh of O(n^2) complexity. Keeping a shared list should provide O(n) complexity. Also updates nodes on being linked (fixes #394)