### PR TITLE
Fixup mod battleunit imagepack search directories

### DIFF
--- a/game/state/gamestate_serialize.cpp
+++ b/game/state/gamestate_serialize.cpp
@@ -618,11 +618,19 @@ bool BattleUnitImagePack::saveImagePack(const UString &path, bool pack, bool pre
 bool BattleUnitImagePack::loadImagePack(GameState &state, const UString &path)
 {
 
-	TRACE_FN_ARGS1("path", path);
-	auto archive = SerializationArchive::readArchive(path);
+	auto file = fw().data->fs.open(path);
+	if (!file)
+	{
+		LogError("Failed to open image pack \"%s\"", path);
+		return false;
+	}
+	auto fullPath = file.systemPath();
+
+	TRACE_FN_ARGS1("path", fullPath);
+	auto archive = SerializationArchive::readArchive(fullPath);
 	if (!archive)
 	{
-		LogError("Failed to read \"%s\"", path);
+		LogError("Failed to read \"%s\"", fullPath);
 		return false;
 	}
 

--- a/game/state/rules/battle/battleunitimagepack.cpp
+++ b/game/state/rules/battle/battleunitimagepack.cpp
@@ -5,7 +5,7 @@
 namespace OpenApoc
 {
 
-UString BattleUnitImagePack::getImagePackPath() { return fw().getDataDir() + "/imagepacks"; }
+UString BattleUnitImagePack::getImagePackPath() { return "/imagepacks"; }
 
 sp<BattleUnitImagePack> BattleUnitImagePack::get(const GameState &state, const UString &id)
 {

--- a/tools/extractors/main.cpp
+++ b/tools/extractors/main.cpp
@@ -114,7 +114,8 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 		     }
 		     else
 		     {
-			     if (!imagePack->saveImagePack(BattleUnitImagePack::getImagePackPath() + "/" +
+			     if (!imagePack->saveImagePack(fw().getDataDir() +
+			                                       BattleUnitImagePack::getImagePackPath() + "/" +
 			                                       imagePackStrings.first,
 			                                   true))
 			     {
@@ -139,7 +140,9 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 		     else
 		     {
 			     if (!imagePack->saveImagePack(
-			             format("%s%s%d", BattleUnitImagePack::getImagePackPath(), "/item", i),
+			             format("%s%s%d",
+			                    fw().getDataDir() + BattleUnitImagePack::getImagePackPath(),
+			                    "/item", i),
 			             true))
 			     {
 				     LogError("Failed to save  item image pack \"%d\"", i);
@@ -161,7 +164,8 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 		     }
 		     else
 		     {
-			     if (!imagePack->saveImagePack(BattleUnitImagePack::getImagePackPath() + "/" +
+			     if (!imagePack->saveImagePack(fw().getDataDir() +
+			                                       BattleUnitImagePack::getImagePackPath() + "/" +
 			                                       imagePackStrings.first,
 			                                   true))
 			     {


### PR DESCRIPTION
As the serialize code doesn't use physfs' open by default, it wasn't searching
the correct data directories for mods.