### PR TITLE
Tooltip fixes

### DIFF
--- a/data/forms/city/tab1.form
+++ b/data/forms/city/tab1.form
@@ -72,9 +72,10 @@
         <font>smalfont</font>
       </label>
       <graphicbutton id="BUTTON_SHOW_BASE">
-        <tooltip text="Bases" font="smallset" background="#808080" padding="1">
+        <tooltip text="Bases" font="smallset" background="#808080">
           <border width="1" colour="#000000"/>
           <border width="1" colour="#FFFFFF"/>
+          <border width="1" colour="#000000" alpha="0"/>
         </tooltip>
         <position x="408" y="75"/>
         <size width="27" height="46"/>

--- a/forms/control.h
+++ b/forms/control.h
@@ -88,9 +88,8 @@ class Control : public std::enable_shared_from_this<Control>
 	UString ToolTipText;
 	sp<BitmapFont> ToolTipFont;
 	// transparent background by default
-	Colour ToolTipBackground = {0, 0, 0, 0};
-	std::list<std::pair<unsigned int, Colour>> ToolTipBorders;
-	unsigned int ToolTipPadding = 0;
+	Colour ToolTipBackground;
+	std::vector<std::pair<unsigned int, Colour>> ToolTipBorders;
 
 	bool canCopy;
 	wp<Control> lastCopiedTo;


### PR DESCRIPTION
Some fixes for bugs and code issues regarding tooltips that I noticed after 42b30ef was merged:
 * Default tooltip settings were moved to `forms/control.cpp` (there were mismatching defaults declared in `forms/control.h` and `forms/control.cpp`)
 * Borders specified in XML files will replace the default borders (they should no longer stack on top of them)
 * Removed tooltip padding option (use a fully transparent border instead)
 * Border thickness used to be ignored