### PR TITLE
If a vehicle ends up with a GotoLocation mission to an unreachable ti…

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -30,6 +30,10 @@
 namespace OpenApoc
 {
 
+using AdjustTargetResult = VehicleTargetHelper::AdjustTargetResult;
+using VehicleAvoidance = VehicleTargetHelper::VehicleAvoidance;
+using Reachability = VehicleTargetHelper::Reachability;
+
 namespace
 {
 // Add {0.5,0.5,0.5} to make it route to the center of the tile
@@ -360,28 +364,11 @@ VehicleMission *VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<
 	mission->pickNearest = pickNearest;
 	mission->reRouteAttempts = attemptsToGiveUpAfter;
 	mission->allowTeleporter = allowTeleporter;
-	// Ground vehicles want to go to a closer road
-	if (v.type->type == VehicleType::Type::Road)
+	if (!VehicleTargetHelper::adjustTargetToClosest(state, v, target, VehicleAvoidance::Ignore,
+	                                                true)
+	         .foundSuitableTarget)
 	{
-		if (!adjustTargetToClosestRoad(v, target))
-		{
-			mission->cancelled = true;
-		}
-	}
-	// ATVs want to go to a closer ground
-	else if (v.type->type == VehicleType::Type::ATV)
-	{
-		if (!adjustTargetToClosestGround(v, target))
-		{
-			mission->cancelled = true;
-		}
-	}
-	else
-	{
-		if (!adjustTargetToClosestFlying(state, v, target))
-		{
-			mission->cancelled = true;
-		}
+		mission->cancelled = true;
 	}
 	mission->targetLocation = target;
 	return mission;
@@ -634,14 +621,14 @@ VehicleMission *VehicleMission::investigateBuilding(GameState &, Vehicle &v,
 	return mission;
 }
 
-bool VehicleMission::adjustTargetToClosestRoad(Vehicle &v, Vec3<int> &target)
+AdjustTargetResult VehicleTargetHelper::adjustTargetToClosestRoad(Vehicle &v, Vec3<int> &target)
 {
 	auto &map = *v.city->map;
 	auto scenery = map.getTile(target)->presentScenery;
 	// Clicked on road
 	if (scenery && scenery->type->tile_type == SceneryTileType::TileType::Road)
 	{
-		return true;
+		return {Reachability::Reachable, true};
 	}
 	// Try to find road in general vicinity of +-10 tiles
 	Vec3<int> closestPos = target;
@@ -669,7 +656,7 @@ bool VehicleMission::adjustTargetToClosestRoad(Vehicle &v, Vec3<int> &target)
 	if (closestDist < INT_MAX)
 	{
 		target = closestPos;
-		return true;
+		return {Reachability::BlockedByScenery, true};
 	}
 	// Try to find road anywhere
 	for (int x = 0; x < map.size.x; x++)
@@ -700,13 +687,13 @@ bool VehicleMission::adjustTargetToClosestRoad(Vehicle &v, Vec3<int> &target)
 	if (closestDist < INT_MAX)
 	{
 		target = closestPos;
-		return true;
+		return {Reachability::BlockedByScenery, true};
 	}
 	LogWarning("No road exists anywhere in the city? Really?");
-	return false;
+	return {Reachability::BlockedByScenery, false};
 }
 
-bool VehicleMission::adjustTargetToClosestGround(Vehicle &v, Vec3<int> &target)
+AdjustTargetResult VehicleTargetHelper::adjustTargetToClosestGround(Vehicle &v, Vec3<int> &target)
 {
 	auto &map = *v.city->map;
 	auto scenery = map.getTile(target)->presentScenery;
@@ -731,7 +718,7 @@ bool VehicleMission::adjustTargetToClosestGround(Vehicle &v, Vec3<int> &target)
 			}
 			// Intentional fall-through
 			case SceneryTileType::WalkMode::Into:
-				return true;
+				return {Reachability::Reachable, true};
 			case SceneryTileType::WalkMode::None:
 				break;
 		}
@@ -787,7 +774,7 @@ bool VehicleMission::adjustTargetToClosestGround(Vehicle &v, Vec3<int> &target)
 	if (closestDist < INT_MAX)
 	{
 		target = closestPos;
-		return true;
+		return {Reachability::BlockedByScenery, true};
 	}
 	// Try to find ground anywhere
 	for (int x = 0; x < map.size.x; x++)
@@ -843,18 +830,20 @@ bool VehicleMission::adjustTargetToClosestGround(Vehicle &v, Vec3<int> &target)
 	if (closestDist < INT_MAX)
 	{
 		target = closestPos;
-		return true;
+		return {Reachability::BlockedByScenery, true};
 	}
 	LogError("NO GROUND IN THE CITY!? WTF?");
-	return false;
+	return {Reachability::BlockedByScenery, false};
 }
 
-bool VehicleMission::adjustTargetToClosestFlying(GameState &state, Vehicle &v, Vec3<int> &target,
-                                                 bool ignoreVehicles, bool pickNearest,
-                                                 bool &pickedNearest)
+AdjustTargetResult
+VehicleTargetHelper::adjustTargetToClosestFlying(GameState &state, Vehicle &v, Vec3<int> &target,
+                                                 const VehicleAvoidance vehicleAvoidance)
 {
 	auto &map = *v.city->map;
-	auto to = map.getTile(target);
+	Tile *targetTile = map.getTile(target);
+
+	Reachability reachability = Reachability::Reachable;
 
 	// Check if target tile has no scenery permanently blocking it
 	// If it does, go up until we've got clear sky
@@ -863,7 +852,7 @@ bool VehicleMission::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 		bool foundScenery = false;
 		bool foundCrash = false;
 
-		for (auto &obj : to->intersectingObjects)
+		for (auto &obj : targetTile->intersectingObjects)
 		{
 			if (obj->getType() == TileObject::Type::Vehicle)
 			{
@@ -875,7 +864,7 @@ bool VehicleMission::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 				}
 			}
 		}
-		for (auto &obj : to->ownedObjects)
+		for (auto &obj : targetTile->ownedObjects)
 		{
 			if (obj->getType() == TileObject::Type::Scenery)
 			{
@@ -894,122 +883,150 @@ bool VehicleMission::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 		}
 		LogInfo("Cannot move to %d %d %d, contains scenery that is not a landing pad", target.x,
 		        target.y, target.z);
+		reachability = Reachability::BlockedByScenery;
 		target.z++;
 		if (target.z >= map.size.z)
 		{
 			LogError("No space in the sky? Reached %d %d %d", target.x, target.y, target.z);
-			return false;
+			return {reachability, false};
 		}
-		to = map.getTile(target);
+		targetTile = map.getTile(target);
+	}
+	if (vehicleAvoidance == VehicleAvoidance::Ignore)
+	{
+		return {reachability, true};
 	}
 	// Check if target tile has no vehicle termporarily blocking it
 	// If it does, find a random location around it that is not blocked
 	bool containsVehicle = false;
-	if (!ignoreVehicles)
+	for (auto &obj : targetTile->intersectingObjects)
 	{
-		for (auto &obj : to->intersectingObjects)
+		if (obj->getType() == TileObject::Type::Vehicle)
 		{
-			if (obj->getType() == TileObject::Type::Vehicle)
+			auto otherVehicle = std::static_pointer_cast<TileObjectVehicle>(obj)->getVehicle();
+			// Don't collide with self.
+			if (v.name == otherVehicle->name)
+				continue;
+			// Non-crashed can go into crashed
+			if (v.crashed || !otherVehicle->crashed)
 			{
-				auto vehicleTile = std::static_pointer_cast<TileObjectVehicle>(obj);
-				// Non-crashed can go into crashed
-				if (v.crashed || !vehicleTile->getVehicle()->crashed)
-				{
-					containsVehicle = true;
-					break;
-				}
+				containsVehicle = true;
+				break;
 			}
 		}
 	}
-	if (containsVehicle)
+	if (!containsVehicle)
 	{
-		// How far to deviate from target point
-		int maxDiff = 2;
-		// Calculate bounds
-		int midX = target.x;
-		midX = midX + maxDiff + 1 > map.size.x ? map.size.x - maxDiff - 1
-		                                       : (midX - maxDiff < 0 ? maxDiff : midX);
-		int midY = target.y;
-		midY = midY + maxDiff + 1 > map.size.y ? map.size.y - maxDiff - 1
-		                                       : (midY - maxDiff < 0 ? maxDiff : midY);
-		int midZ = (int)v.altitude;
-		midZ = midZ + maxDiff + 1 > map.size.z ? map.size.z - maxDiff - 1
-		                                       : (midZ - maxDiff < 0 ? maxDiff : midZ);
+		return {reachability, true};
+	}
+	reachability = Reachability::BlockedByVehicle;
 
-		if (pickNearest)
+	// How far to deviate from target point
+	int maxDiff = 2;
+	// Calculate bounds
+	int midX = target.x;
+	midX = midX + maxDiff + 1 > map.size.x ? map.size.x - maxDiff - 1
+	                                       : (midX - maxDiff < 0 ? maxDiff : midX);
+	int midY = target.y;
+	midY = midY + maxDiff + 1 > map.size.y ? map.size.y - maxDiff - 1
+	                                       : (midY - maxDiff < 0 ? maxDiff : midY);
+	int midZ = (int)v.altitude;
+	midZ = midZ + maxDiff + 1 > map.size.z ? map.size.z - maxDiff - 1
+	                                       : (midZ - maxDiff < 0 ? maxDiff : midZ);
+
+	if (vehicleAvoidance == VehicleAvoidance::PickNearbyPoint)
+	{
+		Vec3<int> newTarget;
+		bool foundNewTarget = false;
+		for (int i = 0; i <= maxDiff && !foundNewTarget; i++)
 		{
-			Vec3<int> newTarget;
-			bool foundNewTarget = false;
-			for (int i = 0; i <= maxDiff && !foundNewTarget; i++)
+			for (int x = midX - i; x <= midX + i && !foundNewTarget; x++)
 			{
-				for (int x = midX - i; x <= midX + i && !foundNewTarget; x++)
+				for (int y = midY - i; y <= midY + i && !foundNewTarget; y++)
 				{
-					for (int y = midY - i; y <= midY + i && !foundNewTarget; y++)
+					for (int z = midZ - i; z <= midZ + i; z++)
 					{
-						for (int z = midZ - i; z <= midZ + i && !foundNewTarget; z++)
+						// Only pick points on the edge of each iteration
+						if (x == midX - i || x == midX + i || y == midY - i || y == midY + i ||
+						    z == midZ - i || z == midZ + i)
 						{
-							// Only pick points on the edge of each iteration
-							if (x == midX - i || x == midX + i || y == midY - i || y == midY + i ||
-							    z == midZ - i || z == midZ + i)
+							auto t = map.getTile(x, y, z);
+							if (t->ownedObjects.empty())
 							{
-								auto t = map.getTile(x, y, z);
-								if (t->ownedObjects.empty())
-								{
-									newTarget = t->position;
-									pickedNearest = true;
-									foundNewTarget = true;
-									break;
-								}
+								newTarget = t->position;
+								foundNewTarget = true;
+								break;
 							}
 						}
 					}
 				}
 			}
-			if (foundNewTarget)
-			{
-				LogWarning("Target %d,%d,%d was unreachable, found new closest target %d,%d,%d",
-				           target.x, target.y, target.z, newTarget.x, newTarget.y, newTarget.z);
-				target = newTarget;
-			}
 		}
-		else
+		if (foundNewTarget)
 		{
-			std::list<Vec3<int>> sideStepLocations;
+			LogWarning("Target %d,%d,%d was unreachable, found new closest target %d,%d,%d",
+			           target.x, target.y, target.z, newTarget.x, newTarget.y, newTarget.z);
+			target = newTarget;
+		}
+	}
+	else if (vehicleAvoidance == VehicleAvoidance::Sidestep)
+	{
+		std::list<Vec3<int>> sideStepLocations;
 
-			for (int x = midX - maxDiff; x <= midX + maxDiff; x++)
+		for (int x = midX - maxDiff; x <= midX + maxDiff; x++)
+		{
+			for (int y = midY - maxDiff; y <= midY + maxDiff; y++)
 			{
-				for (int y = midY - maxDiff; y <= midY + maxDiff; y++)
+				for (int z = midZ - maxDiff; z <= midZ + maxDiff; z++)
 				{
-					for (int z = midZ - maxDiff; z <= midZ + maxDiff; z++)
+					if (!map.tileIsValid(x, y, z))
 					{
-						if (!map.tileIsValid(x, y, z))
-						{
-							continue;
-						}
-						auto t = map.getTile(x, y, z);
-						if (t->ownedObjects.empty())
-						{
-							sideStepLocations.push_back(t->position);
-						}
+						continue;
+					}
+					auto t = map.getTile(x, y, z);
+					if (t->ownedObjects.empty())
+					{
+						sideStepLocations.push_back(t->position);
 					}
 				}
 			}
-			if (!sideStepLocations.empty())
-			{
-				auto newTarget = pickRandom(state.rng, sideStepLocations);
-				LogWarning("Target %d,%d,%d was unreachable, found new random target %d,%d,%d",
-				           target.x, target.y, target.z, newTarget.x, newTarget.y, newTarget.z);
-				target = newTarget;
-			}
+		}
+		if (!sideStepLocations.empty())
+		{
+			auto newTarget = pickRandom(state.rng, sideStepLocations);
+			LogWarning("Target %s was unreachable, side-stepping to  %s.", target, newTarget);
+			target = newTarget;
 		}
 	}
-	return true;
+	else
+	{
+		LogError("Unknown value for vehicleAvoidance: %d", static_cast<int>(vehicleAvoidance));
+	}
+	return {reachability, true};
 }
 
-bool VehicleMission::adjustTargetToClosestFlying(GameState &state, Vehicle &v, Vec3<int> &target)
+AdjustTargetResult
+VehicleTargetHelper::adjustTargetToClosest(GameState &state, Vehicle &v, Vec3<int> &target,
+                                           const VehicleAvoidance vehicleAvoidance,
+                                           bool adjustForFlying)
 {
-	bool pickedNearest = false;
-	return adjustTargetToClosestFlying(state, v, target, false, false, pickedNearest);
+	switch (v.type->type)
+	{
+		case VehicleType::Type::Road:
+			return adjustTargetToClosestRoad(v, target);
+		case VehicleType::Type::ATV:
+			return adjustTargetToClosestGround(v, target);
+		case VehicleType::Type::Flying:
+		case VehicleType::Type::UFO:
+			if (!adjustForFlying)
+			{
+				// Just report given target as reachable.
+				return {Reachability::Reachable, true};
+			}
+			return adjustTargetToClosestFlying(state, v, target, vehicleAvoidance);
+		default:
+			LogError("Vehicle [%s] has unknown type [%s]", v.name, v.type->name);
+	}
 }
 
 bool VehicleMission::takeOffCheck(GameState &state, Vehicle &v)
@@ -2624,92 +2641,92 @@ void VehicleMission::setPathTo(GameState &state, Vehicle &v, Vec3<int> target, i
 {
 	currentPlannedPath.clear();
 	auto vehicleTile = v.tileObject;
-	if (vehicleTile)
+	if (!vehicleTile)
 	{
-		// Ground vehicles want to go to a closer road
-		auto prevTarget = target;
-		if (v.type->type == VehicleType::Type::Road)
-		{
-			if (!adjustTargetToClosestRoad(v, target))
-			{
-				return;
-			}
-		}
-		// ATVs want to go to a closer ground
-		else if (v.type->type == VehicleType::Type::ATV)
-		{
-			if (!adjustTargetToClosestGround(v, target))
-			{
-				cancelled = true;
-				return;
-			}
-		}
-		else if (checkValidity)
-		{
-			adjustTargetToClosestFlying(state, v, target, false, pickNearest, pickedNearest);
-		}
-		if (giveUpIfInvalid && prevTarget != target)
+		LogError("Mission %s: Take off before pathfinding!", this->getName());
+		return;
+	}
+	const auto avoidance =
+	    pickNearest ? VehicleAvoidance::PickNearbyPoint : VehicleAvoidance::Sidestep;
+	auto adjustResult =
+	    VehicleTargetHelper::adjustTargetToClosest(state, v, target, avoidance, checkValidity);
+	if (!adjustResult.foundSuitableTarget)
+	{
+		cancelled = true;
+		return;
+	}
+	// If destination is permanently unreachable, either give up or decrease reRouteAttempts.
+	if (adjustResult.reachability == Reachability::BlockedByScenery)
+	{
+		if (giveUpIfInvalid)
 		{
 			cancelled = true;
 			return;
 		}
-
-		std::list<Vec3<int>> path;
-		float distance = 0.0f;
-		auto position = vehicleTile->getOwningTile()->position;
-		switch (v.type->type)
+		else if (reRouteAttempts > 0)
 		{
-			case VehicleType::Type::Road:
-				path = v.city->findShortestPath(position, target,
-				                                GroundVehicleTileHelper{*v.city->map, v});
-				distance = GroundVehicleTileHelper::getDistanceStatic(position, target);
-				break;
-			case VehicleType::Type::ATV:
-				path = v.city->map->findShortestPath(position, target, maxIterations,
-				                                     GroundVehicleTileHelper{*v.city->map, v});
-				distance = GroundVehicleTileHelper::getDistanceStatic(position, target);
-				break;
-			case VehicleType::Type::Flying:
-			case VehicleType::Type::UFO:
-				path = v.city->map->findShortestPath(position, target, maxIterations,
-				                                     FlyingVehicleTileHelper{*v.city->map, v});
-				distance = FlyingVehicleTileHelper::getDistanceStatic(position, target);
-				break;
+			reRouteAttempts--;
 		}
+	}
+	// If our vehicle avoidance strategy is to pick a nearby point, and if a nearby point was in
+	// fact picked, then allow the mission to finish upon reaching the nearby point.
+	if (adjustResult.reachability == Reachability::BlockedByVehicle &&
+	    avoidance == VehicleAvoidance::PickNearbyPoint)
+	{
+		pickedNearest = true;
+	}
 
-		// Did not reach destination
-		if (path.empty() || path.back() != target)
+	std::list<Vec3<int>> path;
+	float distance = 0.0f;
+	auto position = vehicleTile->getOwningTile()->position;
+	switch (v.type->type)
+	{
+		case VehicleType::Type::Road:
+			path = v.city->findShortestPath(position, target,
+			                                GroundVehicleTileHelper{*v.city->map, v});
+			distance = GroundVehicleTileHelper::getDistanceStatic(position, target);
+			break;
+		case VehicleType::Type::ATV:
+			path = v.city->map->findShortestPath(position, target, maxIterations,
+			                                     GroundVehicleTileHelper{*v.city->map, v});
+			distance = GroundVehicleTileHelper::getDistanceStatic(position, target);
+			break;
+		case VehicleType::Type::Flying:
+		case VehicleType::Type::UFO:
+			path = v.city->map->findShortestPath(position, target, maxIterations,
+			                                     FlyingVehicleTileHelper{*v.city->map, v});
+			distance = FlyingVehicleTileHelper::getDistanceStatic(position, target);
+			break;
+	}
+
+	// Did not reach destination
+	if (path.empty() || path.back() != target)
+	{
+		// If target was close enough to reach
+		if (maxIterations > (int)distance)
 		{
-			// If target was close enough to reach
-			if (maxIterations > (int)distance)
+			// If told to give up - cancel mission
+			if (giveUpIfInvalid)
 			{
-				// If told to give up - cancel mission
-				if (giveUpIfInvalid)
+				cancelled = true;
+				return;
+			}
+			// If not told to give up - subtract attempt
+			else
+			{
+				if (reRouteAttempts > 0)
 				{
-					cancelled = true;
-					return;
-				}
-				// If not told to give up - subtract attempt
-				else
-				{
-					if (reRouteAttempts > 0)
-					{
-						reRouteAttempts--;
-					}
+					reRouteAttempts--;
 				}
 			}
 		}
-
-		// Always start with the current position
-		this->currentPlannedPath.push_back(vehicleTile->getOwningTile()->position);
-		for (auto &p : path)
-		{
-			this->currentPlannedPath.push_back(p);
-		}
 	}
-	else
+
+	// Always start with the current position
+	this->currentPlannedPath.push_back(vehicleTile->getOwningTile()->position);
+	for (auto &p : path)
 	{
-		LogError("Mission %s: Take off before pathfinding!", this->getName());
+		this->currentPlannedPath.push_back(p);
 	}
 }
 


### PR DESCRIPTION
…le, it will repeatedly try to find a path in every game tick. The vehicle will eventually get stuck and slow down the game by spamming pathfinding requests.

Note that vehicles usually don't end up with a GotoLocation with an unreachable destination, but it's possible, i.e. if some road tiles on the way get destroyed after the mission is created.

Other fixes:
* Prevent a vehicle from side-stepping in order to avoid itself.

Implementation notes:
* Moved all adjustTarget* methods to a new class VehicleTargetHelper with a single method that dispatches based on vehicle type.
* Note that it's now that caller's responsibility to set pickedNearest as needed.
* Inverted some conditionals for clearer early returns.

Manually verified these vehicles are un-stuck after this change:
* https://github.com/OpenApoc/OpenApoc/issues/395#issuecomment-486726783
* https://github.com/OpenApoc/OpenApoc/issues/395#issuecomment-486722384