### PR TITLE
Disable gamestate CRC checksums by default

### DIFF
--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -21,7 +21,7 @@
 namespace OpenApoc
 {
 ConfigOptionBool useCRCChecksum("Framework.Serialization", "CRC",
-                                "use a CRC checksum when saving files", true);
+                                "use a CRC checksum when saving files", false);
 ConfigOptionBool useSHA1Checksum("Framework.Serialization", "SHA1",
                                  "use a SHA1 checksum when saving files", false);
 


### PR DESCRIPTION
They aren't really that useful, I added them to detect damaged or partially
updated gamestate trees - but haven't seen that in so long the extra annoyance
to modmakers modifying stuff doesn't seem worth it