### PR TITLE
Destroy the Data implemention before the renderer

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -529,6 +529,9 @@ Framework::~Framework()
 		config().save();
 
 	LogInfo("Shutdown");
+	// Make sure we destroy the data implementation before the renderer to ensure any possibly
+	// cached images are already destroyed
+	this->data.reset();
 	if (createWindow)
 	{
 		displayShutdown();


### PR DESCRIPTION
This should ensure that any possibly cached images are destroyed first,
as their destructors can call back into the Renderer to destroy any
private data.

Doing this should avoid a crash at exit due to use-after-free of the
renderer.