### PR TITLE
fix firing TU cost display in TB mode

### DIFF
--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -572,7 +572,8 @@ void BattleTileView::render()
 					}
 				}
 			}
-			if (previewedPathCost != -1 && drawWaypoints && waypointLocations.empty())
+			if (previewedPathCost != static_cast<int>(PreviewedPathCostSpecial::NONE) &&
+			    drawWaypoints && waypointLocations.empty())
 			{
 				darkenWaypoints = true;
 				for (auto &w : pathPreview)
@@ -607,8 +608,10 @@ void BattleTileView::render()
 					// Yellow if this tile intersects with a unit
 					if (selectedTilePosition.z == z)
 					{
-						drawPathPreview = previewedPathCost != -1;
-						drawAttackCost = calculatedAttackCost != -1;
+						drawPathPreview =
+						    previewedPathCost != static_cast<int>(PreviewedPathCostSpecial::NONE);
+						drawAttackCost = calculatedAttackCost !=
+						                 static_cast<int>(CalculatedAttackCostSpecial::NONE);
 						auto u = selTileOnCurLevel->getUnitIfPresent(true);
 						auto unit = u ? u->getUnit() : nullptr;
 						if (unit &&
@@ -858,15 +861,16 @@ void BattleTileView::render()
 								if (drawAttackCost)
 								{
 									sp<Image> img;
-									switch (calculatedAttackCost)
+									switch (static_cast<CalculatedAttackCostSpecial>(
+									    calculatedAttackCost))
 									{
-										case -4:
+										case CalculatedAttackCostSpecial::NO_WEAPON:
 											img = nullptr;
 											break;
-										case -3:
+										case CalculatedAttackCostSpecial::NO_ARC:
 											img = attackCostNoArc;
 											break;
-										case -2:
+										case CalculatedAttackCostSpecial::OUT_OF_RANGE:
 											img = attackCostOutOfRange;
 											break;
 										default:
@@ -902,12 +906,13 @@ void BattleTileView::render()
 								else if (drawPathPreview)
 								{
 									sp<Image> img;
-									switch (previewedPathCost)
+									switch (
+									    static_cast<PreviewedPathCostSpecial>(previewedPathCost))
 									{
-										case -3:
+										case PreviewedPathCostSpecial::UNREACHABLE:
 											img = pathPreviewUnreachable;
 											break;
-										case -2:
+										case PreviewedPathCostSpecial::TOO_FAR:
 											img = pathPreviewTooFar;
 											break;
 										default:
@@ -1596,7 +1601,7 @@ void BattleTileView::resetAttackCost()
 	if (attackCostTicksAccumulated > 0)
 	{
 		attackCostTicksAccumulated = 0;
-		calculatedAttackCost = -1;
+		calculatedAttackCost = static_cast<int>(CalculatedAttackCostSpecial::NONE);
 	}
 }
 
@@ -1637,7 +1642,7 @@ void BattleTileView::resetPathPreview()
 	if (pathPreviewTicksAccumulated > 0)
 	{
 		pathPreviewTicksAccumulated = 0;
-		previewedPathCost = -1;
+		previewedPathCost = static_cast<int>(PreviewedPathCostSpecial::NONE);
 		pathPreview.clear();
 	}
 }

--- a/game/ui/tileview/battletileview.h
+++ b/game/ui/tileview/battletileview.h
@@ -69,6 +69,7 @@ class BattleTileView : public TileView
 	std::vector<sp<Image>> targetLocationIcons;
 	Vec2<float> targetLocationOffset;
 	std::vector<sp<Image>> tuIndicators;
+	sp<Image> tuSeparator; // forward slash
 	// Must have same amount it items as in targetLocationIcons
 	std::vector<sp<Image>> waypointIcons;
 	std::vector<sp<Image>> waypointDarkIcons;

--- a/game/ui/tileview/battletileview.h
+++ b/game/ui/tileview/battletileview.h
@@ -108,22 +108,26 @@ class BattleTileView : public TileView
 	sp<Image> pathPreviewUnreachable;
 	std::list<Vec3<int>> pathPreview;
 	int pathPreviewTicksAccumulated = 0;
-	// -3 = unreachable
-	// -2 = too far
-	// -1 = no previewed path stored
-	// 0+ = path cost
-	int previewedPathCost = -1;
+	enum class PreviewedPathCostSpecial : int
+	{
+		UNREACHABLE = -3,
+		TOO_FAR = -2,
+		NONE = -1
+	};
+	int previewedPathCost = static_cast<int>(PreviewedPathCostSpecial::NONE);
 	void resetPathPreview();
 
 	sp<Image> attackCostOutOfRange;
 	sp<Image> attackCostNoArc;
 	int attackCostTicksAccumulated = 0;
-	// -4 = no weapon
-	// -3 = no arc
-	// -2 = out of range
-	// -1 = no attack cost stored
-	// 0+ = attack cost
-	int calculatedAttackCost = -1;
+	enum class CalculatedAttackCostSpecial : int
+	{
+		NO_WEAPON = -4,
+		NO_ARC = -3,
+		OUT_OF_RANGE = -2,
+		NONE = -1
+	};
+	int calculatedAttackCost = static_cast<int>(CalculatedAttackCostSpecial::NONE);
 	void resetAttackCost();
 	// updateAttackCost is in battleView as it requires data about selection mode
 

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -1488,7 +1488,7 @@ void BattleView::update()
 	// Update preview calculations in TB mode
 	if (!realTime)
 	{
-		if (previewedPathCost == -1)
+		if (previewedPathCost == static_cast<int>(PreviewedPathCostSpecial::NONE))
 		{
 			pathPreviewTicksAccumulated++;
 			// Show path preview if hovering for over half a second
@@ -1497,7 +1497,7 @@ void BattleView::update()
 				updatePathPreview();
 			}
 		}
-		if (calculatedAttackCost == -1)
+		if (calculatedAttackCost == static_cast<int>(CalculatedAttackCostSpecial::NONE))
 		{
 			attackCostTicksAccumulated++;
 			if (attackCostTicksAccumulated > 5)
@@ -2196,7 +2196,7 @@ void BattleView::updatePathPreview()
 		                     lastSelectedUnit->agent->type->bodyType->maxHeight) ||
 		    unit)
 		{
-			previewedPathCost = -3;
+			previewedPathCost = static_cast<int>(PreviewedPathCostSpecial::UNREACHABLE);
 			return;
 		}
 		if (lastSelectedUnit->canFly() || to->getCanStand(lastSelectedUnit->isLarge()))
@@ -2242,7 +2242,7 @@ void BattleView::updatePathPreview()
 	// Otherwise, show amount of TUs remaining at arrival
 	if (pathPreview.back() != target)
 	{
-		previewedPathCost = -2;
+		previewedPathCost = static_cast<int>(PreviewedPathCostSpecial::TOO_FAR);
 	}
 	else
 	{
@@ -2252,7 +2252,7 @@ void BattleView::updatePathPreview()
 		{
 			// Sometimes it might happen that we barely miss goal after all calculations
 			// In this case, properly display "Too far" and subtract cost
-			previewedPathCost = -2;
+			previewedPathCost = static_cast<int>(PreviewedPathCostSpecial::TOO_FAR);
 			pathPreview.pop_back();
 		}
 	}
@@ -2308,11 +2308,13 @@ void BattleView::updateAttackCost()
 	                  : lastSelectedUnit->agent->getFirstItemInSlot(EquipmentSlotType::LeftHand);
 	if (!weapon)
 	{
-		calculatedAttackCost = -4;
+		calculatedAttackCost = static_cast<int>(CalculatedAttackCostSpecial::NO_WEAPON);
 	}
 	else if (!weapon->canFire(*state, target))
 	{
-		calculatedAttackCost = weapon->type->launcher ? -3 : -2;
+		calculatedAttackCost =
+		    static_cast<int>(weapon->type->launcher ? CalculatedAttackCostSpecial::NO_ARC
+		                                            : CalculatedAttackCostSpecial::OUT_OF_RANGE);
 	}
 	else
 	{
@@ -3953,7 +3955,7 @@ bool BattleView::handleGameStateEvent(Event *e)
 			// update the path preview
 			// a battleunit has died, potentially unblocking/changing the previewed path
 			// but only update if there's a path stored
-			if (previewedPathCost != -1)
+			if (previewedPathCost != static_cast<int>(PreviewedPathCostSpecial::NONE))
 			{
 				updatePathPreview();
 			}


### PR DESCRIPTION
Display the TU cost to fire when hovering over a hostile unit in the battlescape in turn-based mode, like in vanilla apocalypse