### PR TITLE
Make Wolfhound APC All-Terrain Capable via (M) Option

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -256,11 +256,14 @@ ConfigOptionBool optionBSKLauncherSound("OpenApoc.Mod", "BSKLauncherSound",
                                         "(MOD) Original Brainsucker Launcher SFX", true);
 ConfigOptionBool optionInvulnerableRoads("OpenApoc.Mod", "InvulnerableRoads",
                                          "(MOD) Invulnerable roads", false);
-ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes All-Terrain", true);
+ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes All-Terrain",
+                               true);
 
-ConfigOptionBool optionATVAPC("OpenApoc.Mod", "ATVAPC", "(MOD) Wolfhound APC becomes All-Terrain", true);
+ConfigOptionBool optionATVAPC("OpenApoc.Mod", "ATVAPC", "(MOD) Wolfhound APC becomes All-Terrain",
+                              true);
 
-ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles", "Vehicles crash on low HP", false);
+ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
+                                        "Vehicles crash on low HP", false);
 
 ConfigOptionBool optionInfiniteAmmoCheat("OpenApoc.Cheat", "InfiniteAmmo",
                                          "Infinite ammo for X-Com agents and vehicles", false);

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -256,10 +256,11 @@ ConfigOptionBool optionBSKLauncherSound("OpenApoc.Mod", "BSKLauncherSound",
                                         "(MOD) Original Brainsucker Launcher SFX", true);
 ConfigOptionBool optionInvulnerableRoads("OpenApoc.Mod", "InvulnerableRoads",
                                          "(MOD) Invulnerable roads", false);
-ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes All-Terrain",
-                               true);
-ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
-                                        "Vehicles crash on low HP", false);
+ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes All-Terrain", true);
+
+ConfigOptionBool optionATVAPC("OpenApoc.Mod", "ATVAPC", "(MOD) Wolfhound APC becomes All-Terrain", true);
+
+ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles", "Vehicles crash on low HP", false);
 
 ConfigOptionBool optionInfiniteAmmoCheat("OpenApoc.Cheat", "InfiniteAmmo",
                                          "Infinite ammo for X-Com agents and vehicles", false);

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -224,18 +224,24 @@ void GameState::initState()
 
 void GameState::applyMods()
 {
-	if (config().getBool("OpenApoc.Mod.ATVTank")) {
+	if (config().getBool("OpenApoc.Mod.ATVTank"))
+	{
 		vehicle_types["VEHICLETYPE_GRIFFON_AFV"]->type = VehicleType::Type::ATV;
-	} else {		
+	}
+	else
+	{
 		vehicle_types["VEHICLETYPE_GRIFFON_AFV"]->type = VehicleType::Type::Road;
 	}
 
-	if (config().getBool("OpenApoc.Mod.ATVAPC")) {
+	if (config().getBool("OpenApoc.Mod.ATVAPC"))
+	{
 		vehicle_types["VEHICLETYPE_WOLFHOUND_APC"]->type = VehicleType::Type::ATV;
-	} else {
+	}
+	else
+	{
 		vehicle_types["VEHICLETYPE_WOLFHOUND_APC"]->type = VehicleType::Type::Road;
 	}
-			
+
 	if (config().getBool("OpenApoc.Mod.BSKLauncherSound"))
 	{
 		agent_equipment["AEQUIPMENTTYPE_BRAINSUCKER_LAUNCHER"]->fire_sfx =

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -224,15 +224,18 @@ void GameState::initState()
 
 void GameState::applyMods()
 {
-	if (config().getBool("OpenApoc.Mod.ATVTank"))
-	{
+	if (config().getBool("OpenApoc.Mod.ATVTank")) {
 		vehicle_types["VEHICLETYPE_GRIFFON_AFV"]->type = VehicleType::Type::ATV;
-	}
-	else
-	{
+	} else {		
 		vehicle_types["VEHICLETYPE_GRIFFON_AFV"]->type = VehicleType::Type::Road;
 	}
 
+	if (config().getBool("OpenApoc.Mod.ATVAPC")) {
+		vehicle_types["VEHICLETYPE_WOLFHOUND_APC"]->type = VehicleType::Type::ATV;
+	} else {
+		vehicle_types["VEHICLETYPE_WOLFHOUND_APC"]->type = VehicleType::Type::Road;
+	}
+			
 	if (config().getBool("OpenApoc.Mod.BSKLauncherSound"))
 	{
 		agent_equipment["AEQUIPMENTTYPE_BRAINSUCKER_LAUNCHER"]->fire_sfx =

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -110,7 +110,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.Mod", "CrashingVehicles"},
     {"OpenApoc.Mod", "InvulnerableRoads"},
     {"OpenApoc.Mod", "ATVTank"},
-	{"OpenApoc.Mod", "ATVAPC"},
+ 	{"OpenApoc.Mod", "ATVAPC"},
     {"OpenApoc.Mod", "BSKLauncherSound"},
 };
 

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -110,6 +110,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.Mod", "CrashingVehicles"},
     {"OpenApoc.Mod", "InvulnerableRoads"},
     {"OpenApoc.Mod", "ATVTank"},
+	{"OpenApoc.Mod", "ATVAPC"},
     {"OpenApoc.Mod", "BSKLauncherSound"},
 };
 

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -110,7 +110,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.Mod", "CrashingVehicles"},
     {"OpenApoc.Mod", "InvulnerableRoads"},
     {"OpenApoc.Mod", "ATVTank"},
- 	{"OpenApoc.Mod", "ATVAPC"},
+    {"OpenApoc.Mod", "ATVAPC"},
     {"OpenApoc.Mod", "BSKLauncherSound"},
 };
 


### PR DESCRIPTION
The Wolfhound APC can now be made all-terrain, just like the Griffon Tank