### PR TITLE
Make FileSystem::open() const

### DIFF
--- a/framework/fs.h
+++ b/framework/fs.h
@@ -44,8 +44,7 @@ class FileSystem
 	FileSystem(std::vector<UString> paths);
 	~FileSystem();
 	bool addPath(const UString &newPath);
-	IFile open(const UString &path);
-	UString getCorrectCaseFilename(const UString &path);
+	IFile open(const UString &path) const;
 	std::list<UString> enumerateDirectory(const UString &path, const UString &extension) const;
 	std::list<UString> enumerateDirectoryRecursive(const UString &path,
 	                                               const UString &extension) const;

--- a/framework/physfs_fs.cpp
+++ b/framework/physfs_fs.cpp
@@ -277,7 +277,7 @@ FileSystem::FileSystem(std::vector<UString> paths)
 
 FileSystem::~FileSystem() = default;
 
-IFile FileSystem::open(const UString &path)
+IFile FileSystem::open(const UString &path) const
 {
 	TRACE_FN_ARGS1("PATH", path);
 	IFile f;


### PR DESCRIPTION
It doesn't affect FileSystem state, so can be const.

Also FileSystem::getCorrectCaseFilename() isn't implemented or used anywhere, so
remove that from the header.