### PR TITLE
Ensure all option definitions are linked to all tools

### DIFF
--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -8,6 +8,7 @@
 #include "framework/font.h"
 #include "framework/framework.h"
 #include "framework/image.h"
+#include "framework/options.h"
 #include "framework/renderer.h"
 #include "framework/sound.h"
 #include "framework/trace.h"
@@ -15,9 +16,6 @@
 
 namespace OpenApoc
 {
-
-ConfigOptionString defaultTooltipFont("Forms", "TooltipFont", "The default tooltip font",
-                                      "smallset");
 
 Control::Control(bool takesFocus)
     : funcPreRender(nullptr), mouseInside(false), mouseDepressed(false), resolvedLocation(0, 0),
@@ -28,7 +26,7 @@ Control::Control(bool takesFocus)
       ToolTipBackground{128, 128, 128}, ToolTipBorders{
                                             {1, {0, 0, 0}}, {1, {255, 255, 255}}, {1, {0, 0, 0, 0}}}
 {
-	this->ToolTipFont = ui().getFont(defaultTooltipFont.get());
+	this->ToolTipFont = ui().getFont(Options::defaultTooltipFont.get());
 }
 
 Control::~Control() { unloadResources(); }

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -29,7 +29,8 @@ set (FRAMEWORK_SOURCE_FILES
 	trace.cpp
 	video/smk.cpp
 	logger_sdldialog.cpp
-	logger_file.cpp)
+	logger_file.cpp
+	options.cpp)
 
 source_group(framework\\sources FILES ${FRAMEWORK_SOURCE_FILES})
 list(APPEND ALL_SOURCE_FILES ${FRAMEWORK_SOURCE_FILES})
@@ -65,7 +66,8 @@ set (FRAMEWORK_HEADER_FILES
 	ThreadPool/ThreadPool.h
 	video.h
 	logger_sdldialog.h
-	logger_file.h)
+	logger_file.h
+	options.h)
 
 source_group(framework\\headers FILES ${FRAMEWORK_HEADER_FILES})
 list(APPEND ALL_HEADER_FILES ${FRAMEWORK_HEADER_FILES})

--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -5,6 +5,7 @@
 #include "framework/configfile.h"
 #include "framework/filesystem.h"
 #include "framework/logger.h"
+#include "framework/options.h"
 #include <fstream>
 #include <iostream>
 #include <list>
@@ -189,6 +190,8 @@ class ConfigFileImpl
 			this->showHelp();
 			return true;
 		}
+
+		Options::dumpOptionsToLog();
 
 		return false;
 	}

--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -191,8 +191,6 @@ class ConfigFileImpl
 			return true;
 		}
 
-		Options::dumpOptionsToLog();
-
 		return false;
 	}
 

--- a/framework/configfile.h
+++ b/framework/configfile.h
@@ -70,8 +70,9 @@ class ConfigOption
 
   public:
 	ConfigOption(const UString section, const UString name, const UString description);
-	UString getName() const { return name; }
-	UString getDescription() const { return description; }
+	const UString &getName() const { return name; }
+	const UString &getSection() const { return section; }
+	const UString &getDescription() const { return description; }
 	UString getKey() const;
 };
 

--- a/framework/data.cpp
+++ b/framework/data.cpp
@@ -10,6 +10,7 @@
 #include "framework/imageloader_interface.h"
 #include "framework/logger.h"
 #include "framework/musicloader_interface.h"
+#include "framework/options.h"
 #include "framework/palette.h"
 #include "framework/sampleloader_interface.h"
 #include "framework/trace.h"
@@ -26,17 +27,6 @@ using namespace OpenApoc;
 
 namespace OpenApoc
 {
-
-ConfigOptionInt imageCacheSize("Framework.Data", "ImageCacheSize",
-                               "Number of Images to keep in data cache", 100);
-ConfigOptionInt imageSetCacheSize("Framework.Data", "ImageSetCacheSize",
-                                  "Number of ImageSets to keep in data cache", 10);
-ConfigOptionInt voxelCacheSize("Framework.Data", "VoxelCacheSize",
-                               "Number of VoxelMaps to keep in data cache", 1);
-ConfigOptionInt fontStringCacheSize("Framework.Data", "FontStringCacheSize",
-                                    "Number of rendered font stings to keep in data cache", 100);
-ConfigOptionInt paletteCacheSize("Framework.Data", "PaletteCacheSize",
-                                 "Number of Palettes to keep in data cache", 10);
 
 class DataImpl final : public Data
 {
@@ -176,15 +166,15 @@ DataImpl::DataImpl(std::vector<UString> paths) : Data(paths)
 		else
 			LogWarning("Failed to load music loader %s", t);
 	}
-	for (int i = 0; i < imageCacheSize.get(); i++)
+	for (int i = 0; i < Options::imageCacheSize.get(); i++)
 		pinnedImages.push(nullptr);
-	for (int i = 0; i < imageSetCacheSize.get(); i++)
+	for (int i = 0; i < Options::imageSetCacheSize.get(); i++)
 		pinnedImageSets.push(nullptr);
-	for (int i = 0; i < voxelCacheSize.get(); i++)
+	for (int i = 0; i < Options::voxelCacheSize.get(); i++)
 		pinnedLOFVoxels.push(nullptr);
-	for (int i = 0; i < fontStringCacheSize.get(); i++)
+	for (int i = 0; i < Options::fontStringCacheSize.get(); i++)
 		pinnedFontStrings.push(nullptr);
-	for (int i = 0; i < paletteCacheSize.get(); i++)
+	for (int i = 0; i < Options::paletteCacheSize.get(); i++)
 		pinnedPalettes.push(nullptr);
 
 	this->readAliases();

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -9,6 +9,7 @@
 #include "framework/image.h"
 #include "framework/logger_file.h"
 #include "framework/logger_sdldialog.h"
+#include "framework/options.h"
 #include "framework/renderer.h"
 #include "framework/renderer_interface.h"
 #include "framework/sound_interface.h"
@@ -40,269 +41,12 @@
 
 using namespace OpenApoc;
 
-namespace
-{
-
-#ifndef DATA_DIRECTORY
-#define DATA_DIRECTORY "./data"
-#endif
-
-#ifndef RENDERERS
-#ifdef _WIN32
-#pragma message("WARNING: Using default renderer list")
-#else
-#warning RENDERERS not set - using default list
-#endif
-#define RENDERERS "GLES_3_0:GL_2_0"
-#endif
-
-ConfigOptionString dataPathOption("Framework", "Data", "The path containing OpenApoc data",
-                                  "./data");
-ConfigOptionString cdPathOption("Framework", "CD", "The path to the XCom:Apocalypse CD",
-                                "./data/cd.iso");
-ConfigOptionInt threadPoolSizeOption(
-    "Framework", "ThreadPoolSize",
-    "The number of threads to spawn for the threadpool (0 = queried num_cores)", 0);
-ConfigOptionString renderersOption("Framework", "Renderers",
-                                   "':' separated list of renderer backends (in preference order)",
-                                   RENDERERS);
-ConfigOptionString audioBackendsOption("Framework", "AudioBackends",
-                                       "':' separated list of audio backends (in preference order)",
-                                       "SDLRaw:null");
-ConfigOptionInt audioGlobalGainOption("Framework.Audio", "GlobalGain", "Global audio gain (0-20)",
-                                      20);
-ConfigOptionInt audioSampleGainOption("Framework.Audio", "SampleGain", "Sample audio gain (0-20)",
-                                      20);
-ConfigOptionInt audioMusicGainOption("Framework.Audio", "MusicGain", "Music audio gain (0-20)", 20);
-ConfigOptionInt screenWidthOption("Framework.Screen", "Width", "Initial screen width (in pixels)",
-                                  1280);
-ConfigOptionInt screenHeightOption("Framework.Screen", "Height",
-                                   "Initial screen height (in pixels)", 720);
-ConfigOptionBool screenFullscreenOption("Framework.Screen", "Fullscreen", "Enable fullscreen mode",
-                                        false);
-ConfigOptionInt screenScaleXOption("Framework.Screen", "ScaleX",
-                                   "Scale screen in X direction by (percent)", 100);
-ConfigOptionInt screenScaleYOption("Framework.Screen", "ScaleY",
-                                   "Scale screen in Y direction by (percent)", 100);
-ConfigOptionString languageOption("Framework", "Language",
-                                  "The language used ingame (empty for system default)", "");
-
-ConfigOptionInt frameLimit("Framework", "FrameLimit", "Quit after this many frames - 0 = unlimited",
-                           0);
-ConfigOptionInt swapInterval("Framework", "SwapInterval",
-                             "Swap interval (0 = tear, 1 = wait for vsync", 0);
-
-ConfigOptionBool autoScrollOption("Options.Misc", "AutoScroll", "Enable scrolling with mouse",
-                                  true);
-ConfigOptionBool actionMusicOption("Options.Misc", "ActionMusic",
-                                   "Music changes according to action in battle", true);
-ConfigOptionBool autoExecuteOption("Options.Misc", "AutoExecute",
-                                   "Execute remaining orders when player presses end turn button",
-                                   false);
-ConfigOptionInt toolTipDelay("Options.Misc", "ToolTipDelay",
-                             "Delay in milliseconds before showing tooltips (<= 0 to disable)",
-                             500);
-
-ConfigOptionBool optionPauseOnUfoSpotted("Notifications.City", "UfoSpotted", "UFO spotted", true);
-ConfigOptionBool optionPauseOnVehicleLightDamage("Notifications.City", "VehicleLightDamage",
-                                                 "Vehicle lightly damaged", true);
-ConfigOptionBool optionPauseOnVehicleModerateDamage("Notifications.City", "VehicleModerateDamage",
-                                                    "Vehicle moderately damaged", true);
-ConfigOptionBool optionPauseOnVehicleHeavyDamage("Notifications.City", "VehicleHeavyDamage",
-                                                 "Vehicle heavily damaged", true);
-ConfigOptionBool optionPauseOnVehicleDestroyed("Notifications.City", "VehicleDestroyed",
-                                               "Vehicle destroyed", true);
-ConfigOptionBool optionPauseOnVehicleEscaping("Notifications.City", "VehicleEscaping",
-                                              "Vehicle damaged and returning to base", true);
-ConfigOptionBool optionPauseOnVehicleNoAmmo("Notifications.City", "VehicleNoAmmo",
-                                            "Weapon out of ammo", true);
-ConfigOptionBool optionPauseOnVehicleLowFuel("Notifications.City", "VehicleLowFuel",
-                                             "Vehicle low on fuel", true);
-ConfigOptionBool optionPauseOnAgentDiedCity("Notifications.City", "AgentDiedCity", "Agent has died",
-                                            true);
-ConfigOptionBool optionPauseOnAgentArrived("Notifications.City", "AgentArrived",
-                                           "Agent arrived at base", true);
-ConfigOptionBool optionPauseOnCargoArrived("Notifications.City", "CargoArrived",
-                                           "Cargo has arrived at base", true);
-ConfigOptionBool optionPauseOnTransferArrived("Notifications.City", "TransferArrived",
-                                              "Transfer arrived at base", true);
-ConfigOptionBool optionPauseOnRecoveryArrived("Notifications.City", "RecoveryArrived",
-                                              "Crash recovery arrived at base", true);
-ConfigOptionBool optionPauseOnVehicleRepaired("Notifications.City", "VehicleRepaired",
-                                              "Vehicle repaired", true);
-ConfigOptionBool optionPauseOnVehicleRearmed("Notifications.City", "VehicleRearmed",
-                                             "Vehicle rearmed", true);
-ConfigOptionBool optionPauseOnNotEnoughAmmo("Notifications.City", "NotEnoughAmmo",
-                                            "Not enough ammo to rearm vehicle", true);
-ConfigOptionBool optionPauseOnVehicleRefuelled("Notifications.City", "VehicleRefuelled",
-                                               "Vehicle refuelled", true);
-ConfigOptionBool optionPauseOnNotEnoughFuel("Notifications.City", "NotEnoughFuel",
-                                            "Not enough fuel to refuel vehicle", true);
-ConfigOptionBool optionPauseOnUnauthorizedVehicle("Notifications.City", "UnauthorizedVehicle",
-                                                  "Unauthorized vehicle detected", true);
-ConfigOptionBool optionPauseOnHostileSpotted("Notifications.Battle", "HostileSpotted",
-                                             "Hostile unit spotted", true);
-ConfigOptionBool optionPauseOnHostileDied("Notifications.Battle", "HostileDied",
-                                          "Hostile unit has died", true);
-ConfigOptionBool optionPauseOnUnknownDied("Notifications.Battle", "UnknownDied",
-                                          "Unknown Unit has died", true);
-ConfigOptionBool optionPauseOnAgentDiedBattle("Notifications.Battle", "AgentDiedBattle",
-                                              "Unit has died", true);
-ConfigOptionBool optionPauseOnAgentBrainsucked("Notifications.Battle", "AgentBrainsucked",
-                                               "Unit Brainsucked", true);
-ConfigOptionBool optionPauseOnAgentCriticallyWounded("Notifications.Battle",
-                                                     "AgentCriticallyWounded",
-                                                     "Unit critically wounded", true);
-ConfigOptionBool optionPauseOnAgentBadlyInjured("Notifications.Battle", "AgentBadlyInjured",
-                                                "Unit badly injured", true);
-ConfigOptionBool optionPauseOnAgentInjured("Notifications.Battle", "AgentInjured", "Unit injured",
-                                           true);
-ConfigOptionBool optionPauseOnAgentUnderFire("Notifications.Battle", "AgentUnderFire",
-                                             "Unit under fire", true);
-ConfigOptionBool optionPauseOnAgentUnconscious("Notifications.Battle", "AgentUnconscious",
-                                               "Unit has lost consciousness", true);
-ConfigOptionBool optionPauseOnAgentLeftCombat("Notifications.Battle", "AgentLeftCombat",
-                                              "Unit has left combat zone", true);
-ConfigOptionBool optionPauseOnAgentFrozen("Notifications.Battle", "AgentFrozen", "Unit has frozen",
-                                          true);
-ConfigOptionBool optionPauseOnAgentBerserk("Notifications.Battle", "AgentBerserk",
-                                           "Unit has gone beserk", true);
-ConfigOptionBool optionPauseOnAgentPanicked("Notifications.Battle", "AgentPanicked",
-                                            "Unit has panicked", true);
-ConfigOptionBool optionPauseOnAgentPanicOver("Notifications.Battle", "AgentPanicOver",
-                                             "Unit has stopped panicking", true);
-ConfigOptionBool optionPauseOnAgentPsiAttacked("Notifications.Battle", "AgentPsiAttacked",
-                                               "Psionic attack on unit", true);
-ConfigOptionBool optionPauseOnAgentPsiControlled("Notifications.Battle", "AgentPsiControlled",
-                                                 "Unit under Psionic control", true);
-ConfigOptionBool optionPauseOnAgentPsiOver("Notifications.Battle", "AgentPsiOver",
-                                           "Unit freed from Psionic control", true);
-
-ConfigOptionBool optionUFODamageModel("OpenApoc.NewFeature", "UFODamageModel",
-                                      "X-Com 1 Damage model (0-200%)", false);
-ConfigOptionBool optionInstantExplosionDamage("OpenApoc.NewFeature", "InstantExplosionDamage",
-                                              "Explosions damage instantly", false);
-ConfigOptionBool optionGravliftSounds("OpenApoc.NewFeature", "GravliftSounds", "Gravlift sounds",
-                                      true);
-ConfigOptionBool optionNoInstantThrows("OpenApoc.NewFeature", "NoInstantThrows",
-                                       "Throwing requires proper facing and pose", true);
-ConfigOptionBool optionFerryChecksRelationshipWhenBuying(
-    "OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying",
-    "Transtellar checks relationship when buying items", true);
-ConfigOptionBool optionAllowManualCityTeleporters("OpenApoc.NewFeature",
-                                                  "AllowManualCityTeleporters",
-                                                  "Allow manual use of teleporters in city", true);
-ConfigOptionBool optionAllowManualCargoFerry("OpenApoc.NewFeature", "AllowManualCargoFerry",
-                                             "Allow manual ferrying of cargo and non-combatants",
-                                             true);
-ConfigOptionBool optionAllowSoldierTaxiUse("OpenApoc.NewFeature", "AllowSoldierTaxiUse",
-                                           "Allow soldiers to call taxi", true);
-ConfigOptionBool optionAllowUnloadingClips("OpenApoc.NewFeature", "AdvancedInventoryControls",
-                                           "Allow unloading clips and quick equip", true);
-ConfigOptionBool optionPayloadExplosion("OpenApoc.NewFeature", "PayloadExplosion",
-                                        "Ammunition explodes when blown up", true);
-ConfigOptionBool optionDisplayUnitPaths("OpenApoc.NewFeature", "DisplayUnitPaths",
-                                        "Display unit paths in battle", true);
-ConfigOptionBool optionAdditionalUnitIcons("OpenApoc.NewFeature", "AdditionalUnitIcons",
-                                           "Display additional unit icons (fatal, psi)", true);
-ConfigOptionBool optionAllowForceFiringParallel("OpenApoc.NewFeature", "AllowForceFiringParallel",
-                                                "Allow force-firing parallel to the ground", true);
-ConfigOptionBool optionRequireLOSToMaintainPsi("OpenApoc.NewFeature", "RequireLOSToMaintainPsi",
-                                               "Require LOS to maintain psi attack", true);
-ConfigOptionBool optionAllowAttackingOwnedVehicles("OpenApoc.NewFeature",
-                                                   "AllowAttackingOwnedVehicles",
-                                                   "Allow attacking owned vehicles", true);
-ConfigOptionBool optionCallExistingFerry("OpenApoc.NewFeature", "CallExistingFerry",
-                                         "Call existing transport instead of spawning them", true);
-ConfigOptionBool
-    optionAlternateVehicleShieldSound("OpenApoc.NewFeature", "AlternateVehicleShieldSound",
-                                      "Hitting vehicle shield produces alternate sound", true);
-ConfigOptionBool optionEnableAgentTemplates("OpenApoc.NewFeature", "EnableAgentTemplates",
-                                            "Enable agent equipment templates", true);
-ConfigOptionBool optionStoreDroppedEquipment("OpenApoc.NewFeature", "StoreDroppedEquipment",
-                                             "Attempt to recover agent equipment dropped in city",
-                                             true);
-ConfigOptionBool optionFallingGroundVehicles("OpenApoc.NewFeature", "CrashingGroundVehicles",
-                                             "Unsupported ground vehicles crash", true);
-
-ConfigOptionBool optionEnforceCargoLimits("OpenApoc.NewFeature", "EnforceCargoLimits",
-                                          "Enforce vehicle cargo limits", false);
-ConfigOptionBool optionAllowNearbyVehicleLootPickup("OpenApoc.NewFeature",
-                                                    "AllowNearbyVehicleLootPickup",
-                                                    "Allow nearby vehicles to pick up loot", true);
-ConfigOptionBool optionAllowBuildingLootDeposit("OpenApoc.NewFeature", "AllowBuildingLootDeposit",
-                                                "Allow loot to be stashed in the building", true);
-ConfigOptionBool optionArmoredRoads("OpenApoc.NewFeature", "ArmoredRoads", "Armored roads", true);
-ConfigOptionBool optionVanillaCityControls("OpenApoc.NewFeature", "OpenApocCityControls",
-                                           "Improved city control scheme", true);
-ConfigOptionBool optionCollapseRaidedBuilding("OpenApoc.NewFeature", "CollapseRaidedBuilding",
-                                              "Successful raid collapses building", true);
-ConfigOptionBool
-    optionScrambleOnUnintentionalHit("OpenApoc.NewFeature", "ScrambleOnUnintentionalHit",
-                                     "Any hit on hostile building provokes retaliation", false);
-ConfigOptionBool optionMarketRight("OpenApoc.NewFeature", "MarketOnRight",
-                                   "Put market stock on the right side", true);
-ConfigOptionBool optionDGCrashingVehicles("OpenApoc.NewFeature", "CrashingDimensionGate",
-                                          "Uncapable vehicles crash when entering gates", true);
-ConfigOptionBool optionFuelCrashingVehicles("OpenApoc.NewFeature", "CrashingOutOfFuel",
-                                            "Vehicles crash when out of fuel", true);
-ConfigOptionBool optionSkipTurbo("OpenApoc.NewFeature", "SkipTurboMovement",
-                                 "Skip turbo movement calculations", false);
-ConfigOptionBool optionRunAndKneel("OpenApoc.NewFeature", "RunAndKneel",
-                                   "All units run and kneel by default", false);
-ConfigOptionBool optionSeedRng("OpenApoc.NewFeature", "SeedRng", "Seed RNG on game start", true);
-
-ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
-                                         "Stunning hurts relationships", false);
-ConfigOptionBool optionRaidHostileAction("OpenApoc.Mod", "RaidHostileAction",
-                                         "Initiating raid hurts relationships", false);
-ConfigOptionBool optionBSKLauncherSound("OpenApoc.Mod", "BSKLauncherSound",
-                                        "(MOD) Original Brainsucker Launcher SFX", true);
-ConfigOptionBool optionInvulnerableRoads("OpenApoc.Mod", "InvulnerableRoads",
-                                         "(MOD) Invulnerable roads", false);
-ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes All-Terrain",
-                               true);
-
-ConfigOptionBool optionATVAPC("OpenApoc.Mod", "ATVAPC", "(MOD) Wolfhound APC becomes All-Terrain",
-                              true);
-
-ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
-                                        "Vehicles crash on low HP", false);
-
-ConfigOptionString optionScriptsList("OpenApoc.Mod", "ScriptsList",
-                                     "Semicolon-separated list of scripts to load",
-                                     "data/scripts/openapoc_base.lua;");
-
-ConfigOptionBool optionInfiniteAmmoCheat("OpenApoc.Cheat", "InfiniteAmmo",
-                                         "Infinite ammo for X-Com agents and vehicles", false);
-ConfigOptionFloat optionDamageInflictedMultiplierCheat("OpenApoc.Cheat",
-                                                       "DamageInflictedMultiplier",
-                                                       "Multiplier for damage inflicted by X-com",
-                                                       1.0);
-ConfigOptionFloat optionDamageReceivedMultiplierCheat("OpenApoc.Cheat", "DamageReceivedMultiplier",
-                                                      "Multiplier for damage received by X-com",
-                                                      1.0);
-ConfigOptionFloat optionHostilesMultiplierCheat("OpenApoc.Cheat", "HostilesMultiplier",
-                                                "Multiplier for number of hostiles", 1.0f);
-ConfigOptionFloat optionStatGrowthMultiplierCheat("OpenApoc.Cheat", "StatGrowthMultiplier",
-                                                  "Multiplier for agent stat growth", 1.0f);
-
-ConfigOptionBool optionEnableTouchEvents("Framework", "EnableTouchEvents", "Enable touch events",
-#ifdef ANDROID
-                                         true
-#else
-                                         false
-#endif
-);
-
-} // anonymous namespace
-
 namespace OpenApoc
 {
 
-UString Framework::getDataDir() const { return dataPathOption.get(); }
+UString Framework::getDataDir() const { return Options::dataPathOption.get(); }
 
-UString Framework::getCDPath() const { return cdPathOption.get(); }
+UString Framework::getCDPath() const { return Options::cdPathOption.get(); }
 
 Framework *Framework::instance = nullptr;
 
@@ -450,7 +194,7 @@ class FrameworkPrivate
 	FrameworkPrivate()
 	    : quitProgram(false), window(nullptr), context(0), displaySize(0, 0), windowSize(0, 0)
 	{
-		int threadPoolSize = threadPoolSizeOption.get();
+		int threadPoolSize = Options::threadPoolSizeOption.get();
 		if (threadPoolSize > 0)
 		{
 			LogInfo("Set thread pool size to %d", threadPoolSize);
@@ -524,9 +268,9 @@ Framework::Framework(const UString programName, bool createWindow)
 	// This is always set, the default being an empty string (which correctly chooses 'system
 	// language')
 	UString desiredLanguageName;
-	if (!languageOption.get().empty())
+	if (!Options::languageOption.get().empty())
 	{
-		desiredLanguageName = languageOption.get();
+		desiredLanguageName = Options::languageOption.get();
 	}
 
 	LogInfo("Setting up locale \"%s\"", desiredLanguageName);
@@ -534,8 +278,8 @@ Framework::Framework(const UString programName, bool createWindow)
 	boost::locale::generator gen;
 
 	std::vector<UString> resourcePaths;
-	resourcePaths.push_back(cdPathOption.get());
-	resourcePaths.push_back(dataPathOption.get());
+	resourcePaths.push_back(Options::cdPathOption.get());
+	resourcePaths.push_back(Options::dataPathOption.get());
 
 	for (auto &path : resourcePaths)
 	{
@@ -633,7 +377,7 @@ Framework *Framework::tryGetInstance() { return instance; }
 
 void Framework::run(sp<Stage> initialStage)
 {
-	size_t frameCount = frameLimit.get();
+	size_t frameCount = Options::frameLimit.get();
 	if (!createWindow)
 	{
 		LogError("Trying to run framework without window");
@@ -828,7 +572,7 @@ void Framework::translateSdlEvents()
 {
 	SDL_Event e;
 	Event *fwE;
-	bool touch_events_enabled = optionEnableTouchEvents.get();
+	bool touch_events_enabled = Options::optionEnableTouchEvents.get();
 
 	// FIXME: That's not the right way to figure out the primary finger!
 	int primaryFingerID = -1;
@@ -1060,11 +804,11 @@ void Framework::displayInitialise()
 	SDL_GL_SetAttribute(SDL_GL_ALPHA_SIZE, 8);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 
-	SDL_GL_SetSwapInterval(swapInterval.get());
+	SDL_GL_SetSwapInterval(Options::swapInterval.get());
 
-	int scrW = screenWidthOption.get();
-	int scrH = screenHeightOption.get();
-	bool scrFS = screenFullscreenOption.get();
+	int scrW = Options::screenWidthOption.get();
+	int scrH = Options::screenHeightOption.get();
+	bool scrFS = Options::screenFullscreenOption.get();
 
 	if (scrW < 640 || scrH < 480)
 	{
@@ -1140,7 +884,7 @@ void Framework::displayInitialise()
 	p->registeredRenderers["GL_2_0"].reset(getGL20RendererFactory());
 #endif
 
-	for (auto &rendererName : renderersOption.get().split(':'))
+	for (auto &rendererName : Options::renderersOption.get().split(':'))
 	{
 		auto rendererFactory = p->registeredRenderers.find(rendererName);
 		if (rendererFactory == p->registeredRenderers.end())
@@ -1171,8 +915,8 @@ void Framework::displayInitialise()
 
 	// FIXME: Scale is currently stored as an integer in 1/100 units (ie 100 is 1.0 == same
 	// size)
-	int scaleX = screenScaleXOption.get();
-	int scaleY = screenScaleYOption.get();
+	int scaleX = Options::screenScaleXOption.get();
+	int scaleY = Options::screenScaleYOption.get();
 
 	if (scaleX != 100 || scaleY != 100)
 	{
@@ -1269,7 +1013,7 @@ void Framework::audioInitialise()
 	p->registeredSoundBackends["SDLRaw"].reset(getSDLSoundBackend());
 	p->registeredSoundBackends["null"].reset(getNullSoundBackend());
 
-	for (auto &soundBackendName : audioBackendsOption.get().split(':'))
+	for (auto &soundBackendName : Options::audioBackendsOption.get().split(':'))
 	{
 		auto backendFactory = p->registeredSoundBackends.find(soundBackendName);
 		if (backendFactory == p->registeredSoundBackends.end())
@@ -1295,11 +1039,11 @@ void Framework::audioInitialise()
 
 	/* Setup initial gain */
 	this->soundBackend->setGain(SoundBackend::Gain::Global,
-	                            static_cast<float>(audioGlobalGainOption.get()) / 20.0f);
+	                            static_cast<float>(Options::audioGlobalGainOption.get()) / 20.0f);
 	this->soundBackend->setGain(SoundBackend::Gain::Music,
-	                            static_cast<float>(audioMusicGainOption.get()) / 20.0f);
+	                            static_cast<float>(Options::audioMusicGainOption.get()) / 20.0f);
 	this->soundBackend->setGain(SoundBackend::Gain::Sample,
-	                            static_cast<float>(audioSampleGainOption.get()) / 20.0f);
+	                            static_cast<float>(Options::audioSampleGainOption.get()) / 20.0f);
 }
 
 void Framework::audioShutdown()

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -265,6 +265,8 @@ Framework::Framework(const UString programName, bool createWindow)
 
 	enableFileLogger(logPath.cStr());
 
+	Options::dumpOptionsToLog();
+
 	// This is always set, the default being an empty string (which correctly chooses 'system
 	// language')
 	UString desiredLanguageName;

--- a/framework/logger_file.cpp
+++ b/framework/logger_file.cpp
@@ -1,6 +1,6 @@
 #include "framework/logger_file.h"
-#include "framework/configfile.h"
 #include "framework/logger.h"
+#include "framework/options.h"
 
 #include <fstream>
 
@@ -9,15 +9,6 @@ namespace OpenApoc
 
 namespace
 {
-
-ConfigOptionInt fileLogLevelOption(
-    "Logger", "FileLevel",
-    "Loglevel to output to file (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug)", 3);
-
-ConfigOptionInt backtraceLogLevelOption("Logger", "BacktraceLevel",
-                                        "Loglevel to print a backtrace to file log (0 = nothing, 1 "
-                                        "= error, 2 = warning, 3 = info, 4 = debug)",
-                                        1);
 
 LogFunction previousFunction; // To allow chaining log functions
 
@@ -73,8 +64,8 @@ void enableFileLogger(const char *outputFile)
 	{
 		LogError("File logger failed to open file \"%s\"", outputFile);
 	}
-	fileLogLevel = (LogLevel)fileLogLevelOption.get();
-	backtraceLogLevel = (LogLevel)backtraceLogLevelOption.get();
+	fileLogLevel = (LogLevel)Options::fileLogLevelOption.get();
+	backtraceLogLevel = (LogLevel)Options::backtraceLogLevelOption.get();
 	previousFunction = getLogCallback();
 	setLogCallback(FileLogFunction);
 }

--- a/framework/logger_sdldialog.cpp
+++ b/framework/logger_sdldialog.cpp
@@ -1,6 +1,7 @@
 #include "framework/logger_sdldialog.h"
 #include "framework/configfile.h"
 #include "framework/logger.h"
+#include "framework/options.h"
 
 #include <SDL_messagebox.h>
 #include <atomic>
@@ -10,10 +11,6 @@ namespace OpenApoc
 
 namespace
 {
-
-ConfigOptionInt dialogLogLevelOption(
-    "Logger", "dialogLevel",
-    "Loglevel to pop up a dialog(0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug) ", 1);
 
 LogFunction previousFunction; // To allow chaining log functions
 
@@ -42,7 +39,7 @@ void enableSDLDialogLogger(SDL_Window *win)
 		return;
 	}
 	parentWindow = win;
-	dialogLogLevel = (LogLevel)dialogLogLevelOption.get();
+	dialogLogLevel = (LogLevel)Options::dialogLogLevelOption.get();
 	previousFunction = getLogCallback();
 	setLogCallback(SDLDialogLogFunction);
 }

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -1,0 +1,476 @@
+#include "framework/options.h"
+#include "framework/logger.h"
+
+namespace
+{
+using namespace OpenApoc;
+void dumpOption(const ConfigOptionInt &opt)
+{
+	LogInfo("OPTION \"%s.%s\" = %d", opt.getSection(), opt.getName(), opt.get());
+}
+void dumpOption(const ConfigOptionBool &opt)
+{
+	LogInfo("OPTION \"%s.%s\" = %s", opt.getSection(), opt.getName(), opt.get() ? "true" : "false");
+}
+void dumpOption(const ConfigOptionFloat &opt)
+{
+	LogInfo("OPTION \"%s.%s\" = %f", opt.getSection(), opt.getName(), opt.get());
+}
+void dumpOption(const ConfigOptionString &opt)
+{
+	LogInfo("OPTION \"%s.%s\" = \"%s\"", opt.getSection(), opt.getName(), opt.get());
+}
+
+} // anonymous namespace
+
+namespace OpenApoc::Options
+{
+void dumpOptionsToLog()
+{
+	dumpOption(dataPathOption);
+	dumpOption(cdPathOption);
+	dumpOption(threadPoolSizeOption);
+	dumpOption(renderersOption);
+	dumpOption(audioBackendsOption);
+	dumpOption(audioGlobalGainOption);
+	dumpOption(audioSampleGainOption);
+	dumpOption(audioMusicGainOption);
+	dumpOption(screenWidthOption);
+	dumpOption(screenHeightOption);
+	dumpOption(screenFullscreenOption);
+	dumpOption(screenScaleXOption);
+	dumpOption(screenScaleYOption);
+	dumpOption(languageOption);
+
+	dumpOption(frameLimit);
+	dumpOption(swapInterval);
+
+	dumpOption(autoScrollOption);
+	dumpOption(actionMusicOption);
+	dumpOption(autoExecuteOption);
+	dumpOption(toolTipDelay);
+
+	dumpOption(optionPauseOnUfoSpotted);
+	dumpOption(optionPauseOnVehicleLightDamage);
+	dumpOption(optionPauseOnVehicleModerateDamage);
+	dumpOption(optionPauseOnVehicleHeavyDamage);
+	dumpOption(optionPauseOnVehicleDestroyed);
+	dumpOption(optionPauseOnVehicleEscaping);
+	dumpOption(optionPauseOnVehicleNoAmmo);
+	dumpOption(optionPauseOnVehicleLowFuel);
+	dumpOption(optionPauseOnAgentDiedCity);
+	dumpOption(optionPauseOnAgentArrived);
+	dumpOption(optionPauseOnCargoArrived);
+	dumpOption(optionPauseOnTransferArrived);
+	dumpOption(optionPauseOnRecoveryArrived);
+	dumpOption(optionPauseOnVehicleRepaired);
+	dumpOption(optionPauseOnVehicleRearmed);
+	dumpOption(optionPauseOnNotEnoughAmmo);
+	dumpOption(optionPauseOnVehicleRefuelled);
+	dumpOption(optionPauseOnNotEnoughFuel);
+	dumpOption(optionPauseOnUnauthorizedVehicle);
+	dumpOption(optionPauseOnHostileSpotted);
+	dumpOption(optionPauseOnHostileDied);
+	dumpOption(optionPauseOnUnknownDied);
+	dumpOption(optionPauseOnAgentDiedBattle);
+	dumpOption(optionPauseOnAgentBrainsucked);
+	dumpOption(optionPauseOnAgentCriticallyWounded);
+	dumpOption(optionPauseOnAgentBadlyInjured);
+	dumpOption(optionPauseOnAgentInjured);
+	dumpOption(optionPauseOnAgentUnderFire);
+	dumpOption(optionPauseOnAgentUnconscious);
+	dumpOption(optionPauseOnAgentLeftCombat);
+	dumpOption(optionPauseOnAgentFrozen);
+	dumpOption(optionPauseOnAgentBerserk);
+	dumpOption(optionPauseOnAgentPanicked);
+	dumpOption(optionPauseOnAgentPanicOver);
+	dumpOption(optionPauseOnAgentPsiAttacked);
+	dumpOption(optionPauseOnAgentPsiControlled);
+	dumpOption(optionPauseOnAgentPsiOver);
+
+	dumpOption(optionUFODamageModel);
+	dumpOption(optionInstantExplosionDamage);
+	dumpOption(optionGravliftSounds);
+	dumpOption(optionNoInstantThrows);
+	dumpOption(optionFerryChecksRelationshipWhenBuying);
+	dumpOption(optionAllowManualCityTeleporters);
+	dumpOption(optionAllowManualCargoFerry);
+	dumpOption(optionAllowSoldierTaxiUse);
+	dumpOption(optionAllowUnloadingClips);
+	dumpOption(optionPayloadExplosion);
+	dumpOption(optionDisplayUnitPaths);
+	dumpOption(optionAdditionalUnitIcons);
+	dumpOption(optionAllowForceFiringParallel);
+	dumpOption(optionRequireLOSToMaintainPsi);
+	dumpOption(optionAllowAttackingOwnedVehicles);
+	dumpOption(optionCallExistingFerry);
+	dumpOption(optionAlternateVehicleShieldSound);
+	dumpOption(optionEnableAgentTemplates);
+	dumpOption(optionStoreDroppedEquipment);
+	dumpOption(optionFallingGroundVehicles);
+
+	dumpOption(optionEnforceCargoLimits);
+	dumpOption(optionAllowNearbyVehicleLootPickup);
+	dumpOption(optionAllowBuildingLootDeposit);
+	dumpOption(optionArmoredRoads);
+	dumpOption(optionVanillaCityControls);
+	dumpOption(optionCollapseRaidedBuilding);
+	dumpOption(optionScrambleOnUnintentionalHit);
+	dumpOption(optionMarketRight);
+	dumpOption(optionDGCrashingVehicles);
+	dumpOption(optionFuelCrashingVehicles);
+	dumpOption(optionSkipTurbo);
+	dumpOption(optionRunAndKneel);
+	dumpOption(optionSeedRng);
+
+	dumpOption(optionStunHostileAction);
+	dumpOption(optionRaidHostileAction);
+	dumpOption(optionBSKLauncherSound);
+	dumpOption(optionInvulnerableRoads);
+	dumpOption(optionATVTank);
+
+	dumpOption(optionATVAPC);
+
+	dumpOption(optionCrashingVehicles);
+
+	dumpOption(optionScriptsList);
+
+	dumpOption(optionInfiniteAmmoCheat);
+	dumpOption(optionDamageInflictedMultiplierCheat);
+	dumpOption(optionDamageReceivedMultiplierCheat);
+	dumpOption(optionHostilesMultiplierCheat);
+	dumpOption(optionStatGrowthMultiplierCheat);
+
+	dumpOption(optionEnableTouchEvents);
+
+	dumpOption(imageCacheSize);
+	dumpOption(imageSetCacheSize);
+	dumpOption(voxelCacheSize);
+	dumpOption(fontStringCacheSize);
+	dumpOption(paletteCacheSize);
+
+	dumpOption(fileLogLevelOption);
+
+	dumpOption(backtraceLogLevelOption);
+	dumpOption(dialogLogLevelOption);
+
+	dumpOption(defaultTooltipFont);
+
+	dumpOption(useCRCChecksum);
+	dumpOption(useSHA1Checksum);
+
+	dumpOption(enableTrace);
+	dumpOption(traceFile);
+
+	dumpOption(saveDirOption);
+	dumpOption(packSaveOption);
+
+	dumpOption(skipIntroOption);
+	dumpOption(loadGameOption);
+
+	dumpOption(modList);
+
+	dumpOption(asyncLoading);
+}
+
+#ifndef DATA_DIRECTORY
+#define DATA_DIRECTORY "./data"
+#endif
+
+#ifndef RENDERERS
+#ifdef _WIN32
+#pragma message("WARNING: Using default renderer list")
+#else
+#warning RENDERERS not set - using default list
+#endif
+#define RENDERERS "GLES_3_0:GL_2_0"
+#endif
+
+ConfigOptionString dataPathOption("Framework", "Data", "The path containing OpenApoc data",
+                                  "./data");
+ConfigOptionString cdPathOption("Framework", "CD", "The path to the XCom:Apocalypse CD",
+                                "./data/cd.iso");
+ConfigOptionInt threadPoolSizeOption(
+    "Framework", "ThreadPoolSize",
+    "The number of threads to spawn for the threadpool (0 = queried num_cores)", 0);
+ConfigOptionString renderersOption("Framework", "Renderers",
+                                   "':' separated list of renderer backends (in preference order)",
+                                   RENDERERS);
+ConfigOptionString audioBackendsOption("Framework", "AudioBackends",
+                                       "':' separated list of audio backends (in preference order)",
+                                       "SDLRaw:null");
+ConfigOptionInt audioGlobalGainOption("Framework.Audio", "GlobalGain", "Global audio gain (0-20)",
+                                      20);
+ConfigOptionInt audioSampleGainOption("Framework.Audio", "SampleGain", "Sample audio gain (0-20)",
+                                      20);
+ConfigOptionInt audioMusicGainOption("Framework.Audio", "MusicGain", "Music audio gain (0-20)", 20);
+ConfigOptionInt screenWidthOption("Framework.Screen", "Width", "Initial screen width (in pixels)",
+                                  1280);
+ConfigOptionInt screenHeightOption("Framework.Screen", "Height",
+                                   "Initial screen height (in pixels)", 720);
+ConfigOptionBool screenFullscreenOption("Framework.Screen", "Fullscreen", "Enable fullscreen mode",
+                                        false);
+ConfigOptionInt screenScaleXOption("Framework.Screen", "ScaleX",
+                                   "Scale screen in X direction by (percent)", 100);
+ConfigOptionInt screenScaleYOption("Framework.Screen", "ScaleY",
+                                   "Scale screen in Y direction by (percent)", 100);
+ConfigOptionString languageOption("Framework", "Language",
+                                  "The language used ingame (empty for system default)", "");
+
+ConfigOptionInt frameLimit("Framework", "FrameLimit", "Quit after this many frames - 0 = unlimited",
+                           0);
+ConfigOptionInt swapInterval("Framework", "SwapInterval",
+                             "Swap interval (0 = tear, 1 = wait for vsync", 0);
+
+ConfigOptionBool autoScrollOption("Options.Misc", "AutoScroll", "Enable scrolling with mouse",
+                                  true);
+ConfigOptionBool actionMusicOption("Options.Misc", "ActionMusic",
+                                   "Music changes according to action in battle", true);
+ConfigOptionBool autoExecuteOption("Options.Misc", "AutoExecute",
+                                   "Execute remaining orders when player presses end turn button",
+                                   false);
+ConfigOptionInt toolTipDelay("Options.Misc", "ToolTipDelay",
+                             "Delay in milliseconds before showing tooltips (<= 0 to disable)",
+                             500);
+
+ConfigOptionBool optionPauseOnUfoSpotted("Notifications.City", "UfoSpotted", "UFO spotted", true);
+ConfigOptionBool optionPauseOnVehicleLightDamage("Notifications.City", "VehicleLightDamage",
+                                                 "Vehicle lightly damaged", true);
+ConfigOptionBool optionPauseOnVehicleModerateDamage("Notifications.City", "VehicleModerateDamage",
+                                                    "Vehicle moderately damaged", true);
+ConfigOptionBool optionPauseOnVehicleHeavyDamage("Notifications.City", "VehicleHeavyDamage",
+                                                 "Vehicle heavily damaged", true);
+ConfigOptionBool optionPauseOnVehicleDestroyed("Notifications.City", "VehicleDestroyed",
+                                               "Vehicle destroyed", true);
+ConfigOptionBool optionPauseOnVehicleEscaping("Notifications.City", "VehicleEscaping",
+                                              "Vehicle damaged and returning to base", true);
+ConfigOptionBool optionPauseOnVehicleNoAmmo("Notifications.City", "VehicleNoAmmo",
+                                            "Weapon out of ammo", true);
+ConfigOptionBool optionPauseOnVehicleLowFuel("Notifications.City", "VehicleLowFuel",
+                                             "Vehicle low on fuel", true);
+ConfigOptionBool optionPauseOnAgentDiedCity("Notifications.City", "AgentDiedCity", "Agent has died",
+                                            true);
+ConfigOptionBool optionPauseOnAgentArrived("Notifications.City", "AgentArrived",
+                                           "Agent arrived at base", true);
+ConfigOptionBool optionPauseOnCargoArrived("Notifications.City", "CargoArrived",
+                                           "Cargo has arrived at base", true);
+ConfigOptionBool optionPauseOnTransferArrived("Notifications.City", "TransferArrived",
+                                              "Transfer arrived at base", true);
+ConfigOptionBool optionPauseOnRecoveryArrived("Notifications.City", "RecoveryArrived",
+                                              "Crash recovery arrived at base", true);
+ConfigOptionBool optionPauseOnVehicleRepaired("Notifications.City", "VehicleRepaired",
+                                              "Vehicle repaired", true);
+ConfigOptionBool optionPauseOnVehicleRearmed("Notifications.City", "VehicleRearmed",
+                                             "Vehicle rearmed", true);
+ConfigOptionBool optionPauseOnNotEnoughAmmo("Notifications.City", "NotEnoughAmmo",
+                                            "Not enough ammo to rearm vehicle", true);
+ConfigOptionBool optionPauseOnVehicleRefuelled("Notifications.City", "VehicleRefuelled",
+                                               "Vehicle refuelled", true);
+ConfigOptionBool optionPauseOnNotEnoughFuel("Notifications.City", "NotEnoughFuel",
+                                            "Not enough fuel to refuel vehicle", true);
+ConfigOptionBool optionPauseOnUnauthorizedVehicle("Notifications.City", "UnauthorizedVehicle",
+                                                  "Unauthorized vehicle detected", true);
+ConfigOptionBool optionPauseOnHostileSpotted("Notifications.Battle", "HostileSpotted",
+                                             "Hostile unit spotted", true);
+ConfigOptionBool optionPauseOnHostileDied("Notifications.Battle", "HostileDied",
+                                          "Hostile unit has died", true);
+ConfigOptionBool optionPauseOnUnknownDied("Notifications.Battle", "UnknownDied",
+                                          "Unknown Unit has died", true);
+ConfigOptionBool optionPauseOnAgentDiedBattle("Notifications.Battle", "AgentDiedBattle",
+                                              "Unit has died", true);
+ConfigOptionBool optionPauseOnAgentBrainsucked("Notifications.Battle", "AgentBrainsucked",
+                                               "Unit Brainsucked", true);
+ConfigOptionBool optionPauseOnAgentCriticallyWounded("Notifications.Battle",
+                                                     "AgentCriticallyWounded",
+                                                     "Unit critically wounded", true);
+ConfigOptionBool optionPauseOnAgentBadlyInjured("Notifications.Battle", "AgentBadlyInjured",
+                                                "Unit badly injured", true);
+ConfigOptionBool optionPauseOnAgentInjured("Notifications.Battle", "AgentInjured", "Unit injured",
+                                           true);
+ConfigOptionBool optionPauseOnAgentUnderFire("Notifications.Battle", "AgentUnderFire",
+                                             "Unit under fire", true);
+ConfigOptionBool optionPauseOnAgentUnconscious("Notifications.Battle", "AgentUnconscious",
+                                               "Unit has lost consciousness", true);
+ConfigOptionBool optionPauseOnAgentLeftCombat("Notifications.Battle", "AgentLeftCombat",
+                                              "Unit has left combat zone", true);
+ConfigOptionBool optionPauseOnAgentFrozen("Notifications.Battle", "AgentFrozen", "Unit has frozen",
+                                          true);
+ConfigOptionBool optionPauseOnAgentBerserk("Notifications.Battle", "AgentBerserk",
+                                           "Unit has gone beserk", true);
+ConfigOptionBool optionPauseOnAgentPanicked("Notifications.Battle", "AgentPanicked",
+                                            "Unit has panicked", true);
+ConfigOptionBool optionPauseOnAgentPanicOver("Notifications.Battle", "AgentPanicOver",
+                                             "Unit has stopped panicking", true);
+ConfigOptionBool optionPauseOnAgentPsiAttacked("Notifications.Battle", "AgentPsiAttacked",
+                                               "Psionic attack on unit", true);
+ConfigOptionBool optionPauseOnAgentPsiControlled("Notifications.Battle", "AgentPsiControlled",
+                                                 "Unit under Psionic control", true);
+ConfigOptionBool optionPauseOnAgentPsiOver("Notifications.Battle", "AgentPsiOver",
+                                           "Unit freed from Psionic control", true);
+
+ConfigOptionBool optionUFODamageModel("OpenApoc.NewFeature", "UFODamageModel",
+                                      "X-Com 1 Damage model (0-200%)", false);
+ConfigOptionBool optionInstantExplosionDamage("OpenApoc.NewFeature", "InstantExplosionDamage",
+                                              "Explosions damage instantly", false);
+ConfigOptionBool optionGravliftSounds("OpenApoc.NewFeature", "GravliftSounds", "Gravlift sounds",
+                                      true);
+ConfigOptionBool optionNoInstantThrows("OpenApoc.NewFeature", "NoInstantThrows",
+                                       "Throwing requires proper facing and pose", true);
+ConfigOptionBool optionFerryChecksRelationshipWhenBuying(
+    "OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying",
+    "Transtellar checks relationship when buying items", true);
+ConfigOptionBool optionAllowManualCityTeleporters("OpenApoc.NewFeature",
+                                                  "AllowManualCityTeleporters",
+                                                  "Allow manual use of teleporters in city", true);
+ConfigOptionBool optionAllowManualCargoFerry("OpenApoc.NewFeature", "AllowManualCargoFerry",
+                                             "Allow manual ferrying of cargo and non-combatants",
+                                             true);
+ConfigOptionBool optionAllowSoldierTaxiUse("OpenApoc.NewFeature", "AllowSoldierTaxiUse",
+                                           "Allow soldiers to call taxi", true);
+ConfigOptionBool optionAllowUnloadingClips("OpenApoc.NewFeature", "AdvancedInventoryControls",
+                                           "Allow unloading clips and quick equip", true);
+ConfigOptionBool optionPayloadExplosion("OpenApoc.NewFeature", "PayloadExplosion",
+                                        "Ammunition explodes when blown up", true);
+ConfigOptionBool optionDisplayUnitPaths("OpenApoc.NewFeature", "DisplayUnitPaths",
+                                        "Display unit paths in battle", true);
+ConfigOptionBool optionAdditionalUnitIcons("OpenApoc.NewFeature", "AdditionalUnitIcons",
+                                           "Display additional unit icons (fatal, psi)", true);
+ConfigOptionBool optionAllowForceFiringParallel("OpenApoc.NewFeature", "AllowForceFiringParallel",
+                                                "Allow force-firing parallel to the ground", true);
+ConfigOptionBool optionRequireLOSToMaintainPsi("OpenApoc.NewFeature", "RequireLOSToMaintainPsi",
+                                               "Require LOS to maintain psi attack", true);
+ConfigOptionBool optionAllowAttackingOwnedVehicles("OpenApoc.NewFeature",
+                                                   "AllowAttackingOwnedVehicles",
+                                                   "Allow attacking owned vehicles", true);
+ConfigOptionBool optionCallExistingFerry("OpenApoc.NewFeature", "CallExistingFerry",
+                                         "Call existing transport instead of spawning them", true);
+ConfigOptionBool
+    optionAlternateVehicleShieldSound("OpenApoc.NewFeature", "AlternateVehicleShieldSound",
+                                      "Hitting vehicle shield produces alternate sound", true);
+ConfigOptionBool optionEnableAgentTemplates("OpenApoc.NewFeature", "EnableAgentTemplates",
+                                            "Enable agent equipment templates", true);
+ConfigOptionBool optionStoreDroppedEquipment("OpenApoc.NewFeature", "StoreDroppedEquipment",
+                                             "Attempt to recover agent equipment dropped in city",
+                                             true);
+ConfigOptionBool optionFallingGroundVehicles("OpenApoc.NewFeature", "CrashingGroundVehicles",
+                                             "Unsupported ground vehicles crash", true);
+
+ConfigOptionBool optionEnforceCargoLimits("OpenApoc.NewFeature", "EnforceCargoLimits",
+                                          "Enforce vehicle cargo limits", false);
+ConfigOptionBool optionAllowNearbyVehicleLootPickup("OpenApoc.NewFeature",
+                                                    "AllowNearbyVehicleLootPickup",
+                                                    "Allow nearby vehicles to pick up loot", true);
+ConfigOptionBool optionAllowBuildingLootDeposit("OpenApoc.NewFeature", "AllowBuildingLootDeposit",
+                                                "Allow loot to be stashed in the building", true);
+ConfigOptionBool optionArmoredRoads("OpenApoc.NewFeature", "ArmoredRoads", "Armored roads", true);
+ConfigOptionBool optionVanillaCityControls("OpenApoc.NewFeature", "OpenApocCityControls",
+                                           "Improved city control scheme", true);
+ConfigOptionBool optionCollapseRaidedBuilding("OpenApoc.NewFeature", "CollapseRaidedBuilding",
+                                              "Successful raid collapses building", true);
+ConfigOptionBool
+    optionScrambleOnUnintentionalHit("OpenApoc.NewFeature", "ScrambleOnUnintentionalHit",
+                                     "Any hit on hostile building provokes retaliation", false);
+ConfigOptionBool optionMarketRight("OpenApoc.NewFeature", "MarketOnRight",
+                                   "Put market stock on the right side", true);
+ConfigOptionBool optionDGCrashingVehicles("OpenApoc.NewFeature", "CrashingDimensionGate",
+                                          "Uncapable vehicles crash when entering gates", true);
+ConfigOptionBool optionFuelCrashingVehicles("OpenApoc.NewFeature", "CrashingOutOfFuel",
+                                            "Vehicles crash when out of fuel", true);
+ConfigOptionBool optionSkipTurbo("OpenApoc.NewFeature", "SkipTurboMovement",
+                                 "Skip turbo movement calculations", false);
+ConfigOptionBool optionRunAndKneel("OpenApoc.NewFeature", "RunAndKneel",
+                                   "All units run and kneel by default", false);
+ConfigOptionBool optionSeedRng("OpenApoc.NewFeature", "SeedRng", "Seed RNG on game start", true);
+
+ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
+                                         "Stunning hurts relationships", false);
+ConfigOptionBool optionRaidHostileAction("OpenApoc.Mod", "RaidHostileAction",
+                                         "Initiating raid hurts relationships", false);
+ConfigOptionBool optionBSKLauncherSound("OpenApoc.Mod", "BSKLauncherSound",
+                                        "(MOD) Original Brainsucker Launcher SFX", true);
+ConfigOptionBool optionInvulnerableRoads("OpenApoc.Mod", "InvulnerableRoads",
+                                         "(MOD) Invulnerable roads", false);
+ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes All-Terrain",
+                               true);
+
+ConfigOptionBool optionATVAPC("OpenApoc.Mod", "ATVAPC", "(MOD) Wolfhound APC becomes All-Terrain",
+                              true);
+
+ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
+                                        "Vehicles crash on low HP", false);
+
+ConfigOptionString optionScriptsList("OpenApoc.Mod", "ScriptsList",
+                                     "Semicolon-separated list of scripts to load",
+                                     "data/scripts/openapoc_base.lua;");
+
+ConfigOptionBool optionInfiniteAmmoCheat("OpenApoc.Cheat", "InfiniteAmmo",
+                                         "Infinite ammo for X-Com agents and vehicles", false);
+ConfigOptionFloat optionDamageInflictedMultiplierCheat("OpenApoc.Cheat",
+                                                       "DamageInflictedMultiplier",
+                                                       "Multiplier for damage inflicted by X-com",
+                                                       1.0);
+ConfigOptionFloat optionDamageReceivedMultiplierCheat("OpenApoc.Cheat", "DamageReceivedMultiplier",
+                                                      "Multiplier for damage received by X-com",
+                                                      1.0);
+ConfigOptionFloat optionHostilesMultiplierCheat("OpenApoc.Cheat", "HostilesMultiplier",
+                                                "Multiplier for number of hostiles", 1.0f);
+ConfigOptionFloat optionStatGrowthMultiplierCheat("OpenApoc.Cheat", "StatGrowthMultiplier",
+                                                  "Multiplier for agent stat growth", 1.0f);
+
+ConfigOptionBool optionEnableTouchEvents("Framework", "EnableTouchEvents", "Enable touch events",
+#ifdef ANDROID
+                                         true
+#else
+                                         false
+#endif
+);
+
+ConfigOptionInt imageCacheSize("Framework.Data", "ImageCacheSize",
+                               "Number of Images to keep in data cache", 100);
+ConfigOptionInt imageSetCacheSize("Framework.Data", "ImageSetCacheSize",
+                                  "Number of ImageSets to keep in data cache", 10);
+ConfigOptionInt voxelCacheSize("Framework.Data", "VoxelCacheSize",
+                               "Number of VoxelMaps to keep in data cache", 1);
+ConfigOptionInt fontStringCacheSize("Framework.Data", "FontStringCacheSize",
+                                    "Number of rendered font stings to keep in data cache", 100);
+ConfigOptionInt paletteCacheSize("Framework.Data", "PaletteCacheSize",
+                                 "Number of Palettes to keep in data cache", 10);
+
+ConfigOptionInt fileLogLevelOption(
+    "Logger", "FileLevel",
+    "Loglevel to output to file (0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug)", 3);
+
+ConfigOptionInt backtraceLogLevelOption("Logger", "BacktraceLevel",
+                                        "Loglevel to print a backtrace to file log (0 = nothing, 1 "
+                                        "= error, 2 = warning, 3 = info, 4 = debug)",
+                                        1);
+
+ConfigOptionInt dialogLogLevelOption(
+    "Logger", "dialogLevel",
+    "Loglevel to pop up a dialog(0 = nothing, 1 = error, 2 = warning, 3 = info, 4 = debug) ", 1);
+
+ConfigOptionString defaultTooltipFont("Forms", "TooltipFont", "The default tooltip font",
+                                      "smallset");
+ConfigOptionBool useCRCChecksum("Framework.Serialization", "CRC",
+                                "use a CRC checksum when saving files", false);
+ConfigOptionBool useSHA1Checksum("Framework.Serialization", "SHA1",
+                                 "use a SHA1 checksum when saving files", false);
+
+ConfigOptionBool enableTrace("Trace", "enable", "Enable json call/time tracking");
+ConfigOptionString traceFile("Trace", "outputFile", "File to output trace json to",
+                             "openapoc.trace");
+
+ConfigOptionString saveDirOption("Game.Save", "Directory", "Directory containing saved games",
+                                 "./saves");
+ConfigOptionBool packSaveOption("Game.Save", "Pack", "Pack saved games into a zip", true);
+
+ConfigOptionBool skipIntroOption("Game", "SkipIntro", "Skip intro video", false);
+ConfigOptionString loadGameOption("Game", "Load", "Path to save game to load at startup", "");
+
+ConfigOptionString modList("Game", "Mods",
+                           "A colon-separated list of mods to load (relative to data directory)",
+                           "");
+ConfigOptionBool asyncLoading("Game", "ASyncLoading",
+                              "Load in background while displaying animated loading screen", true);
+
+} // namespace OpenApoc::Options

--- a/framework/options.h
+++ b/framework/options.h
@@ -1,0 +1,153 @@
+#include "framework/configfile.h"
+
+namespace OpenApoc::Options
+{
+
+void dumpOptionsToLog();
+
+extern ConfigOptionString dataPathOption;
+extern ConfigOptionString cdPathOption;
+extern ConfigOptionInt threadPoolSizeOption;
+extern ConfigOptionString renderersOption;
+extern ConfigOptionString audioBackendsOption;
+extern ConfigOptionInt audioGlobalGainOption;
+extern ConfigOptionInt audioSampleGainOption;
+extern ConfigOptionInt audioMusicGainOption;
+extern ConfigOptionInt screenWidthOption;
+extern ConfigOptionInt screenHeightOption;
+extern ConfigOptionBool screenFullscreenOption;
+extern ConfigOptionInt screenScaleXOption;
+extern ConfigOptionInt screenScaleYOption;
+extern ConfigOptionString languageOption;
+
+extern ConfigOptionInt frameLimit;
+extern ConfigOptionInt swapInterval;
+
+extern ConfigOptionBool autoScrollOption;
+extern ConfigOptionBool actionMusicOption;
+extern ConfigOptionBool autoExecuteOption;
+extern ConfigOptionInt toolTipDelay;
+
+extern ConfigOptionBool optionPauseOnUfoSpotted;
+extern ConfigOptionBool optionPauseOnVehicleLightDamage;
+extern ConfigOptionBool optionPauseOnVehicleModerateDamage;
+extern ConfigOptionBool optionPauseOnVehicleHeavyDamage;
+extern ConfigOptionBool optionPauseOnVehicleDestroyed;
+extern ConfigOptionBool optionPauseOnVehicleEscaping;
+extern ConfigOptionBool optionPauseOnVehicleNoAmmo;
+extern ConfigOptionBool optionPauseOnVehicleLowFuel;
+extern ConfigOptionBool optionPauseOnAgentDiedCity;
+extern ConfigOptionBool optionPauseOnAgentArrived;
+extern ConfigOptionBool optionPauseOnCargoArrived;
+extern ConfigOptionBool optionPauseOnTransferArrived;
+extern ConfigOptionBool optionPauseOnRecoveryArrived;
+extern ConfigOptionBool optionPauseOnVehicleRepaired;
+extern ConfigOptionBool optionPauseOnVehicleRearmed;
+extern ConfigOptionBool optionPauseOnNotEnoughAmmo;
+extern ConfigOptionBool optionPauseOnVehicleRefuelled;
+extern ConfigOptionBool optionPauseOnNotEnoughFuel;
+extern ConfigOptionBool optionPauseOnUnauthorizedVehicle;
+extern ConfigOptionBool optionPauseOnHostileSpotted;
+extern ConfigOptionBool optionPauseOnHostileDied;
+extern ConfigOptionBool optionPauseOnUnknownDied;
+extern ConfigOptionBool optionPauseOnAgentDiedBattle;
+extern ConfigOptionBool optionPauseOnAgentBrainsucked;
+extern ConfigOptionBool optionPauseOnAgentCriticallyWounded;
+extern ConfigOptionBool optionPauseOnAgentBadlyInjured;
+extern ConfigOptionBool optionPauseOnAgentInjured;
+extern ConfigOptionBool optionPauseOnAgentUnderFire;
+extern ConfigOptionBool optionPauseOnAgentUnconscious;
+extern ConfigOptionBool optionPauseOnAgentLeftCombat;
+extern ConfigOptionBool optionPauseOnAgentFrozen;
+extern ConfigOptionBool optionPauseOnAgentBerserk;
+extern ConfigOptionBool optionPauseOnAgentPanicked;
+extern ConfigOptionBool optionPauseOnAgentPanicOver;
+extern ConfigOptionBool optionPauseOnAgentPsiAttacked;
+extern ConfigOptionBool optionPauseOnAgentPsiControlled;
+extern ConfigOptionBool optionPauseOnAgentPsiOver;
+
+extern ConfigOptionBool optionUFODamageModel;
+extern ConfigOptionBool optionInstantExplosionDamage;
+extern ConfigOptionBool optionGravliftSounds;
+extern ConfigOptionBool optionNoInstantThrows;
+extern ConfigOptionBool optionFerryChecksRelationshipWhenBuying;
+extern ConfigOptionBool optionAllowManualCityTeleporters;
+extern ConfigOptionBool optionAllowManualCargoFerry;
+extern ConfigOptionBool optionAllowSoldierTaxiUse;
+extern ConfigOptionBool optionAllowUnloadingClips;
+extern ConfigOptionBool optionPayloadExplosion;
+extern ConfigOptionBool optionDisplayUnitPaths;
+extern ConfigOptionBool optionAdditionalUnitIcons;
+extern ConfigOptionBool optionAllowForceFiringParallel;
+extern ConfigOptionBool optionRequireLOSToMaintainPsi;
+extern ConfigOptionBool optionAllowAttackingOwnedVehicles;
+extern ConfigOptionBool optionCallExistingFerry;
+extern ConfigOptionBool optionAlternateVehicleShieldSound;
+extern ConfigOptionBool optionEnableAgentTemplates;
+extern ConfigOptionBool optionStoreDroppedEquipment;
+extern ConfigOptionBool optionFallingGroundVehicles;
+
+extern ConfigOptionBool optionEnforceCargoLimits;
+extern ConfigOptionBool optionAllowNearbyVehicleLootPickup;
+extern ConfigOptionBool optionAllowBuildingLootDeposit;
+extern ConfigOptionBool optionArmoredRoads;
+extern ConfigOptionBool optionVanillaCityControls;
+extern ConfigOptionBool optionCollapseRaidedBuilding;
+extern ConfigOptionBool optionScrambleOnUnintentionalHit;
+extern ConfigOptionBool optionMarketRight;
+extern ConfigOptionBool optionDGCrashingVehicles;
+extern ConfigOptionBool optionFuelCrashingVehicles;
+extern ConfigOptionBool optionSkipTurbo;
+extern ConfigOptionBool optionRunAndKneel;
+extern ConfigOptionBool optionSeedRng;
+
+extern ConfigOptionBool optionStunHostileAction;
+extern ConfigOptionBool optionRaidHostileAction;
+extern ConfigOptionBool optionBSKLauncherSound;
+extern ConfigOptionBool optionInvulnerableRoads;
+extern ConfigOptionBool optionATVTank;
+
+extern ConfigOptionBool optionATVAPC;
+
+extern ConfigOptionBool optionCrashingVehicles;
+
+extern ConfigOptionString optionScriptsList;
+
+extern ConfigOptionBool optionInfiniteAmmoCheat;
+extern ConfigOptionFloat optionDamageInflictedMultiplierCheat;
+extern ConfigOptionFloat optionDamageReceivedMultiplierCheat;
+extern ConfigOptionFloat optionHostilesMultiplierCheat;
+extern ConfigOptionFloat optionStatGrowthMultiplierCheat;
+
+extern ConfigOptionBool optionEnableTouchEvents;
+
+extern ConfigOptionInt imageCacheSize;
+extern ConfigOptionInt imageSetCacheSize;
+extern ConfigOptionInt voxelCacheSize;
+extern ConfigOptionInt fontStringCacheSize;
+extern ConfigOptionInt paletteCacheSize;
+
+extern ConfigOptionInt fileLogLevelOption;
+
+extern ConfigOptionInt backtraceLogLevelOption;
+extern ConfigOptionInt dialogLogLevelOption;
+
+extern ConfigOptionString defaultTooltipFont;
+
+extern ConfigOptionBool useCRCChecksum;
+extern ConfigOptionBool useSHA1Checksum;
+
+extern ConfigOptionBool enableTrace;
+extern ConfigOptionString traceFile;
+
+extern ConfigOptionString saveDirOption;
+extern ConfigOptionBool packSaveOption;
+
+extern ConfigOptionBool skipIntroOption;
+extern ConfigOptionString loadGameOption;
+
+extern ConfigOptionString modList;
+
+extern ConfigOptionBool asyncLoading;
+
+} // namespace OpenApoc::Options

--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -2,6 +2,7 @@
 #include "framework/serialization/providers/providerwithchecksum.h"
 #include "framework/configfile.h"
 #include "framework/logger.h"
+#include "framework/options.h"
 #include "framework/trace.h"
 #include "library/strings.h"
 #include "library/strings_format.h"
@@ -20,10 +21,6 @@
 
 namespace OpenApoc
 {
-ConfigOptionBool useCRCChecksum("Framework.Serialization", "CRC",
-                                "use a CRC checksum when saving files", false);
-ConfigOptionBool useSHA1Checksum("Framework.Serialization", "SHA1",
-                                 "use a SHA1 checksum when saving files", false);
 
 static UString calculateSHA1Checksum(const std::string &str)
 {
@@ -201,9 +198,9 @@ bool ProviderWithChecksum::saveDocument(const UString &path, const UString &cont
 			LogWarning("Multiple document entries for path \"%s\"", path);
 		}
 		this->checksums[path.str()] = {};
-		if (useCRCChecksum.get())
+		if (Options::useCRCChecksum.get())
 			this->checksums[path.str()]["CRC"] = calculateChecksum("CRC", contents.str()).str();
-		if (useSHA1Checksum.get())
+		if (Options::useSHA1Checksum.get())
 			this->checksums[path.str()]["SHA1"] = calculateChecksum("SHA1", contents.str()).str();
 		return true;
 	}

--- a/framework/trace.cpp
+++ b/framework/trace.cpp
@@ -1,5 +1,6 @@
 #include "framework/trace.h"
 #include "framework/configfile.h"
+#include "framework/options.h"
 #include <chrono>
 #include <fstream>
 #include <list>
@@ -15,10 +16,6 @@ namespace
 
 using OpenApoc::UString;
 
-OpenApoc::ConfigOptionBool enableTrace("Trace", "enable", "Enable json call/time tracking");
-OpenApoc::ConfigOptionString traceFile("Trace", "outputFile", "File to output trace json to",
-                                       "openapoc.trace");
-
 const unsigned int TRACE_CHUNK_SIZE = 100000;
 
 std::mutex initTraceLock;
@@ -31,7 +28,7 @@ static void initTrace()
 	if (traceInited)
 		return;
 	traceInited = true;
-	if (enableTrace.get())
+	if (OpenApoc::Options::enableTrace.get())
 		OpenApoc::Trace::enable();
 }
 
@@ -103,11 +100,11 @@ class TraceManager
 	}
 	~TraceManager();
 	std::ofstream outFile;
-	TraceManager() : outFile(traceFile.get().str())
+	TraceManager() : outFile(OpenApoc::Options::traceFile.get().str())
 	{
 		if (!outFile)
 		{
-			LogError("Failed to open trace file \"%s\"", traceFile.get());
+			LogError("Failed to open trace file \"%s\"", OpenApoc::Options::traceFile.get());
 			return;
 		}
 	}

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -2,6 +2,7 @@
 #include "framework/configfile.h"
 #include "framework/filesystem.h"
 #include "framework/framework.h"
+#include "framework/options.h"
 #include "framework/serialization/serialize.h"
 #include "framework/trace.h"
 #include "game/state/gamestate.h"
@@ -20,11 +21,7 @@ namespace OpenApoc
 const UString saveManifestName = "save_manifest";
 const UString saveFileExtension = ".save";
 
-ConfigOptionString saveDirOption("Game.Save", "Directory", "Directory containing saved games",
-                                 "./saves");
-ConfigOptionBool packSaveOption("Game.Save", "Pack", "Pack saved games into a zip", true);
-
-SaveManager::SaveManager() : saveDirectory(saveDirOption.get()) {}
+SaveManager::SaveManager() : saveDirectory(Options::saveDirOption.get()) {}
 
 UString SaveManager::createSavePath(const UString &name) const
 {
@@ -224,7 +221,7 @@ bool SaveManager::overrideGame(const SaveMetadata &metadata, const UString &newN
 
 bool SaveManager::saveGame(const SaveMetadata &metadata, const sp<GameState> gameState) const
 {
-	bool pack = packSaveOption.get();
+	bool pack = Options::packSaveOption.get();
 	const UString path = metadata.getFile();
 	TRACE_FN_ARGS1("path", path);
 	auto archive = SerializationArchive::createArchive();
@@ -261,7 +258,7 @@ bool SaveManager::specialSaveGame(SaveType type, const sp<GameState> gameState) 
 
 std::vector<SaveMetadata> SaveManager::getSaveList() const
 {
-	auto dirString = saveDirOption.get();
+	auto dirString = Options::saveDirOption.get();
 	fs::path saveDirectory = dirString.str();
 	std::vector<SaveMetadata> saveList;
 	try

--- a/game/ui/boot.cpp
+++ b/game/ui/boot.cpp
@@ -5,6 +5,7 @@
 #include "forms/ui.h"
 #include "framework/configfile.h"
 #include "framework/framework.h"
+#include "framework/options.h"
 #include "game/state/gamestate.h"
 #include "game/ui/general/loadingscreen.h"
 #include "game/ui/general/mainmenu.h"
@@ -15,8 +16,6 @@
 
 namespace OpenApoc
 {
-ConfigOptionBool skipIntroOption("Game", "SkipIntro", "Skip intro video", false);
-ConfigOptionString loadGameOption("Game", "Load", "Path to save game to load at startup", "");
 
 void BootUp::begin() {}
 
@@ -30,13 +29,13 @@ void BootUp::eventOccurred(Event *e) { std::ignore = e; }
 
 void BootUp::update()
 {
-	bool skipIntro = skipIntroOption.get();
+	bool skipIntro = Options::skipIntroOption.get();
 	// The first forms instance causes it to get loaded
 	sp<GameState> loadedState;
 	std::shared_future<void> loadTask;
 	bool loadGame = false;
 
-	if (loadGameOption.get().empty())
+	if (Options::loadGameOption.get().empty())
 	{
 		loadTask = fw().threadPoolEnqueue([]() {
 			auto &ui_instance = ui();
@@ -46,7 +45,7 @@ void BootUp::update()
 	else
 	{
 		loadGame = true;
-		auto path = loadGameOption.get();
+		auto path = Options::loadGameOption.get();
 		loadedState = mksp<GameState>();
 		loadTask = fw().threadPoolEnqueue([loadedState, path]() {
 			auto &ui_instance = ui();

--- a/game/ui/general/difficultymenu.cpp
+++ b/game/ui/general/difficultymenu.cpp
@@ -5,18 +5,11 @@
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/keycodes.h"
+#include "framework/options.h"
 #include "game/state/city/city.h"
 #include "game/state/gamestate.h"
 #include "game/ui/general/loadingscreen.h"
 #include "game/ui/tileview/cityview.h"
-
-namespace
-{
-OpenApoc::ConfigOptionString
-    modList("Game", "Mods", "A colon-separated list of mods to load (relative to data directory)",
-            "");
-
-} // anonymous namespace
 
 namespace OpenApoc
 {
@@ -49,7 +42,7 @@ std::shared_future<void> loadGame(const UString &path, sp<GameState> state)
 			LogError("Failed to load '%s'", path);
 			return;
 		}
-		auto mods = modList.get().split(":");
+		auto mods = Options::modList.get().split(":");
 		for (const auto &modString : mods)
 		{
 			LogWarning("loading mod \"%s\"", modString);

--- a/game/ui/general/loadingscreen.cpp
+++ b/game/ui/general/loadingscreen.cpp
@@ -6,6 +6,7 @@
 #include "framework/data.h"
 #include "framework/event.h"
 #include "framework/framework.h"
+#include "framework/options.h"
 #include "framework/renderer.h"
 #include "game/state/gameevent.h"
 #include "game/state/gamestate.h"
@@ -16,9 +17,6 @@
 
 namespace OpenApoc
 {
-
-ConfigOptionBool asyncLoading("Game", "ASyncLoading",
-                              "Load in background while displaying animated loading screen", true);
 
 LoadingScreen::LoadingScreen(sp<GameState> state, std::shared_future<void> task,
                              std::function<sp<Stage>()> nextScreenFn, sp<Image> background,
@@ -42,7 +40,7 @@ void LoadingScreen::begin()
 	}
 	fw().displaySetIcon(std::dynamic_pointer_cast<RGBImage>(backgroundimage));
 	loadingimageangle = 0;
-	if (asyncLoading.get() == false)
+	if (Options::asyncLoading.get() == false)
 	{
 		loadingTask.wait();
 	}
@@ -87,7 +85,7 @@ void LoadingScreen::update()
 		loadingimageangle -= (float)(M_PI * 2.0f);
 
 	auto status = this->loadingTask.wait_for(std::chrono::seconds(0));
-	if (asyncLoading.get() == false)
+	if (Options::asyncLoading.get() == false)
 	{
 		LogAssert(status == std::future_status::ready);
 	}


### PR DESCRIPTION
Without this some options may be DCE'd by the linker, so we lose the definitions, so are removed from the config file by the tool that doesn't recognize them.