### PR TITLE
Don't underflow inventory selling partially-filled ammo clips

### DIFF
--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -467,12 +467,20 @@ void BuyAndSellScreen::executeOrders()
 							{
 								economy.currentStock += order;
 								player->balance += order * economy.currentPrice;
-
 								StateRef<AEquipmentType> equipment{state.get(), c->itemId};
-								b.second->inventoryAgentEquipment[c->itemId] -=
-								    order * (equipment->type == AEquipmentType::Type::Ammo
-								                 ? equipment->max_ammo
-								                 : 1);
+
+								const auto numItemsPerUnit =
+								    equipment->type == AEquipmentType::Type::Ammo
+								        ? equipment->max_ammo
+								        : 1;
+								auto numItems = numItemsPerUnit * order;
+
+								LogAssert(b.second->inventoryAgentEquipment[c->itemId] <=
+								          std::numeric_limits<int>::max());
+								numItems = std::min(
+								    numItems, (int)b.second->inventoryAgentEquipment[c->itemId]);
+
+								b.second->inventoryAgentEquipment[c->itemId] -= numItems;
 								break;
 							}
 							case TransactionControl::Type::VehicleAmmo:


### PR DESCRIPTION
Clamp against the current round inventory count, as otherwise selling your last
partially filled clip will underflow the 'unsigned' inventory cound and you get
a silly value.

Note that as the market only tracks whole clips, this cause selling and rebuying
a partially filled clip to refill it for free, but that seems less worse than
giving the player ~4 billion rounds.