### PR TITLE
Make AEquipmentType::ammo_types a set

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -205,7 +205,7 @@ void GameState::initState()
 	{
 		for (auto &w : t.second->weapon_types)
 		{
-			w->ammo_types.emplace_back(this, t.first);
+			w->ammo_types.emplace(this, t.first);
 		}
 	}
 	for (auto &a : this->agent_types)

--- a/game/state/rules/aequipmenttype.h
+++ b/game/state/rules/aequipmenttype.h
@@ -111,7 +111,7 @@ class AEquipmentType : public StateObject
 	// This is not stored in files, but rather filled in gamestate init
 	// In files we only store ammo's link to the weapon
 	// This way, modders can introduce ammunition for existing weapons without having mod conflicts
-	std::list<StateRef<AEquipmentType>> ammo_types;
+	std::set<StateRef<AEquipmentType>> ammo_types;
 
 	// Ammo only
 	std::list<StateRef<AEquipmentType>> weapon_types;

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -79,7 +79,7 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 			else if (itemType.ammo_types.size() ==
 			         1) // weapon without ammo but a single ammo type like lawpistol
 			{
-				displayAmmo(item, *itemType.ammo_types.front());
+				displayAmmo(item, **itemType.ammo_types.begin());
 			}
 			else
 			{
@@ -142,7 +142,7 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 		return;
 	}
 
-	auto &ammoType = itemType.ammo_types.front();
+	auto &ammoType = *itemType.ammo_types.begin();
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", ammoType->accuracy));
 

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -460,7 +460,7 @@ void UfopaediaCategoryView::setFormStats()
 					else if (ref->type == AEquipmentType::Type::Weapon &&
 					         ref->ammo_types.size() == 1)
 					{
-						auto ammoType = ref->ammo_types.front();
+						const auto &ammoType = *ref->ammo_types.begin();
 						statsLabels[row]->setText(tr("Power"));
 						statsValues[row++]->setText(Strings::fromInteger(ammoType->damage));
 						statsLabels[row]->setText(tr("Damage Type"));


### PR DESCRIPTION
It doesn't make sense to have duplicate ammo types, so making it a set collapses
that down