### PR TITLE
Add VehicleMission::MissionType::RestartNextMission enum serialization

### DIFF
--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -1526,6 +1526,7 @@
 		<value>RecoverVehicle</value>
 		<value>AttackVehicle</value>
 		<value>AttackBuilding</value>
+		<value>RestartNextMission</value>
 		<value>Snooze</value>
 		<value>TakeOff</value>
 		<value>Land</value>


### PR DESCRIPTION
This was missing from the serialization generation source, so any saves that
happened to contain missions of this type would fail