### PR TITLE
Check if a tile is out of bounds in BattleUnit::updateGiveWay()

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2339,6 +2339,10 @@ void BattleUnit::updateGiveWay(GameState &state)
 						// Try the new heading
 						Vec3<int> pos = {position.x + newHeading.x, position.y + newHeading.y,
 						                 position.z + z};
+
+						if (!tileObject->map.isTileInBounds(pos))
+							continue;
+
 						auto to = tileObject->map.getTile(pos);
 						// Check if heading on our level is acceptable
 						bool acceptable =

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -85,6 +85,17 @@ class TileMap
 	std::vector<std::set<TileObject::Type>> layerMap;
 
   public:
+	const bool isTileInBounds(int x, int y, int z) const
+	{
+		if (x < 0 || x >= size.x)
+			return false;
+		if (y < 0 || y >= size.y)
+			return false;
+		if (z < 0 || z >= size.z)
+			return false;
+		return true;
+	}
+	const bool isTileInBounds(Vec3<int> pos) const { return isTileInBounds(pos.x, pos.y, pos.z); }
 	const Tile *getTile(int x, int y, int z) const
 	{
 


### PR DESCRIPTION
This was causing tile out-of-bounds errors when a giveWayRequest would try to
move an agent off the edge of the map.