### PR TITLE
Fix unused width specifier on investigation prompt

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3622,8 +3622,8 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 
 			UString title = tr("Commence investigation");
-			UString message = format(tr("All selected units and crafts have arrived at %0s. "
-			                            "Proceed with investigation? (%1d units)"),
+			UString message = format(tr("All selected units and crafts have arrived at %s. "
+			                            "Proceed with investigation? (%d units)"),
 			                         building->name, agents.size());
 			fw().stageQueueCommand(
 			    {StageCmd::Command::PUSH,


### PR DESCRIPTION
Fixes a bug introduced in #448 where I tried to use a POSIX argument position in a format specifier and I ended up using a width specifier instead. Anyways, argument positions are not supported in tinyformat atm so it's better to remove this.