### PR TITLE
Validate UStrings for boost::program_options

### DIFF
--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -493,4 +493,12 @@ bool ConfigOptionFloat::get() const
 		return config().getFloat(section + "." + name);
 }
 
+void validate(boost::any &v, const std::vector<std::string> &values, UString *, int)
+{
+	if (values.size() == 1)
+		v = boost::any(UString(values[0]));
+	else
+		throw po::validation_error(po::validation_error::invalid_option_value);
+}
+
 }; // namespace OpenApoc

--- a/framework/configfile.h
+++ b/framework/configfile.h
@@ -2,6 +2,7 @@
 
 #include "library/sp.h"
 #include "library/strings.h"
+#include <boost/any.hpp>
 
 namespace OpenApoc
 {
@@ -111,5 +112,10 @@ class ConfigOptionFloat
 	bool get() const;
 };
 static inline ConfigFile &config() { return ConfigFile::getInstance(); }
+
+// validate overload required by boost::program_options for UString
+// boost should find this through ADL.
+// this is required for string values with spaces
+void validate(boost::any &v, const std::vector<std::string> &values, UString *, int);
 
 }; // namespace OpenApoc


### PR DESCRIPTION
A bug where option values with spaces were marked as invalid was accidentally introduced in #443. This should fix it