### PR TITLE
fix item fall through gravlift floor

### DIFF
--- a/game/state/tilemap/tile.cpp
+++ b/game/state/tilemap/tile.cpp
@@ -376,8 +376,7 @@ void Tile::updateBattlescapeParameters()
 				continue;
 			}
 			height = std::max(height, (float)mp->type->height);
-			if ((mp->type->floor || o->getType() == TileObject::Type::Feature) &&
-			    !mp->type->gravlift)
+			if (mp->type->floor || (o->getType() == TileObject::Type::Feature && !mp->type->gravlift))
 			{
 				if (!supportProviderForItems ||
 				    supportProviderForItems->type->height < mp->type->height)


### PR DESCRIPTION
This should fix #366 and #284.
Bottom of gravlift couldn't provide support for items and they fell through the floor, possibly out of the world.