### PR TITLE
Fix the Stormdog not having full ammo loaded on game start

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -660,7 +660,8 @@ void GameState::fillPlayerStartingProperty()
 		v->homeBuilding = v->currentBuilding;
 		for (auto &eq : pair.second)
 		{
-			v->addEquipment(*this, eq);
+			auto device = v->addEquipment(*this, eq);
+			device->ammo = eq->max_ammo;
 		}
 	}
 	// Give the player initial vehicle equipment


### PR DESCRIPTION
A quick fix for the stormdog ammo being empty on starting a new game