### PR TITLE
Lock the framework update loop to a set FPS (default 60)

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -42,6 +42,7 @@ void dumpOptionsToLog()
 	dumpOption(screenScaleYOption);
 	dumpOption(languageOption);
 
+	dumpOption(targetFPS);
 	dumpOption(frameLimit);
 	dumpOption(swapInterval);
 
@@ -218,6 +219,8 @@ ConfigOptionInt screenScaleYOption("Framework.Screen", "ScaleY",
 ConfigOptionString languageOption("Framework", "Language",
                                   "The language used ingame (empty for system default)", "");
 
+ConfigOptionInt targetFPS("Framework", "TargetFPS", "The target FPS count - affects game speed!",
+                          60);
 ConfigOptionInt frameLimit("Framework", "FrameLimit", "Quit after this many frames - 0 = unlimited",
                            0);
 ConfigOptionInt swapInterval("Framework", "SwapInterval",

--- a/framework/options.h
+++ b/framework/options.h
@@ -21,6 +21,7 @@ extern ConfigOptionInt screenScaleYOption;
 extern ConfigOptionString languageOption;
 
 extern ConfigOptionInt frameLimit;
+extern ConfigOptionInt targetFPS;
 extern ConfigOptionInt swapInterval;
 
 extern ConfigOptionBool autoScrollOption;


### PR DESCRIPTION
This sleep()s if we're going faster than the expected update rate,
hopefully avoiding any possible issues due to different vsync limits
causing significantly different in-game speeds - as it's set to
progress 1 tick every frame.

Note that if you are 60fps vsync limited (or lower) there's a good
chance the update loop will 'fall behind' due to natural jitter and
precision differences, it'll LogWarning() if that happens, but it
shouldn't cause any real issues, so long as the difference is small.

If you somehow ended up with some weird setup with a significantly lower
than 60fps vsync, however, it will run slower.