### PR TITLE
Don't remove the current TeleportMission in TeleportMission's start()

### DIFF
--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -1805,7 +1805,9 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				item = nullptr;
 
 				// Teleport unit
-				u.missions.clear();
+				// Remove all other missions
+				u.missions.remove_if(
+				    [this](const up<BattleUnitMission> &mission) { return mission.get() != this; });
 				u.stopAttacking();
 				u.setPosition(state, t->getRestingPosition(u.isLarge()), true);
 				u.resetGoal();


### PR DESCRIPTION
Deleting this current mission could cause crashes due to use-after-free errors
on any subsequent mission data access