### PR TITLE
scale weapon range correctly in vehicle equipment sheet

### DIFF
--- a/game/state/rules/city/vequipmenttype.cpp
+++ b/game/state/rules/city/vequipmenttype.cpp
@@ -1,5 +1,6 @@
 #include "game/state/rules/city/vequipmenttype.h"
 #include "game/state/gamestate.h"
+#include "game/state/tilemap/tilemap.h"
 
 namespace OpenApoc
 {
@@ -35,5 +36,9 @@ sp<VEquipmentType> VEquipmentType::get(const GameState &state, const UString &id
 	}
 	return it->second;
 }
+
+// note: the range value in vanilla game files is given in half-metres
+int VEquipmentType::getRangeInTiles() const { return range / 2 / (int)VELOCITY_SCALE_CITY.x; }
+int VEquipmentType::getRangeInMetres() const { return range / 2; }
 
 } // namespace OpenApoc

--- a/game/state/rules/city/vequipmenttype.h
+++ b/game/state/rules/city/vequipmenttype.h
@@ -94,6 +94,9 @@ class VEquipmentType : public StateObject
 
 	// Score requirement
 	int scoreRequirement = 0;
+
+	int getRangeInTiles() const;
+	int getRangeInMetres() const;
 };
 
 } // namespace OpenApoc

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -155,8 +155,9 @@ void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Damage"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->damage));
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Range"));
+	// note: it seems the range value in apoc's game files is given in half-metres
 	form->findControlTyped<Label>("LABEL_3_R")
-	    ->setText(format("%d", type->range / (int)VELOCITY_SCALE_CITY.x));
+	    ->setText(format("%d", type->range / 2 / (int)VELOCITY_SCALE_CITY.x));
 	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Accuracy"));
 	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d%%", type->accuracy));
 

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -155,9 +155,7 @@ void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Damage"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->damage));
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Range"));
-	// note: it seems the range value in apoc's game files is given in half-metres
-	form->findControlTyped<Label>("LABEL_3_R")
-	    ->setText(format("%d", type->range / 2 / (int)VELOCITY_SCALE_CITY.x));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->getRangeInTiles()));
 	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Accuracy"));
 	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d%%", type->accuracy));
 

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -373,9 +373,7 @@ void UfopaediaCategoryView::setFormStats()
 							statsLabels[row]->setText(tr("Accuracy"));
 							statsValues[row++]->setText(format("%d%%", ref->accuracy));
 							statsLabels[row]->setText(tr("Range"));
-							// note: it seems the range value in apoc's game files is given in
-							// half-metres
-							statsValues[row++]->setText(format("%dm", ref->range / 2));
+							statsValues[row++]->setText(format("%dm", ref->getRangeInMetres()));
 							statsLabels[row]->setText(tr("Fire Rate"));
 							statsValues[row++]->setText(format(
 							    "%.2f r/s", (float)TICKS_PER_SECOND / (float)ref->fire_delay));

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -373,7 +373,9 @@ void UfopaediaCategoryView::setFormStats()
 							statsLabels[row]->setText(tr("Accuracy"));
 							statsValues[row++]->setText(format("%d%%", ref->accuracy));
 							statsLabels[row]->setText(tr("Range"));
-							statsValues[row++]->setText(format("%dm", ref->range));
+							// note: it seems the range value in apoc's game files is given in
+							// half-metres
+							statsValues[row++]->setText(format("%dm", ref->range / 2));
 							statsLabels[row]->setText(tr("Fire Rate"));
 							statsValues[row++]->setText(format(
 							    "%.2f r/s", (float)TICKS_PER_SECOND / (float)ref->fire_delay));


### PR DESCRIPTION
As discussed in the discord: the range values in apoc's data file seem to be in half-metres. This fix should scale them accordingly while still displaying the value in tiles, as intended (related issue #361)