### PR TITLE
Fix for Grav-Lift item falling through floor

### DIFF
--- a/game/state/tilemap/tile.cpp
+++ b/game/state/tilemap/tile.cpp
@@ -376,8 +376,8 @@ void Tile::updateBattlescapeParameters()
 				continue;
 			}
 			height = std::max(height, (float)mp->type->height);
-			if ((mp->type->floor || o->getType() == TileObject::Type::Feature) &&
-			    !mp->type->gravlift)
+			if (mp->type->floor ||
+			    (o->getType() == TileObject::Type::Feature && !mp->type->gravlift))
 			{
 				if (!supportProviderForItems ||
 				    supportProviderForItems->type->height < mp->type->height)


### PR DESCRIPTION
I've updated the work by @kaja47 to fix the grav-lift item problem

Co-Authored-By: K. <kaja47@users.noreply.github.com>

Rebased version of PR #480 