### PR TITLE
MSVC build fix: Move version.h generation to library project

### DIFF
--- a/game/ui/gameui.vcxproj
+++ b/game/ui/gameui.vcxproj
@@ -233,13 +233,6 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PreBuildEvent>
-      <Command>cd "$(SolutionDir)"
-gen_version_win.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Generating version.h</Message>
-    </PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
@@ -256,13 +249,6 @@ gen_version_win.bat</Command>
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
-    <PreBuildEvent>
-      <Command>cd "$(SolutionDir)"
-gen_version_win.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Generating version.h</Message>
-    </PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
@@ -281,13 +267,6 @@ gen_version_win.bat</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-    <PreBuildEvent>
-      <Command>cd "$(SolutionDir)"
-gen_version_win.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Generating version.h</Message>
-    </PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
@@ -307,13 +286,6 @@ gen_version_win.bat</Command>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
-    <PreBuildEvent>
-      <Command>cd "$(SolutionDir)"
-gen_version_win.bat</Command>
-    </PreBuildEvent>
-    <PreBuildEvent>
-      <Message>Generating version.h</Message>
-    </PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>

--- a/library/library.vcxproj
+++ b/library/library.vcxproj
@@ -118,6 +118,13 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+	<PreBuildEvent>
+	  <Command>cd "$(SolutionDir)"
+gen_version_win.bat</Command>
+	</PreBuildEvent>
+	<PreBuildEvent>
+	  <Message>Generating version.h</Message>
+	</PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
@@ -134,6 +141,13 @@
       <SubSystem>Windows</SubSystem>
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
+	<PreBuildEvent>
+	  <Command>cd "$(SolutionDir)"
+gen_version_win.bat</Command>
+	</PreBuildEvent>
+	<PreBuildEvent>
+	  <Message>Generating version.h</Message>
+	</PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
@@ -152,6 +166,13 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+	<PreBuildEvent>
+	  <Command>cd "$(SolutionDir)"
+gen_version_win.bat</Command>
+	</PreBuildEvent>
+	<PreBuildEvent>
+	  <Message>Generating version.h</Message>
+	</PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>
@@ -171,6 +192,13 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
+	<PreBuildEvent>
+	  <Command>cd "$(SolutionDir)"
+gen_version_win.bat</Command>
+	</PreBuildEvent>
+	<PreBuildEvent>
+	  <Message>Generating version.h</Message>
+	</PreBuildEvent>
     <Lib>
       <LinkTimeCodeGeneration>false</LinkTimeCodeGeneration>
     </Lib>


### PR DESCRIPTION
This was causing build failures, as it was previously only being built as part
of the gameui, but now other modules (e.g. the savemanager of game/state)
started using the version strings.

Moved to the 'library' project, as everything already depends on that.