### PR TITLE
Snooze for a tick when restarting a GoTo mission that's blocked

### DIFF
--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -2122,6 +2122,7 @@ bool BattleUnitMission::advanceAlongPath(GameState &state, BattleUnit &u, Vec3<f
 	{
 		// Next tile became impassable, pick a new path
 		currentPlannedPath.clear();
+		u.addMission(state, BattleUnitMission::snooze(u, 1));
 		u.addMission(state, Type::RestartNextMission);
 		return false;
 	}


### PR DESCRIPTION
I think this may be a possible cause of a deadlock - if a unit can't route any
closer to it's intended destination, it'll loop in Restart->Goto->Restart
forever.

Adding a 1 tick snooze should allow the game to progress, and possibly allow the
blockage to clear itself if it's temporary (e.g. another unit)