### PR TITLE
[Quick-Fix] for HP repair value for vehicles in repair bay

### DIFF
--- a/data/common_patch/gamestate/facility_types.xml
+++ b/data/common_patch/gamestate/facility_types.xml
@@ -150,7 +150,7 @@
     <key>FACILITYTYPE_VEHICLE_REPAIR_BAY</key>
     <value>
       <capacityType>Repair</capacityType>
-      <capacityAmount>1</capacityAmount>
+      <capacityAmount>12</capacityAmount>
       <ufopaedia_entry>PAEDIAENTRY_VEHICLE_REPAIR_BAY</ufopaedia_entry>
     </value>
   </entry>


### PR DESCRIPTION
This makes the repair bay restore 12HP per hour for vehicles being repaired (currently it's just 1HP an hour!!!)

It is not a complete fix as we need to make future considerations for repair bay capacities and vehicle types in the future to comply with OG

Additionally, in Beta Apoc, repair rate was variable with difficulty level!