### PR TITLE
Mark all unused parameters with [[maybe_unused]]

### DIFF
--- a/forms/multilistbox.cpp
+++ b/forms/multilistbox.cpp
@@ -28,7 +28,7 @@ MultilistBox::MultilistBox(sp<ScrollBar> ExternalScrollBar)
 		fw().renderer->drawRect(c->Location, c->SelectionSize, this->SelectedColour);
 	};
 
-	setFuncPreRender([this](sp<Control> c) {
+	setFuncPreRender([this](sp<Control> c [[maybe_unused]]) {
 		if (isDirty() && !scroller)
 		{
 			// MultilistBox without scroller should be rendered fully

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -1337,7 +1337,8 @@ void Framework::toolTipStopTimer()
 	p->toolTipImage.reset();
 }
 
-void Framework::toolTipTimerCallback(unsigned int interval, void *data)
+void Framework::toolTipTimerCallback(unsigned int interval [[maybe_unused]],
+                                     void *data [[maybe_unused]])
 {
 	// the sdl timer will be removed, so we forget about
 	// clear the timerid and reset the event

--- a/framework/luaframework.cpp
+++ b/framework/luaframework.cpp
@@ -64,8 +64,16 @@ void pushToLua(lua_State *L, sp<Image> &v)
 	else
 		lua_pushnil(L);
 }
-void pushToLua(lua_State *L, sp<LazyImage> &v) { lua_pushnil(L); }
-void pushToLua(lua_State *L, sp<VoxelSlice> &v) { lua_pushnil(L); }
+void pushToLua(lua_State *L, sp<LazyImage> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
+void pushToLua(lua_State *L, sp<VoxelSlice> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
 void pushToLua(lua_State *L, sp<Sample> &v)
 {
 	if (v)
@@ -73,7 +81,11 @@ void pushToLua(lua_State *L, sp<Sample> &v)
 	else
 		lua_pushnil(L);
 }
-void pushToLua(lua_State *L, sp<VoxelMap> &v) { lua_pushnil(L); }
+void pushToLua(lua_State *L, sp<VoxelMap> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
 void pushToLua(lua_State *L, Colour &v)
 {
 	lua_createtable(L, 0, 4);
@@ -87,11 +99,31 @@ void pushToLua(lua_State *L, Colour &v)
 	lua_setfield(L, -2, "a");
 }
 
-void pushToLua(lua_State *L, const sp<Image> &v) { lua_pushnil(L); }
-void pushToLua(lua_State *L, const sp<LazyImage> &v) { lua_pushnil(L); }
-void pushToLua(lua_State *L, const sp<VoxelSlice> &v) { lua_pushnil(L); }
-void pushToLua(lua_State *L, const sp<Sample> &v) { lua_pushnil(L); }
-void pushToLua(lua_State *L, const sp<VoxelMap> &v) { lua_pushnil(L); }
+void pushToLua(lua_State *L, const sp<Image> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
+void pushToLua(lua_State *L, const sp<LazyImage> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
+void pushToLua(lua_State *L, const sp<VoxelSlice> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
+void pushToLua(lua_State *L, const sp<Sample> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
+void pushToLua(lua_State *L, const sp<VoxelMap> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
 void pushToLua(lua_State *L, const Colour &v)
 {
 	lua_createtable(L, 0, 4);
@@ -208,7 +240,7 @@ lua_CFunction getLuaObjectConstMethods<Xorshift128Plus<uint32_t>>(const std::str
 	return nullptr;
 }
 
-void pushToLua(lua_State *L) {}
+void pushToLua(lua_State *L [[maybe_unused]]) { LogError("Unimplemented Lua function"); }
 
 void pushLuaDebugTraceback(lua_State *L)
 {

--- a/framework/luaframework.h
+++ b/framework/luaframework.h
@@ -68,12 +68,13 @@ typename std::enable_if<std::is_enum<T>::value>::type getFromLua(lua_State *L, i
 	v = static_cast<T>(integer);
 }
 // trying to get a value from the stack into a const reference (invalid)
-template <typename T> void getFromLua(lua_State *L, int argNum, const T &v)
+template <typename T> void getFromLua(lua_State *L, int argNum, const T &v [[maybe_unused]])
 {
 	int idx = argNum;
 	if (argNum < 0)
 		argNum = lua_gettop(L) + argNum + 1;
 	luaL_error(L, "this member (#%d) cannot be set directly", argNum);
+	LogError("Invalid Lua function");
 }
 
 // functions for pushing objects to the lua stack
@@ -410,8 +411,10 @@ template <typename C> int containerIndexMap(lua_State *L)
 }
 
 // mapping between method name to a pointer-to-function
-template <typename T> lua_CFunction getLuaObjectConstMethods(const std::string &key)
+template <typename T>
+lua_CFunction getLuaObjectConstMethods(const std::string &key [[maybe_unused]])
 {
+	LogError("Unimplemented Lua function");
 	return nullptr;
 }
 

--- a/game/state/battle/ai/unitaivanilla.cpp
+++ b/game/state/battle/ai/unitaivanilla.cpp
@@ -923,7 +923,7 @@ void UnitAIVanilla::routine(GameState &state, BattleUnit &u)
 	}
 }
 
-void UnitAIVanilla::raiseFlags(GameState &state, BattleUnit &u)
+void UnitAIVanilla::raiseFlags(GameState &state [[maybe_unused]], BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
 	LogWarning("VANILLA AI %s: raiseFlags()", u.id);
@@ -951,7 +951,7 @@ void UnitAIVanilla::raiseFlags(GameState &state, BattleUnit &u)
 	}
 }
 
-void UnitAIVanilla::clearFlags(GameState &state, BattleUnit &u)
+void UnitAIVanilla::clearFlags(GameState &state [[maybe_unused]], BattleUnit &u [[maybe_unused]])
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
 	LogWarning("VANILLA AI %s: clearFlags()", u.id);

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2062,7 +2062,7 @@ void Battle::checkMissionEnd(GameState &state, bool retreated, bool forceReCheck
 	}
 }
 
-void Battle::checkIfBuildingDisabled(GameState &state)
+void Battle::checkIfBuildingDisabled(GameState &state [[maybe_unused]])
 {
 	if (!buildingCanBeDisabled || buildingDisabled || !tryDisableBuilding())
 	{

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -1987,7 +1987,7 @@ void BattleUnit::updateTB(GameState &state)
 	updateRegen(state, TICKS_REGEN_PER_TURN);
 }
 
-void BattleUnit::updateCloak(GameState &state, unsigned int ticks)
+void BattleUnit::updateCloak(GameState &state [[maybe_unused]], unsigned int ticks)
 {
 	if (isConscious())
 	{

--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -243,7 +243,8 @@ AgentMission *AgentMission::awaitPickup(GameState &, Agent &, StateRef<Building>
 	return mission;
 }
 
-AgentMission *AgentMission::teleport(GameState &state, Agent &a, StateRef<Building> b)
+AgentMission *AgentMission::teleport(GameState &state [[maybe_unused]], Agent &a [[maybe_unused]],
+                                     StateRef<Building> b)
 {
 	auto *mission = new AgentMission();
 	mission->type = MissionType::Teleport;
@@ -474,7 +475,7 @@ void AgentMission::start(GameState &state, Agent &a)
 	}
 }
 
-void AgentMission::setPathTo(GameState &state, Agent &a, StateRef<Building> b)
+void AgentMission::setPathTo(GameState &state [[maybe_unused]], Agent &a, StateRef<Building> b)
 {
 	this->currentPlannedPath.clear();
 	auto &map = *a.city->map;

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -1007,6 +1007,6 @@ void Building::decreasePendingInvestigatorCount(GameState &state)
 	}
 }
 
-bool Building::isAlive(GameState &state) const { return !buildingParts.empty(); }
+bool Building::isAlive(GameState &state [[maybe_unused]]) const { return !buildingParts.empty(); }
 
 } // namespace OpenApoc

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -504,7 +504,7 @@ void City::repairScenery(GameState &state)
 	}
 }
 
-void City::repairVehicles(GameState &state)
+void City::repairVehicles(GameState &state [[maybe_unused]])
 {
 	for (auto &b : buildings)
 	{

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1113,7 +1113,7 @@ void VehicleMover::updateFalling(GameState &state, unsigned int ticks)
 	vehicle.updateSprite(state);
 }
 
-void VehicleMover::updateCrashed(GameState &state, unsigned int ticks)
+void VehicleMover::updateCrashed(GameState &state, unsigned int ticks [[maybe_unused]])
 {
 	// Tile underneath us is dead?
 	if (vehicle.tileObject && vehicle.tileObject->getOwningTile() &&
@@ -2348,7 +2348,7 @@ void Vehicle::updateCargo(GameState &state)
 	}
 }
 
-void Vehicle::updateSprite(GameState &state)
+void Vehicle::updateSprite(GameState &state [[maybe_unused]])
 {
 	// Set banking
 	if (ticksToTurn > 0 && angularVelocity > 0.0f)
@@ -2745,8 +2745,9 @@ bool Vehicle::fireWeaponsPointDefense(GameState &state, Vec2<int> arc)
 	return false;
 }
 
-bool Vehicle::fireAtBuilding(GameState &state,
-                             Vec2<int> arc) // TODO: this function must return target only, not fire
+bool Vehicle::fireAtBuilding(
+    GameState &state,
+    Vec2<int> arc [[maybe_unused]]) // TODO: this function must return target only, not fire
 {
 	auto firingRange = getFiringRange();
 
@@ -2799,7 +2800,7 @@ bool Vehicle::fireAtBuilding(GameState &state,
 	return false;
 }
 
-void Vehicle::fireWeaponsManual(GameState &state, Vec2<int> arc)
+void Vehicle::fireWeaponsManual(GameState &state, Vec2<int> arc [[maybe_unused]])
 {
 	attackTarget(state, manualFirePosition);
 }
@@ -2867,8 +2868,8 @@ bool Vehicle::attackTarget(GameState &state, Vec3<float> target)
 	return false;
 }
 
-sp<VEquipment> Vehicle::getFirstFiringWeapon(GameState &state, Vec3<float> &target, bool checkLOF,
-                                             Vec3<float> targetVelocity,
+sp<VEquipment> Vehicle::getFirstFiringWeapon(GameState &state [[maybe_unused]], Vec3<float> &target,
+                                             bool checkLOF, Vec3<float> targetVelocity,
                                              sp<TileObjectVehicle> enemyTile, bool pd)
 {
 	static const std::set<TileObject::Type> sceneryVehicleSet = {TileObject::Type::Scenery,
@@ -3938,7 +3939,7 @@ void Cargo::arrive(GameState &state, bool &cargoArrived, bool &bioArrived, bool 
 	count = 0;
 }
 
-void Cargo::seize(GameState &state, StateRef<Organisation> org)
+void Cargo::seize(GameState &state, StateRef<Organisation> org [[maybe_unused]])
 {
 	switch (type)
 	{

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -457,7 +457,8 @@ VehicleMission *VehicleMission::attackVehicle(GameState &, Vehicle &, StateRef<V
 	return mission;
 }
 
-VehicleMission *VehicleMission::attackBuilding(GameState &state, Vehicle &v,
+VehicleMission *VehicleMission::attackBuilding(GameState &state [[maybe_unused]],
+                                               Vehicle &v [[maybe_unused]],
                                                StateRef<Building> target)
 {
 	auto *mission = new VehicleMission();
@@ -488,7 +489,8 @@ VehicleMission *VehicleMission::followVehicle(GameState &, Vehicle &,
 	return mission;
 }
 
-VehicleMission *VehicleMission::recoverVehicle(GameState &state, Vehicle &v,
+VehicleMission *VehicleMission::recoverVehicle(GameState &state [[maybe_unused]],
+                                               Vehicle &v [[maybe_unused]],
                                                StateRef<Vehicle> target)
 {
 	auto *mission = new VehicleMission();
@@ -497,8 +499,8 @@ VehicleMission *VehicleMission::recoverVehicle(GameState &state, Vehicle &v,
 	return mission;
 }
 
-VehicleMission *VehicleMission::offerService(GameState &state, Vehicle &v,
-                                             StateRef<Building> target)
+VehicleMission *VehicleMission::offerService(GameState &state [[maybe_unused]],
+                                             Vehicle &v [[maybe_unused]], StateRef<Building> target)
 {
 	auto *mission = new VehicleMission();
 	mission->type = MissionType::OfferService;
@@ -586,7 +588,8 @@ VehicleMission *VehicleMission::patrol(GameState &, Vehicle &, bool home, unsign
 	return mission;
 }
 
-VehicleMission *VehicleMission::teleport(GameState &state, Vehicle &v, Vec3<int> target)
+VehicleMission *VehicleMission::teleport(GameState &state [[maybe_unused]],
+                                         Vehicle &v [[maybe_unused]], Vec3<int> target)
 {
 	auto *mission = new VehicleMission();
 	mission->type = MissionType::Teleport;
@@ -614,7 +617,7 @@ VehicleMission *VehicleMission::land(Vehicle &, StateRef<Building> b)
 	return mission;
 }
 
-VehicleMission *VehicleMission::investigateBuilding(GameState &, Vehicle &v,
+VehicleMission *VehicleMission::investigateBuilding(GameState &, Vehicle &v [[maybe_unused]],
                                                     StateRef<Building> target, bool allowTeleporter)
 {
 	auto *mission = new VehicleMission();
@@ -2827,7 +2830,7 @@ void VehicleMission::setFollowPath(GameState &state, Vehicle &v)
 }
 
 bool VehicleMission::advanceAlongPath(GameState &state, Vehicle &v, Vec3<float> &destPos,
-                                      float &destFacing, int &turboTiles)
+                                      float &destFacing [[maybe_unused]], int &turboTiles)
 {
 	if (currentPlannedPath.empty())
 	{

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -144,7 +144,8 @@ void VEquipment::update(int ticks)
 	}
 }
 
-void VEquipment::noAmmoToReload(const GameState &state, const VEquipment *equipment) const
+void VEquipment::noAmmoToReload(const GameState &state [[maybe_unused]],
+                                const VEquipment *equipment) const
 {
 	switch (equipment->type->type)
 	{
@@ -213,7 +214,7 @@ void VEquipment::equipFromBase(GameState &state, StateRef<Base> base)
 	reload(state, base);
 }
 
-void VEquipment::unequipToBase(GameState &state, StateRef<Base> base)
+void VEquipment::unequipToBase(GameState &state [[maybe_unused]], StateRef<Base> base)
 {
 	base->inventoryVehicleEquipment[type.id]++;
 	if (ammo > 0 && type->ammo_type)

--- a/game/state/luagamestate_support.cpp
+++ b/game/state/luagamestate_support.cpp
@@ -25,9 +25,17 @@ const GameState *getConstGameStateFromLua(lua_State *L)
 	return r;
 }
 
-void pushToLua(lua_State *L, sp<TacticalAI> &v) { lua_pushnil(L); }
+void pushToLua(lua_State *L, sp<TacticalAI> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
 void pushToLua(lua_State *L, UnitAI &v) { pushToLua(L, v.type); }
-void pushToLua(lua_State *L, const sp<TacticalAI> &v) { lua_pushnil(L); }
+void pushToLua(lua_State *L, const sp<TacticalAI> &v [[maybe_unused]])
+{
+	lua_pushnil(L);
+	LogError("Unimplemented Lua function");
+}
 void pushToLua(lua_State *L, const UnitAI &v) { pushToLua(L, v.type); }
 
 template <> lua_CFunction getLuaObjectMethods<GameState>(const std::string &key)

--- a/game/state/rules/city/vehicletype.h
+++ b/game/state/rules/city/vehicletype.h
@@ -85,7 +85,8 @@ class VehicleType : public StateObject
 	{
 		return getMaxHealth(first, last) + getMaxShield(first, last);
 	}
-	template <class IterT> int getMaxHealth(IterT first, IterT last) const
+	template <class IterT>
+	int getMaxHealth(IterT first [[maybe_unused]], IterT last [[maybe_unused]]) const
 	{
 		static_assert(std::is_same<typename std::iterator_traits<IterT>::value_type,
 		                           sp<VEquipmentType>>::value,
@@ -111,7 +112,8 @@ class VehicleType : public StateObject
 		return maxShield;
 	}
 	// This is the 'sum' of all armors?
-	template <class IterT> int getArmor(IterT first, IterT last) const
+	template <class IterT>
+	int getArmor(IterT first [[maybe_unused]], IterT last [[maybe_unused]]) const
 	{
 		static_assert(std::is_same<typename std::iterator_traits<IterT>::value_type,
 		                           sp<VEquipmentType>>::value,

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -998,7 +998,7 @@ void Agent::updateEachSecond(GameState &state)
 	}
 }
 
-void Agent::updateDaily(GameState &state) { recentlyFought = false; }
+void Agent::updateDaily(GameState &state [[maybe_unused]]) { recentlyFought = false; }
 
 void Agent::updateHourly(GameState &state)
 {

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -1132,8 +1132,9 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 }
 
 std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destination,
-                                            const GroundVehicleTileHelper &canEnterTile,
-                                            bool approachOnly, bool, bool, bool)
+                                            const GroundVehicleTileHelper &canEnterTile
+                                            [[maybe_unused]],
+                                            bool approachOnly [[maybe_unused]], bool, bool, bool)
 {
 	int originID = getRoadSegmentID(origin);
 	int destinationID = getRoadSegmentID(destination);
@@ -1710,7 +1711,7 @@ void City::groupMove(GameState &state, std::list<StateRef<Vehicle>> &selectedVeh
 	}
 }
 
-void City::fillRoadSegmentMap(GameState &state)
+void City::fillRoadSegmentMap(GameState &state [[maybe_unused]])
 {
 	LogWarning("Begun filling road segment map");
 	// Expecting this to be done on clean intact map

--- a/game/state/tilemap/tileobject.h
+++ b/game/state/tilemap/tileobject.h
@@ -68,8 +68,12 @@ class TileObject : public std::enable_shared_from_this<TileObject>
 	Tile *getOwningTile() const { return this->owningTile; }
 	std::vector<Tile *> getIntersectingTiles() const { return this->intersectingTiles; }
 
-	virtual sp<VoxelMap> getVoxelMap(Vec3<int> /*mapIndex*/, bool /*los*/) const { return nullptr; }
-	virtual bool hasVoxelMap(bool los) const { return false; }
+	virtual sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex [[maybe_unused]],
+	                                 bool los [[maybe_unused]]) const
+	{
+		return nullptr;
+	}
+	virtual bool hasVoxelMap(bool los [[maybe_unused]]) const { return false; }
 	// Vector from voxel map top left back corner to object center
 	virtual Vec3<float> getVoxelOffset() const { return bounds_div_2; }
 	virtual Vec3<float> getVoxelCentrePosition() const { return {0.0, 0.0, 0.0}; }

--- a/game/state/tilemap/tileobject_battlemappart.h
+++ b/game/state/tilemap/tileobject_battlemappart.h
@@ -21,7 +21,7 @@ class TileObjectBattleMapPart : public TileObject
 
 	sp<BattleMapPart> getOwner() const;
 
-	bool hasVoxelMap(bool los) const override { return true; }
+	bool hasVoxelMap(bool los [[maybe_unused]]) const override { return true; }
 	sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex, bool los) const override;
 	Vec3<float> getPosition() const override;
 	float getZOrder() const override;

--- a/game/state/tilemap/tileobject_battleunit.h
+++ b/game/state/tilemap/tileobject_battleunit.h
@@ -38,8 +38,8 @@ class TileObjectBattleUnit : public TileObject
 	void removeFromMap() override;
 	void addToDrawnTiles(Tile *tile) override;
 
-	bool hasVoxelMap(bool los) const override { return true; }
-	sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex, bool) const override;
+	bool hasVoxelMap(bool los [[maybe_unused]]) const override { return true; }
+	sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex, bool los [[maybe_unused]]) const override;
 	Vec3<float> getPosition() const override;
 
   private:

--- a/game/state/tilemap/tileobject_doodad.cpp
+++ b/game/state/tilemap/tileobject_doodad.cpp
@@ -67,7 +67,10 @@ float TileObjectDoodad::getZOrder() const
 	return getCenter().z + 3.5f + (float)getType() / 1000.0f;
 }
 
-bool TileObjectDoodad::hasVoxelMap(bool los) const { return doodad.lock()->voxelMap != nullptr; }
+bool TileObjectDoodad::hasVoxelMap(bool los [[maybe_unused]]) const
+{
+	return doodad.lock()->voxelMap != nullptr;
+}
 
 sp<VoxelMap> TileObjectDoodad::getVoxelMap(Vec3<int> mapIndex, bool los) const
 {

--- a/game/state/tilemap/tileobject_scenery.h
+++ b/game/state/tilemap/tileobject_scenery.h
@@ -20,7 +20,7 @@ class TileObjectScenery : public TileObject
 
 	sp<Scenery> getOwner() const;
 
-	bool hasVoxelMap(bool los) const override { return true; }
+	bool hasVoxelMap(bool los [[maybe_unused]]) const override { return true; }
 	sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex, bool) const override;
 	Vec3<float> getPosition() const override;
 	float getZOrder() const override;

--- a/game/state/tilemap/tileobject_vehicle.h
+++ b/game/state/tilemap/tileobject_vehicle.h
@@ -25,7 +25,7 @@ class TileObjectVehicle : public TileObject
 	sp<Vehicle> getVehicle() const;
 
 	Vec3<float> getVoxelCentrePosition() const override;
-	bool hasVoxelMap(bool los) const override { return true; }
+	bool hasVoxelMap(bool los [[maybe_unused]]) const override { return true; }
 	sp<VoxelMap> getVoxelMap(Vec3<int> mapIndex, bool los) const override;
 	Vec3<float> getPosition() const override;
 	void setPosition(Vec3<float> newPosition) override;

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -50,7 +50,7 @@ VEquipScreen::VEquipScreen(sp<GameState> state)
 	    paperDollPlaceholder->Location, paperDollPlaceholder->Size, EQUIP_GRID_SLOT_SIZE);
 
 	// when hovering the paperdoll, display the selected vehicle stats
-	paperDoll->addCallback(FormEventType::MouseEnter, [this](FormsEvent *e) {
+	paperDoll->addCallback(FormEventType::MouseEnter, [this](FormsEvent *e [[maybe_unused]]) {
 		highlightedVehicle = selected;
 		VehicleSheet(formVehicleItem).display(selected);
 	});
@@ -108,14 +108,16 @@ void VEquipScreen::begin()
 		auto graphic = mksp<Graphic>(vehicle->type->equip_icon_big);
 
 		// when entering a selectbox item, display that vehicle's stats
-		graphic->addCallback(FormEventType::MouseEnter, [this, vehicle](FormsEvent *e) {
-			highlightedVehicle = vehicle;
-			VehicleSheet(formVehicleItem).display(vehicle);
-		});
-		vehicleSelectBox->addCallback(FormEventType::MouseLeave, [this](FormsEvent *e) {
-			highlightedVehicle = selected;
-			VehicleSheet(formVehicleItem).display(selected);
-		});
+		graphic->addCallback(FormEventType::MouseEnter,
+		                     [this, vehicle](FormsEvent *e [[maybe_unused]]) {
+			                     highlightedVehicle = vehicle;
+			                     VehicleSheet(formVehicleItem).display(vehicle);
+		                     });
+		vehicleSelectBox->addCallback(FormEventType::MouseLeave,
+		                              [this](FormsEvent *e [[maybe_unused]]) {
+			                              highlightedVehicle = selected;
+			                              VehicleSheet(formVehicleItem).display(selected);
+		                              });
 		graphic->AutoSize = true;
 		vehicleSelectBox->addItem(graphic);
 		this->vehicleSelectionControls[graphic] = vehicle;

--- a/game/ui/battle/battlebriefing.cpp
+++ b/game/ui/battle/battlebriefing.cpp
@@ -30,9 +30,9 @@ static const std::map<UString, int> alienFunctionMap = {
 };
 }
 
-BattleBriefing::BattleBriefing(sp<GameState> state, StateRef<Organisation> targetOrg,
-                               UString location, bool isBuilding, bool isRaid,
-                               std::shared_future<void> gameStateTask)
+BattleBriefing::BattleBriefing(sp<GameState> state,
+                               StateRef<Organisation> targetOrg [[maybe_unused]], UString location,
+                               bool isBuilding, bool isRaid, std::shared_future<void> gameStateTask)
     : Stage(), menuform(ui().getForm("battle/briefing")), loading_task(std::move(gameStateTask)),
       state(state)
 {

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -35,7 +35,7 @@ const UString ControlGenerator::AGENT_ICON_NAME("ICON_A");
 const UString ControlGenerator::LEFT_LIST_NAME("LEFT");
 const UString ControlGenerator::RIGHT_LIST_NAME("RIGHT");
 
-void ControlGenerator::init(GameState &state)
+void ControlGenerator::init(GameState &state [[maybe_unused]])
 {
 	for (int i = 0; i < 3; i++)
 	{

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -96,7 +96,8 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, sp<AEquipmentTy
 	}
 }
 
-void AEquipmentSheet::displayGrenade(sp<AEquipment> item, sp<AEquipmentType> itemType)
+void AEquipmentSheet::displayGrenade(sp<AEquipment> item [[maybe_unused]],
+                                     sp<AEquipmentType> itemType)
 {
 	form->findControlTyped<Label>("LABEL_2_C")->setText(itemType->damage_type->name);
 
@@ -132,7 +133,8 @@ void AEquipmentSheet::displayAmmo(sp<AEquipment> item, sp<AEquipmentType> itemTy
 	}
 }
 
-void AEquipmentSheet::displayWeapon(sp<AEquipment> item, sp<AEquipmentType> itemType)
+void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
+                                    sp<AEquipmentType> itemType)
 {
 	if (itemType->ammo_types.empty())
 	{
@@ -171,7 +173,10 @@ void AEquipmentSheet::displayArmor(sp<AEquipment> item, sp<AEquipmentType> itemT
 	                   : format("%d", itemType->armor));
 }
 
-void AEquipmentSheet::displayOther(sp<AEquipment> item, sp<AEquipmentType> itemType) {}
+void AEquipmentSheet::displayOther(sp<AEquipment> item [[maybe_unused]],
+                                   sp<AEquipmentType> itemType [[maybe_unused]])
+{
+}
 
 void AEquipmentSheet::displayAlien(sp<AEquipment> item, sp<AEquipmentType> itemType)
 {

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -1948,12 +1948,12 @@ void AEquipScreen::updateAgentControl(sp<Agent> agent)
 	auto agentList = formMain->findControlTyped<ListBox>("AGENT_SELECT_BOX");
 	auto control = ControlGenerator::createLargeAgentControl(
 	    *state, agent, agentList->Size.x, UnitSkillState::Hidden, selstate, !isInVicinity(agent));
-	control->addCallback(FormEventType::MouseEnter, [this, agent](FormsEvent *e) {
+	control->addCallback(FormEventType::MouseEnter, [this, agent](FormsEvent *e [[maybe_unused]]) {
 		AgentSheet(formAgentStats).display(agent, bigUnitRanks, isTurnBased());
 		formAgentStats->setVisible(true);
 		formAgentItem->setVisible(false);
 	});
-	control->addCallback(FormEventType::MouseLeave, [this](FormsEvent *e) {
+	control->addCallback(FormEventType::MouseLeave, [this](FormsEvent *e [[maybe_unused]]) {
 		AgentSheet(formAgentStats).display(selectedAgents.front(), bigUnitRanks, isTurnBased());
 		formAgentStats->setVisible(true);
 		formAgentItem->setVisible(false);

--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -56,7 +56,8 @@ sp<Control> MessageLogScreen::createMessageRow(EventMessage message, sp<GameStat
 	});
 }
 
-sp<Control> MessageLogScreen::createMessageRow(EventMessage message, sp<GameState> state,
+sp<Control> MessageLogScreen::createMessageRow(EventMessage message,
+                                               sp<GameState> state [[maybe_unused]],
                                                std::function<void(FormsEvent *e)> callback)
 {
 	auto control = mksp<Control>();

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -142,7 +142,7 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 	}
 }
 
-void VehicleSheet::displayEngine(sp<VEquipment> item, sp<VEquipmentType> type)
+void VehicleSheet::displayEngine(sp<VEquipment> item [[maybe_unused]], sp<VEquipmentType> type)
 {
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Top Speed"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->top_speed));
@@ -169,7 +169,7 @@ void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 	}
 }
 
-void VehicleSheet::displayGeneral(sp<VEquipment> item, sp<VEquipmentType> type)
+void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEquipmentType> type)
 {
 	int statsCount = 2;
 	if (type->accuracy_modifier)

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -339,7 +339,7 @@ bool CityView::handleClickedVehicle(StateRef<Vehicle> vehicle, bool rightClick,
 }
 
 bool CityView::handleClickedAgent(StateRef<Agent> agent, bool rightClick,
-                                  CitySelectionState selState)
+                                  CitySelectionState selState [[maybe_unused]])
 {
 	orderSelect(agent, rightClick, modifierLCtrl || modifierRCtrl);
 	return true;
@@ -385,7 +385,7 @@ bool CityView::handleClickedProjectile(sp<Projectile> projectile, bool rightClic
 }
 
 bool CityView::handleClickedOrganisation(StateRef<Organisation> organisation, bool rightClick,
-                                         CitySelectionState selState)
+                                         CitySelectionState selState [[maybe_unused]])
 {
 	if (rightClick)
 	{
@@ -1004,11 +1004,13 @@ CityView::CityView(sp<GameState> state)
 	for (int i = 0; i < weaponDisabled.size(); i++)
 	{
 		vehicleForm->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
-		    ->addCallback(FormEventType::CheckBoxSelected,
-		                  [this, i](FormsEvent *e) { orderDisableWeapon(i, true); });
+		    ->addCallback(
+		        FormEventType::CheckBoxSelected,
+		        [this, i](FormsEvent *e [[maybe_unused]]) { orderDisableWeapon(i, true); });
 		vehicleForm->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
-		    ->addCallback(FormEventType::CheckBoxDeSelected,
-		                  [this, i](FormsEvent *e) { orderDisableWeapon(i, false); });
+		    ->addCallback(
+		        FormEventType::CheckBoxDeSelected,
+		        [this, i](FormsEvent *e [[maybe_unused]]) { orderDisableWeapon(i, false); });
 	}
 	vehicleForm->findControl("BUTTON_EQUIP_VEHICLE")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {

--- a/tests/test_tilemap.cpp
+++ b/tests/test_tilemap.cpp
@@ -16,7 +16,7 @@ class FakeSceneryTileObject : public TileObject
 	sp<VoxelMap> voxel;
 
 	Vec3<float> getPosition() const override { return this->position; }
-	bool hasVoxelMap(bool los) const override { return true; }
+	bool hasVoxelMap(bool los [[maybe_unused]]) const override { return true; }
 	sp<VoxelMap> getVoxelMap(Vec3<int>, bool) const override { return this->voxel; }
 
 	FakeSceneryTileObject(TileMap &map, Vec3<float> bounds, sp<VoxelMap> voxelMap)

--- a/tools/code_generators/gamestate_serialize_gen/main.cpp
+++ b/tools/code_generators/gamestate_serialize_gen/main.cpp
@@ -79,8 +79,8 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 	{
 		if (object.external == false)
 			out << "inline\n";
-		out << "void serializeIn(const GameState *state, SerializationNode* node, " << object.name
-		    << " &obj)\n{\n";
+		out << "void serializeIn(const GameState *state [[maybe_unused]], SerializationNode* node, "
+		    << object.name << " &obj [[maybe_unused]])\n{\n";
 
 		out << "\tif (!node) return;\n";
 
@@ -111,8 +111,8 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 
 		if (object.external == false)
 			out << "inline\n";
-		out << "void serializeOut(SerializationNode* node, const " << object.name << " &obj, const "
-		    << object.name << " &ref)\n{\n";
+		out << "void serializeOut(SerializationNode* node [[maybe_unused]], const " << object.name
+		    << " &obj [[maybe_unused]], const " << object.name << " &ref [[maybe_unused]])\n{\n";
 
 		for (auto &member : object.members)
 		{
@@ -150,8 +150,8 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 
 		if (object.external == false)
 			out << "inline\n";
-		out << "bool operator==(const " << object.name << " &a, const " << object.name
-		    << " &b)\n{\n";
+		out << "bool operator==(const " << object.name << " &a [[maybe_unused]], const "
+		    << object.name << " &b [[maybe_unused]])\n{\n";
 
 		for (auto &member : object.members)
 		{


### PR DESCRIPTION
A number of these are incomplete functions where the final functionality
would use that parameter, some are virtual overrides, others could
probably just have that parameter removed

But this should make /new/ warnings more obvious