### PR TITLE
serialize VehicleMission::MissionType::ArriveFromDimensionGate

### DIFF
--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -1453,6 +1453,7 @@
 		<value>Teleport</value>
 		<value>SelfDestruct</value>
 		<value>DepartToSpace</value>
+		<value>ArriveFromDimensionGate</value>
 		<value>InvestigateBuilding</value>
 	</enum>
 	<enum>


### PR DESCRIPTION
Should fix the error regarding unknown vehicle mission type when loading a savegame at the start of a UFO incursion (reported by @BeornTB on discord)