### PR TITLE
Add enum traits

### DIFF
--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -572,8 +572,8 @@ void BattleTileView::render()
 					}
 				}
 			}
-			if (previewedPathCost != static_cast<int>(PreviewedPathCostSpecial::NONE) &&
-			    drawWaypoints && waypointLocations.empty())
+			if (previewedPathCost != PreviewedPathCostSpecial::NONE && drawWaypoints &&
+			    waypointLocations.empty())
 			{
 				darkenWaypoints = true;
 				for (auto &w : pathPreview)
@@ -608,10 +608,8 @@ void BattleTileView::render()
 					// Yellow if this tile intersects with a unit
 					if (selectedTilePosition.z == z)
 					{
-						drawPathPreview =
-						    previewedPathCost != static_cast<int>(PreviewedPathCostSpecial::NONE);
-						drawAttackCost = calculatedAttackCost !=
-						                 static_cast<int>(CalculatedAttackCostSpecial::NONE);
+						drawPathPreview = previewedPathCost != PreviewedPathCostSpecial::NONE;
+						drawAttackCost = calculatedAttackCost != CalculatedAttackCostSpecial::NONE;
 						auto u = selTileOnCurLevel->getUnitIfPresent(true);
 						auto unit = u ? u->getUnit() : nullptr;
 						if (unit &&

--- a/game/ui/tileview/battletileview.h
+++ b/game/ui/tileview/battletileview.h
@@ -2,6 +2,7 @@
 
 #include "game/state/battle/battleunit.h"
 #include "game/ui/tileview/tileview.h"
+#include "library/enum_traits.h"
 #include "library/sp.h"
 #include "library/vec.h"
 #include <list>
@@ -157,4 +158,12 @@ class BattleTileView : public TileView
 	void render() override;
 	void update() override;
 };
+
+template <> struct is_partial_enum<BattleTileView::PreviewedPathCostSpecial> : std::true_type
+{
+};
+template <> struct is_partial_enum<BattleTileView::CalculatedAttackCostSpecial> : std::true_type
+{
+};
+
 } // namespace OpenApoc

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -1488,7 +1488,7 @@ void BattleView::update()
 	// Update preview calculations in TB mode
 	if (!realTime)
 	{
-		if (previewedPathCost == static_cast<int>(PreviewedPathCostSpecial::NONE))
+		if (previewedPathCost == PreviewedPathCostSpecial::NONE)
 		{
 			pathPreviewTicksAccumulated++;
 			// Show path preview if hovering for over half a second
@@ -1497,7 +1497,7 @@ void BattleView::update()
 				updatePathPreview();
 			}
 		}
-		if (calculatedAttackCost == static_cast<int>(CalculatedAttackCostSpecial::NONE))
+		if (calculatedAttackCost == CalculatedAttackCostSpecial::NONE)
 		{
 			attackCostTicksAccumulated++;
 			if (attackCostTicksAccumulated > 5)
@@ -3955,7 +3955,7 @@ bool BattleView::handleGameStateEvent(Event *e)
 			// update the path preview
 			// a battleunit has died, potentially unblocking/changing the previewed path
 			// but only update if there's a path stored
-			if (previewedPathCost != static_cast<int>(PreviewedPathCostSpecial::NONE))
+			if (previewedPathCost != PreviewedPathCostSpecial::NONE)
 			{
 				updatePathPreview();
 			}

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -15,6 +15,7 @@ set (LIBRARY_SOURCE_FILES
 source_group(library\\sources FILES ${LIBRARY_SOURCE_FILES})
 set (LIBRARY_HEADER_FILES
 	colour.h
+	enum_traits.h
 	rect.h
 	sp.h
 	strings.h

--- a/library/enum_traits.h
+++ b/library/enum_traits.h
@@ -1,0 +1,97 @@
+#pragma once
+
+#include <type_traits>
+
+namespace OpenApoc
+{
+
+// Trait for enums that don't define their domain completely
+// enables (in)equality comparisons against underlying type
+template <typename T> struct is_partial_enum : std::false_type
+{
+};
+
+// Trait for enums that are meant to be used as flags
+// enables bitwise operations against same type
+template <typename T> struct is_flag_enum : std::false_type
+{
+};
+
+// Equality comparisons
+template <typename T>
+typename std::enable_if<is_partial_enum<T>::value, bool>::type
+operator==(const T &lhs, const typename std::underlying_type<T>::type &rhs)
+{
+	using UT = typename std::underlying_type<T>::type;
+	return static_cast<UT>(lhs) == rhs;
+}
+
+template <typename T>
+typename std::enable_if<is_partial_enum<T>::value, bool>::type
+operator!=(const T &lhs, const typename std::underlying_type<T>::type &rhs)
+{
+	using UT = typename std::underlying_type<T>::type;
+	return static_cast<UT>(lhs) != rhs;
+}
+
+template <typename T>
+typename std::enable_if<is_partial_enum<T>::value, bool>::type
+operator==(const typename std::underlying_type<T>::type &lhs, const T &rhs)
+{
+	return rhs == lhs;
+}
+
+template <typename T>
+typename std::enable_if<is_partial_enum<T>::value, bool>::type
+operator!=(const typename std::underlying_type<T>::type &lhs, const T &rhs)
+{
+	return rhs != lhs;
+}
+
+// Bitwise operations
+template <typename T>
+typename std::enable_if<is_flag_enum<T>::value, T &>::type operator&=(T &lhs, const T &rhs)
+{
+	using UT = typename std::underlying_type<T>::type;
+	return lhs = static_cast<T>(static_cast<UT>(lhs) & static_cast<UT>(rhs));
+}
+
+template <typename T>
+typename std::enable_if<is_flag_enum<T>::value, T &>::type operator|=(T &lhs, const T &rhs)
+{
+	using UT = typename std::underlying_type<T>::type;
+	return lhs = static_cast<T>(static_cast<UT>(lhs) | static_cast<UT>(rhs));
+}
+
+template <typename T>
+typename std::enable_if<is_flag_enum<T>::value, T &>::type operator^=(T &lhs, const T &rhs)
+{
+	using UT = typename std::underlying_type<T>::type;
+	return lhs = static_cast<T>(static_cast<UT>(lhs) ^ static_cast<UT>(rhs));
+}
+
+template <typename T>
+typename std::enable_if<is_flag_enum<T>::value, T>::type operator&(const T &lhs, const T &rhs)
+{
+	T copy = lhs;
+	copy &= rhs;
+	return copy;
+}
+
+template <typename T>
+typename std::enable_if<is_flag_enum<T>::value, T>::type operator|(const T &lhs, const T &rhs)
+{
+	T copy = lhs;
+	copy |= rhs;
+	return copy;
+}
+
+template <typename T>
+typename std::enable_if<is_flag_enum<T>::value, T>::type operator^(const T &lhs, const T &rhs)
+{
+	T copy = lhs;
+	copy ^= rhs;
+	return copy;
+}
+
+} // namespace OpenApoc

--- a/library/library.vcxproj
+++ b/library/library.vcxproj
@@ -20,6 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="colour.h" />
+    <ClInclude Include="enum_traits.h" />
     <ClInclude Include="line.h" />
     <ClInclude Include="rect.h" />
     <ClInclude Include="resource.h" />


### PR DESCRIPTION
Adds the following traits for strong enums:
 * `is_partial_enum`: enables (in)equality comparisons against underlying type
 * `is_flag_enum`: enables bitwise operations against same enum type

The battleview and battletileview were refactored to use this to reduce the number of const_casts (as noted in #447)