### PR TITLE
fix acquiring enemy for non player vehicles

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -2632,7 +2632,7 @@ sp<TileObjectVehicle> Vehicle::findClosestEnemy(GameState &state, sp<TileObjectV
 			// Can't auto-fire at crashed vehicles
 			continue;
 		}
-		if (otherVehicle->type->aggressiveness == 0)
+		if (otherVehicle->type->aggressiveness == 0 && this->owner == state.getPlayer())
 		{
 			// No auto-acquiring of non-aggressive vehicles
 			continue;


### PR DESCRIPTION
Vehicles controlled by non-xcom organisations would not attack targets if they were non-aggressive (even if they were hostile towards them)