### PR TITLE
remove cache entries from appveyor.yml

### DIFF
--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -21,7 +21,7 @@ init:
   - if "%PLATFORM%"=="Win32" (set VCVARS_ARCH=amd64_x86)
   - if "%PLATFORM%"=="Win32" (set QTPATH=C:\Qt\5.13\msvc2017)
 #clone_depth: 10
-cache: c:\tools\vcpkg\installed
+#cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ init:
   - if "%PLATFORM%"=="Win32" (set VCVARS_ARCH=amd64_x86)
   - if "%PLATFORM%"=="Win32" (set QTPATH=C:\Qt\5.13\msvc2017)
 #clone_depth: 10
-cache: c:\tools\vcpkg\installed
+#cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull


### PR DESCRIPTION
Should cause any caches to be deleted.

Then we can re-add them.

Hoping to solve the "error 500" from artifact storage on appveyor - I
assumed it was storage limits, but having removed a number of builds and
still getting errors not so sure.