### PR TITLE
Appveyor: A number of updates

### DIFF
--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -25,7 +25,7 @@ cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2019.10
+  - git checkout 2019.12
   - cd c:\projects\openapoc
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -4,7 +4,7 @@ branches:
   - master
   - /release.*/
 skip_tags: true
-os: Visual Studio 2017
+os: Visual Studio 2019
 configuration:
   - Release
 #  - Debug
@@ -34,7 +34,7 @@ before_build:
   - curl http://s2.jonnyh.net/pub/cd_minimal.iso.xz -o temp\cd.iso.xz
   - 7z e temp\cd.iso.xz -odata\
   - choco install ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
   - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH%
   - cmake --build .

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -21,7 +21,7 @@ init:
   - if "%PLATFORM%"=="Win32" (set VCVARS_ARCH=amd64_x86)
   - if "%PLATFORM%"=="Win32" (set QTPATH=C:\Qt\5.13\msvc2017)
 #clone_depth: 10
-#cache: c:\tools\vcpkg\installed
+cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -26,7 +26,7 @@ before_build:
   - cd c:\tools\vcpkg
   - git pull
   - git checkout 2019.12
-  - cd c:\projects\openapoc
+  - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run
   - vcpkg remove --outdated

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2019.10
+  - git checkout 2019.12
   - cd c:\projects\openapoc
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ configuration:
 #  - Debug
 platform:
   - x64
-  - Win32
+#  - Win32
 environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
 init:
@@ -60,9 +60,6 @@ after_build:
   - del OpenApoc-%OPENAPOC_VERSION%\portable.txt
   - '"C:\Program Files (x86)\NSIS\makensis.exe" /DGAME_VERSION=%OPENAPOC_VERSION% install\windows\installer.nsi'
   - appveyor PushArtifact install\windows\install-openapoc-%OPENAPOC_VERSION%.exe
-  - copy bin\*.pdb OpenApoc-%OPENAPOC_VERSION%\
-  - 7z a %OPENAPOC_DEBUG_FILENAME% OpenApoc-%OPENAPOC_VERSION%\*.pdb
-  - appveyor PushArtifact %OPENAPOC_DEBUG_FILENAME%
 before_test:
   - 7z e temp\cd.iso.xz -odata\
 test_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ init:
   - if "%PLATFORM%"=="Win32" (set VCVARS_ARCH=amd64_x86)
   - if "%PLATFORM%"=="Win32" (set QTPATH=C:\Qt\5.13\msvc2017)
 #clone_depth: 10
-#cache: c:\tools\vcpkg\installed
+cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -29,6 +29,7 @@ before_build:
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run
+  - vcpkg remove --outdated
   - git submodule update --init --recursive
   - curl http://s2.jonnyh.net/pub/cd_minimal.iso.xz -o temp\cd.iso.xz
   - 7z e temp\cd.iso.xz -odata\

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ before_build:
   - cd c:\tools\vcpkg
   - git pull
   - git checkout 2019.12
-  - cd c:\projects\openapoc
+  - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run
   - git submodule update --init --recursive


### PR DESCRIPTION
- Update the build toolchain to msvc2019
- Update vcpkg to 2019.12
- Don't hardcode git checkout path, instead use %APPVEYOR_BUILD_FOLDER%
- Re-enable vcpkg cache