### PR TITLE
Remove units that retreat from the Battle's visible unit lists

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -4471,7 +4471,11 @@ void BattleUnit::dropDown(GameState &state)
 		}
 	}
 
-	// Remove from list of visible units
+	this->markUnVisible(state);
+}
+
+void BattleUnit::markUnVisible(GameState &state)
+{ // Remove from list of visible units
 	StateRef<BattleUnit> srThis = {&state, id};
 	for (auto &units : state.current_battle->visibleUnits)
 	{
@@ -4499,6 +4503,7 @@ void BattleUnit::dropDown(GameState &state)
 
 void BattleUnit::retreat(GameState &state)
 {
+	this->markUnVisible(state);
 	if (shadowObject)
 	{
 		shadowObject->removeFromMap();

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -717,6 +717,8 @@ class BattleUnit : public StateObject, public std::enable_shared_from_this<Battl
 	void fallUnconscious(GameState &state, StateRef<BattleUnit> attacker = nullptr);
 	// Process unit dying
 	void die(GameState &state, StateRef<BattleUnit> attacker = nullptr, bool violently = true);
+	// Remove unit from any 'visible' lists
+	void markUnVisible(GameState &state);
 
 	// Update
 


### PR DESCRIPTION
These dangling references can cause crashes (e.g. in the brainsucker's AI
"find target" code)