### PR TITLE
Always hide SaveMenu TextEdit control at screen open

### DIFF
--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -150,7 +150,7 @@ void SaveMenu::begin()
 			}
 
 			auto saveNameTextEdit = newControl->findControlTyped<TextEdit>("TEXTEDIT_SAVE_NAME");
-			if (currentAction != SaveMenuAction::Save && saveNameTextEdit != nullptr)
+			if (saveNameTextEdit != nullptr)
 			{
 				saveNameTextEdit->setVisible(false);
 			}


### PR DESCRIPTION
Even if we're saving, we hide the TextEdit until a save slot has been selected,
as until then the names are displayed by a Label and the TextEdit not intended
to be active.