### PR TITLE
Allow the Logger to be hooked

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -28,7 +28,8 @@ set (FRAMEWORK_SOURCE_FILES
 	stagestack.cpp
 	trace.cpp
 	video/smk.cpp
-	logger_sdldialog.cpp)
+	logger_sdldialog.cpp
+	logger_file.cpp)
 
 source_group(framework\\sources FILES ${FRAMEWORK_SOURCE_FILES})
 list(APPEND ALL_SOURCE_FILES ${FRAMEWORK_SOURCE_FILES})
@@ -63,7 +64,8 @@ set (FRAMEWORK_HEADER_FILES
 	trace.h
 	ThreadPool/ThreadPool.h
 	video.h
-	logger_sdldialog.h)
+	logger_sdldialog.h
+	logger_file.h)
 
 source_group(framework\\headers FILES ${FRAMEWORK_HEADER_FILES})
 list(APPEND ALL_HEADER_FILES ${FRAMEWORK_HEADER_FILES})

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -202,8 +202,7 @@ if(APPLE)
 	# OSX doesn't seem to support the c++11 'thread_local' keyword
 	target_compile_definitions(OpenApoc_Framework PRIVATE
 			"-DBROKEN_THREAD_LOCAL")
-	# Disable libunwind use on Apple
-	SET(BACKTRACE_ON_ERROR OFF CACHE BOOL "Print backtrace on logging an error (Requires libunwind on linux, no extra dependencies on windows)" FORCE)
+	SET(BACKTRACE_ON_ERROR ON)
 elseif(WIN32)
 	target_compile_definitions(OpenApoc_Framework PRIVATE "-DGLESWRAP_PLATFORM_WGL")
 else()
@@ -284,6 +283,9 @@ endif()
 if(BACKTRACE_ON_ERROR)
 	if(WIN32)
 		target_link_libraries(OpenApoc_Framework PUBLIC dbghelp)
+	elseif(APPLE)
+		# MacOS always has libunwind with no extra libs needed
+		target_compile_definitions(OpenApoc_Framework PUBLIC -DBACKTRACE_LIBUNWIND)
 	else()
 		find_package(PkgConfig)
 		pkg_check_modules(PC_UNWIND libunwind)

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -27,7 +27,8 @@ set (FRAMEWORK_SOURCE_FILES
 	sound.cpp
 	stagestack.cpp
 	trace.cpp
-	video/smk.cpp)
+	video/smk.cpp
+	logger_sdldialog.cpp)
 
 source_group(framework\\sources FILES ${FRAMEWORK_SOURCE_FILES})
 list(APPEND ALL_SOURCE_FILES ${FRAMEWORK_SOURCE_FILES})
@@ -61,7 +62,8 @@ set (FRAMEWORK_HEADER_FILES
 	stagestack.h
 	trace.h
 	ThreadPool/ThreadPool.h
-	video.h)
+	video.h
+	logger_sdldialog.h)
 
 source_group(framework\\headers FILES ${FRAMEWORK_HEADER_FILES})
 list(APPEND ALL_HEADER_FILES ${FRAMEWORK_HEADER_FILES})

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -6,6 +6,7 @@
 #include "framework/event.h"
 #include "framework/font.h"
 #include "framework/image.h"
+#include "framework/logger_file.h"
 #include "framework/logger_sdldialog.h"
 #include "framework/renderer.h"
 #include "framework/renderer_interface.h"
@@ -513,6 +514,11 @@ Framework::Framework(const UString programName, bool createWindow)
 	p->quitProgram = false;
 	UString settingsPath(PHYSFS_getPrefDir(PROGRAM_ORGANISATION, PROGRAM_NAME));
 	settingsPath += "/settings.cfg";
+
+	UString logPath(PHYSFS_getPrefDir(PROGRAM_ORGANISATION, PROGRAM_NAME));
+	logPath += "/log.txt";
+
+	enableFileLogger(logPath.cStr());
 
 	// This is always set, the default being an empty string (which correctly chooses 'system
 	// language')

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -6,6 +6,7 @@
 #include "framework/event.h"
 #include "framework/font.h"
 #include "framework/image.h"
+#include "framework/logger_sdldialog.h"
 #include "framework/renderer.h"
 #include "framework/renderer_interface.h"
 #include "framework/sound_interface.h"
@@ -578,6 +579,7 @@ Framework::Framework(const UString programName, bool createWindow)
 	if (createWindow)
 	{
 		displayInitialise();
+		enableSDLDialogLogger(p->window);
 		audioInitialise();
 	}
 }

--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -7,9 +7,6 @@
 #include "framework/configfile.h"
 #include "framework/framework.h"
 #include "library/sp.h"
-#include <atomic>
-#include <chrono>
-#include <cstdarg>
 #include <mutex>
 #ifdef BACKTRACE_LIBUNWIND
 #ifndef _GNU_SOURCE
@@ -24,59 +21,12 @@
 #include <DbgHelp.h>
 #endif
 
-#ifndef LOGFILE
-#define LOGFILE "openapoc_log.txt"
-#endif
-
-// Don't have interactive dialogues in unit tests
-#ifdef UNIT_TEST
-#undef ERROR_DIALOG
-#else
-
-#if defined(ERROR_DIALOG)
-#include <SDL_messagebox.h>
-#endif
-
-#endif
-
-#ifdef ANDROID
-#include <android/log.h>
-#define LOGD(...) __android_log_print(ANDROID_LOG_DEBUG, "OpenApoc", __VA_ARGS__)
-#define LOGDV(fmt, ap) __android_log_vprint(ANDROID_LOG_DEBUG, "OpenApoc", fmt, ap)
-#define LOGW(...) __android_log_print(ANDROID_LOG_WARN, "OpenApoc", __VA_ARGS__)
-#define LOGWV(fmt, ap) __android_log_vprint(ANDROID_LOG_WARN, "OpenApoc", fmt, ap)
-#define LOGE(...) __android_log_print(ANDROID_LOG_ERROR, "OpenApoc", __VA_ARGS__)
-#define LOGEV(fmt, ap) __android_log_vprint(ANDROID_LOG_ERROR, "OpenApoc", fmt, ap)
-#define LOG_PATH "/storage/emulated/0/openapoc/data/"
-#else
-#define LOGD(...)
-#define LOGDV(fmt, ap)
-#define LOGW(...)
-#define LOGWV(fmt, ap)
-#define LOGE(...)
-#define LOGEV(fmt, ap)
-#define LOG_PATH
-#endif
-
 #define MAX_SYMBOL_LENGTH 1000
 
 namespace OpenApoc
 {
-ConfigOptionInt stderrLogLevelOption(
-    "Logger", "StderrLevel",
-    "Loglevel to output to stderr (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug) ", 2);
-ConfigOptionInt fileLogLevelOption(
-    "Logger", "FileLevel",
-    "Loglevel to output to file (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug)", 3);
-ConfigOptionInt backtraceLogLevelOption(
-    "Logger", "BacktraceLevel",
-    "Loglevel to print a backtrace on (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug)",
-    1);
-ConfigOptionString logFileOption("Logger", "File", "File to write log to", LOG_PATH LOGFILE);
-ConfigOptionBool showDialogOnErrorOption("Logger", "ShowDialog", "Show dialog on error", true);
-
 #if defined(BACKTRACE_LIBUNWIND)
-static void print_backtrace(FILE *f)
+std::list<UString> getBacktrace()
 {
 	unw_cursor_t cursor;
 	unw_context_t ctx;
@@ -84,7 +34,8 @@ static void print_backtrace(FILE *f)
 	unw_getcontext(&ctx);
 	unw_init_local(&cursor, &ctx);
 
-	fprintf(f, "  called by:\n");
+	std::list<UString> backtrace;
+
 	while (unw_step(&cursor) > 0)
 	{
 		Dl_info info;
@@ -94,9 +45,10 @@ static void print_backtrace(FILE *f)
 		dladdr(reinterpret_cast<void *>(ip), &info);
 		if (info.dli_sname)
 		{
-			fprintf(f, "  0x%zx %s+0x%zx (%s)\n", static_cast<uintptr_t>(ip), info.dli_sname,
-			        static_cast<uintptr_t>(ip) - reinterpret_cast<uintptr_t>(info.dli_saddr),
-			        info.dli_fname);
+			backtrace.push_back(
+			    format("  0x%zx %s+0x%zx (%s)\n", static_cast<uintptr_t>(ip), info.dli_sname,
+			           static_cast<uintptr_t>(ip) - reinterpret_cast<uintptr_t>(info.dli_saddr),
+			           info.dli_fname));
 			continue;
 		}
 		// If dladdr() failed, try libunwind
@@ -104,17 +56,18 @@ static void print_backtrace(FILE *f)
 		char fnName[MAX_SYMBOL_LENGTH];
 		if (!unw_get_proc_name(&cursor, fnName, MAX_SYMBOL_LENGTH, &offsetInFn))
 		{
-			fprintf(f, "  0x%zx %s+0x%zx (%s)\n", static_cast<uintptr_t>(ip), fnName, offsetInFn,
-			        info.dli_fname);
+			backtrace.push_back(format("  0x%zx %s+0x%zx (%s)\n", static_cast<uintptr_t>(ip),
+			                           fnName, offsetInFn, info.dli_fname));
 			continue;
 		}
 		else
-			fprintf(f, "  0x%zx\n", static_cast<uintptr_t>(ip));
+			backtrace.push_back(format("  0x%zx\n", static_cast<uintptr_t>(ip)));
 	}
+	return backtrace;
 }
 #elif defined(BACKTRACE_WINDOWS)
 #define MAX_STACK_FRAMES 100
-static void print_backtrace(FILE *f)
+std::list<UString> getBacktrace()
 {
 	static bool initialised = false;
 	static HANDLE process;
@@ -122,6 +75,7 @@ static void print_backtrace(FILE *f)
 	unsigned int frames;
 	void *ip[MAX_STACK_FRAMES];
 	SYMBOL_INFO *sym;
+	std::list<UString> backtrace;
 
 	if (!initialised)
 	{
@@ -132,189 +86,90 @@ static void print_backtrace(FILE *f)
 
 	if (!process)
 	{
-		fprintf(f, "Failed to get process for backtrace\n");
-		return;
+		return backtrace;
 	}
 
 	sym = (SYMBOL_INFO *)calloc(sizeof(SYMBOL_INFO) + MAX_SYMBOL_LENGTH * (sizeof(char)), 1);
 	if (!sym)
 	{
-		fprintf(f, "Failed to allocate symbol info for backtrace\n");
-		return;
+		return backtrace;
 	}
 	sym->MaxNameLen = MAX_SYMBOL_LENGTH;
 	sym->SizeOfStruct = sizeof(SYMBOL_INFO);
 
-	/* Skip 2 frames (print_backtrace and the LogError function itself) */
-	frames = CaptureStackBackTrace(2, MAX_STACK_FRAMES, ip, NULL);
+	/* Skip 1 frame (getBacktrace and the LogError function itself) */
+	frames = CaptureStackBackTrace(1, MAX_STACK_FRAMES, ip, NULL);
 
 	for (unsigned int frame = 0; frame < frames; frame++)
 	{
 		SymFromAddr(process, (DWORD64)(ip[frame]), 0, sym);
-		fprintf(f, "  0x%p %s+0x%Ix\n", ip[frame], sym->Name,
-		        (uintptr_t)ip[frame] - (uintptr_t)sym->Address);
+		backtrace.push_back(format("  0x%p %s+0x%Ix\n", ip[frame], sym->Name,
+		                           (uintptr_t)ip[frame] - (uintptr_t)sym->Address));
 	}
 
 	free(sym);
+	return backtrace;
 }
 #else
 #warning no backtrace enabled for this platform
-static void print_backtrace(FILE *f)
+std::list<UString> getBacktrace()
 {
 	// TODO: Other platform backtrace?
+	return {};
 }
 #endif
 
-static FILE *outFile = nullptr;
+static std::mutex loggerMutex;
 
-// We store options after init as querying every LogInfo() takes a long time
-
-LogLevel stderrLogLevel;
-LogLevel fileLogLevel;
-LogLevel backtraceLogLevel;
-bool showDialogOnError;
-
-std::atomic<bool> loggerInited = false;
-
-static std::mutex logMutex;
-static std::chrono::time_point<std::chrono::high_resolution_clock> timeInit =
-    std::chrono::high_resolution_clock::now();
-
-static void initLogger()
+void defaultLogFunction(LogLevel level, UString prefix, const UString &text)
 {
-	std::lock_guard<std::mutex> lock(logMutex);
-	// It's possible we've raced and hit initLogger() from more than 1 thread, so check again with
-	// the logMutex held
-	if (loggerInited)
-		return;
-	outFile = NULL;
-
-	// Handle Log calls before the settings are read, just output everything to stdout
-
-	if (!ConfigFile::getInstance().loaded())
+	UString levelPrefix;
+	switch (level)
 	{
-		stderrLogLevel = LogLevel::Debug;
-		fileLogLevel = LogLevel::Nothing;
-		backtraceLogLevel = LogLevel::Nothing;
-		showDialogOnError = false;
-		// Returning without setting loggerInited causes this to be called every Log call until the
-		// config is parsed
-		return;
+		case LogLevel::Error:
+			levelPrefix = "E";
+			break;
+		case LogLevel::Warning:
+			levelPrefix = "W";
+			break;
+		case LogLevel::Info:
+			levelPrefix = "I";
+			break;
+		case LogLevel::Debug:
+			levelPrefix = "D";
+			break;
+		default:
+			levelPrefix = "U";
+			break;
 	}
-
-	loggerInited = true;
-
-	stderrLogLevel = (LogLevel)stderrLogLevelOption.get();
-	fileLogLevel = (LogLevel)fileLogLevelOption.get();
-	backtraceLogLevel = (LogLevel)backtraceLogLevelOption.get();
-	showDialogOnError = showDialogOnErrorOption.get();
-
-	auto logFilePath = logFileOption.get();
-	if (logFilePath.empty())
-	{
-		// No log file set, disabling logging to file
-		fileLogLevel = LogLevel::Nothing;
-		return;
-	}
-	outFile = fopen(logFilePath.cStr(), "w");
-	if (!outFile)
-	{
-		// Failed to open log file, disabling logging to file
-		fileLogLevel = LogLevel::Nothing;
-		return;
-	}
+	std::cerr << levelPrefix << " " << prefix << " " << text << std::endl;
 }
 
-bool _logLevelEnabled(LogLevel level)
+static LogFunction logFunction = defaultLogFunction;
+
+void Log(LogLevel level, UString prefix, const UString &text)
 {
-	if (!loggerInited)
-	{
-		initLogger();
-	}
-	return level <= stderrLogLevel || level <= fileLogLevel;
+	std::lock_guard<std::mutex> lock(loggerMutex);
+	logFunction(level, prefix, text);
 }
 
 void _logAssert(UString prefix, UString string, int line, UString file)
 {
-	Log(LogLevel::Error, prefix,
-	    ::OpenApoc::format("Assertion \"%s\" failed at %s:%d", string.cStr(), file.cStr(), line));
-	exit(EXIT_FAILURE);
+	Log(LogLevel::Error, prefix, format("%s:%d Assertion failed %s", file, line, string));
+	exit(1);
 }
 
-void Log(LogLevel level, UString prefix, const UString &text)
+void setLogCallback(LogFunction function)
 {
-	bool exit_app = false;
-	const char *level_prefix;
-	if (!loggerInited)
-	{
-		initLogger();
-	}
+	std::lock_guard<std::mutex> lock(loggerMutex);
+	logFunction = function;
+}
 
-	{
-		std::lock_guard<std::mutex> lock(logMutex);
+LogFunction getLogCallback()
+{
 
-		bool writeToFile = (level <= fileLogLevel);
-		bool writeToStderr = (level <= stderrLogLevel);
-		if (!writeToFile && !writeToStderr)
-		{
-			// Nothing to do
-			return;
-		}
-
-		auto timeNow = std::chrono::high_resolution_clock::now();
-		unsigned long long clockns =
-		    std::chrono::duration<unsigned long long, std::nano>(timeNow - timeInit).count();
-
-		switch (level)
-		{
-			case LogLevel::Debug:
-				level_prefix = "D";
-				break;
-			case LogLevel::Info:
-				level_prefix = "I";
-				break;
-			case LogLevel::Warning:
-				level_prefix = "W";
-				break;
-			default:
-				level_prefix = "E";
-				exit_app = true;
-				break;
-		}
-
-		if (writeToFile)
-		{
-			fprintf(outFile, "%s %llu %s: %s\n", level_prefix, clockns, prefix.cStr(), text.cStr());
-			// On error print a backtrace to the log file
-			if (level <= backtraceLogLevel)
-				print_backtrace(outFile);
-			fflush(outFile);
-		}
-
-		if (writeToStderr)
-		{
-			fprintf(stderr, "%s %llu %s: %s\n", level_prefix, clockns, prefix.cStr(), text.cStr());
-			if (level <= backtraceLogLevel)
-				print_backtrace(stderr);
-			fflush(stderr);
-		}
-#if defined(ERROR_DIALOG)
-		if (showDialogOnError && level == LogLevel::Error)
-		{
-			SDL_Window *window = nullptr;
-			if (Framework::tryGetInstance() && fw().displayHasWindow())
-			{
-				window = static_cast<SDL_Window *>(fw().getWindowHandle());
-			}
-			SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenApoc error", text.cStr(), window);
-		}
-#endif
-	}
-
-	if (exit_app)
-	{
-		exit(EXIT_FAILURE);
-	}
+	std::lock_guard<std::mutex> lock(loggerMutex);
+	return logFunction;
 }
 
 }; // namespace OpenApoc

--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -124,6 +124,9 @@ static std::mutex loggerMutex;
 void defaultLogFunction(LogLevel level, UString prefix, const UString &text)
 {
 	UString levelPrefix;
+	// Only print Warning/Errors by default
+	if (level >= LogLevel::Info)
+		return;
 	switch (level)
 	{
 		case LogLevel::Error:

--- a/framework/logger.h
+++ b/framework/logger.h
@@ -54,8 +54,7 @@ std::list<UString> getBacktrace();
 NORETURN_FUNCTION void _logAssert(UString prefix, UString string, int line, UString file);
 
 /* Returns if the log level will be output (either to file or stderr or both) */
-bool _logLevelEnabled(LogLevel level);
-static inline bool logLevelEnabled(LogLevel level)
+static inline bool logLevelEnabled(LogLevel level [[maybe_unused]])
 {
 #ifdef NDEBUG
 	if (level >= LogLevel::Debug)

--- a/framework/logger_file.cpp
+++ b/framework/logger_file.cpp
@@ -14,39 +14,53 @@ ConfigOptionInt fileLogLevelOption(
     "Logger", "FileLevel",
     "Loglevel to output to file (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug)", 3);
 
+ConfigOptionInt backtraceLogLevelOption("Logger", "BacktraceLevel",
+                                        "Loglevel to print a backtrace to file log (0 = nothing, 1 "
+                                        "= error, 2 = warning, 3 = info, 4 = debug)",
+                                        1);
+
 LogFunction previousFunction; // To allow chaining log functions
 
 LogLevel fileLogLevel = LogLevel::Nothing;
+LogLevel backtraceLogLevel = LogLevel::Nothing;
 std::ofstream logFile;
 
 void FileLogFunction(LogLevel level, UString prefix, const UString &text)
 {
 	previousFunction(level, prefix, text);
-	if (level > fileLogLevel)
+	if (level <= fileLogLevel)
 	{
-		return;
+		UString levelPrefix;
+		switch (level)
+		{
+			case LogLevel::Error:
+				levelPrefix = "E";
+				break;
+			case LogLevel::Warning:
+				levelPrefix = "W";
+				break;
+			case LogLevel::Info:
+				levelPrefix = "I";
+				break;
+			case LogLevel::Debug:
+				levelPrefix = "D";
+				break;
+			default:
+				levelPrefix = "U";
+				break;
+		}
+		auto message = OpenApoc::format("%s %s: %s", levelPrefix, prefix, text);
+		logFile << message << std::endl;
 	}
-	UString levelPrefix;
-	switch (level)
+
+	if (level <= backtraceLogLevel)
 	{
-		case LogLevel::Error:
-			levelPrefix = "E";
-			break;
-		case LogLevel::Warning:
-			levelPrefix = "W";
-			break;
-		case LogLevel::Info:
-			levelPrefix = "I";
-			return;
-		case LogLevel::Debug:
-			levelPrefix = "D";
-			return;
-		default:
-			levelPrefix = "U";
-			break;
+		auto backtrace = getBacktrace();
+		for (const auto &frame : backtrace)
+		{
+			logFile << frame << std::endl;
+		}
 	}
-	auto message = OpenApoc::format("%s %s: %s", levelPrefix, prefix, text);
-	logFile << message << std::endl;
 }
 
 } // namespace
@@ -60,6 +74,7 @@ void enableFileLogger(const char *outputFile)
 		LogError("File logger failed to open file \"%s\"", outputFile);
 	}
 	fileLogLevel = (LogLevel)fileLogLevelOption.get();
+	backtraceLogLevel = (LogLevel)backtraceLogLevelOption.get();
 	previousFunction = getLogCallback();
 	setLogCallback(FileLogFunction);
 }

--- a/framework/logger_file.cpp
+++ b/framework/logger_file.cpp
@@ -1,0 +1,67 @@
+#include "framework/logger_file.h"
+#include "framework/configfile.h"
+#include "framework/logger.h"
+
+#include <fstream>
+
+namespace OpenApoc
+{
+
+namespace
+{
+
+ConfigOptionInt fileLogLevelOption(
+    "Logger", "FileLevel",
+    "Loglevel to output to file (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug)", 3);
+
+LogFunction previousFunction; // To allow chaining log functions
+
+LogLevel fileLogLevel = LogLevel::Nothing;
+std::ofstream logFile;
+
+void FileLogFunction(LogLevel level, UString prefix, const UString &text)
+{
+	previousFunction(level, prefix, text);
+	if (level > fileLogLevel)
+	{
+		return;
+	}
+	UString levelPrefix;
+	switch (level)
+	{
+		case LogLevel::Error:
+			levelPrefix = "E";
+			break;
+		case LogLevel::Warning:
+			levelPrefix = "W";
+			break;
+		case LogLevel::Info:
+			levelPrefix = "I";
+			return;
+		case LogLevel::Debug:
+			levelPrefix = "D";
+			return;
+		default:
+			levelPrefix = "U";
+			break;
+	}
+	auto message = OpenApoc::format("%s %s: %s", levelPrefix, prefix, text);
+	logFile << message << std::endl;
+}
+
+} // namespace
+
+void enableFileLogger(const char *outputFile)
+{
+	LogAssert(outputFile);
+	logFile.open(outputFile);
+	if (!logFile.good())
+	{
+		LogError("File logger failed to open file \"%s\"", outputFile);
+	}
+	fileLogLevel = (LogLevel)fileLogLevelOption.get();
+	previousFunction = getLogCallback();
+	setLogCallback(FileLogFunction);
+}
+
+} // namespace OpenApoc

--- a/framework/logger_file.h
+++ b/framework/logger_file.h
@@ -1,0 +1,6 @@
+#pragma once
+
+namespace OpenApoc
+{
+void enableFileLogger(const char *outputFile);
+} // namespace OpenApoc

--- a/framework/logger_sdldialog.cpp
+++ b/framework/logger_sdldialog.cpp
@@ -1,0 +1,50 @@
+#include "framework/logger_sdldialog.h"
+#include "framework/configfile.h"
+#include "framework/logger.h"
+
+#include <SDL_messagebox.h>
+#include <atomic>
+
+namespace OpenApoc
+{
+
+namespace
+{
+
+ConfigOptionInt dialogLogLevelOption(
+    "Logger", "dialogLevel",
+    "Loglevel to pop up a dialog(0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug) ", 1);
+
+LogFunction previousFunction; // To allow chaining log functions
+
+std::atomic<SDL_Window *> parentWindow = nullptr;
+LogLevel dialogLogLevel = LogLevel::Nothing;
+
+void SDLDialogLogFunction(LogLevel level, UString prefix, const UString &text)
+{
+	previousFunction(level, prefix, text);
+	if (level > dialogLogLevel)
+	{
+		return;
+	}
+	auto message = OpenApoc::format("%s: %s", prefix, text);
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenApoc error", message.cStr(), parentWindow);
+}
+
+} // namespace
+
+void enableSDLDialogLogger(SDL_Window *win)
+{
+	LogAssert(win);
+	if (parentWindow)
+	{
+		LogError("SDL Dialog already enabled");
+		return;
+	}
+	parentWindow = win;
+	dialogLogLevel = (LogLevel)dialogLogLevelOption.get();
+	previousFunction = getLogCallback();
+	setLogCallback(SDLDialogLogFunction);
+}
+
+} // namespace OpenApoc

--- a/framework/logger_sdldialog.h
+++ b/framework/logger_sdldialog.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <SDL.h>
+
+namespace OpenApoc
+{
+void enableSDLDialogLogger(SDL_Window *win);
+} // namespace OpenApoc


### PR DESCRIPTION
Use callbacks for each log output option (file, SDL dialog), with a default of "anything warning and above to stderr"

This is a prerequisite for things to wrap the Framework where you might want to get logs out - like an editor or something ;)