### PR TITLE
WIP MacOS App bundle creation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,17 @@ if (WIN32)
 	set(sources ${sources} "apocicon.rc")
 endif()
 
+
+if (APPLE)
+set(MACOSX_BUNDLE_BUNDLE_NAME OpenApoc)
+
+ADD_EXECUTABLE(${CMAKE_PROJECT_NAME} MACOSX_BUNDLE game/main.cpp ${sources}
+		${FRAMEWORK_SOURCES})
+else()
 ADD_EXECUTABLE(${CMAKE_PROJECT_NAME} game/main.cpp ${sources}
 		${FRAMEWORK_SOURCES})
+endif()
+
 
 target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_Library)
 target_link_libraries(${CMAKE_PROJECT_NAME} OpenApoc_Framework)
@@ -125,9 +134,12 @@ INCLUDE_DIRECTORIES(${CMAKE_BINARY_DIR})
 # apoc data copy
 SET( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
 
-install(TARGETS ${CMAKE_PROJECT_NAME}
-		RUNTIME DESTINATION bin)
-install(DIRECTORY ${CMAKE_SOURCE_DIR}data/ DESTINATION share/OpenApoc)
+
+if (NOT APPLE)
+		install(TARGETS ${CMAKE_PROJECT_NAME}
+				RUNTIME DESTINATION bin)
+		install(DIRECTORY ${CMAKE_SOURCE_DIR}data/ DESTINATION share/OpenApoc)
+endif()
 
 if(ENABLE_TESTS)
 	enable_testing()

--- a/tools/extractors/CMakeLists.txt
+++ b/tools/extractors/CMakeLists.txt
@@ -116,3 +116,7 @@ add_custom_target(extract-data ALL DEPENDS ${EXTRACTOR_TARGET_LIST})
 else()
 add_custom_target(extract-data DEPENDS ${EXTRACTOR_TARGET_LIST})
 endif()
+
+if (APPLE)
+add_custom_command(TARGET extract-data POST_BUILD COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/data ${CMAKE_BINARY_DIR}/bin/OpenApoc.app/Contents/Resources/data)
+endif()


### PR DESCRIPTION
Very much a WIP:
- Only the OpenApoc executable is packaged - we probably want /at least/
the launcher in there too
- The post-build copy cmake command for the data/ directory into the
resources feels like a hack - same with the fixed location .app bundle
name where it's copying them to? Probably some cmake property we can
query?
- It seems the working directory of app bundles is always "/"? Which
breaks all the loading "local" data, so we chdir() based on the SDL
"base directory", which seems to point to the Resources dir in the
bundle?
- Keying the above off the working directory being "/" is a hack - e.g.
run from the terminal it may be unlikely and maybe a bad idea, but
possible that "/" was the intended working directory - at which point I
don't really know that the SDL "base dir" would be?
- A whole stack of the app bundle metadata isn't set (authors,
"friendly" name, copyright etc.)