### PR TITLE
Store version string in saves

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ exported fixes file")
 
 find_package(Git)
 execute_process(COMMAND ${GIT_EXECUTABLE} -C ${CMAKE_SOURCE_DIR} describe
-		--tags --all --long --always
+		--tags --long --always
 		OUTPUT_VARIABLE OPENAPOC_VERSION_STRING_RAW
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -5,6 +5,7 @@
 #include "framework/serialization/serialize.h"
 #include "framework/trace.h"
 #include "game/state/gamestate.h"
+#include "version.h"
 #include <algorithm>
 #include <sstream>
 
@@ -402,6 +403,9 @@ bool SaveMetadata::serializeManifest(SerializationArchive *archive) const
 
 	auto gameTicksNode = root->addNode("game_ticks");
 	gameTicksNode->setValue(std::to_string(getGameTicks()));
+
+	auto versionNode = root->addNode("game_version");
+	versionNode->setValue(OPENAPOC_VERSION);
 
 	if (this->type != SaveType::Manual)
 	{


### PR DESCRIPTION
Adds the version strings to the save manifest. Hopefully useful to see exact versions when debugging with uploaded saves.

Currently not read by any openapoc code.