### PR TITLE
Add missing text translations in in-game options menu

### DIFF
--- a/data/forms/ingameoptions.form
+++ b/data/forms/ingameoptions.form
@@ -200,7 +200,12 @@
           <position x="18" y="407"/>
           <size width="259" height="28"/>
         </textbutton>
-        <textbutton id="BUTTON_BATTLE">
+        <textbutton id="BUTTON_EXIT_BATTLE" text="Exit Battle">
+          <font>smalfont</font>
+          <position x="18" y="435"/>
+          <size width="259" height="28"/>
+        </textbutton>
+        <textbutton id="BUTTON_SKIRMISH" text="Skirmish Mode">
           <font>smalfont</font>
           <position x="18" y="435"/>
           <size width="259" height="28"/>

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -410,7 +410,7 @@ void RecruitScreen::personnelSheet(sp<Agent> agent, sp<Form> formPersonnelStats)
 	formPersonnelStats->findControlTyped<Graphic>("SELECTED_PORTRAIT")
 	    ->setImage(agent->getPortrait().photo);
 	formPersonnelStats->findControlTyped<Label>("VALUE_SKILL")
-	    ->setText(format(tr("%d"), agent->getSkill()));
+	    ->setText(format("%d", agent->getSkill()));
 }
 
 /**

--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -508,7 +508,7 @@ void ResearchScreen::updateProgressInfo()
 		manufacturing_scroll_left->setVisible(true);
 		manufacturing_scroll_right->setVisible(true);
 		manufacturing_scrollbar->setValue(this->viewFacility->lab->getQuantity());
-		manufacturing_quantity->setText(format(tr("%d"), this->viewFacility->lab->getQuantity()));
+		manufacturing_quantity->setText(format("%d", this->viewFacility->lab->getQuantity()));
 	}
 	else
 	{


### PR DESCRIPTION
The following text strings wouldn't pick up translations:
 * `Exit Battle`
 * `Skirmish Mode`
 * `OpenApoc Features`
 * `Message Toggles`