### PR TITLE
Add tooltips

### DIFF
--- a/data/forms/city/tab1.form
+++ b/data/forms/city/tab1.form
@@ -64,6 +64,10 @@
         <font>smalfont</font>
       </label>
       <graphicbutton id="BUTTON_SHOW_BASE">
+        <tooltip text="Bases" font="smallset" background="#808080" padding="1">
+          <border width="1" colour="#000000"/>
+          <border width="1" colour="#FFFFFF"/>
+        </tooltip>
         <position x="408" y="75"/>
         <size width="27" height="46"/>
         <image/>

--- a/data/forms/ingameoptions.form
+++ b/data/forms/ingameoptions.form
@@ -157,19 +157,7 @@
 			<size width="90" height="16"/>
 		  </label>
 		</checkbox>
-       
-        <checkbox id="TOOL_TIPS">
-          <position x="310" y="450"/>
-          <size width="120" height="16"/>
-          <image>BUTTON_CHECKBOX_FALSE</image>
-          <imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
-          <label text="Tool tips">
-			<position x="24" y="0"/>
-			<font>smalfont</font>
-			<size width="90" height="16"/>
-          </label>
-		</checkbox>
-       
+ 
 		<checkbox id="ACTION_MUSIC">
           <position x="440" y="430"/>
           <size width="120" height="16"/>

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -296,7 +296,7 @@ void Control::eventOccured(Event *e)
 				Vec2<int> pos = {e->forms().MouseInfo.X, e->forms().MouseInfo.Y};
 				e->Handled = true;
 
-				sp<Image> textImage = ToolTipFont->getString(tr(ToolTipText));
+				sp<Image> textImage = ToolTipFont->getString(ToolTipText);
 
 				unsigned totalBorder = ToolTipPadding;
 				for (const auto &b : ToolTipBorders)
@@ -713,6 +713,8 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 			if (ToolTipFont = ui().getFont(child.attribute("font").as_string()))
 			{
 				ToolTipText = child.attribute("text").as_string();
+				if (!ToolTipText.empty())
+					ToolTipText = tr(ToolTipText);
 			}
 			else
 			{

--- a/forms/control.h
+++ b/forms/control.h
@@ -8,7 +8,6 @@
 #include <functional>
 #include <list>
 #include <map>
-#include <optional>
 
 namespace pugi
 {
@@ -88,6 +87,10 @@ class Control : public std::enable_shared_from_this<Control>
 
 	UString ToolTipText;
 	sp<BitmapFont> ToolTipFont;
+	// transparent background by default
+	Colour ToolTipBackground = {0, 0, 0, 0};
+	std::list<std::pair<unsigned int, Colour>> ToolTipBorders;
+	unsigned int ToolTipPadding = 0;
 
 	bool canCopy;
 	wp<Control> lastCopiedTo;

--- a/forms/control.h
+++ b/forms/control.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <optional>
 
 namespace pugi
 {
@@ -17,6 +18,7 @@ class xml_node;
 namespace OpenApoc
 {
 
+class BitmapFont;
 class Form;
 class Event;
 class Surface;
@@ -83,6 +85,9 @@ class Control : public std::enable_shared_from_this<Control>
 	bool takesFocus;
 	bool showBounds;
 	bool Enabled;
+
+	UString ToolTipText;
+	sp<BitmapFont> ToolTipFont;
 
 	bool canCopy;
 	wp<Control> lastCopiedTo;

--- a/forms/forms_enums.h
+++ b/forms/forms_enums.h
@@ -22,6 +22,7 @@ enum class FormEventType
 	KeyPress,
 	KeyUp,
 	TextInput,
+	ToolTip,
 
 	ButtonClick,
 	CheckBoxChange,

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -4,6 +4,7 @@
 #include "framework/configfile.h"
 #include "framework/data.h"
 #include "framework/event.h"
+#include "framework/font.h"
 #include "framework/image.h"
 #include "framework/renderer.h"
 #include "framework/renderer_interface.h"
@@ -96,8 +97,9 @@ ConfigOptionBool actionMusicOption("Options.Misc", "ActionMusic",
 ConfigOptionBool autoExecuteOption("Options.Misc", "AutoExecute",
                                    "Execute remaining orders when player presses end turn button",
                                    false);
-ConfigOptionBool toolTipsOption("Options.Misc", "ToolTips",
-                                "Show tool tips when hovering over controls", true);
+ConfigOptionInt toolTipDelay("Options.Misc", "ToolTipDelay",
+                             "Delay in milliseconds before showing tooltips (<= 0 to disable)",
+                             2000);
 
 ConfigOptionBool optionPauseOnUfoSpotted("Notifications.City", "UfoSpotted", "UFO spotted", true);
 ConfigOptionBool optionPauseOnVehicleLightDamage("Notifications.City", "VehicleLightDamage",
@@ -370,6 +372,11 @@ class FrameworkPrivate
 	sp<Surface> scaleSurface;
 	up<ThreadPool> threadPool;
 
+	int toolTipTimerId = 0;
+	up<Event> toolTipTimerEvent;
+	sp<Image> toolTipImage;
+	Vec2<int> toolTipPosition;
+
 	FrameworkPrivate()
 	    : quitProgram(false), window(nullptr), context(0), displaySize(0, 0), windowSize(0, 0)
 	{
@@ -418,7 +425,7 @@ Framework::Framework(const UString programName, bool createWindow)
 	SDL_SetHint(SDL_HINT_ANDROID_SEPARATE_MOUSE_AND_TOUCH, "1");
 #endif
 	// Initialize subsystems separately?
-	if (SDL_Init(SDL_INIT_EVENTS) < 0)
+	if (SDL_Init(SDL_INIT_EVENTS | SDL_INIT_TIMER) < 0)
 	{
 		LogError("Cannot init SDL2");
 		LogError("SDL error: %s", SDL_GetError());
@@ -619,6 +626,10 @@ void Framework::run(sp<Stage> initialStage)
 		{
 			TraceObj updateObj("Render");
 			p->ProgramStages.current()->render();
+			if (p->toolTipImage)
+			{
+				renderer->draw(p->toolTipImage, p->toolTipPosition);
+			}
 			this->cursor->render();
 			if (p->scaleSurface)
 			{
@@ -1216,6 +1227,49 @@ ApocCursor &Framework::getCursor() { return *this->cursor; }
 void Framework::textStartInput() { SDL_StartTextInput(); }
 
 void Framework::textStopInput() { SDL_StopTextInput(); }
+
+void Framework::toolTipStartTimer(up<Event> e)
+{
+	int delay = config().getInt("Options.Misc.ToolTipDelay");
+	if (delay <= 0)
+	{
+		return;
+	}
+	// remove any pending timers
+	toolTipStopTimer();
+	p->toolTipTimerEvent = std::move(e);
+	p->toolTipTimerId = SDL_AddTimer(delay,
+	                                 [](unsigned int interval, void *data) -> unsigned int {
+		                                 fw().toolTipTimerCallback(interval, data);
+		                                 // remove this sdl timer
+		                                 return 0;
+		                             },
+	                                 nullptr);
+}
+void Framework::toolTipStopTimer()
+{
+	if (p->toolTipTimerId)
+	{
+		SDL_RemoveTimer(p->toolTipTimerId);
+		p->toolTipTimerId = 0;
+	}
+	p->toolTipTimerEvent.reset();
+	p->toolTipImage.reset();
+}
+
+void Framework::toolTipTimerCallback(unsigned int interval, void *data)
+{
+	// the sdl timer will be removed, so we forget about
+	// clear the timerid and reset the event
+	pushEvent(std::move(p->toolTipTimerEvent));
+	p->toolTipTimerId = 0;
+}
+
+void Framework::showToolTip(sp<Image> image, const Vec2<int> &position)
+{
+	p->toolTipImage = image;
+	p->toolTipPosition = position;
+}
 
 UString Framework::textGetClipboard()
 {

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -14,6 +14,7 @@ class GameCore;
 class FrameworkPrivate;
 class ApocCursor;
 class Event;
+class Image;
 class Data;
 class Renderer;
 class SoundBackend;
@@ -83,6 +84,12 @@ class Framework
 
 	void textStartInput();
 	void textStopInput();
+
+	void toolTipStartTimer(up<Event> e);
+	void toolTipStopTimer();
+	void toolTipTimerCallback(unsigned int interval, void *data);
+	void showToolTip(sp<Image> image, const Vec2<int> &position);
+
 	UString textGetClipboard();
 
 	void threadPoolTaskEnqueue(std::function<void()> task);

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -193,8 +193,6 @@ void InGameOptions::begin()
 
 	menuform->findControlTyped<CheckBox>("AUTO_SCROLL")
 	    ->setChecked(config().getBool("Options.Misc.AutoScroll"));
-	menuform->findControlTyped<CheckBox>("TOOL_TIPS")
-	    ->setChecked(config().getBool("Options.Misc.ToolTips"));
 	menuform->findControlTyped<CheckBox>("ACTION_MUSIC")
 	    ->setChecked(config().getBool("Options.Misc.ActionMusic"));
 	menuform->findControlTyped<CheckBox>("AUTO_EXECUTE_ORDERS")
@@ -225,8 +223,6 @@ void InGameOptions::finish()
 
 	config().set("Options.Misc.AutoScroll",
 	             menuform->findControlTyped<CheckBox>("AUTO_SCROLL")->isChecked());
-	config().set("Options.Misc.ToolTips",
-	             menuform->findControlTyped<CheckBox>("TOOL_TIPS")->isChecked());
 	config().set("Options.Misc.ActionMusic",
 	             menuform->findControlTyped<CheckBox>("ACTION_MUSIC")->isChecked());
 	config().set("Options.Misc.AutoExecute",

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -351,6 +351,39 @@ bool UString::endsWith(const UString &suffix) const
 	return boost::ends_with(str(), suffix.str());
 }
 
+UString UString::trimLeft() const
+{
+	auto first = begin();
+	auto last = end();
+	while (first != last && Strings::isWhiteSpace(*first))
+		++first;
+	return {first, last};
+}
+UString UString::trimRight() const
+{
+	auto first = begin();
+	auto last = end();
+	if (first == last)
+		return {};
+	--last;
+	while (first != last && Strings::isWhiteSpace(*last))
+		--last;
+	return {first, ++last};
+}
+UString UString::trim() const
+{
+	auto first = begin();
+	auto last = end();
+	while (first != last && Strings::isWhiteSpace(*first))
+		++first;
+	if (first == last)
+		return {};
+	--last;
+	while (first != last && Strings::isWhiteSpace(*last))
+		--last;
+	return {first, ++last};
+}
+
 UString::ConstIterator UString::begin() const { return UString::ConstIterator(*this, 0); }
 
 UString::ConstIterator UString::end() const
@@ -366,6 +399,19 @@ UString::ConstIterator UString::ConstIterator::operator++()
 	utf8_to_unichar(ptr, num_bytes);
 
 	this->offset += num_bytes;
+	return *this;
+}
+
+UString::ConstIterator UString::ConstIterator::operator--()
+{
+	const char *ptr = s.cStr();
+	ptr += --this->offset;
+	while (static_cast<unsigned char>(*ptr) >= 0b10000000 &&
+	       static_cast<unsigned char>(*ptr) < 0b11000000)
+	{
+		--this->offset;
+		--ptr;
+	}
 	return *this;
 }
 

--- a/library/strings.h
+++ b/library/strings.h
@@ -29,6 +29,7 @@ class UString
 		bool operator!=(const ConstIterator &other) const;
 		bool operator==(const ConstIterator &other) const;
 		ConstIterator operator++();
+		ConstIterator operator--();
 		UniChar operator*() const;
 	};
 
@@ -78,6 +79,10 @@ class UString
 	int compare(const UString &str) const;
 
 	bool endsWith(const UString &suffix) const;
+
+	UString trimLeft() const;
+	UString trimRight() const;
+	UString trim() const;
 
 	bool operator==(const UString &other) const;
 	bool operator!=(const UString &other) const;


### PR DESCRIPTION
Adds configurable tooltips (font, background color, border color)
Note that only the tooltip for the 'Bases' button in the cityscape was implemented. The rest of the tooltips should be added in the appropiate form files
![2019-02-06_15-22](https://user-images.githubusercontent.com/7649096/52364942-0f475380-2a25-11e9-9ca3-6f41e579be59.png)
