### PR TITLE
Fix crash when healing agents not in a building with base

### DIFF
--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -1013,11 +1013,13 @@ void Agent::updateHourly(GameState &state)
 		// agent is in a vehicle stationed in home building
 		base = currentVehicle->currentBuilding->base;
 	}
-	else
+
+	if (!base)
 	{
 		// not in a base
 		return;
 	}
+
 	// Heal
 	if (modified_stats.health < current_stats.health && !recentlyFought)
 	{


### PR DESCRIPTION
Non-xcom agents may have a 'home building' without a base, so check
the existance of a base before deref-ing to see how many medical bays
there are.