### PR TITLE
Don't create tileObject of vehicles between dimensions at game load

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1271,6 +1271,7 @@ void Vehicle::leaveDimensionGate(GameState &state)
 	auto initialFacing = 0.0f;
 
 	LogInfo("Leaving dimension gate %s", this->name);
+	LogAssert(this->betweenDimensions == true);
 	if (this->tileObject)
 	{
 		LogError("Trying to launch already-launched vehicle");
@@ -1298,10 +1299,12 @@ void Vehicle::leaveDimensionGate(GameState &state)
 			    new GameVehicleEvent(GameEventType::UfoSpotted, {&state, shared_from_this()}));
 		}
 	}
+	this->betweenDimensions = false;
 }
 
 void Vehicle::enterDimensionGate(GameState &state)
 {
+	LogAssert(this->betweenDimensions == false);
 	carriedByVehicle.clear();
 	crashed = false;
 	if (this->currentBuilding)
@@ -1323,6 +1326,7 @@ void Vehicle::enterDimensionGate(GameState &state)
 	this->goalFacing = 0.0f;
 	this->ticksToTurn = 0;
 	this->angularVelocity = 0.0f;
+	this->betweenDimensions = true;
 }
 
 void Vehicle::leaveBuilding(GameState &state, Vec3<float> initialPosition, float initialFacing)

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -232,6 +232,9 @@ class Vehicle : public StateObject,
 	sp<TileObjectVehicle> tileObject;
 	sp<TileObjectShadow> shadowObject;
 
+	// If the vehicle is currently traveling through a dimension gate
+	bool betweenDimensions = false;
+
 	/* leave the building and put vehicle into the city */
 	void leaveDimensionGate(GameState &state);
 	/* 'enter' the vehicle into a building*/

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -182,8 +182,9 @@ void GameState::initState()
 		for (auto &v : this->vehicles)
 		{
 			auto vehicle = v.second;
-			if (vehicle->city == city && !vehicle->currentBuilding)
+			if (vehicle->city == city && !vehicle->currentBuilding && !vehicle->betweenDimensions)
 			{
+
 				city->map->addObjectToMap(*this, vehicle);
 			}
 			vehicle->strategyImages = city_common_image_list->strategyImages;

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -459,6 +459,7 @@
 		<member>cargo</member>
 		<member>carriedVehicle</member>
 		<member>carriedByVehicle</member>
+		<member>betweenDimensions</member>
 	</object>
 	<object>
 		<name>VEquipment</name>


### PR DESCRIPTION
Vehicles currently in a dimension gate are currently assigned a tileObject in
GameState::initGame(), despite them not having valid position coords, so appear
on the map at a nonsense location (0,0,0) and hit a LogError() in
Vehicle::leaveDimensionGate() as it doesn't expect an existing tileObject.

So instead store a flag for if a Vehicle is between dimensions - and don't
create TileObjects for Vehicles with that flag set at game load time.

Note: This doesn't fix existing saves where there are vehicles currently in the
gates, as the flag won't be set correctly. New games, or games loaded from a
state where there aren't any Vehicles that happen to be in the gates at that
moment, should be fine going forward.