### PR TITLE
Enable c++17 use

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@
 PROJECT(OpenApoc CXX C)
 
 # check cmake version
-CMAKE_MINIMUM_REQUIRED(VERSION 3.1)
+CMAKE_MINIMUM_REQUIRED(VERSION 3.8)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
@@ -74,23 +77,6 @@ if (LTO)
 		message(WARNING "LTO not supported by this compiler")
 	endif()
 endif(LTO)
-
-# Cmake doesn't seem to have a good way of saying "try the latest standard, but
-# allow fallbacks all the way back to c++11"
-CHECK_CXX_COMPILER_FLAG("-std=c++11" COMPILER_SUPPORTS_CXX11)
-CHECK_CXX_COMPILER_FLAG("-std=c++14" COMPILER_SUPPORTS_CXX14)
-CHECK_CXX_COMPILER_FLAG("-std=c++17" COMPILER_SUPPORTS_CXX17)
-
-if (COMPILER_SUPPORTS_CXX17)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++17")
-elseif (COMPILER_SUPPORTS_CXX14)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14")
-elseif (COMPILER_SUPPORTS_CXX11)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
-else()
-	# Other compilers may use different option flags, or not support switching standard versions, so try anyway
-	message(WARNING "Couldn't find a c++ version this compiler supports, trying with default options")
-endif()
 
 # MSVC has default flags that CMake doesn't set
 if (MSVC)

--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -3,7 +3,7 @@ Openapoc Coding Style Guidelines
 
 This document specifies the guidelines for writing and formatting the c++ code that forms the core of OpenApoc.
 
-Globally, we use 'standard' c++11. This requires reasonably modern compilers (gcc 4.7+, MSVC 2013+ , clang 3.6+ have been tested). You should avoid using compiler-specific stuff where possible. Exceptions to this exist, but should be wrapped in a #ifdef:
+Globally, we use 'standard' c++17. This requires reasonably modern compilers (gcc 8, MSVC 2019+ , clang 7+ have been tested). You should avoid using compiler-specific stuff where possible. Exceptions to this exist, but should be wrapped in a #ifdef:
 ```C++
 #ifdef _MSC_VER
 MSVCIsCrazySometimes

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -4,7 +4,7 @@ branches:
   - master
   - /release.*/
 skip_tags: true
-os: Visual Studio 2015
+os: Visual Studio 2019
 configuration:
   - Release
 #  - Debug
@@ -27,7 +27,7 @@ before_build:
   - curl http://s2.jonnyh.net/pub/cd_minimal.iso.xz -o temp\cd.iso.xz
   - 7z e temp\cd.iso.xz -odata\
   - choco install ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %VCVARS_ARCH%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
   - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%"
   - cmake --build .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
   - master
   - /release.*/
 # skip_tags: true
-os: Visual Studio 2015
+os: Visual Studio 2019
 configuration:
   - Release
 #  - Debug
@@ -28,7 +28,7 @@ before_build:
   - 7z e temp\cd.iso.xz -odata\
   - choco install nsis -pre
   - choco install ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio 14.0\VC\vcvarsall.bat" %VCVARS_ARCH%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
   - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%"
   - cmake --build .


### PR DESCRIPTION
Puts a hard requirement on newer toolchains, but allows us to guarantee use of all c++17 features and avoid nasty compat wrappers, so IMHO worth it