### PR TITLE
Rework mod support, add packages and manager to launcher

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ CMakeSettings.json
 [Dd]ata/cd.iso
 [Dd]ata/XCOM.BIN
 [Dd]ata.old/
+[Dd]ata/mods/
 
 # Netbeans project folder
 nbproject/

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -30,7 +30,8 @@ set (FRAMEWORK_SOURCE_FILES
 	video/smk.cpp
 	logger_sdldialog.cpp
 	logger_file.cpp
-	options.cpp)
+	options.cpp
+	modinfo.cpp)
 
 source_group(framework\\sources FILES ${FRAMEWORK_SOURCE_FILES})
 list(APPEND ALL_SOURCE_FILES ${FRAMEWORK_SOURCE_FILES})
@@ -67,7 +68,8 @@ set (FRAMEWORK_HEADER_FILES
 	video.h
 	logger_sdldialog.h
 	logger_file.h
-	options.h)
+	options.h
+	modinfo.h)
 
 source_group(framework\\headers FILES ${FRAMEWORK_HEADER_FILES})
 list(APPEND ALL_HEADER_FILES ${FRAMEWORK_HEADER_FILES})

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -1138,4 +1138,27 @@ void Framework::threadPoolTaskEnqueue(std::function<void()> task) { p->threadPoo
 
 void *Framework::getWindowHandle() const { return static_cast<void *>(p->window); }
 
+void Framework::setupModDataPaths()
+{
+	auto mods = Options::modList.get().split(":");
+	for (const auto &modString : mods)
+	{
+		LogWarning("loading mod \"%s\"", modString);
+		auto modPath = Options::modPath.get() + "/" + modString;
+		auto modInfo = ModInfo::getInfo(modPath);
+		if (!modInfo)
+		{
+			LogError("Failed to load ModInfo for mod \"%s\"", modString);
+			continue;
+		}
+		auto modDataPath = modPath + "/" + modInfo->getDataPath();
+		LogWarning("Loaded modinfo for mod ID \"%s\"", modInfo->getID());
+		if (modInfo->getDataPath() != "")
+		{
+			LogWarning("Appending data path \"%s\"", modDataPath);
+			this->data->fs.addPath(modDataPath);
+		}
+	}
+}
+
 }; // namespace OpenApoc

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "framework/modinfo.h"
 #include "library/sp.h"
 #include "library/strings.h"
 #include "library/vec.h"
@@ -115,6 +116,8 @@ class Framework
 
 	UString getDataDir() const;
 	UString getCDPath() const;
+
+	void setupModDataPaths();
 };
 
 static inline Framework &fw() { return Framework::getInstance(); }

--- a/framework/fs.h
+++ b/framework/fs.h
@@ -43,6 +43,7 @@ class FileSystem
   public:
 	FileSystem(std::vector<UString> paths);
 	~FileSystem();
+	bool addPath(const UString &newPath);
 	IFile open(const UString &path);
 	UString getCorrectCaseFilename(const UString &path);
 	std::list<UString> enumerateDirectory(const UString &path, const UString &extension) const;

--- a/framework/modinfo.cpp
+++ b/framework/modinfo.cpp
@@ -1,0 +1,105 @@
+#include "framework/modinfo.h"
+#include "dependencies/pugixml/src/pugixml.hpp"
+#include "framework/logger.h"
+
+namespace OpenApoc
+{
+
+using namespace pugi;
+
+// Returns the value if "nodeName" child exists, else empty string
+static UString readNode(const char *nodeName, const xml_node &node)
+{
+	auto childNode = node.child(nodeName);
+	if (childNode)
+		return childNode.text().get();
+	else
+		return "";
+}
+
+std::optional<ModInfo> ModInfo::getInfo(const UString &path)
+{
+	xml_document doc;
+	ModInfo info;
+
+	auto filePath = path + "/modinfo.xml";
+	auto parseResult = doc.load_file(filePath.cStr());
+	if (!parseResult)
+	{
+		LogWarning("Failed to parse ModInfo at \"%s\": %s at offset %u", filePath,
+		           parseResult.description(), parseResult.offset);
+		return {};
+	}
+	auto infoNode = doc.child("openapoc_modinfo");
+	if (!infoNode)
+	{
+		LogWarning("ModInfo at \"%s\" doesn't have an \"openapoc_modinfo\" root node", filePath);
+		return {};
+	}
+
+	info.setName(readNode("name", infoNode));
+	info.setAuthor(readNode("author", infoNode));
+	info.setVersion(readNode("version", infoNode));
+	info.setDescription(readNode("description", infoNode));
+	info.setLink(readNode("link", infoNode));
+	info.setID(readNode("id", infoNode));
+	info.setDataPath(readNode("datapath", infoNode));
+	info.setStatePath(readNode("statepath", infoNode));
+	info.setMinVersion(readNode("minversion", infoNode));
+
+	auto requiresNode = infoNode.child("requires");
+	if (requiresNode)
+	{
+		for (const auto node : requiresNode.children("entry"))
+		{
+			info.requires().push_back(node.value());
+		}
+	}
+
+	auto conflictsNode = infoNode.child("conflicts");
+	if (conflictsNode)
+	{
+		for (const auto node : conflictsNode.children("entry"))
+		{
+			info.conflicts().push_back(node.value());
+		}
+	}
+	return info;
+}
+
+bool ModInfo::writeInfo(const UString &path)
+{
+	xml_document doc;
+	auto infoNode = doc.append_child("openapoc_modinfo");
+	infoNode.append_child("name").text() = name.cStr();
+	infoNode.append_child("author").text() = author.cStr();
+	infoNode.append_child("version").text() = version.cStr();
+	infoNode.append_child("description").text() = description.cStr();
+	infoNode.append_child("link").text() = link.cStr();
+	infoNode.append_child("id").text() = ID.cStr();
+	infoNode.append_child("datapath").text() = dataPath.cStr();
+	infoNode.append_child("statepath").text() = statePath.cStr();
+	infoNode.append_child("minversion").text() = minVersion.cStr();
+
+	auto requiresNode = infoNode.append_child("requires");
+	for (const auto &require : _requires)
+	{
+		requiresNode.append_child("entry").text() = require.cStr();
+	}
+	auto conflictsNode = infoNode.append_child("conflicts");
+	for (const auto &conflict : _conflicts)
+	{
+		conflictsNode.append_child("entry").text() = conflict.cStr();
+	}
+
+	auto filePath = path + "/modinfo.xml";
+	auto saveResult = doc.save_file(filePath.cStr());
+	if (!saveResult)
+	{
+		LogWarning("Failed to save ModInfo to \"%s\"", filePath);
+		return false;
+	}
+
+	return true;
+}
+} // namespace OpenApoc

--- a/framework/modinfo.h
+++ b/framework/modinfo.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "library/strings.h"
+#include <optional>
+
+namespace OpenApoc
+{
+class ModInfo
+{
+  private:
+	UString name;
+	UString author;
+	UString version;
+	UString description;
+	UString link;
+	UString ID;
+	std::list<UString> _requires;
+	std::list<UString> _conflicts;
+	UString dataPath;
+	UString statePath;
+	UString minVersion;
+
+  public:
+	// The user-visible name of the mod
+	const UString &getName() const { return name; }
+	void setName(const UString &newName) { name = newName; }
+	// The author(s)
+	const UString &getAuthor() const { return author; }
+	void setAuthor(const UString &newAuthor) { author = newAuthor; }
+	// The mod version (Using a string to allow any version scheme - this is just user info, we
+	// don't enfore any versioning)
+	const UString &getVersion() const { return version; }
+	void setVersion(const UString &newVersion) { version = newVersion; }
+	// A "short" description
+	const UString &getDescription() const { return description; }
+	void setDescription(const UString &newDescription) { description = newDescription; }
+	// A link - likely to a website?
+	const UString &getLink() const { return link; }
+	void setLink(const UString &newLink) { link = newLink; }
+	// A /UNIQUE/ ID - how this mod is referenced internally.
+	// SUGGESTION: Use a reverse DNS-like format: e.g."
+	// org.openapoc.mod.MY_USERNAME.MY_MOD
+	// as your username is unique on the site, you know it'll never confict (unless someone does
+	// something dumb)
+	const UString &getID() const { return ID; }
+	void setID(const UString &newID) { ID = newID; }
+	// A list of IDs this mod depends on
+	const std::list<UString> &requires() const { return _requires; }
+	std::list<UString> requires() { return _requires; }
+	// A list of IDs this mod is known to not work with
+	const std::list<UString> &conflicts() const { return _conflicts; }
+	std::list<UString> conflicts() { return _conflicts; }
+
+	// A path (relative to this mod's directory) to load a GameState from
+	const UString &getStatePath() const { return statePath; }
+	void setStatePath(const UString &newPath) { statePath = newPath; }
+
+	// A path (relative to this mod's directory) to append to the data list (note, files here
+	// override any with the same name earlier in the mod load order - so it's a good idea to put
+	// everything under a folder named the same as the ID to avoid conflicts)
+	const UString &getDataPath() const { return dataPath; }
+	void setDataPath(const UString &newPath) { dataPath = newPath; }
+
+	// The minimum version of OpenApoc this mod needs to run
+	const UString &getMinVersion() const { return minVersion; }
+	void setMinVersion(const UString &newVersion) { minVersion = newVersion; }
+
+	static std::optional<ModInfo> getInfo(const UString &path);
+	bool writeInfo(const UString &path);
+};
+} // namespace OpenApoc

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -169,6 +169,7 @@ void dumpOptionsToLog()
 	dumpOption(loadGameOption);
 
 	dumpOption(modList);
+	dumpOption(modPath);
 
 	dumpOption(asyncLoading);
 }
@@ -468,8 +469,9 @@ ConfigOptionBool skipIntroOption("Game", "SkipIntro", "Skip intro video", false)
 ConfigOptionString loadGameOption("Game", "Load", "Path to save game to load at startup", "");
 
 ConfigOptionString modList("Game", "Mods",
-                           "A colon-separated list of mods to load (relative to data directory)",
-                           "");
+                           "A colon-separated list of mods to load (relative to mod directory)",
+                           "base");
+ConfigOptionString modPath("Game", "ModPath", "Directory containing mods", "./data/mods");
 ConfigOptionBool asyncLoading("Game", "ASyncLoading",
                               "Load in background while displaying animated loading screen", true);
 

--- a/framework/options.h
+++ b/framework/options.h
@@ -147,6 +147,7 @@ extern ConfigOptionBool skipIntroOption;
 extern ConfigOptionString loadGameOption;
 
 extern ConfigOptionString modList;
+extern ConfigOptionString modPath;
 
 extern ConfigOptionBool asyncLoading;
 

--- a/framework/physfs_fs.cpp
+++ b/framework/physfs_fs.cpp
@@ -221,6 +221,22 @@ std::unique_ptr<char[]> IFile::readAll()
 
 IFile::~IFile() = default;
 
+bool FileSystem::addPath(const UString &newPath)
+{
+	if (!PHYSFS_mount(newPath.cStr(), "/", 0))
+	{
+		LogInfo("Failed to add resource dir \"%s\", error: %s", newPath,
+		        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
+		return false;
+	}
+	else
+	{
+		LogInfo("Resource dir \"%s\" mounted to \"%s\"", newPath,
+		        PHYSFS_getMountPoint(newPath.cStr()));
+		return true;
+	}
+}
+
 FileSystem::FileSystem(std::vector<UString> paths)
 {
 	// FIXME: Is this the right thing to do that?

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -2,6 +2,8 @@
 #include "framework/configfile.h"
 #include "framework/data.h"
 #include "framework/framework.h"
+#include "framework/modinfo.h"
+#include "framework/options.h"
 #include "framework/sound.h"
 #include "framework/trace.h"
 #include "game/state/battle/battle.h"
@@ -1340,6 +1342,33 @@ int GameScore::getTotal()
 {
 	return tacticalMissions + researchCompleted + alienIncidents + craftShotDownUFO +
 	       craftShotDownXCom + incursions + cityDamage;
+}
+
+void GameState::loadMods()
+{
+	auto mods = Options::modList.get().split(":");
+	for (const auto &modString : mods)
+	{
+		LogWarning("loading mod \"%s\"", modString);
+		auto modPath = Options::modPath.get() + "/" + modString;
+		auto modInfo = ModInfo::getInfo(modPath);
+		if (!modInfo)
+		{
+			LogError("Failed to load ModInfo for mod \"%s\"", modString);
+			continue;
+		}
+		LogWarning("Loaded modinfo for mod ID \"%s\"", modInfo->getID());
+		if (modInfo->getStatePath() != "")
+		{
+			auto modStatePath = modPath + "/" + modInfo->getStatePath();
+			LogWarning("Loading mod gamestate \"%s\"", modStatePath);
+
+			if (!this->loadGame(modStatePath))
+			{
+				LogError("Failed to load mod ID \"%s\"", modInfo->getID());
+			}
+		}
+	}
 }
 
 }; // namespace OpenApoc

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -244,6 +244,10 @@ class GameState : public std::enable_shared_from_this<GameState>
 	bool skipTurboCalculations = false;
 
 	LuaGameState luaGameState;
+
+	// Loads all mods set in the options - note this likely requires the mod data directories to
+	// already be added to the filesystem
+	void loadMods();
 };
 
 }; // namespace OpenApoc

--- a/game/ui/boot.cpp
+++ b/game/ui/boot.cpp
@@ -4,7 +4,9 @@
 #include "game/ui/boot.h"
 #include "forms/ui.h"
 #include "framework/configfile.h"
+#include "framework/data.h"
 #include "framework/framework.h"
+#include "framework/modinfo.h"
 #include "framework/options.h"
 #include "game/state/gamestate.h"
 #include "game/ui/general/loadingscreen.h"
@@ -34,6 +36,8 @@ void BootUp::update()
 	sp<GameState> loadedState;
 	std::shared_future<void> loadTask;
 	bool loadGame = false;
+
+	fw().setupModDataPaths();
 
 	if (Options::loadGameOption.get().empty())
 	{
@@ -89,5 +93,4 @@ void BootUp::update()
 void BootUp::render() {}
 
 bool BootUp::isTransition() { return false; }
-
-}; // namespace OpenApoc
+} // namespace OpenApoc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,8 +22,8 @@ target_link_libraries(${TEST} OpenApoc_Library OpenApoc_Framework
 		OpenApoc_GameState)
 target_compile_definitions(${TEST} PRIVATE -DUNIT_TEST)
 add_test(NAME ${TEST}_difficulty1 COMMAND ${TEST}
-		${CMAKE_SOURCE_DIR}/data/difficulty1_patched
-		${CMAKE_SOURCE_DIR}/data/gamestate_common
+		${CMAKE_SOURCE_DIR}/data/mods/base/difficulty1_patched
+		${CMAKE_SOURCE_DIR}/data/mods/base/base_gamestate
 		--Framework.CD=${CD_PATH} --Framework.Data=${CMAKE_SOURCE_DIR}/data)
 
 # MSVC is bad at detecting utf8

--- a/tools/extractors/CMakeLists.txt
+++ b/tools/extractors/CMakeLists.txt
@@ -107,7 +107,7 @@ endfunction(add_extractor)
 
 SET(EXTRACTOR_TARGET_LIST "")
 
-add_extractor(EXTRACTOR_TARGET_LIST "all" "data/gamestate_common")
+add_extractor(EXTRACTOR_TARGET_LIST "all" "data/mods/base/base_gamestate")
 
 option(EXTRACT_DATA "Run the data extractor as part of the default target" ON)
 

--- a/tools/extractors/main.cpp
+++ b/tools/extractors/main.cpp
@@ -13,6 +13,9 @@
 
 using namespace OpenApoc;
 
+static ConfigOptionString outputPath("Extractor", "output",
+                                     "Path to the extractor output directory", "./data");
+
 static void extractDifficulty(const InitialGameStateExtractor &e, UString outputPath,
                               InitialGameStateExtractor::Difficulty difficulty, UString patchPath)
 {
@@ -30,31 +33,31 @@ static void extractDifficulty(const InitialGameStateExtractor &e, UString output
 std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thingsToExtract = {
     {"difficulty1",
      [](const InitialGameStateExtractor &e) {
-	     extractDifficulty(e, "data/difficulty1_patched",
+	     extractDifficulty(e, outputPath.get() + "/mods/base/difficulty1_patched",
 	                       InitialGameStateExtractor::Difficulty::DIFFICULTY_1,
 	                       "data/difficulty1_patch");
      }},
     {"difficulty2",
      [](const InitialGameStateExtractor &e) {
-	     extractDifficulty(e, "data/difficulty2_patched",
+	     extractDifficulty(e, outputPath.get() + "/mods/base/difficulty2_patched",
 	                       InitialGameStateExtractor::Difficulty::DIFFICULTY_2,
 	                       "data/difficulty2_patch");
      }},
     {"difficulty3",
      [](const InitialGameStateExtractor &e) {
-	     extractDifficulty(e, "data/difficulty3_patched",
+	     extractDifficulty(e, outputPath.get() + "/mods/base/difficulty3_patched",
 	                       InitialGameStateExtractor::Difficulty::DIFFICULTY_3,
 	                       "data/difficulty3_patch");
      }},
     {"difficulty4",
      [](const InitialGameStateExtractor &e) {
-	     extractDifficulty(e, "data/difficulty4_patched",
+	     extractDifficulty(e, outputPath.get() + "/mods/base/difficulty4_patched",
 	                       InitialGameStateExtractor::Difficulty::DIFFICULTY_4,
 	                       "data/difficulty4_patch");
      }},
     {"difficulty5",
      [](const InitialGameStateExtractor &e) {
-	     extractDifficulty(e, "data/difficulty5_patched",
+	     extractDifficulty(e, outputPath.get() + "/mods/base/difficulty5_patched",
 	                       InitialGameStateExtractor::Difficulty::DIFFICULTY_5,
 	                       "data/difficulty5_patch");
      }},
@@ -63,7 +66,18 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 	     GameState s;
 	     e.extractCommon(s);
 	     s.loadGame("data/common_patch");
-	     s.saveGame("data/gamestate_common");
+	     s.saveGame(outputPath.get() + "/mods/base/base_gamestate");
+	     ModInfo info;
+	     info.setName("OpenApoc base game");
+	     info.setAuthor("OpenApoc team");
+	     info.setVersion("0.1");
+	     info.setDescription("The base OpenApoc game");
+	     info.setLink("http://www.openapoc.org");
+	     info.setID("org.openapoc.base");
+	     info.setStatePath("base_gamestate");
+	     info.setDataPath("data");
+
+	     info.writeInfo(outputPath.get() + "/mods/base");
      }},
     {"city_bullet_sprites",
      [](const InitialGameStateExtractor &e) {
@@ -71,7 +85,7 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 
 	     for (auto &sprite_pair : bullet_sprites)
 	     {
-		     auto path = "data/" + sprite_pair.first;
+		     auto path = outputPath.get() + "/" + sprite_pair.first;
 		     fw().data->writeImage(path, sprite_pair.second);
 	     }
      }},
@@ -81,7 +95,7 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 
 	     for (auto &sprite_pair : bullet_sprites)
 	     {
-		     auto path = "data/" + sprite_pair.first;
+		     auto path = outputPath.get() + "/" + sprite_pair.first;
 		     fw().data->writeImage(path, sprite_pair.second,
 		                           fw().data->loadPalette("xcom3/tacdata/tactical.pal"));
 	     }

--- a/tools/launcher/launcherwindow.h
+++ b/tools/launcher/launcherwindow.h
@@ -1,3 +1,4 @@
+#include "library/strings.h"
 #include <QMainWindow>
 #include <map>
 #include <memory>
@@ -11,6 +12,7 @@ class LauncherWindow;
 namespace OpenApoc
 {
 class Framework;
+class ModInfo;
 } // namespace OpenApoc
 
 class LauncherWindow : public QMainWindow
@@ -30,10 +32,20 @@ class LauncherWindow : public QMainWindow
 	void browseCDDir();
 	void browseDataDir();
 
+	void enabledModSelected(const QString &modName);
+	void disabledModSelected(const QString &modName);
+	void enableModClicked();
+	void disableModClicked();
+
   private:
 	void setupResolutionDisplay();
 	void saveConfig();
+	void setupModList();
+	void showModInfo(const OpenApoc::ModInfo &info);
+	void rebuildModList();
 
 	std::unique_ptr<OpenApoc::Framework> currentFramework;
 	std::unique_ptr<Ui::LauncherWindow> ui;
+
+	OpenApoc::UString selectedModName;
 };

--- a/tools/launcher/launcherwindow.ui
+++ b/tools/launcher/launcherwindow.ui
@@ -24,7 +24,7 @@
      </rect>
     </property>
     <property name="currentIndex">
-     <number>1</number>
+     <number>0</number>
     </property>
     <widget class="QWidget" name="settingsTab">
      <attribute name="title">
@@ -187,6 +187,233 @@
      <attribute name="title">
       <string>Mods</string>
      </attribute>
+     <widget class="QListWidget" name="enabledModsList">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>50</y>
+        <width>351</width>
+        <height>192</height>
+       </rect>
+      </property>
+      <property name="dragEnabled">
+       <bool>true</bool>
+      </property>
+      <property name="dragDropMode">
+       <enum>QAbstractItemView::InternalMove</enum>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>30</y>
+        <width>251</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Enabled mods</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>250</y>
+        <width>251</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Disabled mods</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="enableButton">
+      <property name="geometry">
+       <rect>
+        <x>370</x>
+        <y>50</y>
+        <width>113</width>
+        <height>32</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Enable</string>
+      </property>
+     </widget>
+     <widget class="QPushButton" name="disableButton">
+      <property name="geometry">
+       <rect>
+        <x>370</x>
+        <y>80</y>
+        <width>113</width>
+        <height>32</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Disable</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="nameLabel">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>50</y>
+        <width>59</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_4">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>20</y>
+        <width>131</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Selected mod info</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="modName">
+      <property name="geometry">
+       <rect>
+        <x>510</x>
+        <y>70</y>
+        <width>271</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>modName</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="authorLabel">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>90</y>
+        <width>59</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Author</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="modAuthor">
+      <property name="geometry">
+       <rect>
+        <x>510</x>
+        <y>110</y>
+        <width>271</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>modAuthor</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="linkLabel">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>130</y>
+        <width>59</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Link</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="modLink">
+      <property name="geometry">
+       <rect>
+        <x>510</x>
+        <y>150</y>
+        <width>271</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>modLink</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="descriptionLabel">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>210</y>
+        <width>111</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Description</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="modDescription">
+      <property name="geometry">
+       <rect>
+        <x>510</x>
+        <y>230</y>
+        <width>271</width>
+        <height>131</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>modDescription</string>
+      </property>
+      <property name="alignment">
+       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      </property>
+      <property name="wordWrap">
+       <bool>true</bool>
+      </property>
+     </widget>
+     <widget class="QListWidget" name="disabledModsList">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>270</y>
+        <width>351</width>
+        <height>211</height>
+       </rect>
+      </property>
+     </widget>
+     <widget class="QLabel" name="versionLabel">
+      <property name="geometry">
+       <rect>
+        <x>500</x>
+        <y>170</y>
+        <width>59</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Version</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="modVersion">
+      <property name="geometry">
+       <rect>
+        <x>510</x>
+        <y>190</y>
+        <width>271</width>
+        <height>16</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>modVersion</string>
+      </property>
+     </widget>
     </widget>
    </widget>
    <widget class="QPushButton" name="playButton">


### PR DESCRIPTION
Now mods are stored in the "Game.ModPath" folder (defaults to ./data/mods) - each mod has it's own subdirectory with a "modinfo.xml", which contains - for example:

```
<?xml version="1.0"?>
<openapoc_modinfo>
    <name>OpenApoc cool mod</name>
    <author>OpenApoc team</author>
    <version>0.1</version>
    <description>A super cool mod for OpenApoc</description>
    <link>http://www.openapoc.org</link>
    <id>org.openapoc.mods.JonnyH.super_cool_mod</id>
    <datapath>new_data_directory</datapath>
    <statepath>gamestate_patch</statepath>
    <minversion>0.0</minversion>
    <requires>
        <entry>org.openapoc.base</entry>
    </requires>
    <conflicts>
        <entry>org.openapoc.mods.JonnyH.conflicting_mod</entry>
    </conflicts>
</openapoc_modinfo>
```

which mean:
All but ```<name>``` and ```<id>``` are technically optional, but it's worth filling out the descriptions anyway, and a mod won't actually /do/ anything without at least one of the ```<datapath>``` or ```<statepath>``` options to load.

Both ```<datapath>``` and ```<statepath>``` are interpreted relative to the current mod's directory. E.g. if you have a mod in ```data/mods/my_mod``` - the modinfo will be in ```data/mods/my_mod/modinfo.xml```, and if you have ```<datapath>my_data_folder</datapath>``` the corresponding filesystem folder should be at ```data/mods/my_mod/my_data_folder```

```<name>``` A user-visible name (IE what they see in the modlist) - should be unique, otherwise they'll conflict in the UI
```<author>``` The author of the mod (visible to the user in the UI)
```<version>``` The version string (currently only visible to the user in the UI, it's not parsed in code or required to be any specific format)
```<description>``` The description of the mod shown in the UI
```<link>``` A link - interpreted as a hyperlink, might be useful to link to a forum thread containing info or the latest version
```<id>``` how the code refers to this mod internally - MUST be unique - I recommend using a "reverse DNS"-style "org.openapoc.mods.YOUR_USERNAME.MOD_NAME" - as the username on the forums should be unique, you can guarantee you're not going to accidently conflict.
```<datapath>``` - optional directory added to the dataPath when loading - allowing you to add new files, or override existing ones by having the same relative path.
```<statepath>``` - optional GameState loaded into the game by this mod - used to update or add any values in the GameState structure
```<minversion>``` - The minimum version of OpenApoc this mod requires (currently not enforced)
```<requires>``` - a list of other mod IDs this mod mod requires - many will probably require the base game (e.g. "org.openapoc.base") - but total conversions or things like completely new weapons may not. Currently not enforced.
```<conflicts>``` - a list of other mod IDs that this mod is known to not work with - the plan here is known conflicts can be flagged and save some pain - might be useful to stop people loading mod packs /and/ the separate mods that it contains. Currently not enforced.
