### PR TITLE
TransactionControl fixes

### DIFF
--- a/forms/transactioncontrol.cpp
+++ b/forms/transactioncontrol.cpp
@@ -132,10 +132,10 @@ void TransactionControl::updateValues()
 						c_sp->suspendUpdates = false;
 					}
 				}
-				if (!suspendUpdates)
-				{
-					this->pushFormEvent(FormEventType::ScrollBarChange, nullptr);
-				}
+			}
+			if (!suspendUpdates)
+			{
+				this->pushFormEvent(FormEventType::ScrollBarChange, nullptr);
 			}
 		}
 	}

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -420,28 +420,22 @@ void TransactionScreen::updateFormValues(bool queueHighlightUpdate)
 	bio2Delta = 0;
 	moneyDelta = 0;
 
-	std::set<sp<TransactionControl>> linkedControls;
 	for (auto &l : transactionControls)
 	{
 		for (auto &c : l.second)
 		{
-			if (linkedControls.find(c) != linkedControls.end())
+			// if this control is linked to others, only update calculations for one control of the
+			// linked group
+			// if this control is not linked, update calculations
+			if (!c->getLinked() || c->getLinked()->front().lock() == c)
 			{
-				continue;
-			}
-			lqDelta += c->getCrewDelta(leftIndex);
-			lq2Delta += c->getCrewDelta(rightIndex);
-			cargoDelta += c->getCargoDelta(leftIndex);
-			bioDelta += c->getBioDelta(leftIndex);
-			cargo2Delta += c->getCargoDelta(rightIndex);
-			bio2Delta += c->getBioDelta(rightIndex);
-			moneyDelta += c->getPriceDelta();
-			if (c->getLinked())
-			{
-				for (auto &l : *c->getLinked())
-				{
-					linkedControls.insert(l.lock());
-				}
+				lqDelta += c->getCrewDelta(leftIndex);
+				lq2Delta += c->getCrewDelta(rightIndex);
+				cargoDelta += c->getCargoDelta(leftIndex);
+				bioDelta += c->getBioDelta(leftIndex);
+				cargo2Delta += c->getCargoDelta(rightIndex);
+				bio2Delta += c->getBioDelta(rightIndex);
+				moneyDelta += c->getPriceDelta();
 			}
 		}
 	}


### PR DESCRIPTION
This fixes a bug introduced in #425 which was causing #440 (unlinked transactioncontrols wouldn't update the resource deltas)

Also refactors the algorithm for calculating deltas from transaction controls: previous implementation would store a set of known linked controls to avoid duplicating calculations.