### PR TITLE
Fix BattleMapPart death explosion doodad position

### DIFF
--- a/game/state/battle/battlemappart.cpp
+++ b/game/state/battle/battlemappart.cpp
@@ -52,12 +52,12 @@ void BattleMapPart::die(GameState &state, bool explosive, bool violently)
 				break;
 			case BattleMapPartType::Type::LeftWall:
 				state.current_battle->placeDoodad({&state, "DOODAD_29_EXPLODING_TERRAIN"},
-				                                  tileObject->getCenter() -
+				                                  tileObject->getCenter() +
 				                                      Vec3<float>(-0.5f, 0.0f, 0.0f));
 				break;
 			case BattleMapPartType::Type::RightWall:
 				state.current_battle->placeDoodad({&state, "DOODAD_29_EXPLODING_TERRAIN"},
-				                                  tileObject->getCenter() -
+				                                  tileObject->getCenter() +
 				                                      Vec3<float>(0.0f, -0.5f, 0.0f));
 				break;
 			case BattleMapPartType::Type::Feature:

--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -1577,6 +1577,13 @@ void BattleTileView::render()
 		                      state.battle_common_sample_list->burn->format.channels;
 		fw().soundBackend->playSample(state.battle_common_sample_list->burn, closestFirePosition);
 	}
+
+	if (this->debugHotkeyMode)
+	{
+		auto font = ui().getFont("smallset");
+		auto cursorPositionString = font->getString(format("Cursor at %s", selectedTilePosition));
+		r.draw(cursorPositionString, {0, 0});
+	}
 }
 
 void BattleTileView::update()


### PR DESCRIPTION
The double negative (x=center.x - (-0.5)) looks wrong for the left wall, as the left wall should be (-0.5) from the center? As the tilemap origin 0,0 is at the top-left?