### PR TITLE
Fix LOFtemps for vehicles with exactly 16-high LOFTemp stacks

### DIFF
--- a/tools/extractors/extract_vehicles.cpp
+++ b/tools/extractors/extract_vehicles.cpp
@@ -533,7 +533,11 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		int freeSpace = v.size_z * 16 - v.loftemps_height;
 		int start = (freeSpace + 1) / 2;
 		int end = v.size_z * 16 - freeSpace / 2;
-		end = end % 16;
+		if (end > 16)
+		{
+			LogInfo("Vehicle %s has height %d", vehicle->name, end);
+			end = end % 16;
+		}
 		if (freeSpace > 32)
 		{
 			LogError(


### PR DESCRIPTION
This is what was causing the Alien Assault ship to be unhittable/unselectable

Note this data is stored in the saved game state, so new games will be required