### PR TITLE
Fix vehicles becoming stuck in buildings when clearing missions

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -3200,15 +3200,11 @@ bool Vehicle::setMission(GameState &state, VehicleMission *mission)
 
 bool Vehicle::clearMissions(GameState &state, bool forced)
 {
-	if (forced)
-	{
-		missions.clear();
-		return true;
-	}
 	for (auto it = missions.begin(); it != missions.end();)
 	{
-		if ((*it)->type == VehicleMission::MissionType::Land ||
-		    (*it)->type == VehicleMission::MissionType::TakeOff)
+		if (((*it)->type == VehicleMission::MissionType::Land ||
+		     (*it)->type == VehicleMission::MissionType::TakeOff) &&
+		    !forced)
 		{
 			it++;
 		}

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -338,8 +338,10 @@ class Vehicle : public StateObject,
 
 	void setManualFirePosition(const Vec3<float> &pos);
 
-	// Adds mission to list of missions, returns true if successful
-	bool addMission(GameState &state, VehicleMission *mission, bool toBack = false);
+	// Adds mission to list of missions, returns iterator to mission if successful, missions.end()
+	// otherwise
+	typename decltype(missions)::iterator addMission(GameState &state, VehicleMission *mission,
+	                                                 bool toBack = false);
 	// Replaces all missions with provided mission, returns true if successful
 	bool setMission(GameState &state, VehicleMission *mission);
 	bool clearMissions(GameState &state, bool forced = false);


### PR DESCRIPTION
When calling `Vehicle::setMission`, it's possible for some missions to reach the front in the vehicle's mission list without being properly started. Here's an example:

Before clearMissions:
```
front          back
  v              v
Snooze, TakeOff, X
```

After clearMissions:
```
TakeOff
```

After addMission:
```
TakeOff, X
```

Here, the TakeOff mission was never started although it is at the front of the list. X can be another mission like AttackVehicle, GotoLocation, GotoBuilding, etc.
This may be the cause of #456, although it won't fix the already broken saves.