### PR TITLE
Fix some unset variables in the TileView

### DIFF
--- a/game/ui/tileview/tileview.cpp
+++ b/game/ui/tileview/tileview.cpp
@@ -13,8 +13,7 @@ namespace OpenApoc
 TileView::TileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratTileSize,
                    TileViewMode initialMode)
     : Stage(), map(map), isoTileSize(isoTileSize), stratTileSize(stratTileSize),
-      viewMode(initialMode), scrollUpKB(false), scrollDownKB(false), scrollLeftKB(false),
-      scrollRightKB(false), dpySize(fw().displayGetWidth(), fw().displayGetHeight()),
+      viewMode(initialMode), dpySize(fw().displayGetWidth(), fw().displayGetHeight()),
       strategyViewBoxColour(212, 176, 172, 255), strategyViewBoxThickness(2.0f),
       selectedTilePosition(0, 0, 0), maxZDraw(map.size.z), centerPos(0, 0, 0),
       isoScrollSpeed(0.5, 0.5), stratScrollSpeed(2.0f, 2.0f)

--- a/game/ui/tileview/tileview.h
+++ b/game/ui/tileview/tileview.h
@@ -33,15 +33,15 @@ class TileView : public Stage, public TileTransform
 	Vec2<int> stratTileSize;
 	TileViewMode viewMode;
 
-	bool scrollUpKB;
-	bool scrollDownKB;
-	bool scrollLeftKB;
-	bool scrollRightKB;
+	bool scrollUpKB = false;
+	bool scrollDownKB = false;
+	bool scrollLeftKB = false;
+	bool scrollRightKB = false;
 
-	bool scrollUpM;
-	bool scrollDownM;
-	bool scrollLeftM;
-	bool scrollRightM;
+	bool scrollUpM = false;
+	bool scrollDownM = false;
+	bool scrollLeftM = false;
+	bool scrollRightM = false;
 
 	bool autoScroll = false;
 


### PR DESCRIPTION
Some weren't set in the constructor, which might cause the tileView to start
scrolling until the first mouse move event