### PR TITLE
Fix MSVC build failure: missing SDL_keycode.h

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -247,7 +247,7 @@ target_include_directories(OpenApoc_Framework PUBLIC ${GLM_INCLIDE_DIR})
 #Require SDL2 for input/graphics/sound/pretty much everything
 if(WIN32)
 	find_package(SDL2 CONFIG REQUIRED)
-	target_link_libraries(OpenApoc_Framework PRIVATE SDL2::SDL2 SDL2::SDL2main)
+	target_link_libraries(OpenApoc_Framework PUBLIC SDL2::SDL2 SDL2::SDL2main)
 	#Workaround vcpkg bug
 	set_target_properties(SDL2::SDL2 SDL2::SDL2main PROPERTIES
 		MAP_IMPORTED_CONFIG_MINSIZEREL Release


### PR DESCRIPTION
Not sure why this affected me and not the CI - maybe different paths?

But as the SDL headers are used in public framework headers, we need to use PUBLIC here so things that then link to the framework also inherit the SDL include paths etc.