### PR TITLE
Dont restart text input mode while using the same TextEdit

### DIFF
--- a/forms/textedit.cpp
+++ b/forms/textedit.cpp
@@ -42,18 +42,19 @@ void TextEdit::eventOccured(Event *e)
 			    e->forms().EventFlag == FormEventType::MouseClick ||
 			    e->forms().EventFlag == FormEventType::KeyDown)
 			{
-				editing = true;
-
-				fw().textStartInput();
-				// e->Handled = true;
-				// FIXME: Should we really fall through here?
+				if (!editing)
+				{
+					editing = true;
+					fw().textStartInput();
+					// e->Handled = true;
+					// FIXME: Should we really fall through here?
+				}
 			}
 		}
 		if (editing)
 		{
 			if (e->forms().RaisedBy == shared_from_this())
 			{
-
 				if (e->forms().EventFlag == FormEventType::LostFocus)
 				{
 					editing = false;


### PR DESCRIPTION
Preventing the widget from restarting the SDL text editing mode allows sequences such as `´`, `e` to properly transform into an input `é`, for example