### PR TITLE
Fix a number of unset variables in default-constructed game objects

### DIFF
--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -55,6 +55,7 @@ class Vehicle;
 class Building;
 class BattleScanner;
 enum class BattleUnitType;
+class Agent;
 class BattleUnitTileHelper;
 
 class BattleScore

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -83,7 +83,7 @@ class City : public StateObject, public std::enable_shared_from_this<City>
 	void initMap(GameState &state);
 
 	UString id;
-	Vec3<int> size;
+	Vec3<int> size = {0, 0, 0};
 
 	StateRefMap<SceneryTileType> tile_types;
 	std::map<Vec3<int>, StateRef<SceneryTileType>> initial_tiles;

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -22,7 +22,6 @@
 
 namespace OpenApoc
 {
-Scenery::Scenery() : damaged(false), falling(false), destroyed(false) {}
 
 void Scenery::ceaseSupportProvision()
 {

--- a/game/state/city/scenery.h
+++ b/game/state/city/scenery.h
@@ -38,17 +38,17 @@ class Scenery : public SupportedMapPart, public std::enable_shared_from_this<Sce
 		return offsetPos;
 	}
 
-	Vec3<int> initialPosition;
-	Vec3<float> currentPosition;
+	Vec3<int> initialPosition = {0, 0, 0};
+	Vec3<float> currentPosition = {0, 0, 0};
 	void setPosition(const Vec3<float> &pos);
 	unsigned int ticksUntilCollapse = 0;
 	std::set<Vec3<int>> supportedParts;
 	std::list<Vec3<int>> supportedBy;
 
-	bool damaged;
-	bool falling;
+	bool damaged = false;
+	bool falling = false;
 	float fallingSpeed = 0.0f;
-	bool destroyed;
+	bool destroyed = false;
 	int supportHardness = 0;
 
 	// Update relation with attacker which killed or hit us
@@ -84,7 +84,7 @@ class Scenery : public SupportedMapPart, public std::enable_shared_from_this<Sce
 	StateRef<Building> building;
 	StateRef<City> city;
 
-	Scenery();
+	Scenery() = default;
 	~Scenery() = default;
 
   private:

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1255,12 +1255,6 @@ void VehicleMover::updateSliding(GameState &state, unsigned int ticks)
 
 VehicleMover::~VehicleMover() = default;
 
-Vehicle::Vehicle()
-    : attackMode(AttackMode::Standard), altitude(Altitude::Standard), position(0, 0, 0),
-      velocity(0, 0, 0)
-{
-}
-
 Vehicle::~Vehicle() = default;
 
 void Vehicle::leaveDimensionGate(GameState &state)

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "game/state/city/vehiclemission.h"
 #include "game/state/gametime.h"
 #include "game/state/rules/city/vehicletype.h"
 #include "game/state/shared/equipment.h"
@@ -155,7 +156,7 @@ class Vehicle : public StateObject,
 	STATE_OBJECT(Vehicle)
   public:
 	~Vehicle() override;
-	Vehicle();
+	Vehicle() = default;
 
 	enum class AttackMode
 	{
@@ -164,7 +165,7 @@ class Vehicle : public StateObject,
 		Defensive,
 		Evasive
 	};
-	AttackMode attackMode;
+	AttackMode attackMode = AttackMode::Standard;
 
 	enum class Altitude
 	{
@@ -173,7 +174,7 @@ class Vehicle : public StateObject,
 		Standard = 6,
 		Low = 3
 	};
-	Altitude altitude;
+	Altitude altitude = Altitude::Standard;
 	// Adjusts position by altitude preference
 	Vec3<int> getPreferredPosition(Vec3<int> position) const;
 	Vec3<int> getPreferredPosition(int x, int y, int z = 0) const;
@@ -187,10 +188,10 @@ class Vehicle : public StateObject,
 	std::list<sp<VEquipment>> equipment;
 	std::list<StateRef<VEquipmentType>> loot;
 	StateRef<City> city;
-	Vec3<float> position;
-	Vec3<float> goalPosition;
+	Vec3<float> position = {0, 0, 0};
+	Vec3<float> goalPosition = {0, 0, 0};
 	std::list<Vec3<float>> goalWaypoints;
-	Vec3<float> velocity;
+	Vec3<float> velocity = {0, 0, 0};
 	float facing = 0.0f;
 	float goalFacing = 0.0f;
 	float angularVelocity = 0.0f;
@@ -369,7 +370,7 @@ class Vehicle : public StateObject,
 	up<VehicleMover> mover;
 	sp<Doodad> smokeDoodad;
 	std::list<sp<Image>>::iterator animationFrame;
-	int animationDelay;
+	int animationDelay = 0;
 
 	// Following members are not serialized, but rather are set in initCity method
 

--- a/game/state/rules/aequipmenttype.cpp
+++ b/game/state/rules/aequipmenttype.cpp
@@ -6,7 +6,6 @@
 
 namespace OpenApoc
 {
-AEquipmentType::AEquipmentType() : body_part(BodyPart::Body) {}
 
 const UString &AEquipmentType::getPrefix()
 {

--- a/game/state/rules/aequipmenttype.h
+++ b/game/state/rules/aequipmenttype.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "game/state/city/research.h"
+#include "game/state/rules/agenttype.h"
 #include "game/state/stateobject.h"
 #include "library/sp.h"
 #include "library/strings.h"
@@ -21,7 +22,6 @@ class DamageType;
 class DamageModifier;
 class AgentType;
 class UfopaediaEntry;
-enum class BodyPart;
 
 enum class TriggerType
 {
@@ -64,7 +64,7 @@ class AEquipmentType : public StateObject
 		Loot
 	};
 
-	AEquipmentType();
+	AEquipmentType() = default;
 	~AEquipmentType() override = default;
 
 	// Shared stuff
@@ -74,11 +74,11 @@ class AEquipmentType : public StateObject
 	int weight = 0;
 	StateRef<BattleUnitImagePack> held_image_pack;
 	sp<Image> dropped_sprite;
-	Vec2<float> dropped_offset;
+	Vec2<float> dropped_offset = {0, 0};
 	sp<Image> dropped_shadow_sprite;
-	Vec2<float> shadow_offset;
+	Vec2<float> shadow_offset = {0, 0};
 	sp<Image> equipscreen_sprite;
-	Vec2<int> equipscreen_size;
+	Vec2<int> equipscreen_size = {0, 0};
 	StateRef<Organisation> manufacturer;
 	int store_space = 0;
 	int armor = 0;
@@ -102,7 +102,7 @@ class AEquipmentType : public StateObject
 	// Armor only
 	sp<Image> body_sprite;
 	StateRef<DamageModifier> damage_modifier;
-	BodyPart body_part;
+	BodyPart body_part = BodyPart::Body;
 	StateRef<BattleUnitImagePack> body_image_pack;
 	bool provides_flight = false;
 

--- a/game/state/rules/agenttype.h
+++ b/game/state/rules/agenttype.h
@@ -2,7 +2,6 @@
 
 #include "framework/image.h"
 #include "game/state/gametime.h"
-#include "game/state/rules/aequipmenttype.h"
 #include "game/state/shared/equipment.h"
 #include "game/state/stateobject.h"
 #include "library/sp.h"
@@ -30,6 +29,7 @@ class AgentMission;
 class VoxelMap;
 class City;
 enum class AIType;
+class AEquipmentType;
 
 enum class BodyPart
 {

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -88,8 +88,6 @@ int getCorridorSectorID(sp<Base> base, Vec2<int> pos)
 }
 } // namespace
 
-BattleMap::BattleMap() {}
-
 sp<BattleMap> BattleMap::get(const GameState &state, const UString &id)
 {
 	auto it = state.battle_maps.find(id);

--- a/game/state/rules/battle/battlemap.h
+++ b/game/state/rules/battle/battlemap.h
@@ -39,13 +39,13 @@ class BattleMap : public StateObject
 		Maximum = 4
 	};
 
-	BattleMap();
+	BattleMap() = default;
 	~BattleMap() override = default;
 
 	UString id;
 
-	Vec3<int> chunk_size;
-	Vec3<int> max_battle_size;
+	Vec3<int> chunk_size = {0, 0, 0};
+	Vec3<int> max_battle_size = {0, 0, 0};
 
 	std::map<MapDirection, bool> allow_entrance;
 	std::map<MapDirection, bool> allow_exit;

--- a/game/state/rules/battle/battlemapsector.cpp
+++ b/game/state/rules/battle/battlemapsector.cpp
@@ -6,8 +6,6 @@
 namespace OpenApoc
 {
 
-BattleMapSector::BattleMapSector() {}
-
 bool BattleMapSector::LineOfSightBlock::contains(Vec3<int> tile)
 {
 	return tile.x >= start.x && tile.y >= start.y && tile.z >= start.z && tile.x < end.x &&

--- a/game/state/rules/battle/battlemapsector.h
+++ b/game/state/rules/battle/battlemapsector.h
@@ -25,7 +25,7 @@ class BattleMapSector : public StateObject
 {
 	STATE_OBJECT(BattleMapSector)
   public:
-	BattleMapSector();
+	BattleMapSector() = default;
 	~BattleMapSector() override = default;
 
 	class LineOfSightBlock
@@ -52,7 +52,7 @@ class BattleMapSector : public StateObject
 		sp<LineOfSightBlock> clone(Vec3<int> shift);
 	};
 
-	Vec3<int> size;
+	Vec3<int> size = {0, 0, 0};
 	int occurrence_min = 0;
 	int occurrence_max = 0;
 

--- a/game/state/rules/battle/battlemapsector.h
+++ b/game/state/rules/battle/battlemapsector.h
@@ -32,9 +32,9 @@ class BattleMapSector : public StateObject
 	{
 	  public:
 		// Inclusive lower boundary
-		Vec3<int> start;
+		Vec3<int> start = {0, 0, 0};
 		// Exclusive upper boundary
-		Vec3<int> end;
+		Vec3<int> end = {0, 0, 0};
 
 		int ai_patrol_priority = 0;
 		int ai_target_priority = 0;

--- a/game/state/rules/city/baselayout.h
+++ b/game/state/rules/city/baselayout.h
@@ -13,7 +13,7 @@ class BaseLayout : public StateObject
 	STATE_OBJECT(BaseLayout)
   public:
 	std::set<Rect<int>> baseCorridors;
-	Vec2<int> baseLift;
+	Vec2<int> baseLift = {0, 0};
 };
 
 }; // namespace OpenApoc

--- a/game/state/rules/city/scenerytiletype.h
+++ b/game/state/rules/city/scenerytiletype.h
@@ -44,7 +44,7 @@ class SceneryTileType : public StateObject
 	sp<VoxelMap> voxelMap;
 	// FIXME: If the damaged tile links form a loop this will leak?
 	StateRef<SceneryTileType> damagedTile;
-	Vec2<float> imageOffset;
+	Vec2<float> imageOffset = {0, 0};
 	bool isLandingPad = false;
 	Colour minimap_colour;
 

--- a/game/state/rules/city/vehicletype.h
+++ b/game/state/rules/city/vehicletype.h
@@ -328,7 +328,7 @@ class VehicleType : public StateObject
 
 	sp<Image> equip_icon_small;
 
-	MapIconType mapIconType;
+	MapIconType mapIconType = MapIconType::Arrow;
 
 	// Flying and ground vehicles have a directional sprite (with optional non-flat banking)
 	std::map<Banking, std::map<Direction, sp<Image>>> directional_sprites;

--- a/game/state/rules/city/vequipmenttype.cpp
+++ b/game/state/rules/city/vequipmenttype.cpp
@@ -5,15 +5,6 @@
 namespace OpenApoc
 {
 
-// A bit painful but as not everything is expected to be set we have to zero all the non-constructed
-// types
-VEquipmentType::VEquipmentType()
-    : type(EquipmentSlotType::VehicleGeneral), weight(0), max_ammo(0), store_space(0), speed(0),
-      damage(0), accuracy(0), fire_delay(0), tail_size(0), guided(false), turn_rate(0), range(0),
-      firing_arc_1(0), firing_arc_2(0), point_defence(false), explosion_graphic(0), power(0),
-      top_speed(0), accuracy_modifier(0), cargo_space(0), passengers(0), alien_space(0),
-      missile_jamming(0), shielding(0), cloaking(false), teleporting(false){};
-
 const UString &VEquipmentType::getPrefix()
 {
 	static UString prefix = "VEQUIPMENTTYPE_";

--- a/game/state/rules/city/vequipmenttype.h
+++ b/game/state/rules/city/vequipmenttype.h
@@ -23,7 +23,7 @@ class VEquipmentType : public StateObject
 {
 	STATE_OBJECT(VEquipmentType)
   public:
-	VEquipmentType();
+	VEquipmentType() = default;
 
 	enum class User
 	{
@@ -35,39 +35,39 @@ class VEquipmentType : public StateObject
 	~VEquipmentType() override = default;
 
 	// Shared stuff
-	EquipmentSlotType type;
+	EquipmentSlotType type = EquipmentSlotType::VehicleGeneral;
 	UString id;
 	UString name;
-	int weight;
-	int max_ammo;
+	int weight = 0;
+	int max_ammo = 0;
 	StateRef<VAmmoType> ammo_type;
 	sp<Image> equipscreen_sprite;
-	Vec2<int> equipscreen_size;
+	Vec2<int> equipscreen_size = {0, 0};
 	StateRef<Organisation> manufacturer;
-	int store_space;
+	int store_space = 0;
 	std::set<User> users;
 
 	// Weapons
-	int speed;
+	int speed = 0;
 	std::list<sp<Image>> projectile_sprites; // A list of sprites forming the projectile
 	                                         // 'bullet'/'beam' - 'nullptr' gaps are expected
-	int damage;
-	int accuracy;
+	int damage = 0;
+	int accuracy = 0;
 	// Fire delay, in ticks, to fire a shot
-	int fire_delay;
-	int tail_size;
-	bool guided;
+	int fire_delay = 0;
+	int tail_size = 0;
+	bool guided = false;
 	// How much can it turn per tick.
 	// Based on the fact that retribution (tr = 10) turns 90 degrees (PI/2) per second
 	// One point of turn rate is equal to PI/20 turned per second
-	int turn_rate;
+	int turn_rate = 0;
 	// Divide by 32 to get range in tiles
-	int range;
+	int range = 0;
 	// Projectile's ttl, in voxels travelled
 	float ttl = 0.0f;
-	int firing_arc_1;
-	int firing_arc_2;
-	bool point_defence;
+	int firing_arc_1 = 0;
+	int firing_arc_2 = 0;
+	bool point_defence = false;
 	sp<Sample> fire_sfx;
 	sp<Sample> impact_sfx;
 	StateRef<DoodadType> explosion_graphic;
@@ -78,18 +78,18 @@ class VEquipmentType : public StateObject
 	std::list<StateRef<VEquipmentType>> splitIntoTypes;
 
 	// Engine stuff
-	int power;
-	int top_speed;
+	int power = 0;
+	int top_speed = 0;
 
 	// Other ('general') equipment stuff
-	int accuracy_modifier;
-	int cargo_space;
-	int passengers;
-	int alien_space;
-	int missile_jamming;
-	int shielding;
-	bool cloaking;
-	bool teleporting;
+	int accuracy_modifier = 0;
+	int cargo_space = 0;
+	int passengers = 0;
+	int alien_space = 0;
+	int missile_jamming = 0;
+	int shielding = 0;
+	bool cloaking = false;
+	bool teleporting = false;
 	bool dimensionShifting = false;
 
 	// Score requirement

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -129,9 +129,9 @@ class Agent : public StateObject,
 	// Note that agent cannot ever leave vehicle into city, or enter vehicle from citu
 
 	// Agent's position in the city
-	Vec3<float> position;
+	Vec3<float> position = {0, 0, 0};
 	// Position agent is moving towards
-	Vec3<float> goalPosition;
+	Vec3<float> goalPosition = {0, 0, 0};
 
 	StateRef<Lab> lab_assigned = nullptr;
 	bool assigned_to_lab = false;


### PR DESCRIPTION
Also replaces some 'trivial' constructors with default constructor and member initialization - it's a lot more obvious having the initializer at declaration to see if you've missed something.