### PR TITLE
Wip/lazy renderer image destruction

### DIFF
--- a/framework/render/gl20/ogl_2_0_renderer.cpp
+++ b/framework/render/gl20/ogl_2_0_renderer.cpp
@@ -6,7 +6,10 @@
 #include "library/sp.h"
 #include <array>
 #include <glm/gtx/rotate_vector.hpp>
+#include <list>
 #include <memory>
+#include <mutex>
+#include <thread>
 
 /* Workaround MSVC not liking int64_t being defined here and in allegro */
 #define GLEXT_64_TYPES_DEFINED
@@ -17,6 +20,9 @@ namespace
 {
 
 using namespace OpenApoc;
+
+// Forward declaration needed for RendererImageData
+class OGL20Renderer;
 
 class Program
 {
@@ -532,11 +538,12 @@ class FBOData : public RendererImageData
 	GLuint fbo;
 	GLuint tex;
 	Vec2<float> size;
+	OGL20Renderer *owner;
 	// Constructor /only/ to be used for default surface (FBO ID == 0)
-	FBOData(GLuint fbo, Vec2<int> size)
+	FBOData(GLuint fbo, Vec2<int> size, OGL20Renderer *owner)
 	    // FIXME: Check FBO == 0
 	    // FIXME: Warn if trying to texture from FBO 0
-	    : fbo(fbo), tex(-1), size(size)
+	    : fbo(fbo), tex(-1), size(size), owner(owner)
 	{
 	}
 
@@ -560,7 +567,7 @@ class FBOData : public RendererImageData
 		return img;
 	}
 
-	FBOData(Vec2<int> size) : size(size.x, size.y)
+	FBOData(Vec2<int> size, OGL20Renderer *owner) : size(size.x, size.y), owner(owner)
 	{
 		gl20::GenTextures(1, &this->tex);
 		BindTexture b(this->tex);
@@ -579,13 +586,7 @@ class FBOData : public RendererImageData
 		LogAssert(gl20::CheckFramebufferStatusEXT(gl20::FRAMEBUFFER_EXT) ==
 		          gl20::FRAMEBUFFER_COMPLETE_EXT);
 	}
-	~FBOData() override
-	{
-		if (tex)
-			gl20::DeleteTextures(1, &tex);
-		if (fbo)
-			gl20::DeleteFramebuffersEXT(1, &fbo);
-	}
+	~FBOData() override;
 };
 
 class GLRGBImage : public RendererImageData
@@ -594,7 +595,9 @@ class GLRGBImage : public RendererImageData
 	GLuint texID;
 	Vec2<float> size;
 	std::weak_ptr<RGBImage> parent;
-	GLRGBImage(sp<RGBImage> parent) : size(parent->size), parent(parent)
+	OGL20Renderer *owner;
+	GLRGBImage(sp<RGBImage> parent, OGL20Renderer *owner)
+	    : size(parent->size), parent(parent), owner(owner)
 	{
 		RGBImageLock l(parent, ImageLockUse::Read);
 		gl20::GenTextures(1, &this->texID);
@@ -606,7 +609,7 @@ class GLRGBImage : public RendererImageData
 		gl20::TexImage2D(gl20::TEXTURE_2D, 0, gl20::RGBA, parent->size.x, parent->size.y, 0,
 		                 gl20::RGBA, gl20::UNSIGNED_BYTE, l.getData());
 	}
-	~GLRGBImage() override { gl20::DeleteTextures(1, &this->texID); }
+	~GLRGBImage() override;
 };
 
 class GLPalette : public RendererImageData
@@ -615,7 +618,9 @@ class GLPalette : public RendererImageData
 	GLuint texID;
 	Vec2<float> size;
 	std::weak_ptr<Palette> parent;
-	GLPalette(sp<Palette> parent) : size(Vec2<float>(parent->colours.size(), 1)), parent(parent)
+	OGL20Renderer *owner;
+	GLPalette(sp<Palette> parent, OGL20Renderer *owner)
+	    : size(Vec2<float>(parent->colours.size(), 1)), parent(parent), owner(owner)
 	{
 		gl20::GenTextures(1, &this->texID);
 		BindTexture b(this->texID);
@@ -626,7 +631,7 @@ class GLPalette : public RendererImageData
 		gl20::TexImage2D(gl20::TEXTURE_2D, 0, gl20::RGBA, parent->colours.size(), 1, 0, gl20::RGBA,
 		                 gl20::UNSIGNED_BYTE, parent->colours.data());
 	}
-	~GLPalette() override { gl20::DeleteTextures(1, &this->texID); }
+	~GLPalette() override;
 };
 
 class GLPaletteImage : public RendererImageData
@@ -635,7 +640,9 @@ class GLPaletteImage : public RendererImageData
 	GLuint texID;
 	Vec2<float> size;
 	std::weak_ptr<PaletteImage> parent;
-	GLPaletteImage(sp<PaletteImage> parent) : size(parent->size), parent(parent)
+	OGL20Renderer *owner;
+	GLPaletteImage(sp<PaletteImage> parent, OGL20Renderer *owner)
+	    : size(parent->size), parent(parent), owner(owner)
 	{
 		PaletteImageLock l(parent, ImageLockUse::Read);
 		gl20::GenTextures(1, &this->texID);
@@ -648,7 +655,7 @@ class GLPaletteImage : public RendererImageData
 		gl20::TexImage2D(gl20::TEXTURE_2D, 0, 1, parent->size.x, parent->size.y, 0, gl20::RED,
 		                 gl20::UNSIGNED_BYTE, l.getData());
 	}
-	~GLPaletteImage() override { gl20::DeleteTextures(1, &this->texID); }
+	~GLPaletteImage() override;
 };
 
 class OGL20Renderer : public Renderer
@@ -673,7 +680,7 @@ class OGL20Renderer : public Renderer
 		this->flush();
 		this->currentSurface = s;
 		if (!s->rendererPrivateData)
-			s->rendererPrivateData.reset(new FBOData(s->size));
+			s->rendererPrivateData.reset(new FBOData(s->size, this));
 
 		FBOData *fbo = static_cast<FBOData *>(s->rendererPrivateData.get());
 		gl20::BindFramebufferEXT(gl20::FRAMEBUFFER_EXT, fbo->fbo);
@@ -683,17 +690,25 @@ class OGL20Renderer : public Renderer
 	sp<Surface> getSurface() override { return currentSurface; }
 	sp<Surface> defaultSurface;
 
+	std::thread::id bound_thread;
+	std::mutex destroyed_texture_list_mutex;
+	std::list<GLuint> destroyed_texture_list;
+	std::mutex destroyed_framebuffer_list_mutex;
+	std::list<GLuint> destroyed_framebuffer_list;
+
   public:
 	OGL20Renderer()
 	    : rgbProgram(new RGBProgram()), colourProgram(new SolidColourProgram()),
 	      paletteProgram(new PaletteProgram()), currentBoundProgram(0), currentBoundFBO(0)
 	{
+		this->bound_thread = std::this_thread::get_id();
 		GLint viewport[4];
 		gl20::GetIntegerv(gl20::VIEWPORT, viewport);
 		LogInfo("Viewport {%d,%d,%d,%d}", viewport[0], viewport[1], viewport[2], viewport[3]);
 		LogAssert(viewport[0] == 0 && viewport[1] == 0);
 		this->defaultSurface = mksp<Surface>(Vec2<int>{viewport[2], viewport[3]});
-		this->defaultSurface->rendererPrivateData.reset(new FBOData(0, {viewport[2], viewport[3]}));
+		this->defaultSurface->rendererPrivateData.reset(
+		    new FBOData(0, {viewport[2], viewport[3]}, this));
 		this->currentSurface = this->defaultSurface;
 
 		GLint maxTexUnits;
@@ -716,7 +731,7 @@ class OGL20Renderer : public Renderer
 			return;
 		this->flush();
 		if (!p->rendererPrivateData)
-			p->rendererPrivateData.reset(new GLPalette(p));
+			p->rendererPrivateData.reset(new GLPalette(p, this));
 		this->currentPalette = p;
 	}
 	sp<Palette> getPalette() override { return this->currentPalette; }
@@ -734,7 +749,7 @@ class OGL20Renderer : public Renderer
 			GLRGBImage *img = dynamic_cast<GLRGBImage *>(rgbImage->rendererPrivateData.get());
 			if (!img)
 			{
-				img = new GLRGBImage(rgbImage);
+				img = new GLRGBImage(rgbImage, this);
 				image->rendererPrivateData.reset(img);
 			}
 			this->drawRgb(*img, position, size, Scaler::Linear, center, angle);
@@ -759,7 +774,7 @@ class OGL20Renderer : public Renderer
 			GLRGBImage *img = dynamic_cast<GLRGBImage *>(rgbImage->rendererPrivateData.get());
 			if (!img)
 			{
-				img = new GLRGBImage(rgbImage);
+				img = new GLRGBImage(rgbImage, this);
 				image->rendererPrivateData.reset(img);
 			}
 			this->drawRgb(*img, position, size, scaler, {0, 0}, 0, tint);
@@ -773,7 +788,7 @@ class OGL20Renderer : public Renderer
 			    dynamic_cast<GLPaletteImage *>(paletteImage->rendererPrivateData.get());
 			if (!img)
 			{
-				img = new GLPaletteImage(paletteImage);
+				img = new GLPaletteImage(paletteImage, this);
 				image->rendererPrivateData.reset(img);
 			}
 			if (scaler != Scaler::Nearest)
@@ -792,7 +807,7 @@ class OGL20Renderer : public Renderer
 			FBOData *fbo = dynamic_cast<FBOData *>(surface->rendererPrivateData.get());
 			if (!fbo)
 			{
-				fbo = new FBOData(image->size);
+				fbo = new FBOData(image->size, this);
 				image->rendererPrivateData.reset(fbo);
 			}
 			this->drawSurface(*fbo, position, size, scaler, tint);
@@ -885,7 +900,28 @@ class OGL20Renderer : public Renderer
 		this->drawFilledRect(C, sizeC, c);
 		this->drawFilledRect(D, sizeD, c);
 	}
-	void flush() override { /* Nothing to flush */}
+	void flush() override
+	{
+		// Cleanup any outstanding destroyed texture or framebuffer objects
+		{
+			std::lock_guard lock(this->destroyed_texture_list_mutex);
+
+			for (auto &id : this->destroyed_texture_list)
+			{
+				gl20::DeleteTextures(1, &id);
+			}
+			this->destroyed_texture_list.clear();
+		}
+		{
+			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+
+			for (auto &id : this->destroyed_framebuffer_list)
+			{
+				gl20::DeleteFramebuffersEXT(1, &id);
+			}
+			this->destroyed_framebuffer_list.clear();
+		}
+	}
 	UString getName() override { return "OGL2.0 Renderer"; }
 	sp<Surface> getDefaultSurface() override { return this->defaultSurface; }
 
@@ -983,6 +1019,35 @@ class OGL20Renderer : public Renderer
 		Line l(p0, p1, thickness);
 		l.draw(colourProgram->posLoc);
 	}
+	// These can be called from any thread - e.g. from the Image destructors
+	void delete_texture_object(GLuint id)
+	{
+		// If we're already on the bound thread, just immediately destroy
+		if (this->bound_thread == std::this_thread::get_id())
+		{
+			gl20::DeleteTextures(1, &id);
+			return;
+		}
+		// Otherwise add it to a list for future destruction
+		{
+			std::lock_guard lock(this->destroyed_texture_list_mutex);
+			this->destroyed_texture_list.push_back(id);
+		}
+	}
+	void delete_framebuffer_object(GLuint id)
+	{
+		// If we're already on the bound thread, just immediately destroy
+		if (this->bound_thread == std::this_thread::get_id())
+		{
+			gl20::DeleteFramebuffersEXT(1, &id);
+			return;
+		}
+		// Otherwise add it to a list for future destruction
+		{
+			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+			this->destroyed_framebuffer_list.push_back(id);
+		}
+	}
 };
 
 class OGL20RendererFactory : public OpenApoc::RendererFactory
@@ -1023,6 +1088,17 @@ class OGL20RendererFactory : public OpenApoc::RendererFactory
 		return nullptr;
 	}
 };
+
+FBOData::~FBOData()
+{
+	if (tex)
+		owner->delete_texture_object(tex);
+	if (fbo)
+		owner->delete_framebuffer_object(fbo);
+}
+GLRGBImage::~GLRGBImage() { owner->delete_texture_object(this->texID); }
+GLPalette::~GLPalette() { owner->delete_texture_object(this->texID); }
+GLPaletteImage::~GLPaletteImage() { owner->delete_texture_object(this->texID); }
 
 } // anonymous namespace
 

--- a/framework/render/gl20/ogl_2_0_renderer.cpp
+++ b/framework/render/gl20/ogl_2_0_renderer.cpp
@@ -904,7 +904,7 @@ class OGL20Renderer : public Renderer
 	{
 		// Cleanup any outstanding destroyed texture or framebuffer objects
 		{
-			std::lock_guard lock(this->destroyed_texture_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_texture_list_mutex);
 
 			for (auto &id : this->destroyed_texture_list)
 			{
@@ -913,7 +913,7 @@ class OGL20Renderer : public Renderer
 			this->destroyed_texture_list.clear();
 		}
 		{
-			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_framebuffer_list_mutex);
 
 			for (auto &id : this->destroyed_framebuffer_list)
 			{
@@ -1030,7 +1030,7 @@ class OGL20Renderer : public Renderer
 		}
 		// Otherwise add it to a list for future destruction
 		{
-			std::lock_guard lock(this->destroyed_texture_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_texture_list_mutex);
 			this->destroyed_texture_list.push_back(id);
 		}
 	}
@@ -1044,7 +1044,7 @@ class OGL20Renderer : public Renderer
 		}
 		// Otherwise add it to a list for future destruction
 		{
-			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_framebuffer_list_mutex);
 			this->destroyed_framebuffer_list.push_back(id);
 		}
 	}

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -1642,7 +1642,7 @@ class OGLES30Renderer final : public Renderer
 		}
 		// Cleanup any outstanding destroyed texture or framebuffer objects
 		{
-			std::lock_guard lock(this->destroyed_texture_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_texture_list_mutex);
 
 			for (auto &id : this->destroyed_texture_list)
 			{
@@ -1651,7 +1651,7 @@ class OGLES30Renderer final : public Renderer
 			this->destroyed_texture_list.clear();
 		}
 		{
-			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_framebuffer_list_mutex);
 
 			for (auto &id : this->destroyed_framebuffer_list)
 			{
@@ -1673,7 +1673,7 @@ class OGLES30Renderer final : public Renderer
 		}
 		// Otherwise add it to a list for future destruction
 		{
-			std::lock_guard lock(this->destroyed_texture_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_texture_list_mutex);
 			this->destroyed_texture_list.push_back(id);
 		}
 	}
@@ -1687,7 +1687,7 @@ class OGLES30Renderer final : public Renderer
 		}
 		// Otherwise add it to a list for future destruction
 		{
-			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+			std::lock_guard<std::mutex> lock(this->destroyed_framebuffer_list_mutex);
 			this->destroyed_framebuffer_list.push_back(id);
 		}
 	}

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -7,6 +7,9 @@
 #include <algorithm>
 #include <cstdint>
 #include <glm/gtx/rotate_vector.hpp>
+#include <list>
+#include <mutex>
+#include <thread>
 
 #define GLESWRAP_GLES3
 #include "framework/render/gles30_v2/gleswrap.h"
@@ -20,6 +23,9 @@ namespace OpenApoc
 {
 namespace
 {
+
+// Forward declaration needed for RendererImageData
+class OGLES30Renderer;
 
 using GL = gles_wrap::Gles3;
 
@@ -676,9 +682,10 @@ class SpriteDrawMachine
 class GLRGBTexture final : public RendererImageData
 {
   public:
-	GL::GLuint tex_id;
+	GL::GLuint tex_id = 0;
 	Vec2<unsigned int> size;
-	GLRGBTexture(sp<RGBImage> i)
+	OGLES30Renderer *owner;
+	GLRGBTexture(sp<RGBImage> i, OGLES30Renderer *owner) : size(i->size), owner(owner)
 	{
 		TRACE_FN;
 		RGBImageLock l(i);
@@ -692,15 +699,16 @@ class GLRGBTexture final : public RendererImageData
 		gl->TexParameteri(GL::TEXTURE_2D, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
 		gl->TexParameteri(GL::TEXTURE_2D, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
 	}
-	~GLRGBTexture() override { gl->DeleteTextures(1, &this->tex_id); }
+	~GLRGBTexture() override;
 };
 
 class GLPaletteTexture final : public RendererImageData
 {
   public:
-	GL::GLuint tex_id;
+	GL::GLuint tex_id = 0;
 	Vec2<unsigned int> size;
-	GLPaletteTexture(sp<PaletteImage> i)
+	OGLES30Renderer *owner;
+	GLPaletteTexture(sp<PaletteImage> i, OGLES30Renderer *owner) : size(i->size), owner(owner)
 	{
 		TRACE_FN;
 		PaletteImageLock l(i);
@@ -714,7 +722,7 @@ class GLPaletteTexture final : public RendererImageData
 		gl->TexParameteri(GL::TEXTURE_2D, GL::TEXTURE_WRAP_S, GL::CLAMP_TO_EDGE);
 		gl->TexParameteri(GL::TEXTURE_2D, GL::TEXTURE_WRAP_T, GL::CLAMP_TO_EDGE);
 	}
-	~GLPaletteTexture() override { gl->DeleteTextures(1, &this->tex_id); }
+	~GLPaletteTexture() override;
 };
 
 class BindFramebuffer
@@ -748,8 +756,12 @@ class GLSurface final : public RendererImageData
 	GL::GLuint fbo_id;
 	GL::GLuint tex_id;
 	Vec2<unsigned int> size;
-	GLSurface(GL::GLuint fbo, Vec2<unsigned int> size) : fbo_id(fbo), tex_id(0), size(size) {}
-	GLSurface(Vec2<unsigned int> size)
+	OGLES30Renderer *owner;
+	GLSurface(GL::GLuint fbo, Vec2<unsigned int> size, OGLES30Renderer *owner)
+	    : fbo_id(fbo), tex_id(0), size(size), owner(owner)
+	{
+	}
+	GLSurface(Vec2<unsigned int> size, OGLES30Renderer *owner) : size(size), owner(owner)
 	{
 		LogAssert(size.x > 0 && size.y > 0);
 		TRACE_FN;
@@ -772,13 +784,7 @@ class GLSurface final : public RendererImageData
 			LogError("Surface framebuffer not complete");
 		}
 	}
-	~GLSurface() override
-	{
-		if (this->fbo_id)
-			gl->DeleteFramebuffers(1, &this->fbo_id);
-		if (this->tex_id)
-			gl->DeleteTextures(1, &this->tex_id);
-	}
+	~GLSurface() override;
 	sp<Image> readBack() override
 	{
 		BindFramebuffer b(this->fbo_id);
@@ -882,12 +888,14 @@ class TexturedDrawMachine
 	{
 		VertexDesc vertices[4];
 	};
+	OGLES30Renderer *owner;
 
   public:
 	unsigned int used_buffers = 0;
-	TexturedDrawMachine(unsigned int bufferCount, GL::GLuint position_attr = 0,
-	                    GL::GLuint texcoord_attr = 1, GL::GLuint tint_attr = 2)
-	    : current_buffer(0), tex_program_id(0)
+	TexturedDrawMachine(unsigned int bufferCount, OGLES30Renderer *owner,
+	                    GL::GLuint position_attr = 0, GL::GLuint texcoord_attr = 1,
+	                    GL::GLuint tint_attr = 2)
+	    : current_buffer(0), tex_program_id(0), owner(owner)
 	{
 		TRACE_FN;
 		LogAssert(bufferCount > 0);
@@ -1011,7 +1019,7 @@ class TexturedDrawMachine
 		auto tex = std::dynamic_pointer_cast<GLRGBTexture>(i->rendererPrivateData);
 		if (!tex)
 		{
-			tex = mksp<GLRGBTexture>(i);
+			tex = mksp<GLRGBTexture>(i, owner);
 			i->rendererPrivateData = tex;
 		}
 		gl->ActiveTexture(RGB_IMAGE_TEX_SLOT);
@@ -1039,7 +1047,7 @@ class TexturedDrawMachine
 		if (!tex)
 		{
 			LogWarning("Drawing using undefined surface contents");
-			tex = mksp<GLSurface>(i->size);
+			tex = mksp<GLSurface>(i->size, owner);
 			i->rendererPrivateData = tex;
 		}
 		gl->ActiveTexture(RGB_IMAGE_TEX_SLOT);
@@ -1065,7 +1073,7 @@ class TexturedDrawMachine
 		auto tex = std::dynamic_pointer_cast<GLPaletteTexture>(i->rendererPrivateData);
 		if (!tex)
 		{
-			tex = mksp<GLPaletteTexture>(i);
+			tex = mksp<GLPaletteTexture>(i, owner);
 			i->rendererPrivateData = tex;
 		}
 		gl->ActiveTexture(PALETTE_IMAGE_TEX_SLOT);
@@ -1274,7 +1282,7 @@ class OGLES30Renderer final : public Renderer
 		auto fbo = std::dynamic_pointer_cast<GLSurface>(s->rendererPrivateData);
 		if (!fbo)
 		{
-			fbo = mksp<GLSurface>(s->size);
+			fbo = mksp<GLSurface>(s->size, this);
 			s->rendererPrivateData = fbo;
 		}
 		gl->BindFramebuffer(GL::DRAW_FRAMEBUFFER, fbo->fbo_id);
@@ -1305,6 +1313,12 @@ class OGLES30Renderer final : public Renderer
 	sp<Surface> default_surface;
 	sp<Surface> current_surface;
 	sp<Palette> current_palette;
+
+	std::thread::id bound_thread;
+	std::mutex destroyed_texture_list_mutex;
+	std::list<GL::GLuint> destroyed_texture_list;
+	std::mutex destroyed_framebuffer_list_mutex;
+	std::list<GL::GLuint> destroyed_framebuffer_list;
 
   public:
 	OGLES30Renderer();
@@ -1626,9 +1640,57 @@ class OGLES30Renderer final : public Renderer
 			this->spriteMachine->flush(viewport_size, flip_y);
 			this->state = State::Idle;
 		}
+		// Cleanup any outstanding destroyed texture or framebuffer objects
+		{
+			std::lock_guard lock(this->destroyed_texture_list_mutex);
+
+			for (auto &id : this->destroyed_texture_list)
+			{
+				gl->DeleteTextures(1, &id);
+			}
+			this->destroyed_texture_list.clear();
+		}
+		{
+			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+
+			for (auto &id : this->destroyed_framebuffer_list)
+			{
+				gl->DeleteFramebuffers(1, &id);
+			}
+			this->destroyed_framebuffer_list.clear();
+		}
 	}
 	UString getName() override { return "GLES30 Renderer"; }
 	sp<Surface> getDefaultSurface() override { return this->default_surface; }
+	// These can be called from any thread - e.g. from the Image destructors
+	void delete_texture_object(GL::GLuint id)
+	{
+		// If we're already on the bound thread, just immediately destroy
+		if (this->bound_thread == std::this_thread::get_id())
+		{
+			gl->DeleteTextures(1, &id);
+			return;
+		}
+		// Otherwise add it to a list for future destruction
+		{
+			std::lock_guard lock(this->destroyed_texture_list_mutex);
+			this->destroyed_texture_list.push_back(id);
+		}
+	}
+	void delete_framebuffer_object(GL::GLuint id)
+	{
+		// If we're already on the bound thread, just immediately destroy
+		if (this->bound_thread == std::this_thread::get_id())
+		{
+			gl->DeleteFramebuffers(1, &id);
+			return;
+		}
+		// Otherwise add it to a list for future destruction
+		{
+			std::lock_guard lock(this->destroyed_framebuffer_list_mutex);
+			this->destroyed_framebuffer_list.push_back(id);
+		}
+	}
 };
 
 void GLESWRAP_APIENTRY debug_message_proc(GL::KhrDebug::GLenum, GL::KhrDebug::GLenum, GL::GLuint,
@@ -1654,16 +1716,17 @@ void GLESWRAP_APIENTRY debug_message_proc(GL::KhrDebug::GLenum, GL::KhrDebug::GL
 OGLES30Renderer::OGLES30Renderer() : state(State::Idle)
 {
 	TRACE_FN;
+	this->bound_thread = std::this_thread::get_id();
 	this->spriteMachine.reset(
 	    new SpriteDrawMachine{spriteBufferSize, spriteBufferCount, spritesheetPageSize});
-	this->texturedMachine.reset(new TexturedDrawMachine{texturedBufferCount});
+	this->texturedMachine.reset(new TexturedDrawMachine{texturedBufferCount, this});
 	this->colouredDrawMachine.reset(new ColouredDrawMachine{quadBufferCount});
 	GL::GLint viewport[4];
 	gl->GetIntegerv(GL::VIEWPORT, viewport);
 	LogInfo("Viewport {%d,%d,%d,%d}", viewport[0], viewport[1], viewport[2], viewport[3]);
 	this->default_surface = mksp<Surface>(Vec2<int>{viewport[2], viewport[3]});
 	this->default_surface->rendererPrivateData =
-	    mksp<GLSurface>(0, Vec2<int>{viewport[2], viewport[3]});
+	    mksp<GLSurface>(0, Vec2<int>{viewport[2], viewport[3]}, this);
 	this->current_surface = default_surface;
 	gl->Enable(GL::BLEND);
 	gl->BlendFuncSeparate(GL::SRC_ALPHA, GL::ONE_MINUS_SRC_ALPHA, GL::SRC_ALPHA, GL::DST_ALPHA);
@@ -1735,6 +1798,16 @@ class OGLES30RendererFactory : public RendererFactory
 		}
 	}
 };
+
+GLRGBTexture::~GLRGBTexture() { owner->delete_texture_object(this->tex_id); }
+GLPaletteTexture::~GLPaletteTexture() { owner->delete_texture_object(this->tex_id); }
+GLSurface::~GLSurface()
+{
+	if (this->fbo_id)
+		owner->delete_framebuffer_object(this->fbo_id);
+	if (this->tex_id)
+		owner->delete_texture_object(this->tex_id);
+}
 
 } // anonymous namespace
 


### PR DESCRIPTION
This defers destruction of GL objects where the destructor is called from the non-renderer thread.

This should hopefully solve crashes with some drivers - e.g. issue #568 or #542 (and maybe a number of others)