### PR TITLE
List control tweaks

### DIFF
--- a/data/forms/ingameoptions.form
+++ b/data/forms/ingameoptions.form
@@ -117,7 +117,7 @@
         <listbox id="NOTIFICATIONS_LIST" scrollbarid="NOTIFICATIONS_SCROLL">
           <position x="311" y="76"/>
           <size width="240" height="330"/>
-          <item size="0" spacing="4"/>
+          <item size="16" spacing="4"/>
           <hovercolour r="255" g="255" b="255" a="0"/>
           <selcolour r="255" g="255" b="255" a="0"/>
         </listbox>

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -205,6 +205,25 @@ void ListBox::update()
 	}
 	if (scroller)
 	{
+		size_t mainAxisSize = 0;
+		switch (ListOrientation)
+		{
+			case Orientation::Vertical:
+				mainAxisSize = Size.y;
+				break;
+			case Orientation::Horizontal:
+				mainAxisSize = Size.x;
+				break;
+			default:
+				LogWarning("Unknown ListBox::ListOrientation value: %d",
+				           static_cast<int>(ListOrientation));
+				return;
+		}
+		size_t mainAxisContentSize =
+		    Controls.empty() ? 0 : ItemSize * Controls.size() + ItemSpacing * (Controls.size() - 1);
+		int scrollerLength =
+		    mainAxisContentSize > mainAxisSize ? mainAxisContentSize - mainAxisSize : 0;
+		scroller->setMaximum(scroller->getMinimum() + scrollerLength);
 		scroller->update();
 		Vec2<int> newScrollOffset = this->scrollOffset;
 		switch (ScrollOrientation)

--- a/forms/scrollbar.cpp
+++ b/forms/scrollbar.cpp
@@ -91,10 +91,14 @@ void ScrollBar::eventOccured(Event *e)
 		switch (BarOrientation)
 		{
 			case Orientation::Vertical:
-				mousePosition = e->forms().MouseInfo.Y;
+				// MouseInfo.X/Y is relative to the control that raised it
+				// make it relative to this control instead
+				mousePosition = e->forms().MouseInfo.Y +
+				                e->forms().RaisedBy->getLocationOnScreen().y - resolvedLocation.y;
 				break;
 			case Orientation::Horizontal:
-				mousePosition = e->forms().MouseInfo.X;
+				mousePosition = e->forms().MouseInfo.X +
+				                e->forms().RaisedBy->getLocationOnScreen().x - resolvedLocation.x;
 				break;
 		}
 	}
@@ -123,8 +127,8 @@ void ScrollBar::eventOccured(Event *e)
 		capture = false;
 	}
 
-	if (e->type() == EVENT_FORM_INTERACTION && e->forms().RaisedBy == shared_from_this() &&
-	    e->forms().EventFlag == FormEventType::MouseMove && capture)
+	if (e->type() == EVENT_FORM_INTERACTION && e->forms().EventFlag == FormEventType::MouseMove &&
+	    capture)
 	{
 		this->setValue(static_cast<int>(mousePosition / segmentsize) + Minimum);
 	}

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -157,12 +157,12 @@ void InGameOptions::loadList(int id)
 	{
 		auto checkBox = mksp<CheckBox>(fw().data->loadImage("BUTTON_CHECKBOX_TRUE"),
 		                               fw().data->loadImage("BUTTON_CHECKBOX_FALSE"));
-		checkBox->Size = {240, 16};
+		checkBox->Size = {240, listControl->ItemSize};
 		UString full_name = p.first + "." + p.second;
 		checkBox->setData(mksp<UString>(full_name));
 		checkBox->setChecked(config().getBool(full_name));
 		auto label = checkBox->createChild<Label>(tr(config().describe(p.first, p.second)), font);
-		label->Size = {216, 16};
+		label->Size = {216, listControl->ItemSize};
 		label->Location = {24, 0};
 		listControl->addItem(checkBox);
 	}


### PR DESCRIPTION
 * Allow mouse-move interactions with captured scrollbar even outside of its' bounds (easier dragging, especially near the left end of the scrollbar)
 * Adjust the scroll limits according to the parent listbox's contents (easier scrolling in a listbox with many items)