### PR TITLE
fix UString::substr to use offsets in codepoints (instead of bytes)

### DIFF
--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -189,6 +189,11 @@ UString::UString(UniChar uc) : u8Str()
 	u8Str = {buf, bytes};
 }
 
+UString::UString(UString::ConstIterator first, UString::ConstIterator last)
+    : UString(first.s.u8Str.substr(first.offset, last.offset - first.offset))
+{
+}
+
 const std::string &UString::str() const { return this->u8Str; }
 
 const char *UString::cStr() const { return this->u8Str.c_str(); }
@@ -201,7 +206,14 @@ bool UString::operator==(const UString &other) const { return (this->u8Str) == (
 
 UString UString::substr(size_t offset, size_t length) const
 {
-	return this->u8Str.substr(offset, length);
+	auto sub_start = std::next(this->begin(), offset);
+	auto sub_end = sub_start;
+	while (length != 0 && sub_end != this->end())
+	{
+		++sub_end;
+		--length;
+	}
+	return UString{sub_start, sub_end};
 }
 
 UString UString::toUpper() const

--- a/library/strings.h
+++ b/library/strings.h
@@ -16,6 +16,21 @@ class UString
 	std::string u8Str;
 
   public:
+	class ConstIterator : public std::iterator<std::forward_iterator_tag, UniChar>
+	{
+	  private:
+		const UString &s;
+		size_t offset;
+		friend class UString;
+		ConstIterator(const UString &s, size_t initial_offset) : s(s), offset(initial_offset) {}
+
+	  public:
+		// Just enough to struggle through a range-based for
+		bool operator!=(const ConstIterator &other) const;
+		ConstIterator operator++();
+		UniChar operator*() const;
+	};
+
 	// ASSUMPTIONS:
 	// All std::string/char are utf8
 	// All lengths/offsets are in unicode code-points (not bytes/anything)
@@ -24,6 +39,7 @@ class UString
 	UString(UniChar uc);
 	UString(const char *cstr);
 	UString(UString &&other);
+	UString(ConstIterator first, ConstIterator last);
 	UString();
 	~UString();
 
@@ -65,20 +81,6 @@ class UString
 	bool operator!=(const UString &other) const;
 	bool operator<(const UString &other) const;
 
-	class ConstIterator : public std::iterator<std::forward_iterator_tag, UniChar>
-	{
-	  private:
-		const UString &s;
-		size_t offset;
-		friend class UString;
-		ConstIterator(const UString &s, size_t initial_offset) : s(s), offset(initial_offset) {}
-
-	  public:
-		// Just enough to struggle through a range-based for
-		bool operator!=(const ConstIterator &other) const;
-		ConstIterator operator++();
-		UniChar operator*() const;
-	};
 	ConstIterator begin() const;
 	ConstIterator end() const;
 


### PR DESCRIPTION
Fixes #471 