### PR TITLE
Remove appveyor 32bit builds and debug packages

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ configuration:
 #  - Debug
 platform:
   - x64
-  - Win32
+    #  - Win32
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 init:
@@ -60,9 +60,9 @@ after_build:
   - del OpenApoc-%OPENAPOC_VERSION%\portable.txt
   - '"C:\Program Files (x86)\NSIS\makensis.exe" /DGAME_VERSION=%OPENAPOC_VERSION% install\windows\installer.nsi'
   - appveyor PushArtifact install\windows\install-openapoc-%OPENAPOC_VERSION%.exe
-  - copy bin\*.pdb OpenApoc-%OPENAPOC_VERSION%\
-  - 7z a %OPENAPOC_DEBUG_FILENAME% OpenApoc-%OPENAPOC_VERSION%\*.pdb
-  - appveyor PushArtifact %OPENAPOC_DEBUG_FILENAME%
+    #  - copy bin\*.pdb OpenApoc-%OPENAPOC_VERSION%\
+    #  - 7z a %OPENAPOC_DEBUG_FILENAME% OpenApoc-%OPENAPOC_VERSION%\*.pdb
+    #  - appveyor PushArtifact %OPENAPOC_DEBUG_FILENAME%
 before_test:
   - 7z e temp\cd.iso.xz -odata\
 test_script:


### PR DESCRIPTION
We keep running out of space on appveyor artifact storage, and nobody
but devs use the debug packages, who likely have a local build anyway.

And anyone who cares enough to help dev/test likely has a 64bit capable
windows machine anyway, and I've not yet seen a 32/64bit build
difference issue as we're not doing type size/pointer nonsense.