### PR TITLE
Add a clang-tidy script, and run it in the travis 'lint' pass

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,5 @@
 ---
-Checks:          'clang-diagnostic-*,clang-analyzer-*,-clang-analyzer-alpha*,misc-static-assert,modernize-use-auto,modernize-use-default,modernize-usenullptr,modernize-use-override,readability-identifier-naming'
+Checks:          'clang-diagnostic-*,clang-analyzer-*,misc-static-assert,modernize-use-auto,modernize-use-default,modernize-usenullptr,modernize-use-override,performance-*,readability-non-const-parameter,readability-redundant-*,readability-simplify-*,bugprone-*'
 HeaderFilterRegex: 'forms/.*|framework/.*|game/.*|library/.*|tests/.*|tools/.*'
 AnalyzeTemporaryDtors: false
 User:            jonny

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,20 +30,21 @@ before_install:
   - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key|sudo apt-key add -
   - sudo add-apt-repository 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-8 main' -y
   - sudo apt-get update -q
-  - sudo apt-get install g++-9 clang-8 clang-format-8 -y
+  - sudo apt-get install g++-9 clang-8 clang-format-8 clang-tidy-8 ninja-build -y
   - eval "${MATRIX_ENV}"
   - env
-  - if [ "$TRAVIS_OS_NAME" = "linux" -a "$PASS" = "build" ]; then ./tools/travis-scripts/build_prepare_linux.sh; fi
+  - ./tools/travis-scripts/build_prepare_linux.sh
   - ${CXX} --version
   - ${CC} --version
 
 
 before_script:
   - export CFLAGS="-Wall -Wextra" CXXFLAGS="-Wall -Wextra"
-  - if [ "$PASS" = "build" ]; then $(which time) cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCLANG_TIDY=clang-tidy-8 -DCLANG_FORMAT=clang-format-8 -DENABLE_TESTS=ON -DCMAKE_C_FLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}"; fi
+  - $(which time) cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCLANG_TIDY=clang-tidy-8 -DCLANG_FORMAT=clang-format-8 -DENABLE_TESTS=ON -DCMAKE_C_FLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -GNinja
 
 
 script:
 # Create the GameState as that triggers the generated source commands
-  - if [ "$PASS" = "build" ]; then echo "Building revision $(git describe --tags --all --long --always)"; $(which time) make -j2 && `which time` ctest -V -j 2; fi
-  - if [ "$PASS" = "lint" ]; then echo "Linting range ${TRAVIS_COMMIT_RANGE}"; CLANG_FORMAT=${CLANG_FORMAT} ./tools/lint.sh ${TRAVIS_COMMIT_RANGE}; fi
+  - if [ "$PASS" = "build" ]; then echo "Building revision $(git describe --tags --all --long --always)"; $(which time) ninja && `which time` ctest -V -j 2; fi
+  - if [ "$PASS" = "lint" ]; then echo "clang-format linting range ${TRAVIS_COMMIT_RANGE}"; CLANG_FORMAT=${CLANG_FORMAT} ./tools/lint.sh ${TRAVIS_COMMIT_RANGE}; fi
+  - if [ "$PASS" = "lint" ]; then ninja generated-source && echo "clang-tidy linting range ${TRAVIS_COMMIT_RANGE}"; CLANG_TIDY=clang-tidy BUILD_DIR=$(pwd) ./tools/lint-tidy.sh ${TRAVIS_COMMIT_RANGE}; fi

--- a/game/state/CMakeLists.txt
+++ b/game/state/CMakeLists.txt
@@ -251,3 +251,8 @@ add_custom_command(OUTPUT
 		DEPENDS
 		OpenApoc_LuaGamestateSupportGen
 		${CMAKE_SOURCE_DIR}/game/state/gamestate_serialize.xml)
+
+add_custom_target(generated-source
+		DEPENDS
+		gamestate_serialize_generated.h gamestate_serialize_generated.cpp
+		luagamestate_support_generated.h luagamestate_support_generated.cpp)

--- a/tools/lint-tidy.sh
+++ b/tools/lint-tidy.sh
@@ -1,0 +1,54 @@
+#! /bin/bash
+#
+# A clang-tidy lint script. Usage:
+# ./lint.sh
+#   Runs clang-tidy on the current git stage
+# ./lint.sh revision..range
+#   Runs clang-tidy on the specified range of commits
+
+set -eo pipefail
+
+[ -z "${CLANG_TIDY}" ] && CLANG_TIDY="clang-tidy"
+
+if [ ! -d "${BUILD_DIR}" ]; then
+  echo >&2 "BUILD_DIR not set";
+  exit 1;
+fi;
+
+if [ ! -f "${BUILD_DIR}/compile_commands.json" ]; then
+  echo >&2 "${BUILD_DIR}/compile_commands.json not found - is BUILD_DIR set correctly?"
+  exit 1;
+fi;
+
+if [ -z "$(command -v ${CLANG_TIDY})" ]; then
+  echo >&2 "clang tidy binary \"${CLANG_TIDY}\" not found"
+  exit 1;
+fi;
+
+# Default to 'cached', or the revision passed as an argument
+GIT_REVISION=${1:---cached}
+
+MODIFIED_FILES=$(git diff --name-only --diff-filter=ACMRTUXB ${GIT_REVISION})
+
+
+RET=0
+
+for f in ${MODIFIED_FILES}; do
+  # Skip any non C++ files
+  if ! echo "${f}" | egrep -q "[.](cpp)$"; then
+    continue;
+  fi
+  echo "Running clang-tidy on ${f}"
+
+  ${CLANG_TIDY} -p "${BUILD_DIR}" "${f}"
+  RESULT=$?
+  if [ ${RESULT} != 0 ]; then
+    RET=1;
+    echo "File ${f} failed clang-tidy checks"
+  fi;
+done;
+
+echo "All specificed files checked"
+
+exit ${RET};
+


### PR DESCRIPTION
This runs clang-tidy with a subset of possibly-useful checks on modified files in the travis CI, hopefully pointing out possible issues. Only build failures would fail the pass, however, so it's more for info than anything else.