### PR TITLE
Avoid drawing vehicle equipment at (0, 0)

### DIFF
--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -1013,6 +1013,7 @@ void Control::copyControlData(sp<Control> CopyOf)
 
 	CopyOf->Name = this->Name;
 	CopyOf->Location = this->Location;
+	CopyOf->resolvedLocation = this->resolvedLocation;
 	CopyOf->Size = this->Size;
 	CopyOf->SelectionSize = this->SelectionSize;
 	CopyOf->BackgroundColour = this->BackgroundColour;

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -292,6 +292,7 @@ void ListBox::addItem(sp<Control> Item)
 		selected = Item;
 	}
 	this->setDirty();
+	this->update();
 }
 
 void ListBox::replaceItem(sp<Control> Item)

--- a/forms/multilistbox.cpp
+++ b/forms/multilistbox.cpp
@@ -284,6 +284,7 @@ void MultilistBox::addItem(sp<Control> Item)
 {
 	this->setDirty();
 	Item->setParent(shared_from_this());
+	this->update();
 }
 
 void MultilistBox::replaceItem(sp<Control> Item)

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -403,53 +403,60 @@ void VEquipScreen::render()
 	{
 		auto inventoryControl = form->findControlTyped<Graphic>("INVENTORY");
 		Vec2<int> inventoryPosition = inventoryControl->getLocationOnScreen();
-		for (auto &invPair : base->inventoryVehicleEquipment)
+		if (inventoryPosition == Vec2<int>(0, 0))
 		{
-			// The gap between the bottom of the inventory image and the count label
-			static const int INVENTORY_COUNT_Y_GAP = 4;
-			// The gap between the end of one inventory image and the start of the next
-			static const int INVENTORY_IMAGE_X_GAP = 4;
-			auto equipIt = state->vehicle_equipment.find(invPair.first);
-			if (equipIt == state->vehicle_equipment.end())
+			LogWarning("Attempted to draw inventory items at (0, 0) - skipping");
+		}
+		else 
+		{
+			for (auto &invPair : base->inventoryVehicleEquipment)
 			{
-				// It's not vehicle equipment, skip
-				continue;
-			}
-			auto equipmentType = StateRef<VEquipmentType>{state.get(), equipIt->first};
-			if (equipmentType->type != this->selectionType)
-			{
-				// Skip equipment of different types
-				continue;
-			}
-			if (!equipmentType->users.count(allowedEquipmentUser))
-			{
-				// The selected vehicle is not a valid user of the equipment, don't draw
-				continue;
-			}
-			int count = invPair.second;
-			if (count == 0)
-			{
-				// Not in stock
-				continue;
-			}
-			auto countImage = labelFont->getString(format("%d", count));
-			auto &equipmentImage = equipmentType->equipscreen_sprite;
-			fw().renderer->draw(equipmentImage, inventoryPosition);
+				// The gap between the bottom of the inventory image and the count label
+				static const int INVENTORY_COUNT_Y_GAP = 4;
+				// The gap between the end of one inventory image and the start of the next
+				static const int INVENTORY_IMAGE_X_GAP = 4;
+				auto equipIt = state->vehicle_equipment.find(invPair.first);
+				if (equipIt == state->vehicle_equipment.end())
+				{
+					// It's not vehicle; equipment, skip
+					continue;
+				}
+				auto equipmentType = StateRef<VEquipmentType>{ state.get(), equipIt->first };
+				if (equipmentType->type != this->selectionType)
+				{
+					// Skip equipment of different types
+					continue;
+				}
+				if (!equipmentType->users.count(allowedEquipmentUser))
+				{
+					// The selected vehicle is not a valid user of the equipment, don't draw
+					continue;
+				}
+				int count = invPair.second;
+				if (count == 0)
+				{
+					// Not in stock
+					continue;
+				}
+				auto countImage = labelFont->getString(format("%d", count));
+				auto &equipmentImage = equipmentType->equipscreen_sprite;
+				fw().renderer->draw(equipmentImage, inventoryPosition);
 
-			Vec2<int> countLabelPosition = inventoryPosition;
-			countLabelPosition.y += INVENTORY_COUNT_Y_GAP + equipmentImage->size.y;
-			// FIXME: Center in X?
-			fw().renderer->draw(countImage, countLabelPosition);
+				Vec2<int> countLabelPosition = inventoryPosition;
+				countLabelPosition.y += INVENTORY_COUNT_Y_GAP + equipmentImage->size.y;
+				// FIXME: Center in X?
+				fw().renderer->draw(countImage, countLabelPosition);
 
-			Vec2<int> inventoryEndPosition = inventoryPosition;
-			inventoryEndPosition.x += equipmentImage->size.x;
-			inventoryEndPosition.y += equipmentImage->size.y;
+				Vec2<int> inventoryEndPosition = inventoryPosition;
+				inventoryEndPosition.x += equipmentImage->size.x;
+				inventoryEndPosition.y += equipmentImage->size.y;
 
-			this->inventoryItems.emplace_back(Rect<int>{inventoryPosition, inventoryEndPosition},
-			                                  equipmentType);
+				this->inventoryItems.emplace_back(Rect<int>{inventoryPosition, inventoryEndPosition},
+				                                  equipmentType);
 
-			// Progress inventory offset by width of image + gap
-			inventoryPosition.x += INVENTORY_IMAGE_X_GAP + equipmentImage->size.x;
+				// Progress inventory offset by width of image + gap
+				inventoryPosition.x += INVENTORY_IMAGE_X_GAP + equipmentImage->size.x;
+			}
 		}
 	}
 	if (this->drawHighlightBox)

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -403,60 +403,53 @@ void VEquipScreen::render()
 	{
 		auto inventoryControl = form->findControlTyped<Graphic>("INVENTORY");
 		Vec2<int> inventoryPosition = inventoryControl->getLocationOnScreen();
-		if (inventoryPosition == Vec2<int>(0, 0))
+		for (auto &invPair : base->inventoryVehicleEquipment)
 		{
-			LogWarning("Attempted to draw inventory items at (0, 0) - skipping");
-		}
-		else 
-		{
-			for (auto &invPair : base->inventoryVehicleEquipment)
+			// The gap between the bottom of the inventory image and the count label
+			static const int INVENTORY_COUNT_Y_GAP = 4;
+			// The gap between the end of one inventory image and the start of the next
+			static const int INVENTORY_IMAGE_X_GAP = 4;
+			auto equipIt = state->vehicle_equipment.find(invPair.first);
+			if (equipIt == state->vehicle_equipment.end())
 			{
-				// The gap between the bottom of the inventory image and the count label
-				static const int INVENTORY_COUNT_Y_GAP = 4;
-				// The gap between the end of one inventory image and the start of the next
-				static const int INVENTORY_IMAGE_X_GAP = 4;
-				auto equipIt = state->vehicle_equipment.find(invPair.first);
-				if (equipIt == state->vehicle_equipment.end())
-				{
-					// It's not vehicle; equipment, skip
-					continue;
-				}
-				auto equipmentType = StateRef<VEquipmentType>{ state.get(), equipIt->first };
-				if (equipmentType->type != this->selectionType)
-				{
-					// Skip equipment of different types
-					continue;
-				}
-				if (!equipmentType->users.count(allowedEquipmentUser))
-				{
-					// The selected vehicle is not a valid user of the equipment, don't draw
-					continue;
-				}
-				int count = invPair.second;
-				if (count == 0)
-				{
-					// Not in stock
-					continue;
-				}
-				auto countImage = labelFont->getString(format("%d", count));
-				auto &equipmentImage = equipmentType->equipscreen_sprite;
-				fw().renderer->draw(equipmentImage, inventoryPosition);
-
-				Vec2<int> countLabelPosition = inventoryPosition;
-				countLabelPosition.y += INVENTORY_COUNT_Y_GAP + equipmentImage->size.y;
-				// FIXME: Center in X?
-				fw().renderer->draw(countImage, countLabelPosition);
-
-				Vec2<int> inventoryEndPosition = inventoryPosition;
-				inventoryEndPosition.x += equipmentImage->size.x;
-				inventoryEndPosition.y += equipmentImage->size.y;
-
-				this->inventoryItems.emplace_back(Rect<int>{inventoryPosition, inventoryEndPosition},
-				                                  equipmentType);
-
-				// Progress inventory offset by width of image + gap
-				inventoryPosition.x += INVENTORY_IMAGE_X_GAP + equipmentImage->size.x;
+				// It's not vehicle equipment, skip
+				continue;
 			}
+			auto equipmentType = StateRef<VEquipmentType>{state.get(), equipIt->first};
+			if (equipmentType->type != this->selectionType)
+			{
+				// Skip equipment of different types
+				continue;
+			}
+			if (!equipmentType->users.count(allowedEquipmentUser))
+			{
+				// The selected vehicle is not a valid user of the equipment, don't draw
+				continue;
+			}
+			int count = invPair.second;
+			if (count == 0)
+			{
+				// Not in stock
+				continue;
+			}
+			auto countImage = labelFont->getString(format("%d", count));
+			auto &equipmentImage = equipmentType->equipscreen_sprite;
+			fw().renderer->draw(equipmentImage, inventoryPosition);
+
+			Vec2<int> countLabelPosition = inventoryPosition;
+			countLabelPosition.y += INVENTORY_COUNT_Y_GAP + equipmentImage->size.y;
+			// FIXME: Center in X?
+			fw().renderer->draw(countImage, countLabelPosition);
+
+			Vec2<int> inventoryEndPosition = inventoryPosition;
+			inventoryEndPosition.x += equipmentImage->size.x;
+			inventoryEndPosition.y += equipmentImage->size.y;
+
+			this->inventoryItems.emplace_back(Rect<int>{inventoryPosition, inventoryEndPosition},
+			                                  equipmentType);
+
+			// Progress inventory offset by width of image + gap
+			inventoryPosition.x += INVENTORY_IMAGE_X_GAP + equipmentImage->size.x;
 		}
 	}
 	if (this->drawHighlightBox)


### PR DESCRIPTION
Proposed fix for issue #796. Since the source of the problem appears to be the location of the inventory on screen being off for the first few frames avoiding drawing the inventory until the correct coordinates come along should fix it.