### PR TITLE
WORK IN PROGRESS - Rework the translation system to allow generation of gettext .pot files

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "dependencies/lua"]
 	path = dependencies/lua
 	url = https://github.com/lua/lua.git
+[submodule "dependencies/fmt"]
+	path = dependencies/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -258,8 +258,13 @@ add_custom_target(tidy ${CLANG_TIDY}
 
 set(LANGUAGES en_GB fr_FR de_DE cs es it pl pt_BR ru_RU uk)
 
+set(SOURCE_POT_FILE ${CMAKE_SOURCE_DIR}/data/languages/source.pot)
+set(FORM_POT_FILE ${CMAKE_SOURCE_DIR}/data/languages/forms.pot)
+
 find_package(Gettext)
 if (GETTEXT_FOUND)
+
+
 		foreach(LANG ${LANGUAGES})
 				GETTEXT_PROCESS_PO_FILES(${LANG} PO_FILES
 						${CMAKE_SOURCE_DIR}/data/languages/ufo_string_${LANG}.po)
@@ -272,3 +277,23 @@ if (GETTEXT_FOUND)
 						${CMAKE_SOURCE_DIR}/data/languages/${LANG}/LC_MESSAGES/ufo_string.mo)
 		endforeach()
 endif(GETTEXT_FOUND)
+
+
+FIND_PROGRAM(XGETTEXT_EXECUTABLE xgettext)
+
+IF(XGETTEXT_EXECUTABLE)
+    SET(XGETTEXT_FOUND TRUE)
+ELSE(XGETTEXT_EXECUTABLE)
+    MESSAGE(STATUS "xgettext not found.")
+    SET(XGETTTEXT_FOUND FALSE)
+ENDIF(XGETTEXT_EXECUTABLE)
+
+
+if (XGETTEXT_FOUND)
+		add_custom_command(OUTPUT ${SOURCE_POT_FILE}
+				COMMAND ${XGETTEXT_EXECUTABLE} -ktformat -ktr -o ${SOURCE_POT_FILE} ${FORMAT_SOURCES}
+				DEPENDS ${FORMAT_SOURCES})
+		add_custom_target(extract-source-translations
+				DEPENDS ${SOURCE_POT_FILE})
+
+endif()

--- a/data/languages/base_gamestate.pot
+++ b/data/languages/base_gamestate.pot
@@ -1,0 +1,2469 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenApoc\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2020-01-04 16:20+0800\n"
+"Last-Translator: JonnyH\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/x-com-apocalypse/apocalypse/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+
+msgid ""
+msgstr ""
+
+msgid " For researching advanced Alien organic technology."
+msgstr ""
+
+msgid "-"
+msgstr ""
+
+msgid "40mm Auto Cannon"
+msgstr ""
+
+msgid "40mm Auto Cannon Turret"
+msgstr ""
+
+msgid "A Chrysalis is the most vulnerable stage of Alien development because it possesses no attack mechanisms. Its skin is tough, but vulnerable to fire and incendiary ammunition. A new Alien will grow inside the Chrysalis and emerge after a period of three days. It seems that a variety of Alien forms could develop at this stage, dependent on the genetic information carried by the Hyperworm. The physiology of these new forms contains many new cell structures. We have now gained a significant understanding of Alien genetics."
+msgstr ""
+
+msgid "A Marsec vehicle renowned for its handling and power. Once loaded with weapons systems it proves to be a useful military vehicle and an ideal transport for X-COM Agents."
+msgstr ""
+
+msgid "A Psionic projection device for psionically trained Agents. This device must be used in order to initiate Psionic attacks in combat situations. The target needs to be within clear line of sight of the operator before an attack can begin. The Agent has a choice of four different attacks of increasing difficulty. Psionic Probe reveals information about the target, Psionic Panic reduces morale, Psionic Stun will render the target unconscious and psionic control will allow complete control of the target."
+msgstr ""
+
+msgid "A beam weapon deployed on Alien craft."
+msgstr ""
+
+msgid "A close combat weapon that uses an Elerium Plasma Generator to enhance the blade. It is a very powerful device but can only be used against adjacent targets."
+msgstr ""
+
+msgid "A compact anti-grav unit suitable for Hoverbikes and smaller vehicles only."
+msgstr ""
+
+msgid "A compact but highly sophisticated life support kit. Wounds and bleeding can be healed quickly by injecting Nanobots into the bloodstream. When the device is activated the operator must select a part of the body affected by critical wounds. The device will cure these wounds quickly, but only if the Agent remains inactive while it is in operation."
+msgstr ""
+
+msgid "A compact ground launched missile system for small road vehicles. This will turn a humble road car into a serious threat to airborne vehicles."
+msgstr ""
+
+msgid "A complex AI unit manufactured by Cyberweb. It is designed to assist the aiming and intelligent targeting for all installed weapons systems."
+msgstr ""
+
+msgid "A computer controlled, fully automated goods vehicle. The road going Autotrans is a more economical version of the Airtrans, but the AI is still so advanced that they can anticipate demand for their services with uncanny accuracy and rarely need to be ordered in advance."
+msgstr ""
+
+msgid "A craft capable of carrying our agents into the Alien Dimensions is required. The vast Alien structures must be explored and studied. This will help us understand their function and their weaknesses."
+msgstr ""
+
+msgid "A device based on disruption field research which could be used to disable Alien disruption shields."
+msgstr ""
+
+msgid "A discreet, but powerful computer targeting turret system. Designed for small road vehicles."
+msgstr ""
+
+msgid "A gigantic monster that has ravaged the city."
+msgstr ""
+
+msgid "A grenade which disperses an incendiary agent, creating fires within a large radius. The incendiary grenade was originally created by Diablo and is popular with many of the city's criminal gangs."
+msgstr ""
+
+msgid "A grenade which releases the X-COM developed anti-Alien gas. It does not harm humans or terrain but will be lethal for any Alien remaining within its dense gas cloud."
+msgstr ""
+
+msgid "A guided missile launcher that can fire explosive or incendiary missiles. It is an extremely devastating device and should be used with extreme caution. It is unwieldy because of its bulk and Agents with heavy launchers should at least be equipped with a supplementary weapon such as the Megapol Lawpistol."
+msgstr ""
+
+msgid "A high explosive system for breaking through barriers or impassable terrain. Extra care must be taken when throwing this device. Its increased size means that it can't be thrown the same distance as a conventional grenade."
+msgstr ""
+
+msgid "A high powered anti-grav unit generally restricted to military or police vehicles."
+msgstr ""
+
+msgid "A high powered road vehicle engine for standard size road vehicles"
+msgstr ""
+
+msgid "A humanoid Alien with an exo-skeleton structure."
+msgstr ""
+
+msgid "A large anti-grav unit designed for military vehicles or commercial transports."
+msgstr ""
+
+msgid "A large worm-like creature quickly develops inside the protective skin of the Alien egg. This worm appears to contain the embryos of a further four life forms. We cannot tell how the next stage in the life cycle develops from the autopsy results, but the tissues will be useful for our toxicology research."
+msgstr ""
+
+msgid "A larger and more powerful version of the Small Disruption Shield designed for larger Alien craft. Its absorption level is much greater, but will still malfunction if the power level is reduced to zero."
+msgstr ""
+
+msgid "A larger, better equipped lab for researching the larger pieces of Alien technology. The lab can accommodate ten Quantum Physicists."
+msgstr ""
+
+msgid "A laser gun with a laser sight designed for accurate long range shooting. This weapon is a good complement for the Marsec M4000 Machine Gun and should be used by Agents with good accuracy ratings."
+msgstr ""
+
+msgid "A lightweight armour developed by X-COM using Alien disruption field technology. This offers superb protection and excellent mobility."
+msgstr ""
+
+msgid "A live Brainsucker is a valuable specimen - we must research it as soon as possible."
+msgstr ""
+
+msgid "A live Multiworm egg gives us an excellent opportunity to observe the Alien life cycle in progress."
+msgstr ""
+
+msgid "A live Multiworm is a rare catch and must be studied immediately as it is a highly unstable life form."
+msgstr ""
+
+msgid "A living Psimorph is an extremely dangerous entity which must be kept unconscious, otherwise its Psionic ability would result in subversion of our personnel."
+msgstr ""
+
+msgid "A long range missile system with a powerful fusion warhead. Only useful against ground targets or slow moving vehicles."
+msgstr ""
+
+msgid "A low powered road engine for bikes and small vehicles."
+msgstr ""
+
+msgid "A military automatic firing projectile weapon. It is good at close range using automatic fire, but not accurate enough to be effective at longer ranges."
+msgstr ""
+
+msgid "A missile launcher which transforms the heavy tank into an effective air defense unit."
+msgstr ""
+
+msgid "A more complex and capable version of the Light Weapons Control. Accuracy is improved over the smaller model."
+msgstr ""
+
+msgid "A more high-powered version of the Superdynamics standard, but still small enough for a Hoverbike."
+msgstr ""
+
+msgid "A more powerful and accurate cannon system manufactured by Marsec and designed for small road vehicles."
+msgstr ""
+
+msgid "A multiple warhead missile."
+msgstr ""
+
+msgid "A popular but expensive alternative to the Bolter laser gun. The rare Elerium fuel is used to power both the plasma chamber and the electro-magnetic accelerators that propel the ultra-heated plasma to near light speeds."
+msgstr ""
+
+msgid "A powerful Alien grenade."
+msgstr ""
+
+msgid "A powerful Biological warfare weapon designed to target the Micronoid parasites."
+msgstr ""
+
+msgid "A powerful cannon which fires explosive shells over large distances. Its effectiveness is limited to static or slow moving targets."
+msgstr ""
+
+msgid "A powerful explosive that will detonate when a sizable moving object moves within its detection field. The range of the proximity field can be programmed."
+msgstr ""
+
+msgid "A powerful road engine normally reserved for police or military use."
+msgstr ""
+
+msgid "A security station using Alien disrupter technology."
+msgstr ""
+
+msgid "A small bipedal Alien creature."
+msgstr ""
+
+msgid "A sophisticated single handed missile launcher. Although the guided missiles are small they are quite destructive."
+msgstr ""
+
+msgid "A standard issue hand gun which is good at short range and quite powerful. Its usefulness should not be underestimated because it allows an Agent to use other equipment, such as a grenade, with the spare hand."
+msgstr ""
+
+msgid "A standard module for transporting goods. X-COM Agents should have cargo capacity at a building after a tactical combat mission in order to retrieve equipment and Alien artifacts."
+msgstr ""
+
+msgid "A standard road vehicle anti-grav unit."
+msgstr ""
+
+msgid "A superior weapons control system."
+msgstr ""
+
+msgid "A swarming amoebae-like Alien life form."
+msgstr ""
+
+msgid "A toxin needs to be developed to combat the higher Alien life forms."
+msgstr ""
+
+msgid "Access Lift"
+msgstr ""
+
+msgid "Accommodation and recreation for X-COM Agents. New living quarters will have to be built as more Agents, Scientists and Engineers are hired."
+msgstr ""
+
+msgid "Advanced Alien Containment"
+msgstr ""
+
+msgid "Advanced Biochemistry Lab"
+msgstr ""
+
+msgid "Advanced Control System"
+msgstr ""
+
+msgid "Advanced Quantum Physics Lab"
+msgstr ""
+
+msgid "Advanced Security Station"
+msgstr ""
+
+msgid "Advanced Workshop"
+msgstr ""
+
+msgid "Agents which are naturally talented in Psionic skills need to train hard to maintain and improve their power, attack and defense. The Psi-Gym is equipped with the latest Psionic technology and Psionic training is not possible without such a facility. Agents assigned to Psionic training will automatically use any Psi Gym at a base, but if the capacity of the gyms is exceeded then training will not take place at 100% efficiency."
+msgstr ""
+
+msgid "Air Defense Missile"
+msgstr ""
+
+msgid "Airguard 52mm Cannon Round"
+msgstr ""
+
+msgid "Airguard Anti-Air Cannon"
+msgstr ""
+
+msgid "Airtaxi"
+msgstr ""
+
+msgid "Airtrans"
+msgstr ""
+
+msgid "Alien"
+msgstr ""
+
+msgid "Alien Artifact"
+msgstr ""
+
+msgid "Alien Assault Ship"
+msgstr ""
+
+msgid "Alien Battleship"
+msgstr ""
+
+msgid "Alien Bomber"
+msgstr ""
+
+msgid "Alien Containment"
+msgstr ""
+
+msgid "Alien Control System"
+msgstr ""
+
+msgid "Alien Craft"
+msgstr ""
+
+msgid "Alien Craft Control Systems"
+msgstr ""
+
+msgid "Alien Craft Energy Source"
+msgstr ""
+
+msgid "Alien Craft Propulsion"
+msgstr ""
+
+msgid "Alien Destroyer"
+msgstr ""
+
+msgid "Alien Detector"
+msgstr ""
+
+msgid "Alien Egg's Vomit Tube"
+msgstr ""
+
+msgid "Alien Energy Source"
+msgstr ""
+
+msgid "Alien Escort"
+msgstr ""
+
+msgid "Alien Escort Ship"
+msgstr ""
+
+msgid "Alien Farm"
+msgstr ""
+
+msgid "Alien Fast Attack Ship"
+msgstr ""
+
+msgid "Alien Gas"
+msgstr ""
+
+msgid "Alien Gas Grenade"
+msgstr ""
+
+msgid "Alien Grey"
+msgstr ""
+
+msgid "Alien Mothership"
+msgstr ""
+
+msgid "Alien Probe"
+msgstr ""
+
+msgid "Alien Propulsion System"
+msgstr ""
+
+msgid "Alien Scout"
+msgstr ""
+
+msgid "Alien Scout Ship"
+msgstr ""
+
+msgid "Alien Transporter"
+msgstr ""
+
+msgid "Alien building"
+msgstr ""
+
+msgid "Alien building 1"
+msgstr ""
+
+msgid "Alien building 2"
+msgstr ""
+
+msgid "Alien building 3"
+msgstr ""
+
+msgid "Alien building 4"
+msgstr ""
+
+msgid "Alien building 5"
+msgstr ""
+
+msgid "Alien building 6"
+msgstr ""
+
+msgid "Alien building 7"
+msgstr ""
+
+msgid "Alien building 8"
+msgstr ""
+
+msgid "Alien building 9"
+msgstr ""
+
+msgid "Alien craft energy generator."
+msgstr ""
+
+msgid "Alien craft guidance System."
+msgstr ""
+
+msgid "Alien craft propulsion."
+msgstr ""
+
+msgid "Alien inter-dimensional craft"
+msgstr ""
+
+msgid "Alien weapons technology is based on a complex sub-atomic particle system. The Disruptor Beam is generated from an inter-dimensional power source. It propels sub-atomic particles which disintegrate molecules in their path. The weapon does not require ammunition since the energy chamber appears to be a self-perpetuating energy source."
+msgstr ""
+
+msgid "Aliens"
+msgstr ""
+
+msgid "All equipment and raw materials must be safely stored. Spare storage capacity should be maintained in order to allow for purchases and transfers from other bases."
+msgstr ""
+
+msgid "All kinds of small flying vehicles are produced here, such as Hovercars, Hoverbikes and transports. There are many Elerium supplies stored here which could be the target of hostile raiders."
+msgstr ""
+
+msgid "All military vehicles can be equipped with a variety of weapons, engines and special equipment. The engines and weapons are divided into road and airborne categories. Careful attention to improving vehicle equipment is an essential part of military strategy."
+msgstr ""
+
+msgid "All research into the origins of the Aliens and their home world is collected in this section."
+msgstr ""
+
+msgid "All research relating to the various types of Alien craft and their propulsion systems is collected here."
+msgstr ""
+
+msgid "All results of Alien research are recorded here, including results of autopsies and analysis of living specimens."
+msgstr ""
+
+msgid "All types of building materials and components are created here. The high walkways and open factory floors create a dangerous environment for any firearms combat."
+msgstr ""
+
+msgid "All types of consumer durables are produced here. The vast factory complex is highly automated and there are many robots on the production lines."
+msgstr ""
+
+msgid "Allows a vehicle to carry an extra four passengers in addition to the standard passenger capacity for the vehicle type."
+msgstr ""
+
+msgid "Ammunition for Toxigun. A fast acting poison which targets all Alien life forms with equally devastating effects. This toxin effectively supersedes the A or B types."
+msgstr ""
+
+msgid "Ammunition for Toxigun. It contains a lethal fast acting poison designed to target Alien life forms. It is not so effective against the more advanced bipedal Alien types."
+msgstr ""
+
+msgid "Ammunition for Toxigun. It contains a lethal fast acting poison designed to target Alien lifeforms. It effectively renders the earlier A-type toxin obsolete because it is more powerful and more effective against the higher Alien life forms."
+msgstr ""
+
+msgid "Ammunition for an Alien weapon."
+msgstr ""
+
+msgid "Ammunition for the Laser Sniper Gun."
+msgstr ""
+
+msgid "Ammunition for the Lawpistol."
+msgstr ""
+
+msgid "Ammunition for the M4000 Machine Gun."
+msgstr ""
+
+msgid "Ammunition for the Plasma Gun."
+msgstr ""
+
+msgid "An Alien beam weapon."
+msgstr ""
+
+msgid "An Alien device which limits detection."
+msgstr ""
+
+msgid "An Alien energy shield."
+msgstr ""
+
+msgid "An Alien guided missile launched from Alien craft."
+msgstr ""
+
+msgid "An Alien guided missile weapon."
+msgstr ""
+
+msgid "An Alien guided missile."
+msgstr ""
+
+msgid "An Alien missile with an immobilizing effect."
+msgstr ""
+
+msgid "An Alien organic weapon."
+msgstr ""
+
+msgid "An Alien teleportation device."
+msgstr ""
+
+msgid "An X-COM developed Disruptor Beam weapon based on Alien technology. It is a faster firing and more effective weapon than the Devastator Cannon."
+msgstr ""
+
+msgid "An X-COM weapon designed to shoot high powered projectiles containing anti-Alien toxic fluids. It is designed to cause minimal harm to other targets and is not very good at penetrating armor."
+msgstr ""
+
+msgid "An arms factory produces munitions and weaponry of all sizes from the smallest Lawpistol slug to the most destructive fusion bombs. Any combat within the factory would be extremely dangerous, so any X-COM Agents must proceed with extreme caution when investigating these buildings."
+msgstr ""
+
+msgid "An expensive but effective single-handed plasma weapon. Its small size and power make it a versatile weapon. It can be used effectively at long or short range and leaves one hand free to use other equipment or grenades."
+msgstr ""
+
+msgid "An expensive, Elerium powered armor system. This armour offers less protection than the Megapol armour on average but will not slow down the wearer so much. The expensive torso section also has an integrated levitation unit which will allow the wearer to fly or hover in the air. This is an extremely useful ability, but an airborne Agent will suffer an accuracy penalty while using weapons or throwing grenades."
+msgstr ""
+
+msgid "An extremely dangerous Alien that must be kept sedated."
+msgstr ""
+
+msgid "An extremely large warrior creature."
+msgstr ""
+
+msgid "An intelligent Alien proximity mine"
+msgstr ""
+
+msgid "An intelligent, airborne humanoid Alien warrior."
+msgstr ""
+
+msgid "An unusual jelly like Alien life form."
+msgstr ""
+
+msgid "Android"
+msgstr ""
+
+msgid "Annihilator"
+msgstr ""
+
+msgid "Anthropod"
+msgstr ""
+
+msgid "Anthropod Autopsy"
+msgstr ""
+
+msgid "Anti-Alien Gas"
+msgstr ""
+
+msgid "Any research involving Alien creatures must be conducted in a Biochemistry Lab. These labs can accommodate up to five Biochemists working at one time and each lab can be assigned a specific research project."
+msgstr ""
+
+msgid "Apartments"
+msgstr ""
+
+msgid "Appliances Factory"
+msgstr ""
+
+msgid "Armor Piercing"
+msgstr ""
+
+msgid "Armor piercing ammunition for the Auto Cannon."
+msgstr ""
+
+msgid "Arms Factory"
+msgstr ""
+
+msgid "Astrodome"
+msgstr ""
+
+msgid "Atmosphere Processor"
+msgstr ""
+
+msgid "Auto Cannon AP Clip"
+msgstr ""
+
+msgid "Auto Cannon HE Clip"
+msgstr ""
+
+msgid "Auto Cannon IN Clip"
+msgstr ""
+
+msgid "Autotaxi"
+msgstr ""
+
+msgid "Autotrans"
+msgstr ""
+
+msgid "Base Facilities"
+msgstr ""
+
+msgid "Bio-Transport"
+msgstr ""
+
+msgid "Bio-Transport Module"
+msgstr ""
+
+msgid "Biochemistry Lab"
+msgstr ""
+
+msgid "Biological Warfare"
+msgstr ""
+
+msgid "Biotrans"
+msgstr ""
+
+msgid "Blazer Turbo Bike"
+msgstr ""
+
+msgid "Bolter 4000 Laser Gun"
+msgstr ""
+
+msgid "Boomeroid"
+msgstr ""
+
+msgid "Brainsuck"
+msgstr ""
+
+msgid "Brainsucker"
+msgstr ""
+
+msgid "Brainsucker Autopsy"
+msgstr ""
+
+msgid "Brainsucker Launcher"
+msgstr ""
+
+msgid "Brainsucker Pod"
+msgstr ""
+
+msgid "Brainsucker Pods"
+msgstr ""
+
+msgid "Building security"
+msgstr ""
+
+msgid "Buildings"
+msgstr ""
+
+msgid "Car Factory"
+msgstr ""
+
+msgid "Car Park"
+msgstr ""
+
+msgid "Cargo Module"
+msgstr ""
+
+msgid "Cells"
+msgstr ""
+
+msgid "Chief of Police"
+msgstr ""
+
+msgid "Chrysalis"
+msgstr ""
+
+msgid "Chrysalis Autopsy"
+msgstr ""
+
+msgid "Citizens of Mega-Primus use two types of vehicle. There are common road traveling vehicles that use a low cost anti-gravity system embedded in the road surface and airborne flyers which employ more sophisticated Elerium powered anti-gravity engines. The bold red military vehicles are available for X-COM to purchase."
+msgstr ""
+
+msgid "City regulations stipulate the highest possible water quality. The tall water purifiers are largely automated buildings and are difficult areas for combat, they also provide good hiding places for Alien spawn. The tall structures are also vulnerable to collapse, so explosive munitions should be avoided."
+msgstr ""
+
+msgid "Civilian"
+msgstr ""
+
+msgid "Civilian Car"
+msgstr ""
+
+msgid "Civilian Female"
+msgstr ""
+
+msgid "Civilian Female 1"
+msgstr ""
+
+msgid "Civilian Female 2"
+msgstr ""
+
+msgid "Civilian Male"
+msgstr ""
+
+msgid "Civilian Male 1"
+msgstr ""
+
+msgid "Civilian Male 2"
+msgstr ""
+
+msgid "Cloaking Field"
+msgstr ""
+
+msgid "Construction Factory"
+msgstr ""
+
+msgid "Construction Vehicle"
+msgstr ""
+
+msgid "Control Chamber"
+msgstr ""
+
+msgid "Corporate Boss"
+msgstr ""
+
+msgid "Corporate HQ"
+msgstr ""
+
+msgid "Corporate hood"
+msgstr ""
+
+msgid "Cult Leader"
+msgstr ""
+
+msgid "Cult Of Sirius"
+msgstr ""
+
+msgid "Cult of Sirius"
+msgstr ""
+
+msgid "Cultist"
+msgstr ""
+
+msgid "Cyberweb"
+msgstr ""
+
+msgid "Dead Anthropod"
+msgstr ""
+
+msgid "Dead Brainsucker"
+msgstr ""
+
+msgid "Dead Chrysalis"
+msgstr ""
+
+msgid "Dead Hyperworm"
+msgstr ""
+
+msgid "Dead Megaspawn"
+msgstr ""
+
+msgid "Dead Micronoid Aggregate"
+msgstr ""
+
+msgid "Dead Multiworm"
+msgstr ""
+
+msgid "Dead Multiworm egg"
+msgstr ""
+
+msgid "Dead Overspawn"
+msgstr ""
+
+msgid "Dead Popper"
+msgstr ""
+
+msgid "Dead Psimorph"
+msgstr ""
+
+msgid "Dead Queenspawn"
+msgstr ""
+
+msgid "Dead Skeletoid"
+msgstr ""
+
+msgid "Dead Spitter"
+msgstr ""
+
+msgid "Debugger Cannon"
+msgstr ""
+
+msgid "Devastator Cannon"
+msgstr ""
+
+msgid "Developed by X-COM to target Alien life forms. When the warhead explodes it releases a cloud of gas deadly to Aliens but harmless to humans."
+msgstr ""
+
+msgid "Diablo"
+msgstr ""
+
+msgid "Diablo is a criminal syndicate with a particularly violent reputation. They have muscled in on the Psiclone trade and have consequently become bigger and more powerful than Psyke. Gang members are intensely loyal to their cause and hostile to any outsiders."
+msgstr ""
+
+msgid "Dimension Destabiliser"
+msgstr ""
+
+msgid "Dimension Force Field"
+msgstr ""
+
+msgid "Dimension Gate Generator"
+msgstr ""
+
+msgid "Dimension Gates"
+msgstr ""
+
+msgid "Dimension Missile"
+msgstr ""
+
+msgid "Dimension Missile Launcher"
+msgstr ""
+
+msgid "Dimension Probe"
+msgstr ""
+
+msgid "Dimension Shifter"
+msgstr ""
+
+msgid "Disruptor Armor"
+msgstr ""
+
+msgid "Disruptor Armor (head)"
+msgstr ""
+
+msgid "Disruptor Armor (left arm)"
+msgstr ""
+
+msgid "Disruptor Armor (legs)"
+msgstr ""
+
+msgid "Disruptor Armor (right arm)"
+msgstr ""
+
+msgid "Disruptor Armor (torso)"
+msgstr ""
+
+msgid "Disruptor Beam"
+msgstr ""
+
+msgid "Disruptor Bomb"
+msgstr ""
+
+msgid "Disruptor Bomb Launcher"
+msgstr ""
+
+msgid "Disruptor Gun"
+msgstr ""
+
+msgid "Disruptor Inversion Bomb"
+msgstr ""
+
+msgid "Disruptor Inversion Bomb Launcher"
+msgstr ""
+
+msgid "Disruptor Multi-Bomb"
+msgstr ""
+
+msgid "Disruptor Multi-Bomb Fragment"
+msgstr ""
+
+msgid "Disruptor Multi-Bomb Launcher"
+msgstr ""
+
+msgid "Due to the size of the Megaspawn we need a lot of free space in the Alien Containment facility to hold it and an advanced Bio-lab to study it."
+msgstr ""
+
+msgid "Each building in Mega-Primus is a vast labyrinth of corridors, atriums, rooms, halls and service ducts. If Aliens have infiltrated a building they will be found in just a small part of the complex, with plenty of places to escape from the combat zone. Buildings with lower populations or numerous service areas provide much better places for Aliens to hide and breed."
+msgstr ""
+
+msgid "Education is a serious matter for citizens of Mega-Primus and the latest Psionic devices are used to fill students' minds with the correct understanding of any topic in the curriculum. The buildings themselves are reminiscent of the old style schools and contain little more than corridors and classrooms."
+msgstr ""
+
+msgid "Elerium"
+msgstr ""
+
+msgid "Elerium-115"
+msgstr ""
+
+msgid "Energen"
+msgstr ""
+
+msgid "Energen builds power stations which use fusion power cells to generate energy. This is an alternative but cheaper large scale power system than equivalent Elerium units. However, the corporation is wary of attempts by Solmine to create cheaper Elerium energy systems. This can only be achieved by lowering the price of Elerium which could happen if the rebellious mining colonies are totally subdued."
+msgstr ""
+
+msgid "Energy Pod"
+msgstr ""
+
+msgid "Entropy Enzyme"
+msgstr ""
+
+msgid "Entropy Launcher"
+msgstr ""
+
+msgid "Entropy Pod"
+msgstr ""
+
+msgid "Equipment"
+msgstr ""
+
+msgid "Evonet"
+msgstr ""
+
+msgid "Explorer"
+msgstr ""
+
+msgid "Explosive"
+msgstr ""
+
+msgid "Explosive 1"
+msgstr ""
+
+msgid "Explosive ammunition for the MiniLauncher."
+msgstr ""
+
+msgid "Extropians"
+msgstr ""
+
+msgid "Falling Object"
+msgstr ""
+
+msgid "Fires Brainsucker pods."
+msgstr ""
+
+msgid "Flyer Factory"
+msgstr ""
+
+msgid "Food Chamber"
+msgstr ""
+
+msgid "For researching advanced Alien technology."
+msgstr ""
+
+msgid "For transporting Alien life forms."
+msgstr ""
+
+msgid "ForceWeb"
+msgstr ""
+
+msgid "Fusion Powerfuel"
+msgstr ""
+
+msgid "GLM Air Defense"
+msgstr ""
+
+msgid "GLM Air defense"
+msgstr ""
+
+msgid "GLM Array"
+msgstr ""
+
+msgid "Gang leader"
+msgstr ""
+
+msgid "Gangster"
+msgstr ""
+
+msgid "General Metro"
+msgstr ""
+
+msgid "Government"
+msgstr ""
+
+msgid "GravBall League"
+msgstr ""
+
+msgid "GravBall is a fast paced aerial version of Soccer where the players use anti-grav backpacks to fly around an immense stadium. Due to the fast and violent nature of the game, players wear tough armor, injuries are still common though. Cybernetic implants are used to substitute for mangled limbs, but a GravBall player must be at least 50% original human flesh in order to qualify in the GravBall league. Due to the popularity of the sport the GravBall League, which owns all the stadiums in the city, has become a prosperous corporation. However, alternative recreations such as Sensovision or the illegal Psiclone are proving to be serious competition."
+msgstr ""
+
+msgid "Gravball League"
+msgstr ""
+
+msgid "Griffon AFV"
+msgstr ""
+
+msgid "Ground Launched Missile"
+msgstr ""
+
+msgid "Hawk Air Warrior"
+msgstr ""
+
+msgid "Heavy Disruptor Beam"
+msgstr ""
+
+msgid "Heavy Launcher AG Missile"
+msgstr ""
+
+msgid "Heavy Launcher Alien Gas Missile"
+msgstr ""
+
+msgid "Heavy Launcher HE Missile"
+msgstr ""
+
+msgid "Heavy Launcher IN Missile"
+msgstr ""
+
+msgid "Heavy Weapons Control"
+msgstr ""
+
+msgid "Heavy transportation is mainly undertaken by these heavy duty air transports. Manufactured goods are transported entirely by air, given the unreliability and dangers of road transport in the deregulated areas, or slums. The Airtrans is a computer controlled craft, but must be manned by law according to the inter-personal contact ordinances."
+msgstr ""
+
+msgid "High Explosive ammunition for the Auto Cannon."
+msgstr ""
+
+msgid "High energy Laser Beam weapon designed for military and police vehicles. Powerful atomic cells provide the energy source."
+msgstr ""
+
+msgid "High explosive ammunition for the Heavy Launcher."
+msgstr ""
+
+msgid "Hospital"
+msgstr ""
+
+msgid "Hotel"
+msgstr ""
+
+msgid "Hoverbike"
+msgstr ""
+
+msgid "Hydro-Farm"
+msgstr ""
+
+msgid "Hyperworm"
+msgstr ""
+
+msgid "Hyperworm Autopsy"
+msgstr ""
+
+msgid "Hyperworm's Bite"
+msgstr ""
+
+msgid "Hyperworms"
+msgstr ""
+
+msgid "In order to combat the increasing aggression and power of Alien craft we must build an inter-dimensional weapons platform."
+msgstr ""
+
+msgid "Incendiary"
+msgstr ""
+
+msgid "Incendiary Grenade"
+msgstr ""
+
+msgid "Incendiary ammunition for the Auto Cannon."
+msgstr ""
+
+msgid "Incendiary ammunition for the Heavy Launcher."
+msgstr ""
+
+msgid "Incendiary ammunition for the MiniLauncher."
+msgstr ""
+
+msgid "Incubator"
+msgstr ""
+
+msgid "Incubator Chamber"
+msgstr ""
+
+msgid "Instantly transports a vehicle over short ranges."
+msgstr ""
+
+msgid "Investigate the genetic relationships between Alien life forms."
+msgstr ""
+
+msgid "Investigate the source of the Alien intelligence and their secret purpose."
+msgstr ""
+
+msgid "It is clear that the Alien life cycle is an extremely rapid sequence of changes. The eggs always develop into Multiworms which then give birth to Hyperworms which form a Chrysalis. At this stage the genetic variation produces a variety of Alien types which develop inside the Chrysalis. The whole process from the egg hatching to emergence from the Chrysalis only seems to take about ten days, provided that there is an adequate supply of food. Fortunately these life forms do not survive very well in our world and it is unclear how an invasion could be successful."
+msgstr ""
+
+msgid "It is difficult to disable the Megaspawn's weapon systems because they are an intrinsic part of its structure. One weapon uses energy beams while the other fires a powerful organic missile, which is generated by specialized organs. Our tests also conclude that the Megaspawn is protected from Psionic attacks."
+msgstr ""
+
+msgid "It is now clear to us that the Micronoid organisms are the source of the Alien intelligence and they are using the various Alien forms to initiate an assault on our dimension. The large Alien life forms cannot survive in our dimension - the Micronoids must transfer to a new host in order to conquer our world and the ideal host is our own race. Brainsuckers are used to introduce Micronoids into the human bloodstream which then gain control of the brain and have access to all the knowledge and abilities of the host. We now understand the physiology of the Micronoids sufficiently in order to develop a specific toxin that will kill the organisms in the bloodstream."
+msgstr ""
+
+msgid "Janitor Missile"
+msgstr ""
+
+msgid "Janitor Missile Array"
+msgstr ""
+
+msgid "Justice Missile"
+msgstr ""
+
+msgid "Justice Missile Launcher"
+msgstr ""
+
+msgid "Lancer 7000 Laser Gun"
+msgstr ""
+
+msgid "Large Disruption Shield"
+msgstr ""
+
+msgid "Large Flyer Factory"
+msgstr ""
+
+msgid "Larger anti-grav units give more speed and acceleration for Hovercars and other small airborne vehicles."
+msgstr ""
+
+msgid "Larger corporations may have a prestigious and expensive office building as a corporate head quarters. No expense would be spared on the interior decoration of these buildings. The equally lavish ventilation system may also be appreciated by Alien life forms."
+msgstr ""
+
+msgid "Larger pieces of technology require more space and power to construct. The Advanced Workshop is designed for large construction projects such as new vehicles. The facility can accommodate up to ten Engineers."
+msgstr ""
+
+msgid "Laser Beam"
+msgstr ""
+
+msgid "Laser Defense Array"
+msgstr ""
+
+msgid "Lifetree"
+msgstr ""
+
+msgid "Light Disruptor Beam"
+msgstr ""
+
+msgid "Light Weapons Control"
+msgstr ""
+
+msgid "Lineage Plasma Cannon"
+msgstr ""
+
+msgid "Live Alien specimens require an enclosed, controlled environment. The Alien Containment system can generate different types of atmosphere at various pressures. The unit is also secure enough to prevent the escape of Aliens into the base. This facility can accommodate up to twenty human sized life forms."
+msgstr ""
+
+msgid "Live Anthropod"
+msgstr ""
+
+msgid "Live Brainsucker"
+msgstr ""
+
+msgid "Live Chrysalis"
+msgstr ""
+
+msgid "Live Hyperworm"
+msgstr ""
+
+msgid "Live Megaspawn"
+msgstr ""
+
+msgid "Live Micronoid Aggregate"
+msgstr ""
+
+msgid "Live Multiworm"
+msgstr ""
+
+msgid "Live Multiworm egg"
+msgstr ""
+
+msgid "Live Overspawn"
+msgstr ""
+
+msgid "Live Popper"
+msgstr ""
+
+msgid "Live Psimorph"
+msgstr ""
+
+msgid "Live Queenspawn"
+msgstr ""
+
+msgid "Live Skeletoid"
+msgstr ""
+
+msgid "Live Spitter"
+msgstr ""
+
+msgid "Living Quarters"
+msgstr ""
+
+msgid "Longevity is the major obsession of medical research. Life can be prolonged by genetically reprogramming cell death mechanisms, but disease is still a major killer. Nano technology is employed to destroy cancer cells and solve all kinds of medical problems. Operations are no longer performed by humans - artificial intelligence's are employed instead. The Sanctuary Clinic controls hospitals, pharmaceutical plants and the procreation parks."
+msgstr ""
+
+msgid "Lower Class Female"
+msgstr ""
+
+msgid "Lower Class Female 1"
+msgstr ""
+
+msgid "Lower Class Female 2"
+msgstr ""
+
+msgid "Lower Class Male"
+msgstr ""
+
+msgid "Lower Class Male 1"
+msgstr ""
+
+msgid "Lower Class Male 2"
+msgstr ""
+
+msgid "Luxury Apartments"
+msgstr ""
+
+msgid "Maintenance Factory"
+msgstr ""
+
+msgid "Manufacturing is largely automated but the ideas for new products still come from human designers. Synthemesh employs many designers to keep generating the latest fashions which fuel consumer demand. The manufacturing plants produce mostly consumer durables, but the corporation also controls a fleet of construction vehicles which are used to build or repair the city infrastructure."
+msgstr ""
+
+msgid "MarSec"
+msgstr ""
+
+msgid "Marsec"
+msgstr ""
+
+msgid "Marsec Armour"
+msgstr ""
+
+msgid "Marsec Body Unit"
+msgstr ""
+
+msgid "Marsec Head Unit"
+msgstr ""
+
+msgid "Marsec Heavy Launcher"
+msgstr ""
+
+msgid "Marsec High Explosive"
+msgstr ""
+
+msgid "Marsec Left Arm Unit"
+msgstr ""
+
+msgid "Marsec Leg Units"
+msgstr ""
+
+msgid "Marsec M4000 Gun Clip"
+msgstr ""
+
+msgid "Marsec M4000 Machine Gun"
+msgstr ""
+
+msgid "Marsec MiniLauncher"
+msgstr ""
+
+msgid "Marsec Proximity Mine"
+msgstr ""
+
+msgid "Marsec Right Arm Unit"
+msgstr ""
+
+msgid "Medi-Kit"
+msgstr ""
+
+msgid "Medi-kit"
+msgstr ""
+
+msgid "Medical Bay"
+msgstr ""
+
+msgid "Medium Disruptor Beam"
+msgstr ""
+
+msgid "Medium Weapons Control"
+msgstr ""
+
+msgid "Mega-Primus has numerous police stations equipped with Hovercars, road vehicles and substantial armories. These stations are generally well defended against raiders or Alien infiltration."
+msgstr ""
+
+msgid "Mega-Primus is a city state ruled by thirteen elected senators. This Government is directly responsible for the legal system and the mass transit systems. All other city services, including the policing of the city, are contracted to various corporations. In practice the immense bureaucracy holds the most power. Senior civil servants are responsible for maintaining the city edicts and defining citizenship and its obligations. They cannot be removed from their jobs except through proven misconduct."
+msgstr ""
+
+msgid "Mega-Primus is highly automated and requires the services of many robots to perform routine tasks. They are all produced in Robot Factories, which are also largely automated using the latest Nano technological construction techniques."
+msgstr ""
+
+msgid "Megapod Chamber"
+msgstr ""
+
+msgid "Megapol"
+msgstr ""
+
+msgid "Megapol AP Grenade"
+msgstr ""
+
+msgid "Megapol Armour"
+msgstr ""
+
+msgid "Megapol Auto Cannon"
+msgstr ""
+
+msgid "Megapol Body Armor"
+msgstr ""
+
+msgid "Megapol Helmet"
+msgstr ""
+
+msgid "Megapol Laser Pod"
+msgstr ""
+
+msgid "Megapol Laser Sniper Gun"
+msgstr ""
+
+msgid "Megapol Lawpistol"
+msgstr ""
+
+msgid "Megapol Lawpistol Clip"
+msgstr ""
+
+msgid "Megapol Left Arm Armor"
+msgstr ""
+
+msgid "Megapol Leg Armor"
+msgstr ""
+
+msgid "Megapol Plasma Gun"
+msgstr ""
+
+msgid "Megapol Plasma Pod"
+msgstr ""
+
+msgid "Megapol Right Arm Armor"
+msgstr ""
+
+msgid "Megapol Smoke Grenade"
+msgstr ""
+
+msgid "Megapol Stun Grapple"
+msgstr ""
+
+msgid "Megapol Stun Grenade"
+msgstr ""
+
+msgid "Megapol not only runs the city police force and prison service, it also manufactures vehicles, weapons and munitions. It directly competes with the Marsec corporation for lucrative markets in the mining colonies and Mega-Primus. The major problems for Megapol are the criminal gangs that distribute Psiclone and the UFO incursions which are regarded as a threat to city security. Police vehicles bravely intercept UFOs as they materialize from the Dimension Gates, but they are woefully under equipped to deal with them."
+msgstr ""
+
+msgid "Megapol's police Hovercars are the scourge of the slum dwelling criminal gangs. They are well armed and able to travel freely within and outside the city boundaries, scouring the ground or air for unlicensed or criminal vehicles. They are no match for heavier military vehicles, but Megapol is able to manufacture many of these scout cars and can replace any losses. The vehicle's styling is required to conform to city aesthetic ordinances concerning pleasurable design of public vehicles."
+msgstr ""
+
+msgid "Megaspawn"
+msgstr ""
+
+msgid "Megaspawn Autopsy"
+msgstr ""
+
+msgid "Megaspawn's Disruptor"
+msgstr ""
+
+msgid "Megaspawn's Launcher"
+msgstr ""
+
+msgid "Metro Multipower Plus"
+msgstr ""
+
+msgid "Metro Powergrav"
+msgstr ""
+
+msgid "Metro Roadgrav"
+msgstr ""
+
+msgid "Metro Roadhog"
+msgstr ""
+
+msgid "Metro Turbograv"
+msgstr ""
+
+msgid "Micronoid"
+msgstr ""
+
+msgid "Micronoid Aggregate"
+msgstr ""
+
+msgid "Micronoid Aggregate Autopsy"
+msgstr ""
+
+msgid "Micronoid Autopsy"
+msgstr ""
+
+msgid "Mid-powered Laser Beam gun commonly used in airborne police vehicles. The atomic power cells contained in these weapons allow for many thousands of shots before they expire."
+msgstr ""
+
+msgid "Military vehicles are rarely required within the boundaries of Mega-Primus, but if trouble erupts in the deregulated areas then the Wolfhound Armored Personnel Carrier is normally deployed into the conflict zone. Its armament load is small and is primarily used for secure transport."
+msgstr ""
+
+msgid "Mind Bender"
+msgstr ""
+
+msgid "Mind Shield"
+msgstr ""
+
+msgid "Mini Launcher Alien Gas Missile"
+msgstr ""
+
+msgid "MiniLauncher AG Missile"
+msgstr ""
+
+msgid "MiniLauncher HE Missile"
+msgstr ""
+
+msgid "MiniLauncher IN Missile"
+msgstr ""
+
+msgid "Missile Evasion Matrix"
+msgstr ""
+
+msgid "Motion Scanner"
+msgstr ""
+
+msgid "Multi-Cannon Round"
+msgstr ""
+
+msgid "Multi-Tracker"
+msgstr ""
+
+msgid "Multiworm"
+msgstr ""
+
+msgid "Multiworm Autopsy"
+msgstr ""
+
+msgid "Multiworm Egg"
+msgstr ""
+
+msgid "Multiworm Egg Autopsy"
+msgstr ""
+
+msgid "Multiworm egg"
+msgstr ""
+
+msgid "Multiworm's Spit"
+msgstr ""
+
+msgid "Mutant Alliance"
+msgstr ""
+
+msgid "NOT USED"
+msgstr ""
+
+msgid "NOT USED IN GAME ANYMORE!"
+msgstr ""
+
+msgid "NOT USED!"
+msgstr ""
+
+msgid "Nanotech"
+msgstr ""
+
+msgid "Needed for building new vehicle types."
+msgstr ""
+
+msgid "Nutrivend"
+msgstr ""
+
+msgid "Nutrivend has developed a highly efficient organic farming system that produces huge quantities of fruit, vegetables and livestock of all known varieties. The corporation also owns food processing plants and shops. The city regulations governing the additives in food are so strict that rival producers cannot compete economically, with the single exception of Evonet."
+msgstr ""
+
+msgid "Office buildings are designed to be attractive work environments. They are heavily populated and any Alien activity would soon be discovered. However, the ducting between floors and walls could be the ideal places for Aliens to hide and move around."
+msgstr ""
+
+msgid "Offices"
+msgstr ""
+
+msgid "One Way To Win"
+msgstr ""
+
+msgid "One way to win"
+msgstr ""
+
+msgid "Open fields are unsustainable because of exposure to harmful radiation caused by the collapse of the ozone layer. The Hydro-Farms of Mega-Primus are efficient, clean and highly productive. Their controlled environments can produce any kind of vegetable or fruit, or rear any kind of animal. Unfortunately they are also quite good at nurturing the odd Alien which finds its way inside."
+msgstr ""
+
+msgid "Organic Factory"
+msgstr ""
+
+msgid "Organizations"
+msgstr ""
+
+msgid "Osiron"
+msgstr ""
+
+msgid "Our Scientists believe that this building influences the atmospheric conditions within the Alien world."
+msgstr ""
+
+msgid "Our final mission awaits our forces. This building sustains the three Dimension Gates which create a direct connection with our dimension. Soon after the building is destroyed the Dimension Gates will fade away and the link with the Alien world will be broken forever. The Aliens will be vanquished and victory will be ours."
+msgstr ""
+
+msgid "Our initial results show that the distinct Alien life forms are related genetically and form part of a complex life cycle."
+msgstr ""
+
+msgid "Our studies show that the Hyperworms can consume large quantities of both organic and metallic matter. Its powerful jaws can also be used in close combat. It has a very high metabolic rate and can move at fast speeds with a snake-like action. It has a short life span and only lives for two to five days depending on how much food it can find. At the end of this feeding period it finds a safe place and suddenly inflates into a balloon like structure which is fixed firmly to its surrounding terrain. This structure appears to be some form of Chrysalis, inside which another life form begins to grow."
+msgstr ""
+
+msgid "Outdoor Parks"
+msgstr ""
+
+msgid "Overspawn Autopsy"
+msgstr ""
+
+msgid "Overspawn Autopsy 1"
+msgstr ""
+
+msgid "PSI-Grenade"
+msgstr ""
+
+msgid "Passenger Module"
+msgstr ""
+
+msgid "People Tubes"
+msgstr ""
+
+msgid "Personal Cloaking Field"
+msgstr ""
+
+msgid "Personal Disruptor Shield"
+msgstr ""
+
+msgid "Personal Teleporter"
+msgstr ""
+
+msgid "Personal armor can be developed based on disrupter research"
+msgstr ""
+
+msgid "Phoenix Hovercar"
+msgstr ""
+
+msgid "Plasma"
+msgstr ""
+
+msgid "Plasma Defense Array"
+msgstr ""
+
+msgid "Plasma Multi-System"
+msgstr ""
+
+msgid "Plasma Turret Cannon"
+msgstr ""
+
+msgid "Police"
+msgstr ""
+
+msgid "Police Car"
+msgstr ""
+
+msgid "Police Hovercar"
+msgstr ""
+
+msgid "Police Station"
+msgstr ""
+
+msgid "Politically the Technocrat's philosophy is really no different to the Extropians, except they are a little less colorful and more skeptical of technological solutions to social problems. They believe in a structured and ordered society which rigidly adheres to laws and punishes corruption. They draw most support from the smaller corporations and the populations of the mining colonies."
+msgstr ""
+
+msgid "Politician"
+msgstr ""
+
+msgid "Popper"
+msgstr ""
+
+msgid "Popper Autopsy"
+msgstr ""
+
+msgid "Popper's Bomb"
+msgstr ""
+
+msgid "Power Station"
+msgstr ""
+
+msgid "Power Sword"
+msgstr ""
+
+msgid "Primarily a short range anti-air missile system. It is effective against smaller air vehicles."
+msgstr ""
+
+msgid "Procreation Park"
+msgstr ""
+
+msgid "Prophet Missile"
+msgstr ""
+
+msgid "Prophet Missile Array"
+msgstr ""
+
+msgid "Psi-Gym"
+msgstr ""
+
+msgid "Psi-gym"
+msgstr ""
+
+msgid "Psiclone"
+msgstr ""
+
+msgid "Psimorph"
+msgstr ""
+
+msgid "Psimorph Autopsy"
+msgstr ""
+
+msgid "Psimorph's Mindbender"
+msgstr ""
+
+msgid "Psionic Blast"
+msgstr ""
+
+msgid "Psyke"
+msgstr ""
+
+msgid "Psyke is a criminal syndicate which is based in the slum areas. The organization is originally thought to have developed the Psiclone implant in 2081 with the aid of a renegade Marsec scientist. The design was quickly copied by the other syndicates creating an unprecedented level of gang warfare. The degradation of city life is frequently blamed on Psyke's activities, but they are no longer the biggest gang in the region."
+msgstr ""
+
+msgid "Quantum Physics Lab"
+msgstr ""
+
+msgid "Queenspawn"
+msgstr ""
+
+msgid "Queenspawn Autopsy"
+msgstr ""
+
+msgid "Queenspawn's Tentacles"
+msgstr ""
+
+msgid "Recycling is the business of Evonet. According to city regulations all waste has to be recycled, Evonet have turned this into a profitable enterprise through the construction of their recyclotoriums. These buildings process organic waste, including sewage, into foodstuffs for human and animal consumption. The corporation also owns the sewage works and the highly sophisticated water plants which purify water according to the high standards required by the city Senate."
+msgstr ""
+
+msgid "Recyclotorium"
+msgstr ""
+
+msgid "Reduced detection of vehicles."
+msgstr ""
+
+msgid "Rendor Plasma Gun"
+msgstr ""
+
+msgid "Repair bays are required for repairing damaged craft. A single bay can only deal with one vehicle at a time, but if there is more than one damaged vehicle per repair bay, then all vehicles will still be repaired, but at less than 100% efficiency."
+msgstr ""
+
+msgid "Repeater 40mm Cannon Round"
+msgstr ""
+
+msgid "Rescue Station"
+msgstr ""
+
+msgid "Rescue Stations are fully equipped to deal with any emergency, whether it is a fire or a road traffic accident. However, there are rarely any serious problems in the city and the stations only have a skeleton staff. They could be good hiding place for Aliens, but the relatively open internal structure of the buildings would not help them in a combat situation."
+msgstr ""
+
+msgid "Rescue Transport"
+msgstr ""
+
+msgid "Research the primary stages of the Alien life cycle."
+msgstr ""
+
+msgid "Retaliator"
+msgstr ""
+
+msgid "Retribution Missile"
+msgstr ""
+
+msgid "Retribution Missile Launcher"
+msgstr ""
+
+msgid "Robot Factory"
+msgstr ""
+
+msgid "Ruins"
+msgstr ""
+
+msgid "Rumble Cannon"
+msgstr ""
+
+msgid "S.E.L.F."
+msgstr ""
+
+msgid "SD Deluxe"
+msgstr ""
+
+msgid "SD Elite"
+msgstr ""
+
+msgid "SD Special"
+msgstr ""
+
+msgid "SD Sports"
+msgstr ""
+
+msgid "SD Standard"
+msgstr ""
+
+msgid "SD Turbo"
+msgstr ""
+
+msgid "Sanctuary Clinic"
+msgstr ""
+
+msgid "Santuary Clinic"
+msgstr ""
+
+msgid "School"
+msgstr ""
+
+msgid "Security Station"
+msgstr ""
+
+msgid "Security is a very important issue for a base when it contains vital personnel and technology. Advanced Security Stations provide the best protection for base facilities. Weapon emplacements are based on Alien Disruptor technology."
+msgstr ""
+
+msgid "Senate"
+msgstr ""
+
+msgid "Sensodrome"
+msgstr ""
+
+msgid "Sensodromes contain studios for all types of Sensovision broadcasting. The Psionic projectors on top of the building send signals to Sensovision arenas and into peoples homes."
+msgstr ""
+
+msgid "Sensovision"
+msgstr ""
+
+msgid "Sentient Engine Liberation Front"
+msgstr ""
+
+msgid "Sewage Works"
+msgstr ""
+
+msgid "Shopping Mall"
+msgstr ""
+
+msgid "Should a base come under attack a Security Station will act as a defensive buffer which can assist Agents in defensive fire. Heavy Plasma Gun emplacements are directed down adjacent corridors. The Security Station is designed so that it will not obstruct the smooth functioning of the base."
+msgstr ""
+
+msgid "Since giving birth is now a risky process all babies are now developed in artificial wombs. This has the added advantage of allowing the prospective parents to view the baby's progress by visiting special Procreation Parks. These buildings are designed to be attractive places to visit with open green spaces, bushes and trees."
+msgstr ""
+
+msgid "Since its introduction during the first Alien invasion, Elerium has proved to be an essential power source for interplanetary travel and military use. It is mined from distant planetary systems and transported back to Earth where its rarity ensures a high price. Tiny quantities contained in small pods fetch a high price. Corporations store pods in preference to gold because the stability of its value is guaranteed."
+msgstr ""
+
+msgid "Skeletoid"
+msgstr ""
+
+msgid "Skeletoid Autopsy"
+msgstr ""
+
+msgid "Sleeping Chamber"
+msgstr ""
+
+msgid "Slums"
+msgstr ""
+
+msgid "Small Disruption Shield"
+msgstr ""
+
+msgid "Smoke"
+msgstr ""
+
+msgid "Solmine"
+msgstr ""
+
+msgid "Space Liner"
+msgstr ""
+
+msgid "Space Port"
+msgstr ""
+
+msgid "Space Ship"
+msgstr ""
+
+msgid "Spawn Hyperworms"
+msgstr ""
+
+msgid "Spawning Chamber"
+msgstr ""
+
+msgid "Spitter"
+msgstr ""
+
+msgid "Spitter Autopsy"
+msgstr ""
+
+msgid "Spitter's Vomit Funnel"
+msgstr ""
+
+msgid "Stasis Bomb"
+msgstr ""
+
+msgid "Stasis Bomb Launcher"
+msgstr ""
+
+msgid "Stasis Field Bomb"
+msgstr ""
+
+msgid "Stasis Field Bomb Launcher"
+msgstr ""
+
+msgid "Stores"
+msgstr ""
+
+msgid "Stormdog"
+msgstr ""
+
+msgid "Stun"
+msgstr ""
+
+msgid "Stun Gas"
+msgstr ""
+
+msgid "Superdynamics"
+msgstr ""
+
+msgid "Synthemesh"
+msgstr ""
+
+msgid "Technocrats"
+msgstr ""
+
+msgid "Teleporter"
+msgstr ""
+
+msgid "Temple of Sirius"
+msgstr ""
+
+msgid "The Alien Bomber is equipped with an unusual missile launcher which fires a missile that splits into multiple, independently targeted missiles. It also has a light beam weapon to deal with close air combat. There is a limited crew on board."
+msgstr ""
+
+msgid "The Alien Dimension"
+msgstr ""
+
+msgid "The Alien Dimension consists of a bleak, hostile environment with an organic city. This city undoubtedly constructs Alien craft and nurtures the Alien brood. The structure of the buildings is immensely strong, but there appears to be weak point which will allow our Agents and vehicles to gain access to the building south of the dimension gates. If we can research this building further then we will have the necessary information to send in our squads to destroy it. We should then be able to gain access to the next building via the organic tubing that joins the Alien city together like a giant umbilical cord."
+msgstr ""
+
+msgid "The Alien Genetic Structure"
+msgstr ""
+
+msgid "The Alien Life Cycle"
+msgstr ""
+
+msgid "The Alien city is a complex organic growth in which each building type functions as a highly specialized organ. The Megapod Chamber is the reproduction organ of the Alien city which nutures numerous egg shaped structures. These Megapods are giant seeds which grow to a large size before being transported to a new location. The seeds then grow and develop into other Alien buildings. The Megapod Chamber is extremely well defended but once it is destroyed we will be close to victory."
+msgstr ""
+
+msgid "The Alien food source appears to be plants. This building provides the perfect balance of light and heat for the Alien plants."
+msgstr ""
+
+msgid "The Alien genetic structure"
+msgstr ""
+
+msgid "The Alien life cycle"
+msgstr ""
+
+msgid "The Alien queen is ultimately the production unit for all Alien life forms. Its mobility is severely limited when fully grown and it also requires exactly the right atmospheric conditions in order to breed properly and produce the Alien eggs. These conditions are only provided by the spawning chambers inside an Alien building, which also provide a food source by plugging directly into the Queenspawn's blood supply. This confirms that the Aliens cannot conquer our dimension without a steady supply of Alien reinforcements through the Dimension Gates, although their motive for such incursions is still unknown."
+msgstr ""
+
+msgid "The Alien scare first began on 7th March, 2084 when a strange Dimension Gate appeared in the skies above Mega-Primus. During the following days strange UFOs came and went, but they did not appear to attack anything or abduct anyone. It was only when strange reports of Alien monsters lurking in the recesses of city buildings filtered through to the senatorial security committee that the plan to enlist X-COM was proposed."
+msgstr ""
+
+msgid "The Alien threat can only be stopped by destroying their ability to create Dimension gates. A full assault on the Alien Dimensions requires a craft of immense power."
+msgstr ""
+
+msgid "The Aliens have developed a very effective teleportation system that allows a craft to jump instantly over short distances. The unit is automatically activated when a vehicle is under fire and receiving damage. Its offensive use is limited because the destination cannot be controlled accurately."
+msgstr ""
+
+msgid "The Aliens have manufactured an energy shield that can protect an entire vehicle. It is far more effective than any armor system and can turn a small vehicle into a deadly weapons platform. The disruption field it generates can absorb any kind of beam or projectile, but it loses power for each hit. Power levels are gradually restored but the unit will cease functioning if the power level is reduced to zero."
+msgstr ""
+
+msgid "The Anthropod is a robust humanoid Alien soldier."
+msgstr ""
+
+msgid "The Anthropod is capable of performing all the actions of an equivalent human soldier and can use weapons and equipment. It can feed voraciously, but strangely it does not seem to live very long in our environment, with a life span of only five days. There seems to be no further stage of development beyond this form."
+msgstr ""
+
+msgid "The Anthropod is the Alien creature that most resembles the human form."
+msgstr ""
+
+msgid "The Assault Ship effectively replaces the Alien Transport as a troop carrier. It can deposit large numbers of Aliens into city buildings and is armed with a powerful beam weapon. This craft is highly dangerous and must be stopped at all costs."
+msgstr ""
+
+msgid "The Astrodome contains huge stadiums and other facilities for various modern sports. GravBall is the most popular sport in the city, despite being dangerous. Five players in each team are equipped with anti-grav units and ball throwers. The six remaining team members are firmly routed on the ground and are used to protect the goal area or retrieve fallen balls. The maze of corridors and high stands makes the Astrodome a dangerous place for combat."
+msgstr ""
+
+msgid "The Boomeroid is a devastating and terrifying weapon. It is actually a semi-intelligent device that hurls itself towards any moving organic target and then explodes when it reaches a pre-set range.The Boomeroid has to be primed for explosion proximity as well as time delay."
+msgstr ""
+
+msgid "The Car Factory produces many of the smaller vehicles that are part of everyday life in Mega-Primus."
+msgstr ""
+
+msgid "The Chrysalis appears to be an important stage in the Alien life cycle. The cell structures we have discovered seem to suggest that the emerging Aliens have a different physiology to those previously encountered. This could indicate that there will be further stages to our biological research. The Chrysalis contains no advanced brain structure and will not respond to Psionic attacks."
+msgstr ""
+
+msgid "The Cloaking Field is an Alien defense system that disrupts the detectors of missiles or weapon control systems. Effectively this means that the craft is almost invisible to radar, infra-red and visual sighting. It is very effective but the field must be disabled temporarily if the craft is using any of its own weapons systems."
+msgstr ""
+
+msgid "The Cult Of Sirius builds temples to worship the superior Alien master race. It is rumored that these temples contain altars where bizarre rituals take place."
+msgstr ""
+
+msgid "The Cyberweb corporation developed artificial life forms to provide a willing and obedient workforce for the future. However, popular protest against unemployment forced the Senate to pass laws against artificial life. No more Androids could be built and they were banned from employment except the most menial and degrading jobs. Cyberweb had to change strategy and compete with the Nanotech corporation for medical and military contracts. The unfortunate Androids were either banished from the city or had to be bought and sold as household servants or pets. Androids are good for combat, although they possess no Psionic abilities, and the few that remain may well risk seeking employment by X-COM and join the battle against the Aliens."
+msgstr ""
+
+msgid "The Cyberweb evasion system is designed to track hostile missiles and disrupt their guidance systems using various forms of radiation. It is not totally effective but a very useful complement for other defense systems."
+msgstr ""
+
+msgid "The Destroyer is heavily armored and its behavior is aggressive. It is armed with a powerful Alien Missile Launcher capable of immense destruction. It can also deposit Alien beings into the city."
+msgstr ""
+
+msgid "The Dimension Gates appear to be the means by which the Alien craft travel from their home world. Our craft cannot travel through these gates without being annihilated by an anti-matter implosion. We must disable a UFO and recover its control systems, propulsion systems and power sources for research."
+msgstr ""
+
+msgid "The Disruptor Gun is a remarkable piece of technology. It propels a beam of sub-atomic particles at immense speeds and quantity. The chamber which generates the energy is an inter-dimensional device which materializes energy from an alternative dimension. The power source, once initiated, is self-perpetuating and no ammunition or energy pods are required to sustain the fire power. Our replicators can reproduce this technology fairly accurately."
+msgstr ""
+
+msgid "The Extraterrestrial combat force known as X-COM was originally founded in 1998 to defend the Earth from Alien invasion. After a period of obsolescence, X-COM was revived in 2040 to fight the second Alien war under the seas of the Earth. X-COM has now been enlisted to investigate recent Alien incursions. The city's senators have agreed to fund a covert initiative, with the assistance of local Megapol stations, who will pass on reports of possible Alien activity directly to the X-COM base commander. X-COM is under pressure to solve the Alien problem before new elections to the Senate. Senators and the corporate elite of Mega-Primus are nervous about the prospect of popular panic undermining the social fabric of the city."
+msgstr ""
+
+msgid "The Extropians are one of the city's major political organizations that dominate the Senate. The Extropian philosophy is basically a faith in a bright technological future - a brave new world free of disease, pollution, old age and dull aesthetics. They pioneered the city regulations governing the future-retro styling of the architecture and vehicles. They have strong support from Solmine, Marsec and the larger corporations."
+msgstr ""
+
+msgid "The General Metro corporation designs and manufactures road vehicles. Since the corporation installed an efficient anti-grav system inside the road structure it became possible to produce low powered anti-grav road vehicles which were cheap and efficient, despite being limited to the road system. The vehicle designs were based on the exuberant styling of the 1950s according to the requirements of city planners. General Metro is a major competitor to Superdynamics, as both corporations provide transport systems."
+msgstr ""
+
+msgid "The Hawk is essentially a heavy weapons platform capable of carrying a significant payload. It is the most powerful vehicle manufactured by Marsec and should be the first line of defense against any invasion force, wherever it comes from."
+msgstr ""
+
+msgid "The Heavy Dispruptor Beam is an immensely powerful weapon. Its only drawbacks are its size and difficulty of manufacture. The energy chamber is enormous, drawing energy from another dimension. It is possible that the weapon's original power source is actually located in some alternative dimension."
+msgstr ""
+
+msgid "The Hyperworm corpse is extremely heavy for its size and appears to be a primitive creature."
+msgstr ""
+
+msgid "The Hyperworm is a small, highly active carnivore."
+msgstr ""
+
+msgid "The Hyperworms' function appears to be little more than feeding. It has powerful jaws and razor sharp teeth designed for ripping and slicing. Its belly appears to be small and the body contains some curious structures containing folds of tough skin. It appears to be quite vulnerable to fire and incendiary ammunition. There is no recognizable brain structure in the Hyperworm and it is well protected from Psionic influence."
+msgstr ""
+
+msgid "The Incubator is a warm and humid collection of chambers in which Alien eggs are stored ready for hatching. They will be well protected by Alien warriors because of their vulnerability at this stage of the life cycle. You should also expect to meet many Multiworms preparing to give birth to the Hyperworm vermin which burst from the innards of their parents in their final death agony."
+msgstr ""
+
+msgid "The Lifetree corporation runs the city schools and universities. They have developed a controversial but highly effective Psionic tutoring system which imparts knowledge far more efficiently than reading or listening to lecturers. If the student resists the knowledge transfer then pain results. Lifetree have been accused of brainwashing since the introduction of the 'moral education' program which is designed to turn the youth into model citizens. They are competing with Sensovision in the production of Psionic devices."
+msgstr ""
+
+msgid "The Maintenance Factory produces the nutrients and energy for all other buildings. This is done by pumping the nutrient liquid through the connecting tube that runs through the city, just like blood in a cardiovascular system. The destruction of this building will be a significant blow to the Aliens and allow us to destoy all remaining structures."
+msgstr ""
+
+msgid "The Marsec corporation has privileged access to Elerium supplies due to a strong security role in the Elerium mining colonies. The Lineage weapons technology represents the ultimate Elerium powered accelerators. They are expensive but devastating."
+msgstr ""
+
+msgid "The Marsec version of the defense array uses more powerful and accurate plasma beam weapons to defend against missile attacks."
+msgstr ""
+
+msgid "The Medium Disruptor Beam is a more powerful version of the Light Disruptor Beam. It uses the same sub-atomic, inter-dimensional technology but the energy chamber is larger. It is capable of penetrating the heaviest armor."
+msgstr ""
+
+msgid "The Megapol AP Grenade is a standard anti-personnel grenade with a timer mechanism. It can also be activated on impact making it highly useful in time-critical combat situations."
+msgstr ""
+
+msgid "The Megapol Auto Cannon is a bulky but versatile weapon. It can fire armor piercing rounds, high explosive shells or incendiary shells. It is best used at medium range with explosive or incendiary ammunition, or at close range with armor piercing rounds."
+msgstr ""
+
+msgid "The Megaspawn is essentially a huge organic weapons platform. It has two distinct weapons systems grown into its body. Although these must be added artificially, the nervous system is directly connected to them, suggesting that the creature is solely a genetically engineered combat unit."
+msgstr ""
+
+msgid "The Mothership is an extremely large, well equipped vessel. It is armed with a Heavy Disruptor Beam, Disruptor Multi-Bombs and Stasis Field Bombs. It represents a very serious threat to the city because its purpose seems to be mass destruction rather than infiltration. If the Aliens become desperate they will deploy this craft to raze the city to the ground. They must be stopped at all costs."
+msgstr ""
+
+msgid "The Multiworm corpse decays rapidly, consumed by its own defense mechanisms. If research is not undertaken soon then we will not be able to preserve the remains."
+msgstr ""
+
+msgid "The Multiworm is clearly a crucial stage in the complex Alien life cycle. It is capable of attacking by propelling a fluid from pores along the side of the body containing a complex mix of micro-organisms that use enzymes and acids to break down the molecular structure of the target. Fortunately the range of the propellant is fairly short. The Multiworm is slow moving, but care should be taken in combat because it may release its offspring in the throes of death, creating an even greater threat."
+msgstr ""
+
+msgid "The Nanotech corporation has specialized in developing microscopic robots which are used in the medical and pharmaceutical industries. The intelligence of these devices is limited, but they can be designed to perform a wide variety of tasks, such as killing bacteria or manufacturing chemicals. Nanotech also produce the highly effective Medi-Kits used in military combat which use Nanobots to perform battlefield surgery and tissue repair."
+msgstr ""
+
+msgid "The Organizations which operate in Mega-Primus consist of corporations, political groups, criminal gangs and the government. All of them are at risk from Alien infiltration but some are more vulnerable than others. "
+msgstr ""
+
+msgid "The Osiron syndicate is the wealthiest criminal operation in the city area. Although they are based in the slum areas they are able to conduct apparently legitimate business in the city and there is no proven link between Osiron and violent crime. It is widely suspected that they employ the services of the other gangs where possible, only resorting to direct action if necessary."
+msgstr ""
+
+msgid "The Overspawn is a hybrid creature, derived from the Megaspawn genetic pool. It is difficult to kill, but will eventually succumb to bombardment by Disruptor Beams and other powerful weapons. Fortunately it has no ranged combat capability."
+msgstr ""
+
+msgid "The Overspawn is an extremely dangerous Alien terror weapon."
+msgstr ""
+
+msgid "The People Tube network is the mass transit system for the whole city. The anti-gravity pathways suspend the traveler above the floor and safely propels them at speeds of about 25 miles an hour."
+msgstr ""
+
+msgid "The Personal Cloaking Field generates a warping effect that bends various wave forms. Effectively this means that the user is considerably less visible to radar, infra-red and visual sighting. The field is disabled temporarily if the user initiates combat."
+msgstr ""
+
+msgid "The Personal Disruptor Shield generates an energy field which warps the space around the user. This causes beams or projectiles to be deflected and dissipated. Any hit causes the shield's energy to drain and if it reaches a critically low level it will malfunction. It is a highly sophisticated device that we can reproduce only with great effort."
+msgstr ""
+
+msgid "The Phoenix is manufactured by Marsec mainly for military purposes. This sleek but rugged vehicle is used for reconnaissance in dangerous environments such as the Mars colony. A variety of weapon and engine configurations can be used and a well equipped Phoenix is more than a match for a police Hovercar."
+msgstr ""
+
+msgid "The Plasma Multi-System is a series of connected plasma turrets designed to provide all round fire power. This weapon is ideally suited to installation in larger, less maneuverable craft."
+msgstr ""
+
+msgid "The Plasma Turret Cannon is a powerful weapon, but lacks the ability to track and hit fast airborne vehicles."
+msgstr ""
+
+msgid "The Popper is little more than a walking bomb. Its simple brain structure means that Psionic attacks have a very low chance of success. Its body contains no obvious explosive device, although there are several chemicals mixed into the creatures stomach creating a highly unstable explosive compound."
+msgstr ""
+
+msgid "The Popper runs at high speed towards its victim and explodes when within a range of about fifteen feet. If the Popper is attacked with armor piercing, incendiary or explosive ammunition then the explosive effect is likely to be triggered. We recommend that other forms of weaponry be used against this creature in most combat situations."
+msgstr ""
+
+msgid "The Prophet system is more effective than the Janitor missiles against faster moving targets. Its guidance systems are much more accurate, but the array only has a limited missile capacity."
+msgstr ""
+
+msgid "The Psiclone implant is manufactured and distributed by criminal gangs. It allows the user to experience any mental state or images just by imagining them. Its widespread popularity and detrimental effect on the health of young citizens led the Senate to ban the use or distribution of the device. The price of Psiclone implants has subsequently soared and this has resulted in open warfare between the criminal gangs and Megapol."
+msgstr ""
+
+msgid "The Psimorph creature is a large mass of tentacles."
+msgstr ""
+
+msgid "The Psimorph is a rare and highly specialized Alien. Its Psionic powers and defense are formidable, it is likely to be used as an Alien commander in battle situations. Despite its ability to fly, its mobility is limited due to its bulk and lack of a skeletal structure. Unlike other Alien types it seems to survive quite well in our environment. It represents a serious threat to our Agents. Our best form of defense is with biological weapons and strong Psi-defense."
+msgstr ""
+
+msgid "The Real Alien Threat"
+msgstr ""
+
+msgid "The Recyclotorium is capable of recycling all kinds of waste product, organic or mineral. The city is an ecologically self contained area. This would not be possible without these complex recycling stations."
+msgstr ""
+
+msgid "The Senate building accommodates the civil service, law courts and the Senate chamber. It is a maze of lavish marble interiors and large corridors. It is a building which should be protected from Alien infiltration at all costs."
+msgstr ""
+
+msgid "The Skeletoid is a highly effective Alien soldier with great intelligence and the ability to fly. Its agile body is capable of withstanding great damage and it can use a variety of weapons and equipment. The brain is susceptible to Psionic influence, but some form of resistance does seem to exist."
+msgstr ""
+
+msgid "The Spitter is humanoid in form but has a funnel shaped head."
+msgstr ""
+
+msgid "The Stun Grapple is a powerful police weapon used for stunning and capturing prisoners. It is effective against Aliens but can only be activated at a very short range. Larger Aliens may need weakening before they can be stunned."
+msgstr ""
+
+msgid "The Stun Grenade can be used to stun targets within a small area for a brief time. Larger Aliens may need weakening before they can be stunned."
+msgstr ""
+
+msgid "The Transtellar corporation owns the Space Port and many of the Space Liners that ship to the city. They also own many warehouses spread throughout the city which are used by many corporations involved in importing and exporting. The city goods transport service and the taxi service are owned and run by Transtellar. The corporation has been regarded suspiciously by Megapol which considers the corporation susceptible to Alien contamination."
+msgstr ""
+
+msgid "The Valkyrie is the standard military vehicle manufactured by Marsec. Its sleek lines appear reminiscent of old rocket designs, but it is a fully capable anti-grav dependent craft with a variety of engine configurations. There is space for many types of armaments and equipment loads. It is capable of solar system travel and is feared by the criminal cartels when it is used to police the space lanes to Mars and beyond."
+msgstr ""
+
+msgid "The aim is to develop a toxin that specifically targets the early stages of the Alien life cycle."
+msgstr ""
+
+msgid "The airborne rescue vehicle serves as an ambulance and fire engine. It is specially equipped to deal with rescue situations involving car accidents and other disasters. However dealing with the Alien invasion is well beyond the scope of the rescue service which normally has little to do given the strict safety regulations governing all aspects of city life."
+msgstr ""
+
+msgid "The alarming appearance of the Spitter reflects the fact that this creature's only purpose is to be used in combat. The funnel head propels a liquid containing micro-organisms which secrete acids and enzymes. The large stomach of the creature generates the deadly vomit and would suggest that it sucks up the remains of any victim with its funnel head. With no discernible brain structure this creature is immune from Psionic attacks."
+msgstr ""
+
+msgid "The capture and study of live Alien specimens will help us understand the nature of the Alien threat. In order to do this we need an inter-dimensional transport vehicle that can contain and sustain Alien life forms."
+msgstr ""
+
+msgid "The capture of a Micronoid Aggregate is an essential step in the advancement of our knowledge. This formless mass of micro-organisms is found inside the bloodstream of other Alien forms. Each microscopic organism is an independent and intelligent life form. They communicate with each other using Psionic projection, but they are unresponsive to human Psionics. It is unclear whether these creatures are parasites or an integral part of the Alien spawn."
+msgstr ""
+
+msgid "The cavernous interior of this factory is designed for construction of the largest vehicles such as the Valkyrie Interceptor, or the great Space Liners. There are large quantities of valuable construction materials, such as Elerium, stored in various parts of the building."
+msgstr ""
+
+msgid "The city edict of 2076 effectively banished Androids from most areas of city life. They were forced into slum areas and treated as little more than vermin. They considered themselves to be artificial life forms of equal intellect to human beings and decided to fight back. SELF is an organization dedicated to fight for equality for all sentient life forms, whether flesh or machine. Their activity has been limited to pressure group politics, but there are demands within their ranks to resort to more direct, violent action."
+msgstr ""
+
+msgid "The connection between the basement level and the outside world is provided by a set of heavy duty gravlifts."
+msgstr ""
+
+msgid "The control stations onboard the Alien craft direct the propulsion system and control its ability to transform matter into anti-matter."
+msgstr ""
+
+msgid "The creature has internal devices that generate an anti-grav field allowing it to float through the air. Without this mechanism the Psimorph would collapse in a mass of jelly-like flesh and tentacles. It has a number of separate brain structures which are extremely well developed indicating potential leadership functions and Psionic capabilities. All of the major organs are duplicated about twelve times which would seem to be a defense mechanism allowing the creature to function despite sustaining massive damage."
+msgstr ""
+
+msgid "The development of the Retaliator shifts the emphasis from exploration to attack. Our Engineers have at last produced a craft which can match the capabilities of many of the Alien ships."
+msgstr ""
+
+msgid "The discovery of Elerium sources in distant solar systems has produced a new gold rush. The Solmine corporation owns most of the mining operations and it imports Elerium directly to Mega-Primus. These mining operations sustain the economies of the numerous small colonies, but they are still governed from Earth. There have been demands for independence and some rebellions. Major corporations, fearing diminished profits and raised Elerium prices have suppressed these revolts with the aid of Solmine and Marsec."
+msgstr ""
+
+msgid "The energy source for the Alien craft is generated in special dimension chambers which suck incredible amounts of energy from the Alien Dimension. These systems are highly unstable and should be treated with caution in combat situations."
+msgstr ""
+
+msgid "The enormous Space Port is a vital connection to the outside world. Many passengers pass through on vacation to Mars or other distant destinations. Large quantities of manufactured goods are exported to the mining colonies and raw materials are imported. The Space Port generates huge revenues, but it would also be lucrative for any raider or terrorist."
+msgstr ""
+
+msgid "The enormous hulk of the Queenspawn requires great effort to transport and contain."
+msgstr ""
+
+msgid "The entertainment industry entered a new phase with the advent of Psionic projectors. Actors connected to Psionic sensors can record their thoughts and experiences in any environment. The recorded patterns are edited into 'Sensovision' experiences and replayed at 'Sensodromes' where many people can connect to Psionic receivers. The receiver allows people to see, hear, feel and smell what the actor experienced. Sensoviosion actors are wealthy celebrities and the Sensovision corporation is now selling the expensive receiver sets into peoples homes. The only competition comes from the addictive and illegal Psionic implant known as Psiclone, which is supplied by the criminal syndicates."
+msgstr ""
+
+msgid "The first manned inter-dimensional vehicle produced for the initial exploration of Alien structures. The craft only has a small equipment and armament load and must conduct its excursions with great care."
+msgstr ""
+
+msgid "The first wave of Alien incursions resulted in many genetic experiments involving crossbreeding humans and the Alien species known as Sectoids. These hybrids have survived in human society, but they have been denied the right to procreate within the city. They also suffer discrimination in employment and education. Although they are genetically almost identical to humans, they retain some Alien facial characteristics and are renowned (and distrusted) for their Psionic abilities. Hybrids Psionic abilities may well prove useful to X-COM in the war against the Aliens. The Mutant Alliance is active in city politics and promotes the concerns of the hybrid community."
+msgstr ""
+
+msgid "The gestation period for a Multiworm is approximately two days. During this time the egg will protect itself with a weapon that launches a fluid containing micro-organisms. These organisms consist of various types, some containing acids designed to erode metallic compounds and others containing unusual enzymes that rapidly break down organic matter. Fortunately the range of this weapon is limited. The Alien embryos are not sufficiently advanced to be susceptible to Psionic attacks."
+msgstr ""
+
+msgid "The highest quality medical care is available only from a dedicated medical unit. Any injuries would otherwise have to be dealt with by the city hospitals, where the safety of Agents cannot be guaranteed. Injured Agents are automatically healed when they reside at a base with a Medical Bay, but if the capacity of the Medical Bays are exceeded then healing will not take place at 100% efficiency."
+msgstr ""
+
+msgid "The highly efficient Power Stations use cold fusion technology to generate energy for the city. They should be protected from Alien infiltration as far as possible. Any damage to them could result in serious power shortages."
+msgstr ""
+
+msgid "The huge Space Liners enable commerce with Mars, the Moon and the deep space mining colonies. Huge quantities of manufactured goods are transported outwards, the Space Liners then return laden with raw materials and small quantities of the precious Elerium."
+msgstr ""
+
+msgid "The large hospitals of Mega-Primus are important buildings with high revenue potential. The very best Nano technology is used for the benefit of those that can afford it. Life extension is the service in most demand, but there is also the possibility of limb replacements and strength enhancements which are popular with GravBall players."
+msgstr ""
+
+msgid "The largest and most complex weapons control system available from Cyberweb.An expensive unit that should only be used on heavily loaded weapons platforms."
+msgstr ""
+
+msgid "The life span of a Brainsucker is very short, eight hours at most. It has no reproduction or feeding system. Instead it attacks human victims by grasping the head with its claws and inserting its proboscis into the victims throat. The Brainsucker dies immediately after a successful attack, but our tests reveal that the victim is subsequently transformed into an Alien controlled entity. We will not understand the mechanism which causes this until we have completed studies on the full Alien life cycle."
+msgstr ""
+
+msgid "The massive form of the Alien queen is designed to lay huge numbers of Alien eggs during its life time. The Queenspawn uses a complex asexual reproduction system to produce large numbers of Alien eggs in order to create new types of Alien creature. The importance of the Queenspawn for Alien population growth makes it an important strategic target."
+msgstr ""
+
+msgid "The meanest Marsec manufactured land based vehicle is an extremely heavily armored all-terrain vehicle with a choice of three different turret mountings. Projectile and Plasma Cannons can be fitted, or a missile launching unit for targeting airborne vehicles."
+msgstr ""
+
+msgid "The missile explodes with devastating power. It seems to use an inter-dimensional flux to suck in anti-matter from an alternate dimension. This instantly generates an atomic reaction which destroys the missile and most of its surrounding matter. It should not be used in situations where buildings and civilians need to be protected."
+msgstr ""
+
+msgid "The multi-bomb has a short range but splits into fast, multiple independently targeted missiles. This makes it a deadly weapon against numerous small targets."
+msgstr ""
+
+msgid "The mysterious atmospheric phenomenon from which the UFOs are emerging requires urgent attention. We must find out where the Alien craft are coming from."
+msgstr ""
+
+msgid "The nerve center of the Alien city is concentrated in this building. The more intelligent Alien life forms are employed here to maintain and defend the building and its complex functions. Psimorphs will probably be found supervising operations and coordinating the defenders."
+msgstr ""
+
+msgid "The ominous and highly secretive Marsec corporation took over from X-COM as the leading provider of off-world security, as X-COM centered its activities around Mega-Primus. During the initial years of their operation Marsec was empowered to impose order on the rebellious Mars colony. Marsec (Mars Security) developed high technology weaponry and vehicles by recruiting top Scientists from Earth and using the equipment left by X-COM. With the establishment of the remote Elerium mining colonies, Marsec secured contracts for military equipment despite competition from Megapol."
+msgstr ""
+
+msgid "The pod has a hard and extremely tough skin, this peels back in the presence of human beings. A creature popularly referred to as a Brainsucker then emerges fully formed and active. Our conclusion is that these pods are a genetically engineered device designed to attack only human life forms."
+msgstr ""
+
+msgid "The pod is a genetically engineered missile that flies directly towards a target. It is fired from the Entropy Launcher."
+msgstr ""
+
+msgid "The primary mission of this craft is to deposit Alien life forms inside city buildings. This represents a serious challenge for our ground forces, but if they can be shot down before they unload their passengers, then the problem will be minimized. The craft is armed with the same beam weapon as the Scout Ships or Probes, but it is slower moving and an easier target to hit."
+msgstr ""
+
+msgid "The private car is a luxury which is only afforded by celebrities and gangsters. The road system in the city is an anti-grav ducting system that allows for fast and safe travel by low powered anti-grav vehicles. Although the car hovers over the road it is not capable of leaving it, except through exceptionally careless manual driving."
+msgstr ""
+
+msgid "The propulsion system of the Alien craft is built into the external fabric of the craft itself. It generates a dimensional field that warps the craft through space and allows the craft to pass undamaged through Dimension Gates."
+msgstr ""
+
+msgid "The refinement of Elerium powered anti-grav propulsion units has created a new industry for ecologically friendly power sources. Superdynamics has developed sophisticated plants for producing power units of all sizes as well as a variety of airborne anti-grav vehicles. The cost of manufacture is high and Elerium is also in short supply. This means that privately owned vehicles are rare, but Superdynamics developed and installed the anti-grav system for the People Tubes. These safe and efficient tube ways rapidly became the mass transit system for Mega-Primus in direct competition to the road network."
+msgstr ""
+
+msgid "The remains of an Alien Chrysalis produces pungent fumes as it decays rapidly."
+msgstr ""
+
+msgid "The road going Autotaxi is a more luxurious and relaxed form of public transport than the bustling People Tubes. Although a driver is not technically required regulations specify that a 'driver' is needed to fulfill the required inter-personal contact, which is necessary in a society dominated by automation."
+msgstr ""
+
+msgid "The road going anti-grav 'bike' is a plaything of rich speed freaks. It is extremely fast and maneuverable. Consequently it is ideal for the lone X-COM Agent."
+msgstr ""
+
+msgid "The sewage works recycles everything possible from the organic waste produced by the city. The solid waste produces food and fertilizer for the Hydro-Farms. Water is then passed back to the water purifying stations. Since the building is largely automated, its dank, dark maze of pipes and walkways provide an ideal habitat for Alien creatures."
+msgstr ""
+
+msgid "The slum dwellings located outside the city boundaries are the remnants of an old civilization. They are still heavily populated and used by gangsters and political groups as a base of support. They are dangerous places which are difficult to attack with ground forces. There is always the prospect of finding Psiclone or Elerium during a successful raid."
+msgstr ""
+
+msgid "The standard Megapol patrol vehicle is proudly styled in the current retro fashion, but is still capable of carrying several types of weapon system. The recent prevalence for criminals to engage in road combats has led to an increase in patrols and an upgrade in armament."
+msgstr ""
+
+msgid "The standard cannon for police and military vehicles; it fires a high velocity armor piercing shell."
+msgstr ""
+
+msgid "The structure of the vehicle suggests an organic construction process. The skin is composed of a strong and unusual compound that allows the craft to travel without harm through the Dimension Gates. This unmanned craft is equipped with an unusual type of beam weapon. Its limited capability suggests that it is purely designed to collect information and then return to the Alien Dimension."
+msgstr ""
+
+msgid "The study of a live Alien Chrysalis could represent a significant advance in our knowledge of the Alien life cycle."
+msgstr ""
+
+msgid "The ultimate engine upgrade for large airborne vehicles."
+msgstr ""
+
+msgid "The ultimate expression of X-COM technology - a mean, fast and devastating craft which, if properly equipped, is more than a match for the biggest Alien attack ships. The Annihilator will help secure X-COM domination of the Alien Dimension."
+msgstr ""
+
+msgid "The ultimate road vehicle engine, strictly for armored military vehicles."
+msgstr ""
+
+msgid "The unusual Hoverbike with 'side car' is used for military purposes or for the personal pleasure of wayward youth who enjoy speed and altitude. Its good power to weight ratio means that this is the most maneuverable air vehicle but it can only carry light armaments. The Hoverbike can be a valuable means of transport for the Agent on investigative missions where speed of response is essential."
+msgstr ""
+
+msgid "The vast shopping malls are popular places for citizens. Although most goods are purchased via the Internet, the shopping mall allows potential customers to try before they buy."
+msgstr ""
+
+msgid "The warehouse is used to store large quantities of merchandise for import or export. The cavernous interiors are easy to defend and raiders should be careful."
+msgstr ""
+
+msgid "The wealthy citizen would not normally travel by people-tube or road, but instead hire the services of a fast and reliable Airtaxi. The styling is conspicuously based on the more humble road going version, but the ride is more refined. Expect the occasional Airtaxi you see to contain a VIP, or flamboyant Sensovision celebrity."
+msgstr ""
+
+msgid "The wealthy citizens of Mega-Primus reside in exclusive apartment buildings. Alien infiltration can be particularly dangerous here, because the people which own and control most of the city could be exposed to danger."
+msgstr ""
+
+msgid "There is a possibility that a multi-toxin can be suspended in gaseous form, which would increase the efficiency of our Biological weaponry."
+msgstr ""
+
+msgid "These labs are specifically equipped for high energy particle experiments designed to analyze and replicate Alien technology. The lab can accommodate five Quantum Physicists and each lab can be assigned a specific research project."
+msgstr ""
+
+msgid "These pods contain a dormant Alien creature."
+msgstr ""
+
+msgid "This Alien missile system is incredibly destructive. The explosive force exceeds the Retribution Missiles and its speed is greater. Fortunately the range is quite limited."
+msgstr ""
+
+msgid "This Megapol produced defense system uses a large number of accurate, short range laser guns to shoot down incoming missiles."
+msgstr ""
+
+msgid "This X-COM produced unit is designed to contain Alien specimens, alive or dead. In order to retrieve Alien life forms, X-COM Agents must have Bio-Transport capability at a building after a tactical combat mission."
+msgstr ""
+
+msgid "This bizarre cult has whipped up a religious frenzy following the appearance of the Dimension Gates. The cult has long believed in redemption of the human race by a superior Alien race. They believe the UFOs and Aliens to be harmless and are rapidly gaining credibility and recruits from the general population. This represents a considerable threat to X-COM because the cultists will do anything to assist the Aliens in their purpose, whatever that might be."
+msgstr ""
+
+msgid "This building produces strange organic mushroooms which grow into Alien craft. All other Alien technology is produced here as well - weapons for craft and equipment for Alien warriors. The nature of this building makes it an essential target for our forces, even though it is very well defended."
+msgstr ""
+
+msgid "This building seems to function as a nocturnal rejuvenation center for the Aliens. We have identified the weak points that will allow us to destroy this building. You will receive a full briefing before you enter the combat zone. Once this task is accomplished we can gain information about the next Alien building through the exposed tubing that connects the Alien city."
+msgstr ""
+
+msgid "This conventional missile contains a highly effective gas which targets Alien life forms. The gas is harmless against humans and structures making it ideal for forcing Aliens to flee from cover."
+msgstr ""
+
+msgid "This craft is fast and nimble. On its own it represents no threat, but is deadly when combined with other Alien combat ships. It is armed with a missile which generates a Stasis Field on impact. This field holds the target still for a small period of time so craft that rely on evasion for defense, become vulnerable."
+msgstr ""
+
+msgid "This craft is well armored, highly maneuverable and armed with a powerful beam weapon. It is designed to protect other more vulnerable Alien ships. Avoid these craft if the threat to our vehicles is too great and concentrate on shooting down the Alien Transports."
+msgstr ""
+
+msgid "This creature has a light body with a strong exoskeleton structure which is further covered in tough skin. Unusual spherical implants appear to provide flying capability. The mechanism is different to the Elerium powered gravity wave and we do not know how it works at this stage. The brain structure is well developed."
+msgstr ""
+
+msgid "This creature is a rapacious carnivore whose feeding frenzy contributes to the rapid growth of younger lifeforms called Hyperworms which are reared inside its body. The gestation period for the Hyperworms is about three days and each Multiworm gives birth to four offspring. The birth process is lethal for the parent - the Hyperworms explode from the Multiworms body and consume it within a matter of seconds. The brain structure of the Multiworm is undeveloped and it is unlikely to be affected by Psionic attacks. The tissue analysis from the autopsy will provide an invaluable contribution to our biological warfare research."
+msgstr ""
+
+msgid "This creature was built for warfare, immensely strong and aggressive. Underneath the thick outer skin a significant digestive system is revealed. There is a well protected brain structure that seems to match human size in terms of its neuron count. The well formed brain is vulnerable to Psionic influence although it is not capable of Psionic attacks. This indicates an important weakness of this species. The tissues recovered from this specimen will contribute to our biological warfare research."
+msgstr ""
+
+msgid "This enormous creature is deposited by an Alien Mothership. Its primary objective appears to be destruction of the city and annihilation of X-COM bases. The terror and panic that it causes amongst the population indicates a change in Alien strategy. It is possible that they have abandoned their attempts at infiltration and are now only concerned with revenge and retribution against X-COM."
+msgstr ""
+
+msgid "This explosive device generates an instant smoke cloud that inhibits visibility. This can be used in combat situations for surprise attacks or to provide cover for retreating Agents."
+msgstr ""
+
+msgid "This explosive device uses a tiny dimensional flux generator which allows anti-matter to seep through a tiny dimensional warp. The resultant explosion is very powerful."
+msgstr ""
+
+msgid "This extraordinary device uses inter-dimensional capability to transport the user over short distances via a dimensional flux. The energy level depletes according to the distance jumped, but it recovers over time."
+msgstr ""
+
+msgid "This immense craft is heavily armored, well armed and has a large crew. It is equipped with a Heavy Disruptor Beam and Disruptor Missiles. If the Aliens can produce just a handful of these devastating leviathans, the future of our world looks bleak."
+msgstr ""
+
+msgid "This inter-dimensional transport is designed for transporting Alien life forms or Alien technology captured during tactical missions in the Alien Dimension."
+msgstr ""
+
+msgid "This is a huge egg laying Alien creature."
+msgstr ""
+
+msgid "This is a standard issue armour which provides very effective protection but inhibits the wearer's speed. The leg, torso, arms and helmet are all separate components and can be mixed with other armour types. Under no circumstances should an Agent be sent into combat without full armour cover."
+msgstr ""
+
+msgid "This is an extremely powerful long range missile system, which should only be used with extreme caution. The destructive fusion warhead is designed to be used against distant ground targets."
+msgstr ""
+
+msgid "This is an immensely devastating version of the standard Disruptor Gun. Again it is based on the same inter-dimensional technology that seems to power the Dimension Gates. It is possible that these weapons are actually drawing power from some remote source connected by an inter-dimensional field. This amazing technology seems to be incongruous with the Aliens' organic weaponry and may originate from some other Alien intelligence."
+msgstr ""
+
+msgid "This is not one single creature but billions of micro-organisms. These organisms have been found in the cardiovascular systems of other Aliens, but until now we were unaware of their extraordinary capability to act independently. It is clear that our research must concentrate on these unusual life forms."
+msgstr ""
+
+msgid "This larger and better equipped version of the Biochemistry Lab will enable the study of live Alien specimens. Psionic devices are available to assist in communication with intelligent Alien beings. The Advanced Biochemistry Lab allows up to ten Biochemists to work at any one time."
+msgstr ""
+
+msgid "This launcher propels devastating Dimension Missiles which contain an immensely powerful explosive system. The missile is guided to its target and is very accurate at long ranges. The technology is reproducible and quite distinct from the organic weaponry that is used by most Aliens."
+msgstr ""
+
+msgid "This life form appears to have a simple structure with no distinguishable organs apart from an efficient heart and cardiovascular system. There appears to be no means of ingesting food or separate brain structure rendering it immune from Psionic influence. It seems that this creature has little purpose in life except that it is known to attack humans and seems to be designed to do only that. Its complex organic structure may be useful for developing toxins to counter any threat to our race."
+msgstr ""
+
+msgid "This multipurpose craft is used to build and repair any type of building within the city boundary. It will also repair roads, bridges and other structures. The aesthetic regulations also require construction vehicles to be equipped for landscape gardening and forestry work."
+msgstr ""
+
+msgid "This research could reveal a weakness in the Alien defenses."
+msgstr ""
+
+msgid "This small Alien creature has been seen to attack humans by jumping on the head and gripping with all its limbs."
+msgstr ""
+
+msgid "This stationary Alien life form appears to be some form of Alien egg."
+msgstr ""
+
+msgid "This structure appears to be the source of all Alien eggs. Few Aliens enter the building but many are seen to leave. Our Scientists fear the existence of a frightful Alien Queen. Excercise extreme caution if you encounter such an Alien."
+msgstr ""
+
+msgid "This unfortunate creature dedicates its short life to combat and protection of more vulnerable Alien forms. It has limited intelligence and attacks using its funnel head which projects a mix of deadly micro-organisms up to medium range. Despite its humanoid form it is incapable of using other weapons or equipment. It has no eyes, ears or nose but it can accurately detect the presence of nearby organic life forms. This ability is based on a specialized form of Psionic receptor and makes the creature very dangerous in combat situations."
+msgstr ""
+
+msgid "This ungainly creature has a huge funnel for propelling a deadly liquid."
+msgstr ""
+
+msgid "This unmanned automated probe is designed to explore the Alien Dimension and has minimal armaments and defenses. The Probe will enable X-COM to test its new adaptation of the Aliens inter-dimensional technology. Exploration is a vital requirement for developing further knowledge of the Alien threat and the probe is just the first step."
+msgstr ""
+
+msgid "This unusual Alien weapon causes an inter-dimensional flux field to surround the target when it is hit, rendering it immobile and inactive. The field only lasts a short while but during this time the target vehicle is extremely vulnerable."
+msgstr ""
+
+msgid "This vessel appears to be a surveillance craft. Its structure is very strange and there is no evidence of any crew or cargo. The craft's internals appear to have been intentionally destroyed by the Aliens from a remote location. The craft is armed with small beam weapon. The craft does not appear to be a great threat to the city, but can only be a precursor to more dangerous incursions."
+msgstr ""
+
+msgid "This weapon is an organic launcher for Brainsucker Pods. If the pod lands within the vicinity of a human target it will burst open and the Brainsucker will attack the victim. It is not a useful weapon for us to replicate, even if it were possible."
+msgstr ""
+
+msgid "This weapon is essentially an organism that is genetically engineered to launch a living missile which flies directly towards its chosen target. The missile then erupts and a foul smelling sticky goo smothers the unfortunate victim. The substance is a combination of enzymes and acids that can erode metallic or organic compounds. Unfortunately this weapon is not very effective against Aliens and we cannot replicate it."
+msgstr ""
+
+msgid "To secure and research large or dangerous Alien life forms."
+msgstr ""
+
+msgid "Toxigun"
+msgstr ""
+
+msgid "Toxigun A-Clip"
+msgstr ""
+
+msgid "Toxigun B-Clip"
+msgstr ""
+
+msgid "Toxigun C-Clip"
+msgstr ""
+
+msgid "Toxin A"
+msgstr ""
+
+msgid "Toxin B"
+msgstr ""
+
+msgid "Toxin C"
+msgstr ""
+
+msgid "Toxin Type A"
+msgstr ""
+
+msgid "Toxin Type B"
+msgstr ""
+
+msgid "Toxin Type C"
+msgstr ""
+
+msgid "Tracker Gun"
+msgstr ""
+
+msgid "Tracker Gun Clip"
+msgstr ""
+
+msgid "Training Area"
+msgstr ""
+
+msgid "Training in physical skills is essential for X-COM Agents. Without a fully equipped training area, Agents residing at the base would waste a lot of time when they could be improving their weapons skills, reactions and stamina. Agents assigned to combat training will automatically use any training facilities at a base, but if the capacity of Training Areas is exceeded then training will not take place at 100% efficiency."
+msgstr ""
+
+msgid "Transports a vehicle between Dimensions."
+msgstr ""
+
+msgid "Transtellar"
+msgstr ""
+
+msgid "UFO type 1"
+msgstr ""
+
+msgid "UFO type 10"
+msgstr ""
+
+msgid "UFO type 2"
+msgstr ""
+
+msgid "UFO type 3"
+msgstr ""
+
+msgid "UFO type 4"
+msgstr ""
+
+msgid "UFO type 5"
+msgstr ""
+
+msgid "UFO type 6"
+msgstr ""
+
+msgid "UFO type 7"
+msgstr ""
+
+msgid "UFO type 8"
+msgstr ""
+
+msgid "UFO type 9"
+msgstr ""
+
+msgid "UFOs"
+msgstr ""
+
+msgid "Upper Class Female"
+msgstr ""
+
+msgid "Upper Class Female 1"
+msgstr ""
+
+msgid "Upper Class Female 2"
+msgstr ""
+
+msgid "Upper Class Male"
+msgstr ""
+
+msgid "Upper Class Male 1"
+msgstr ""
+
+msgid "Upper Class Male 2"
+msgstr ""
+
+msgid "Valkyrie Interceptor"
+msgstr ""
+
+msgid "Vast apartment blocks are standard accommodation in the city. They should be treated carefully in any combat situation because of the high density of civilians at all times of day. An Alien incident in an accommodation block should be dealt with promptly."
+msgstr ""
+
+msgid "Vehicle Equipment"
+msgstr ""
+
+msgid "Vehicle Repair Bay"
+msgstr ""
+
+msgid "Vehicles"
+msgstr ""
+
+msgid "Vortex Mine"
+msgstr ""
+
+msgid "Warehouse"
+msgstr ""
+
+msgid "Water Purifier"
+msgstr ""
+
+msgid "We must analyze the data from our Alien Dimension probe."
+msgstr ""
+
+msgid "We must discover a way to beat the Aliens once and for all"
+msgstr ""
+
+msgid "We need to build an automated device that can be sent through a Dimension gate. This will provide invaluable data which can prepare us for manned missions."
+msgstr ""
+
+msgid "When this unit is activated the display shows anything moving relative to its position. The sensors can penetrate any kind of terrain."
+msgstr ""
+
+msgid "Wolfhound APC"
+msgstr ""
+
+msgid "Workshop"
+msgstr ""
+
+msgid "X-COM"
+msgstr ""
+
+msgid "X-COM Advanced Control System"
+msgstr ""
+
+msgid "X-COM Agent (Android)"
+msgstr ""
+
+msgid "X-COM Agent (Human)"
+msgstr ""
+
+msgid "X-COM Agent (Hybrid)"
+msgstr ""
+
+msgid "X-COM Agents should be equipped in preparation for tactical missions. You can choose from a variety of guns, missile launchers, ammunition types, grenades and armor."
+msgstr ""
+
+msgid "X-COM Base"
+msgstr ""
+
+msgid "X-COM Biochemist"
+msgstr ""
+
+msgid "X-COM Body Shield"
+msgstr ""
+
+msgid "X-COM Disruptor Armour"
+msgstr ""
+
+msgid "X-COM Disruptor Base Turret"
+msgstr ""
+
+msgid "X-COM Engineers require the best facilities for the construction of new technology. The latest atomic replicators are installed which can accurately recreate most substances and micro-structures in the known universe. The facility can be used to create small pieces of equipment such as personal weaponry and armor. The workshop can accommodate five Engineers and each Workshop can be assigned to produce a specific item."
+msgstr ""
+
+msgid "X-COM Head Shield"
+msgstr ""
+
+msgid "X-COM Laser Base Turret"
+msgstr ""
+
+msgid "X-COM Left Arm Shield"
+msgstr ""
+
+msgid "X-COM Leg Shields"
+msgstr ""
+
+msgid "X-COM Mechanic"
+msgstr ""
+
+msgid "X-COM Quantum Physicist"
+msgstr ""
+
+msgid "X-COM Right Arm Shield"
+msgstr ""
+
+msgid "X-COM Scientists have devised a superior and more compact weapons control system designed specifically for X-COM vehicles. It assists targeting of the more agile UFOs."
+msgstr ""
+
+msgid "X-COM bases are constructed from a variety of component units designed to perform different functions. The construction of a new base requires a bare minimum of living quarters and storage facilities. Beyond these requirements a base is designed to accommodate research, training and vehicle repair facilities. Bases will also need to be defended against aggression using well equipped Agents and security stations."
+msgstr ""
+
+msgid "X-Com"
+msgstr ""
+
+msgid "X-Com Base Turret's Disruptor"
+msgstr ""
+
+msgid "X-Com Base Turret's Laser"
+msgstr ""
+
+msgid "Zorium"
+msgstr ""
+

--- a/data/languages/forms.pot
+++ b/data/languages/forms.pot
@@ -1,0 +1,840 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: OpenApoc\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2020-01-04 16:20+0800\n"
+"Last-Translator: JonnyH\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/x-com-apocalypse/apocalypse/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+
+msgid "0"
+msgstr ""
+
+msgid "0%"
+msgstr ""
+
+msgid "1"
+msgstr ""
+
+msgid "223"
+msgstr ""
+
+msgid "AGENT NAME GOES HERE"
+msgstr ""
+
+msgid "ALIEN INFILTRATION"
+msgstr ""
+
+msgid "ALIENS"
+msgstr ""
+
+msgid "Accuracy"
+msgstr ""
+
+msgid "Agent equipment"
+msgstr ""
+
+msgid "Agent tab"
+msgstr ""
+
+msgid "Agents"
+msgstr ""
+
+msgid "Aggressive"
+msgstr ""
+
+msgid "Aggressive mode"
+msgstr ""
+
+msgid "Aimed shot"
+msgstr ""
+
+msgid "Airborne vehicle equipment/fuel"
+msgstr ""
+
+msgid "Alien Containment"
+msgstr ""
+
+msgid "Alien Craft"
+msgstr ""
+
+msgid "Alien Incidents in City"
+msgstr ""
+
+msgid "Alien Score Level"
+msgstr ""
+
+msgid "Alien infiltration graph"
+msgstr ""
+
+msgid "Aliens"
+msgstr ""
+
+msgid "Always pause to display this message?"
+msgstr ""
+
+msgid "Anthropod"
+msgstr ""
+
+msgid "Assign project"
+msgstr ""
+
+msgid "Assign units to squad"
+msgstr ""
+
+msgid "Attack building"
+msgstr ""
+
+msgid "Attack hostile unit"
+msgstr ""
+
+msgid "Auto shot"
+msgstr ""
+
+msgid "BASE ATTACK"
+msgstr ""
+
+msgid "BASES"
+msgstr ""
+
+msgid "BUY NEW BASE"
+msgstr ""
+
+msgid "Base Facilities"
+msgstr ""
+
+msgid "Bases"
+msgstr ""
+
+msgid "Bases tab"
+msgstr ""
+
+msgid "Biochemistry tab"
+msgstr ""
+
+msgid "Biochemists"
+msgstr ""
+
+msgid "Brainsucker"
+msgstr ""
+
+msgid "Bravery"
+msgstr ""
+
+msgid "Buildings"
+msgstr ""
+
+msgid "Buy This Building"
+msgstr ""
+
+msgid "Buy new base"
+msgstr ""
+
+msgid "Buy/Sell"
+msgstr ""
+
+msgid "CATEGORY"
+msgstr ""
+
+msgid "CUSTOMIZE FORCES"
+msgstr ""
+
+msgid "Casualty penalty"
+msgstr ""
+
+msgid "Cautious mode"
+msgstr ""
+
+msgid "Center and pause game"
+msgstr ""
+
+msgid "Center on message"
+msgstr ""
+
+msgid "Chrysalis"
+msgstr ""
+
+msgid "Civilian"
+msgstr ""
+
+msgid "Civilians"
+msgstr ""
+
+msgid "Click on building to buy"
+msgstr ""
+
+msgid "Combat Training"
+msgstr ""
+
+msgid "Combat rating"
+msgstr ""
+
+msgid "Computer"
+msgstr ""
+
+msgid "Continue"
+msgstr ""
+
+msgid "Control body"
+msgstr ""
+
+msgid "Crawl"
+msgstr ""
+
+msgid "Current Project"
+msgstr ""
+
+msgid "Customize forces"
+msgstr ""
+
+msgid "DEBRIEFING"
+msgstr ""
+
+msgid "DELETE OLD SAVED GAME"
+msgstr ""
+
+msgid "Damage to City"
+msgstr ""
+
+msgid "Days of Physical Gym Training"
+msgstr ""
+
+msgid "Days of Psi Gym Training"
+msgstr ""
+
+msgid "Debug Menu"
+msgstr ""
+
+msgid "Default"
+msgstr ""
+
+msgid "Default equipment tech level"
+msgstr ""
+
+msgid "Default equipped armor"
+msgstr ""
+
+msgid "Defensive"
+msgstr ""
+
+msgid "Double speed"
+msgstr ""
+
+msgid "Down"
+msgstr ""
+
+msgid "Drop object"
+msgstr ""
+
+msgid "EMPLOYEE TYPE"
+msgstr ""
+
+msgid "EQUIP VEHICLE"
+msgstr ""
+
+msgid "Easy"
+msgstr ""
+
+msgid "End turn"
+msgstr ""
+
+msgid "Engineering tab"
+msgstr ""
+
+msgid "Engineers"
+msgstr ""
+
+msgid "Engines"
+msgstr ""
+
+msgid "Equip agent"
+msgstr ""
+
+msgid "Equip vehicle"
+msgstr ""
+
+msgid "Equipment"
+msgstr ""
+
+msgid "Equipment captured"
+msgstr ""
+
+msgid "Equipment lost"
+msgstr ""
+
+msgid "Evasive"
+msgstr ""
+
+msgid "Excellent"
+msgstr ""
+
+msgid "Exit Psionics"
+msgstr ""
+
+msgid "Finance"
+msgstr ""
+
+msgid "Function>"
+msgstr ""
+
+msgid "Game Turn:"
+msgstr ""
+
+msgid "Go to building"
+msgstr ""
+
+msgid "Go to map point"
+msgstr ""
+
+msgid "Group formation"
+msgstr ""
+
+msgid "Guards"
+msgstr ""
+
+msgid "HIRE AND FIRE"
+msgstr ""
+
+msgid "Hard"
+msgstr ""
+
+msgid "Health"
+msgstr ""
+
+msgid "Hidden Movement"
+msgstr ""
+
+msgid "High altitude"
+msgstr ""
+
+msgid "Highest altitude"
+msgstr ""
+
+msgid "Hire/Fire staff"
+msgstr ""
+
+msgid "Hostile forces have invaded your base. Equip your Agents before battle."
+msgstr ""
+
+msgid "Hostile vehicles tab"
+msgstr ""
+
+msgid "Hotseat multiplayer"
+msgstr ""
+
+msgid "Hyperworm"
+msgstr ""
+
+msgid "ITEM"
+msgstr ""
+
+msgid "ITEM NAME GOES HERE"
+msgstr ""
+
+msgid "Initial finds>"
+msgstr ""
+
+msgid "Investigate building for Alien activity"
+msgstr ""
+
+msgid "Kneel down"
+msgstr ""
+
+msgid "LABEL_1"
+msgstr ""
+
+msgid "LABEL_10"
+msgstr ""
+
+msgid "LABEL_2"
+msgstr ""
+
+msgid "LABEL_3"
+msgstr ""
+
+msgid "LABEL_4"
+msgstr ""
+
+msgid "LABEL_5"
+msgstr ""
+
+msgid "LABEL_6"
+msgstr ""
+
+msgid "LABEL_7"
+msgstr ""
+
+msgid "LABEL_8"
+msgstr ""
+
+msgid "LABEL_9"
+msgstr ""
+
+msgid "LOAD GAME"
+msgstr ""
+
+msgid "Lab Size Needed"
+msgstr ""
+
+msgid "Lab Type"
+msgstr ""
+
+msgid "Leadership bonus"
+msgstr ""
+
+msgid "Level indicator"
+msgstr ""
+
+msgid "Live Aliens captured"
+msgstr ""
+
+msgid "Load Saved Game"
+msgstr ""
+
+msgid "Low altitude"
+msgstr ""
+
+msgid "MAINTENANCE"
+msgstr ""
+
+msgid "MESSAGE HISTORY"
+msgstr ""
+
+msgid "MISSION BRIEFING"
+msgstr ""
+
+msgid "Medium"
+msgstr ""
+
+msgid "Medium altitude"
+msgstr ""
+
+msgid "Megaspawn"
+msgstr ""
+
+msgid "Message history"
+msgstr ""
+
+msgid "Micronoid"
+msgstr ""
+
+msgid "Mission performance"
+msgstr ""
+
+msgid "Multiworm"
+msgstr ""
+
+msgid "Multiworm Egg"
+msgstr ""
+
+msgid "No shot"
+msgstr ""
+
+msgid "No, cancel operation"
+msgstr ""
+
+msgid "Normal speed"
+msgstr ""
+
+msgid "Novice"
+msgstr ""
+
+msgid "Number of Android Agents"
+msgstr ""
+
+msgid "Number of Human Agents"
+msgstr ""
+
+msgid "Number of Hybrid Agents"
+msgstr ""
+
+msgid "Number to make"
+msgstr ""
+
+msgid "OFFER CASH SETTLEMENT"
+msgstr ""
+
+msgid "OPTIONS"
+msgstr ""
+
+msgid "Offer settlement"
+msgstr ""
+
+msgid "Options"
+msgstr ""
+
+msgid "Organisation Tech Level"
+msgstr ""
+
+msgid "Organizations"
+msgstr ""
+
+msgid "Organizations tab"
+msgstr ""
+
+msgid "Owner>"
+msgstr ""
+
+msgid "PLAYER / TECH LEVEL / SCORE SETTINGS"
+msgstr ""
+
+msgid "Panic unit"
+msgstr ""
+
+msgid "Pause"
+msgstr ""
+
+msgid "Pay organization"
+msgstr ""
+
+msgid "Performance log"
+msgstr ""
+
+msgid "Player:"
+msgstr ""
+
+msgid "Popper"
+msgstr ""
+
+msgid "Probe unit"
+msgstr ""
+
+msgid "Progress"
+msgstr ""
+
+msgid "Project"
+msgstr ""
+
+msgid "Psi-Training"
+msgstr ""
+
+msgid "Psi-attack"
+msgstr ""
+
+msgid "Psi-defence"
+msgstr ""
+
+msgid "Psi-energy"
+msgstr ""
+
+msgid "Psimorph"
+msgstr ""
+
+msgid "QUANTITY"
+msgstr ""
+
+msgid "Quadruple speed"
+msgstr ""
+
+msgid "Quantum Physicists"
+msgstr ""
+
+msgid "Quantum physics tab"
+msgstr ""
+
+msgid "Queenspawn"
+msgstr ""
+
+msgid "Quit"
+msgstr ""
+
+msgid "RESEARCH AND MANUFACTURE"
+msgstr ""
+
+msgid "Raid building"
+msgstr ""
+
+msgid "Raid mode"
+msgstr ""
+
+msgid "Reactions"
+msgstr ""
+
+msgid "Remaining finds>"
+msgstr ""
+
+msgid "Research Completed"
+msgstr ""
+
+msgid "Research and manufacture"
+msgstr ""
+
+msgid "Reserve TUs for aimed shot"
+msgstr ""
+
+msgid "Reserve TUs for auto shot"
+msgstr ""
+
+msgid "Reserve TUs for kneel"
+msgstr ""
+
+msgid "Reserve TUs for snap shot"
+msgstr ""
+
+msgid "Return to base"
+msgstr ""
+
+msgid "Review briefing"
+msgstr ""
+
+msgid "Road vehicle equipment/fuel"
+msgstr ""
+
+msgid "Run"
+msgstr ""
+
+msgid "SAVE GAME"
+msgstr ""
+
+msgid "SCORE"
+msgstr ""
+
+msgid "SELECT PROJECT"
+msgstr ""
+
+msgid "SELECT SKIRMISH LOCATION"
+msgstr ""
+
+msgid "SKIRMISH"
+msgstr ""
+
+msgid "SQUAD ASSIGNMENT"
+msgstr ""
+
+msgid "Safe mode"
+msgstr ""
+
+msgid "Scroll Down"
+msgstr ""
+
+msgid "Scroll Left"
+msgstr ""
+
+msgid "Scroll Right"
+msgstr ""
+
+msgid "Scroll Up"
+msgstr ""
+
+msgid "Select"
+msgstr ""
+
+msgid "Send selected units to investigate incident"
+msgstr ""
+
+msgid "Show available armor"
+msgstr ""
+
+msgid "Show available equipment"
+msgstr ""
+
+msgid "Show ten most infiltrated organizations not under Alien control."
+msgstr ""
+
+msgid "Side:"
+msgstr ""
+
+msgid "Single file"
+msgstr ""
+
+msgid "Skeletoid"
+msgstr ""
+
+msgid "Skill"
+msgstr ""
+
+msgid "Slow speed"
+msgstr ""
+
+msgid "Snap shot"
+msgstr ""
+
+msgid "Speed"
+msgstr ""
+
+msgid "Spitters"
+msgstr ""
+
+msgid "Squad icons"
+msgstr ""
+
+msgid "Stamina"
+msgstr ""
+
+msgid "Standard"
+msgstr ""
+
+msgid "Start Campaign Game"
+msgstr ""
+
+msgid "Start real time game"
+msgstr ""
+
+msgid "Start turn-based game"
+msgstr ""
+
+msgid "Stop project"
+msgstr ""
+
+msgid "Strength"
+msgstr ""
+
+msgid "Stun unit"
+msgstr ""
+
+msgid "Superhuman"
+msgstr ""
+
+msgid "Switch camera mode"
+msgstr ""
+
+msgid "Switch map view"
+msgstr ""
+
+msgid "TICK TOCK"
+msgstr ""
+
+msgid "TOTAL"
+msgstr ""
+
+msgid "TOTAL OVERHEADS>"
+msgstr ""
+
+msgid "Tactical Missions"
+msgstr ""
+
+msgid "The Alien Dimension"
+msgstr ""
+
+msgid "Throw object"
+msgstr ""
+
+msgid "Toggle camera mode"
+msgstr ""
+
+msgid "Toggle map level display mode"
+msgstr ""
+
+msgid "Total"
+msgstr ""
+
+msgid "Total Skill: 0"
+msgstr ""
+
+msgid "Transfer"
+msgstr ""
+
+msgid "UFO Incursions"
+msgstr ""
+
+msgid "UFOs Shot Down"
+msgstr ""
+
+msgid "Ufopaedia"
+msgstr ""
+
+msgid "Ultra fast"
+msgstr ""
+
+msgid "Unassigned Agents"
+msgstr ""
+
+msgid "Unit location"
+msgstr ""
+
+msgid "Up"
+msgstr ""
+
+msgid "VALUE_1"
+msgstr ""
+
+msgid "VALUE_10"
+msgstr ""
+
+msgid "VALUE_2"
+msgstr ""
+
+msgid "VALUE_3"
+msgstr ""
+
+msgid "VALUE_4"
+msgstr ""
+
+msgid "VALUE_5"
+msgstr ""
+
+msgid "VALUE_6"
+msgstr ""
+
+msgid "VALUE_7"
+msgstr ""
+
+msgid "VALUE_8"
+msgstr ""
+
+msgid "VALUE_9"
+msgstr ""
+
+msgid "VEHICLE NAME GOES HERE"
+msgstr ""
+
+msgid "Vehicle Assignments"
+msgstr ""
+
+msgid "Vehicle Equipment"
+msgstr ""
+
+msgid "Vehicle location / passengers"
+msgstr ""
+
+msgid "Vehicles"
+msgstr ""
+
+msgid "View all organizations"
+msgstr ""
+
+msgid "View allied organizations"
+msgstr ""
+
+msgid "View friendly organizations"
+msgstr ""
+
+msgid "View hostile organizations"
+msgstr ""
+
+msgid "View neutral organizations"
+msgstr ""
+
+msgid "View unfriendly organizations"
+msgstr ""
+
+msgid "WAGES"
+msgstr ""
+
+msgid "WEEK"
+msgstr ""
+
+msgid "Walk"
+msgstr ""
+
+msgid "Weapons"
+msgstr ""
+
+msgid "X-COM Agents"
+msgstr ""
+
+msgid "X-COM Craft Shot Down"
+msgstr ""
+
+msgid "X-COM Vehicles tab"
+msgstr ""
+
+msgid "Yes, prime grenade"
+msgstr ""
+
+msgid "_____________________________________________________"
+msgstr ""
+

--- a/data/languages/source.pot
+++ b/data/languages/source.pot
@@ -1,0 +1,1630 @@
+# SOME DESCRIPTIVE TITLE.
+# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
+# This file is distributed under the same license as the PACKAGE package.
+# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+#
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:374
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: PACKAGE VERSION\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2020-02-11 18:11-0800\n"
+"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
+"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
+"Language-Team: LANGUAGE <LL@li.org>\n"
+"Language: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Transfer-Encoding: 8bit\n"
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/battle/battle.cpp:3733
+msgid "Very Good"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/battle/battle.cpp:3737
+msgid "Good"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/battle/battle.cpp:3741
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/messagebox.cpp:46
+msgid "OK"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/battle/battle.cpp:3745
+msgid "Poor"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/battle/battle.cpp:3749
+msgid "Very Poor"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:71
+msgid "Mission completed in Alien building."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:73
+msgid "X-COM returning from UFO mission."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:75
+msgid "Building has been disabled"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:87
+msgid "UFO spotted."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:89
+msgid "UFO crash landed:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:91
+msgid "Unmanned UFO recovered:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:93
+msgid "Vehicle successfully recovered:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:95
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:394
+msgid "Vehicle out of fuel:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:99
+msgid "Vehicle lightly damaged:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:101
+msgid "Vehicle moderately damaged:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:103
+msgid "Vehicle heavily damaged:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:105
+msgid "Vehicle returning to base as damaged:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:107
+msgid ": Weapon out of ammo:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:109
+msgid "Vehicle low on fuel:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:111
+msgid "Vehicle Repaired:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:113
+msgid "Vehicle Rearmed:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:115
+msgid "Vehicle Refuelled:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:117
+msgid "Vehicle has no engine:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:121
+msgid "An illegal road vehicle has been detected."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:125
+msgid "An illegal flyer has been detected."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:128
+msgid "Not enough ammo to rearm vehicle:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:130
+msgid "Not enough fuel to refuel vehicle"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:145
+msgid "New transfer arrived:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:149
+msgid "New recruit arrived:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:154
+msgid ""
+": Unable to reach destination due to damaged people tube network and / or "
+"poor diplomatic relations with Transtellar."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:157
+msgid "Hostile unit spotted"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:159
+msgid "Unit Brainsucked:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:161
+msgid "Unit has died:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:163
+msgid "Hostile unit has died"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:165
+msgid "Unknown Unit has died"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:167
+msgid "Unit critically wounded"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:169
+msgid "Unit badly injured:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:171
+msgid "Unit injured:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:173
+msgid "Unit under fire:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:175
+msgid "Unit has lost consciousness:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:177
+msgid "Unit has left combat zone:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:179
+msgid "Unit has frozen:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:181
+msgid "Unit has gone berserk:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:183
+msgid "Unit has panicked:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:185
+msgid "Unit has stopped panicking:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:187
+msgid "Psionic attack on unit:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:189
+msgid "Unit under Psionic control:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:191
+msgid "Unit freed from Psionic control:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:193
+msgid "No line of fire"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:208
+msgid "X-COM returning from mission at:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:210
+msgid "X-COM returning from raid at:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:212
+msgid "Building under attack :"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:213
+msgid "Attacked by:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:215
+msgid "Live Alien spotted."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:217
+msgid "Cargo expires soon:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:232
+msgid "Agent(s) rearmed:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:238
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:242
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:248
+msgid "Cargo expired:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:238
+msgid "Returned to base"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:243
+msgid "Refunded by supplier: "
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:252
+msgid "Cargo seized:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:252
+msgid "By hostile organisation: "
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:258
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:263
+msgid "Cargo arrived:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:258
+msgid "Supplier: "
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:268
+msgid "Transferred Alien specimens have arrived:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:272
+msgid "Transferred goods have arrived:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:275
+msgid "Items from tactical combat zone have arrived:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:277
+msgid "Base mission completed at:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:291
+msgid "Turn:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:291
+msgid "Side:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:366
+msgid "Agent has died:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:371
+msgid "X-COM base destroyed by hostile forces."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:375
+msgid "X-COM Base destroyed due to collapsing building."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:381
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:386
+msgid "Vehicle destroyed:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:382
+msgid "destroyed by"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gameevent.cpp:391
+msgid "Scrapped vehicle recovered in irreparable condition:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:74
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:110
+msgid "January"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:74
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:110
+msgid "February"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:74
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:110
+msgid "March"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:75
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:111
+msgid "April"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:75
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:111
+msgid "May"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:75
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:111
+msgid "June"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:76
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:112
+msgid "July"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:76
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:112
+msgid "August"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:76
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:112
+msgid "September"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:77
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:113
+msgid "October"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:77
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:113
+msgid "November"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:77
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:113
+msgid "December"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:81
+msgid "Sunday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:81
+msgid "Monday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:81
+msgid "Tuesday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:81
+msgid "Wednesday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:82
+msgid "Thursday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:82
+msgid "Friday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:82
+msgid "Saturday"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:86
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:117
+msgid "1st"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:86
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:117
+msgid "2nd"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:86
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:117
+msgid "3rd"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:86
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:117
+msgid "4th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:87
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:118
+msgid "5th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:87
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:118
+msgid "6th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:87
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:118
+msgid "7th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:87
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:118
+msgid "8th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:88
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:119
+msgid "9th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:88
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:119
+msgid "10th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:88
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:119
+msgid "11th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:88
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:119
+msgid "12th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:89
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:120
+msgid "13th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:89
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:120
+msgid "14th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:89
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:120
+msgid "15th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:89
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:120
+msgid "16th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:90
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:121
+msgid "17th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:90
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:121
+msgid "18th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:90
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:121
+msgid "19th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:90
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:121
+msgid "20th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:91
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:122
+msgid "21st"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:91
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:122
+msgid "22nd"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:91
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:122
+msgid "23rd"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:91
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:122
+msgid "24th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:92
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:123
+msgid "25th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:92
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:123
+msgid "26th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:92
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:123
+msgid "27th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:92
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:123
+msgid "28th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:93
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:124
+msgid "29th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:93
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:124
+msgid "30th"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:93
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:124
+msgid "31st"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/gametime.cpp:132
+msgid "Week"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:270
+msgid "Rookie"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:272
+msgid "Squaddie"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:274
+msgid "Squad leader"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:276
+msgid "Sergeant"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:278
+msgid "Captain"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:280
+msgid "Colonel"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/state/shared/agent.cpp:282
+msgid "Commander"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/aliencontainmentscreen.cpp:28
+msgid "ALIEN CONTAINMENT"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/aliencontainmentscreen.cpp:46
+msgid "Confirm Alien Containment Orders"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/aliencontainmentscreen.cpp:106
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:333
+msgid "Alien Containment space exceeded"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/aliencontainmentscreen.cpp:107
+msgid "Alien Containment space exceeded. Destroy more Aliens!"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:111
+msgid "Transfer"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:112
+msgid "At least two bases are required before transfers become possible."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:317
+msgid "Area Occupied By Existing Facility"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:318
+msgid ""
+"Existing facilities in this area of the base must be destroyed before "
+"construction work can begin."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:327
+msgid "Planning Permission Denied"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:328
+msgid ""
+"Planning permission is denied for this proposed extension to the base, on "
+"the grounds that the additional excavations required would seriously weaken "
+"the foundations of the building."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:338
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:109
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:613
+msgid "Funds exceeded"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:339
+msgid ""
+"The proposed construction work is not possible with your available funds."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:364
+msgid "Destroy facility"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:364
+msgid "Are you sure?"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:374
+msgid "Facility in use"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:399
+msgid "Cost to build"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:401
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:497
+msgid "Days to build"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:403
+msgid "Maintenance cost"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:412
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:503
+msgid "Capacity"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:414
+msgid "Usage"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:426
+msgid "Corridor"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/basescreen.cpp:430
+msgid "Earth"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:31
+msgid "BUY AND SELL"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:69
+msgid "Confirm Sales/Purchases"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:110
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:613
+msgid "Order limited by your available funds."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:162
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:327
+msgid "Storage space exceeded"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:164
+msgid "Storage space exceeded. Sell off more items!"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:165
+msgid "Order limited by the available storage space at this base."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:258
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:291
+msgid ""
+"Hostile organization refuses to carry out the requested transportation for "
+"this company."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:260
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:264
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:278
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:369
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:373
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:387
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:426
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:430
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:444
+msgid "Proceed?"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:262
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:276
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:371
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:385
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:428
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:442
+msgid ""
+"No free transport to carry out the requested transportation detected in the "
+"city."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:367
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/buyandsellscreen.cpp:400
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:424
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:457
+msgid "This hostile organization refuses to carry out the requested transfer."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:122
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:635
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:321
+msgid "Accomodation exceeded"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:123
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:636
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:322
+msgid "Transfer limited by available accommodation."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:238
+msgid "X-COM Agents"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:241
+msgid "Biochemists"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:244
+msgid "Quantum Physicists"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:247
+msgid "Engineers"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:480
+msgid "unit(s) hired"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:480
+msgid "unit(s) fired."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:483
+msgid "units(s) transferred"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/recruitscreen.cpp:488
+msgid "Confirm Orders"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:330
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:414
+msgid "Total Skill: {}"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:342
+msgid "Biochemistry"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:347
+msgid "Quantum Physics"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:352
+msgid "Engineering"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:480
+#, c-format
+msgid "{}%%"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchscreen.cpp:488
+msgid "No Project"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:46
+msgid "Select Biochemistry Project"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:47
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:52
+msgid "Progress"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:48
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:53
+msgid "Skill"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:51
+msgid "Select Physics Project"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:56
+msgid "Select Manufacturing Project"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:57
+msgid "Unit Cost"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:58
+msgid "Skill Hours"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:61
+msgid "Select Unknown Project"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:83
+msgid "PROJECT COMPLETE"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:83
+msgid "This project is already complete."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:93
+msgid "PROJECT TOO LARGE"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:93
+msgid "This project requires an advanced lab or workshop."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:102
+msgid "FUNDS EXCEEDED"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:103
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3806
+msgid "Production costs exceed your available funds."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:238
+msgid "Complete"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:297
+msgid "Small"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:300
+msgid "Large"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/researchselect.cpp:303
+msgid "UNKNOWN"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:35
+msgid "TRANSFER"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:103
+msgid "Confirm Transfers"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:328
+msgid "Transfer limited by available storage space."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/base/transferscreen.cpp:334
+msgid "Transfer limited by available Alien Containment space."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/battle/battledebriefing.cpp:49
+msgid "promoted to"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/alertscreen.cpp:75
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:134
+msgid "No Agents Selected"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/alertscreen.cpp:76
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:135
+msgid ""
+"You need to select the agents you want to become active within the building."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/basebuyscreen.cpp:43
+msgid "This Building will cost ${}"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/basebuyscreen.cpp:156
+msgid "No Sale"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/basebuyscreen.cpp:156
+msgid "Not enough money to buy this building."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:37
+msgid ""
+"X-COM is ALLIED with this organization. The relationship cannot be improved."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:43
+msgid "ALLIED"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:48
+msgid "FRIENDLY"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:53
+msgid "NEUTRAL"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:60
+msgid ""
+"Whilst X-COM continue to oppose our Alien friends we will remain hostile. "
+"Negotiations are impossible."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:66
+msgid "UNFRIENDLY"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:79
+msgid ""
+"This organization is under Alien control.The Alien race will not enter "
+"negotiations with X-COM."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:97
+msgid "It will cost: $"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/bribescreen.cpp:98
+msgid "to improve relations to:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:106
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:115
+msgid "No Entrance"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:106
+msgid "Cannot raid as building destroyed"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:116
+msgid ""
+"Our Agents are unable to find an entrance to this building. Our Scientists "
+"back at HQ must complete their research."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:192
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:217
+msgid "No Hostile Forces Discovered"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/buildingscreen.cpp:218
+msgid "You have not found any hostile forces in this building."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/scorescreen.cpp:89
+msgid "SCORE"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/scorescreen.cpp:160
+msgid "Initial funds>"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/scorescreen.cpp:163
+msgid "Remaining finds>"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/city/scorescreen.cpp:166
+msgid "FINANCE"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/components/controlgenerator.cpp:537
+msgid "Skill {}"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/components/locationscreen.cpp:30
+msgid "AGENT LOCATION"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/components/locationscreen.cpp:42
+msgid "VEHICLE LOCATION"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:58
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:187
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:78
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:127
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:234
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:317
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:357
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:436
+msgid "Weight"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:104
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:123
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:149
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:365
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:444
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:455
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:464
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:477
+msgid "Power"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:110
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:146
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:49
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:75
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:159
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:177
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:373
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:396
+msgid "Accuracy"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:113
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:149
+msgid "Fire rate"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:117
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:153
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:157
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:375
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:468
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:481
+msgid "Range"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:120
+msgid "Ammo Type:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:126
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:165
+msgid "Rounds"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:132
+msgid "(Recharges)"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:156
+msgid "Ammo types:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:170
+msgid "Protection"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:184
+msgid "Alien Organism"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipmentsheet.cpp:184
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:518
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:541
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:590
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/transactioncontrol.cpp:615
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:232
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2470
+msgid "Alien Artifact"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:164
+msgid "MIND PROBE"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:168
+msgid "EQUIP AGENT"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:518
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:542
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:590
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2470
+msgid "You must research Alien technology before you can use it."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:582
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:652
+msgid "NOT ENOUGH TU'S"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:583
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:653
+msgid "TU cost per item picked up:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:1856
+msgid "WARNING"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/aequipscreen.cpp:1857
+msgid ""
+"You will lose any equipment left on the floor. Are you sure you wish to "
+"leave this agent?"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:41
+msgid "Health"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:57
+msgid "Reactions"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:65
+msgid "Time Units"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:65
+msgid "Speed"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:86
+msgid "Stamina"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:95
+msgid "Bravery"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:103
+msgid "Strength"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:111
+msgid "Psi-energy"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:119
+msgid "Psi-attack"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/agentsheet.cpp:127
+msgid "Psi-defence"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/ingameoptions.cpp:117
+msgid "Message Toggles"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/ingameoptions.cpp:117
+msgid "OpenApoc Features"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/ingameoptions.cpp:310
+msgid "Abort Mission"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/ingameoptions.cpp:311
+msgid "Units Lost :"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/messagebox.cpp:58
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/messagebox.cpp:77
+msgid "Yes"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/messagebox.cpp:65
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/messagebox.cpp:84
+msgid "No"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/messagebox.cpp:91
+msgid "Cancel"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/transactioncontrol.cpp:110
+msgid "Order canceled by the hostile manufacturer."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/transactioncontrol.cpp:111
+msgid ""
+"Manufacturer has no intact buildings in this city to deliver goods from."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:73
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:308
+msgid "Constitution"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:74
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:315
+msgid "Armor"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:76
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:147
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:367
+msgid "Top Speed"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:77
+msgid "Acceleration"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:79
+msgid "Fuel"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:80
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:191
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:319
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:407
+msgid "Passengers"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:81
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:184
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:402
+msgid "Cargo"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:155
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:371
+msgid "Damage"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:198
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:412
+msgid "Aliens Held"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:205
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:417
+msgid "Jamming"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:212
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:422
+msgid "Shielding"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:220
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:427
+msgid "Cloaks Craft"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/general/vehiclesheet.cpp:225
+msgid "Teleports"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battletileview.cpp:321
+msgid "Too Far"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battletileview.cpp:322
+msgid "Blocked"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battletileview.cpp:323
+msgid "Out of range"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battletileview.cpp:324
+msgid "No arc of throw"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:175
+msgid "Execute remaining movement orders for this unit?"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:1679
+msgid "All hostile units have fled the combat zone. You win."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:1685
+msgid "All your units have fled the combat zone. You win."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:1689
+msgid "All hostile units are dead or unconscious. You win."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:1694
+msgid "All your units have fled the combat zone. You lose."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:1698
+msgid "All hostile units have fled the combat zone. You lose."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:1702
+msgid "All your units are unconscious or dead. You lose."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2123
+msgid "Activates now."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2131
+msgid "Activates at end of turn."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2135
+msgid "Turns before activation:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2140
+#, c-format
+msgid "Delay = %i"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:2150
+#, c-format
+msgid "Range = %2.1fm."
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:4027
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:4036
+msgid "None"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/battleview.cpp:4033
+msgid "Empty"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:1518
+msgid "Welcome to X-COM Apocalypse"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2056
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2060
+msgid "At"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2066
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2078
+msgid "Returning to base"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2069
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2080
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2085
+msgid "Traveling to:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2086
+msgid "map point"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2089
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2257
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2383
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2506
+msgid "Reporting to base"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2102
+msgid "Wounded"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2108
+msgid "Not assigned to training"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2110
+msgid "(Android training not possible)"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2114
+msgid "Combat training (efficiency="
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2123
+msgid "Psionic training (efficiency="
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2247
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2373
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2496
+msgid "No project assigned"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2255
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2504
+msgid "Not assigned to lab"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2381
+msgid "Not assigned to workshop"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2706
+msgid ": allied with:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2709
+msgid ": friendly with:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2712
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:288
+msgid ": neutral towards:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2715
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:291
+msgid ": unfriendly towards:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:2718
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:294
+msgid ": hostile towards:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3605
+msgid "Commence investigation"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3606
+msgid ""
+"All selected units and crafts have arrived at {}. Proceed with "
+"investigation? ({} units)"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3673
+msgid "RESEARCH COMPLETE"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3674
+msgid "Research project completed:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3675
+msgid "Do you wish to view the UFOpaedia report?"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3744
+msgid "MANUFACTURE COMPLETED"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3745
+msgid "Quantity:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3746
+msgid "Do you wish to reasign the Workshop?"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3803
+msgid "MANUFACTURING HALTED"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3805
+msgid "Completion status:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3821
+msgid "FACILITY COMPLETED"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3947
+msgid "Click on building for selected vehicle to attack"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3954
+msgid "Click on target vehicle for selected vehicle"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3965
+msgid "Click on destination building for selected vehicles"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3969
+msgid "Click on destination building for selected vehicle"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3976
+msgid "Click on destination building for selected people"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3980
+msgid "Click on destination building for selected person"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3990
+msgid "Click on destination map point for selected vehicle"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/tileview/cityview.cpp:3996
+msgid "Manual control"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:271
+msgid "Balance"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:273
+msgid "Income"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:282
+msgid ": allied towards:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:285
+msgid ": friendly towards:"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:299
+msgid "Alien Infiltration"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:344
+msgid "Weapons space"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:346
+msgid "Weapons slots"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:348
+msgid "Engine size"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:350
+msgid "Equipment space"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:359
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:438
+msgid "Size"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:377
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:470
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:483
+msgid "Fire Rate"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:382
+msgid "Ammo type"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:384
+msgid "Ammo capacity"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:389
+msgid "Turn Rate"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:446
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:457
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:466
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:479
+msgid "Damage Type"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:478
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:480
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:482
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:484
+msgid "Depends on clip"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:495
+msgid "Construction cost"
+msgstr ""
+
+#: /Users/jonny/code/projects/OpenApoc/game/ui/ufopaedia/ufopaediacategoryview.cpp:499
+msgid "Weekly cost"
+msgstr ""

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -146,3 +146,5 @@ target_compile_options(OpenApoc_LibPugixml PRIVATE "-w")
 target_compile_options(OpenApoc_LibLodepng PRIVATE "-w")
 target_compile_options(OpenApoc_Miniz PRIVATE "-w")
 target_compile_options(OpenApoc_Lua PRIVATE "-w")
+
+add_subdirectory(fmt)

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -515,7 +515,7 @@ void Control::configureChildrenFromXml(pugi::xml_node *parent)
 			}
 			else
 			{
-				LogError("Radiobutton \"%s\" has no group", node.attribute("id").as_string());
+				LogError("Radiobutton \"{}\" has no group", node.attribute("id").as_string());
 			}
 			auto rb = this->createChild<RadioButton>(group);
 			rb->configureFromXml(&node);
@@ -612,7 +612,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 			auto pal = fw().data->loadPalette(child.text().get());
 			if (!pal)
 			{
-				LogError("Control referenced palette \"%s\" that cannot be loaded",
+				LogError("Control referenced palette \"{}\" that cannot be loaded",
 				         child.text().get());
 			}
 			this->palette = pal;
@@ -683,7 +683,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 				}
 				else
 				{
-					LogWarning("Control \"%s\" has not supported size x value \"%s\"", this->Name,
+					LogWarning("Control \"{}\" has not supported size x value \"{}\"", this->Name,
 					           specialsizex);
 				}
 			}
@@ -712,13 +712,13 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 					else
 					{
 						LogWarning(
-						    "Control \"%s\" with \"item\" size.y does not have ListBox parent ",
+						    "Control \"{}\" with \"item\" size.y does not have ListBox parent ",
 						    this->Name);
 					}
 				}
 				else
 				{
-					LogWarning("Control \"%s\" has not supported size y value \"%s\"", this->Name,
+					LogWarning("Control \"{}\" has not supported size y value \"{}\"", this->Name,
 					           specialsizey);
 				}
 			}
@@ -733,7 +733,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 			}
 			else
 			{
-				LogWarning("Could not find font for tooltip of control \"%s\"", Name);
+				LogWarning("Could not find font for tooltip of control \"{}\"", Name);
 			}
 			UString backgroundString = child.attribute("background").as_string();
 			if (!backgroundString.empty())
@@ -801,7 +801,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 		}
 	}
 
-	LogInfo("Control \"%s\" has %zu subcontrols (%d, %d, %d, %d)", this->Name, Controls.size(),
+	LogInfo("Control \"{}\" has {} subcontrols ({}, {}, {}, {})", this->Name, Controls.size(),
 	        Location.x, Location.y, Size.x, Size.y);
 }
 
@@ -1142,7 +1142,7 @@ void Control::pushFormEvent(FormEventType type, Event *parentEvent)
 			break;
 		}
 		default:
-			LogError("Unexpected event type %d", (int)type);
+			LogError("Unexpected event type {}", (int)type);
 	}
 	this->triggerEventCallbacks(event);
 }

--- a/forms/control.h
+++ b/forms/control.h
@@ -122,13 +122,13 @@ class Control : public std::enable_shared_from_this<Control>
 		auto c = this->findControl(name);
 		if (!c)
 		{
-			LogError("Failed to find control \"%s\" within form \"%s\"", name, this->Name);
+			LogError("Failed to find control \"{}\" within form \"{}\"", name, this->Name);
 			return nullptr;
 		}
 		sp<T> typedControl = std::dynamic_pointer_cast<T>(c);
 		if (!typedControl)
 		{
-			LogError("Failed to cast control \"%s\" within form \"%s\" to type \"%s\"", name,
+			LogError("Failed to cast control \"{}\" within form \"{}\" to type \"{}\"", name,
 			         this->Name, typeid(T).name());
 			return nullptr;
 		}

--- a/forms/form.cpp
+++ b/forms/form.cpp
@@ -63,20 +63,20 @@ sp<Form> Form::loadForm(const UString &path)
 	auto file = fw().data->fs.open(path);
 	if (!file)
 	{
-		LogWarning("Failed to open form file \"%s\"", path);
+		LogWarning("Failed to open form file \"{}\"", path);
 		return nullptr;
 	}
 	auto data = file.readAll();
 	if (!data)
 	{
-		LogWarning("Failed to read form data from \"%s\"", path);
+		LogWarning("Failed to read form data from \"{}\"", path);
 		return nullptr;
 	}
 	pugi::xml_document doc;
 	auto result = doc.load_buffer(data.get(), file.size());
 	if (!result)
 	{
-		LogWarning("Failed to parse form file at \"%s\" - \"%s\" at \"%llu\"", path,
+		LogWarning("Failed to parse form file at \"{}\" - \"{}\" at \"{}\"", path,
 		           result.description(), (unsigned long long)result.offset);
 		return nullptr;
 	}
@@ -84,13 +84,13 @@ sp<Form> Form::loadForm(const UString &path)
 	auto node = doc.child("openapoc");
 	if (!node)
 	{
-		LogWarning("No root \"openapoc\" root element in form file \"%s\"", path);
+		LogWarning("No root \"openapoc\" root element in form file \"{}\"", path);
 		return nullptr;
 	}
 	auto child = node.child("form");
 	if (!child)
 	{
-		LogWarning("No child node of \"form\" in form file \"%s\"", path);
+		LogWarning("No child node of \"form\" in form file \"{}\"", path);
 		return nullptr;
 	}
 	auto form = mksp<Form>();

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -239,7 +239,7 @@ void ListBox::update()
 				break;
 			}
 			default:
-				LogWarning("Unknown ListBox::ListOrientation value: %d",
+				LogWarning("Unknown ListBox::ListOrientation value: {}",
 				           static_cast<int>(ListOrientation));
 				break;
 		}

--- a/forms/textedit.cpp
+++ b/forms/textedit.cpp
@@ -74,7 +74,7 @@ void TextEdit::eventOccured(Event *e)
 			}
 			if (e->forms().EventFlag == FormEventType::KeyDown)
 			{
-				LogInfo("Key pressed: %d", e->forms().KeyInfo.KeyCode);
+				LogInfo("Key pressed: {}", e->forms().KeyInfo.KeyCode);
 				switch (e->forms().KeyInfo.KeyCode)
 				{
 					case SDLK_BACKSPACE:

--- a/forms/ui.cpp
+++ b/forms/ui.cpp
@@ -37,11 +37,11 @@ sp<Form> UI::getForm(UString ID)
 	{
 		auto formPath = UString("forms/") + ID + ".form";
 
-		LogInfo("Trying to load form \"%s\" from \"%s\"", ID, formPath);
+		LogInfo("Trying to load form \"{}\" from \"{}\"", ID, formPath);
 		auto form = Form::loadForm(formPath);
 		if (!form)
 		{
-			LogError("Failed to find form \"%s\" at \"%s\"", ID, formPath);
+			LogError("Failed to find form \"{}\" at \"{}\"", ID, formPath);
 			return nullptr;
 		}
 		forms[ID] = form;
@@ -54,11 +54,11 @@ sp<BitmapFont> UI::getFont(UString FontData)
 	if (fonts.find(FontData) == fonts.end())
 	{
 		auto fontPath = UString("fonts/") + FontData + ".font";
-		LogInfo("Trying to load font \"%s\" from \"%s\"", FontData, fontPath);
+		LogInfo("Trying to load font \"{}\" from \"{}\"", FontData, fontPath);
 		auto font = ApocalypseFont::loadFont(fontPath);
 		if (!font)
 		{
-			LogError("Failed to find font \"%s\" at \"%s\"", FontData, fontPath);
+			LogError("Failed to find font \"{}\" at \"{}\"", FontData, fontPath);
 			return nullptr;
 		}
 		fonts[FontData] = font;
@@ -76,12 +76,12 @@ std::vector<UString> UI::getFormIDs()
 	{
 		if (name.substr(0, 6) != "forms/")
 		{
-			LogWarning("Unexpected form file prefix for \"%s\"", name);
+			LogWarning("Unexpected form file prefix for \"{}\"", name);
 			continue;
 		}
 		if (!name.endsWith(".form"))
 		{
-			LogWarning("Unexpected extension on form file \"%s\"", name);
+			LogWarning("Unexpected extension on form file \"{}\"", name);
 			continue;
 		}
 		else

--- a/framework/ThreadPool/ThreadPool.h
+++ b/framework/ThreadPool/ThreadPool.h
@@ -61,7 +61,7 @@ inline ThreadPool::ThreadPool(size_t threads) : stop(false)
 				}
 				catch (std::exception &e)
 				{
-					LogError("Exception occurred in threadpool: %s", e.what());
+					LogError("Exception occurred in threadpool: {}", e.what());
 				}
 			}
 		});

--- a/framework/apocresources/apocfont.cpp
+++ b/framework/apocresources/apocfont.cpp
@@ -18,14 +18,14 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 	auto file = fw().data->fs.open(fontDescPath);
 	if (!file)
 	{
-		LogWarning("Failed to open font file at path \"%s\"", fontDescPath);
+		LogWarning("Failed to open font file at path \"{}\"", fontDescPath);
 		return nullptr;
 	}
 
 	auto data = file.readAll();
 	if (!data)
 	{
-		LogWarning("Failed to read font file at path \"%s\"", fontDescPath);
+		LogWarning("Failed to read font file at path \"{}\"", fontDescPath);
 		return nullptr;
 	}
 
@@ -35,7 +35,7 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 
 	if (!parseResult)
 	{
-		LogWarning("Failed to parse font file at \"%s\" - \"%s\" at \"%llu\"", fontDescPath,
+		LogWarning("Failed to parse font file at \"{}\" - \"{}\" at \"{}\"", fontDescPath,
 		           parseResult.description(), (unsigned long long)parseResult.offset);
 		return nullptr;
 	}
@@ -43,14 +43,14 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 	auto openapocNode = doc.child("openapoc");
 	if (!openapocNode)
 	{
-		LogWarning("Failed to find \"openapoc\" root node in font file at \"%s\"", fontDescPath);
+		LogWarning("Failed to find \"openapoc\" root node in font file at \"{}\"", fontDescPath);
 		return nullptr;
 	}
 
 	auto fontNode = openapocNode.child("apocfont");
 	if (!fontNode)
 	{
-		LogWarning("Failed to find \"openapoc::apocfont\" node in font file at \"%s\"",
+		LogWarning("Failed to find \"openapoc::apocfont\" node in font file at \"{}\"",
 		           fontDescPath);
 		return nullptr;
 	}
@@ -72,19 +72,19 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 	height = fontNode.attribute("height").as_int();
 	if (height <= 0)
 	{
-		LogError("apocfont \"%s\" with invalid \"height\" attribute", fontName);
+		LogError("apocfont \"{}\" with invalid \"height\" attribute", fontName);
 		return nullptr;
 	}
 	spacewidth = fontNode.attribute("spacewidth").as_int();
 	if (spacewidth <= 0)
 	{
-		LogError("apocfont \"%s\" with invalid \"spacewidth\" attribute", fontName);
+		LogError("apocfont \"{}\" with invalid \"spacewidth\" attribute", fontName);
 		return nullptr;
 	}
 	kerning = fontNode.attribute("kerning").as_int();
 	if (kerning <= 0)
 	{
-		LogError("apocfont \"%s\" with invalid \"kerning\" attribute", fontName);
+		LogError("apocfont \"{}\" with invalid \"kerning\" attribute", fontName);
 		return nullptr;
 	}
 
@@ -94,14 +94,14 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 		UString glyphPath = glyphNode.attribute("glyph").value();
 		if (glyphPath.empty())
 		{
-			LogError("Font \"%s\" has glyph with missing string attribute - skipping glyph",
+			LogError("Font \"{}\" has glyph with missing string attribute - skipping glyph",
 			         fontName);
 			continue;
 		}
 		UString glyphString = glyphNode.attribute("string").value();
 		if (glyphString.empty())
 		{
-			LogError("apocfont \"%s\" has glyph with missing string attribute - skipping glyph",
+			LogError("apocfont \"{}\" has glyph with missing string attribute - skipping glyph",
 			         fontName);
 			continue;
 		}
@@ -110,7 +110,7 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 
 		if (pointString.length() != 1)
 		{
-			LogError("apocfont \"%s\" glyph \"%s\" has %lu codepoints, expected one - skipping "
+			LogError("apocfont \"{}\" glyph \"{}\" has %lu codepoints, expected one - skipping "
 			         "glyph",
 			         fontName, glyphString, pointString.length());
 			continue;
@@ -119,7 +119,7 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 
 		if (charMap.find(c) != charMap.end())
 		{
-			LogError("Font \"%s\" has multiple glyphs for string \"%s\" - skipping glyph", fontName,
+			LogError("Font \"{}\" has multiple glyphs for string \"{}\" - skipping glyph", fontName,
 			         glyphString);
 			continue;
 		}

--- a/framework/apocresources/apocpalette.cpp
+++ b/framework/apocresources/apocpalette.cpp
@@ -69,14 +69,14 @@ sp<Palette> loadPCXPalette(Data &data, const UString fileName)
 	auto length = fileName.length();
 	if (length < 4 || fileName.substr(length - 4, 4).toUpper() != ".PCX")
 	{
-		LogInfo("Skipping file \"%s\" as it doesn't look like a .pcx", fileName);
+		LogInfo("Skipping file \"{}\" as it doesn't look like a .pcx", fileName);
 		return nullptr;
 	}
 
 	auto file = data.fs.open(fileName);
 	if (!file)
 	{
-		LogInfo("File \"%s\" failed to be opened", fileName);
+		LogInfo("File \"{}\" failed to be opened", fileName);
 		return nullptr;
 	}
 
@@ -84,7 +84,7 @@ sp<Palette> loadPCXPalette(Data &data, const UString fileName)
 	// files will never be smaller than sizeof(header) + sizeof(palette)
 	if (file.size() < sizeof(PcxHeader) + 256 * 3)
 	{
-		LogInfo("File \"%s\" has size %zu - too small for header and palette", fileName,
+		LogInfo("File \"{}\" has size {} - too small for header and palette", fileName,
 		        file.size());
 		return nullptr;
 	}
@@ -94,19 +94,19 @@ sp<Palette> loadPCXPalette(Data &data, const UString fileName)
 	file.read(reinterpret_cast<char *>(&header), sizeof(header));
 	if (!file)
 	{
-		LogInfo("File \"%s\" failed to read PCX header", fileName);
+		LogInfo("File \"{}\" failed to read PCX header", fileName);
 		return nullptr;
 	}
 
 	if (header.Identifier != PcxIdentifier)
 	{
-		LogInfo("File \"%s\" doesn't have PCX header magic", fileName);
+		LogInfo("File \"{}\" doesn't have PCX header magic", fileName);
 		return nullptr;
 	}
 
 	if (header.BitsPerPixel != 8)
 	{
-		LogInfo("File \"%s\" has non-8-bit image", fileName);
+		LogInfo("File \"{}\" has non-8-bit image", fileName);
 		return nullptr;
 	}
 
@@ -122,7 +122,7 @@ sp<Palette> loadPCXPalette(Data &data, const UString fileName)
 		file.read(reinterpret_cast<char *>(&colour), 3);
 		if (!file)
 		{
-			LogWarning("Unexpected EOF at index %u", i);
+			LogWarning("Unexpected EOF at index {}", i);
 			return nullptr;
 		}
 		if (i == 0)

--- a/framework/apocresources/loftemps.cpp
+++ b/framework/apocresources/loftemps.cpp
@@ -27,7 +27,7 @@ LOFTemps::LOFTemps(IFile &datFile, IFile &tabFile)
 		datFile.seekg(offset * 4, std::ios::beg);
 		if (!datFile)
 		{
-			LogError("Seeking beyond end of file reading offset %u", offset * 4);
+			LogError("Seeking beyond end of file reading offset {}", offset * 4);
 			return;
 		}
 
@@ -46,7 +46,7 @@ LOFTemps::LOFTemps(IFile &datFile, IFile &tabFile)
 
 		if (width % 8)
 		{
-			LogError("Non-8-bit-aligned width: %u", width);
+			LogError("Non-8-bit-aligned width: {}", width);
 			return;
 		}
 
@@ -61,7 +61,7 @@ LOFTemps::LOFTemps(IFile &datFile, IFile &tabFile)
 				uint32_t bitmask;
 				if (!datFile.readule32(bitmask))
 				{
-					LogError("Failed to read bitmask at {%u,%u}", x, y);
+					LogError("Failed to read bitmask at {{{},{}}}", x, y);
 					return;
 				}
 				for (unsigned int bit = 0; bit < 32; bit++)
@@ -78,7 +78,7 @@ LOFTemps::LOFTemps(IFile &datFile, IFile &tabFile)
 				}
 			}
 		}
-		LogInfo("Read voxel slice of size {%u,%u}", width, height);
+		LogInfo("Read voxel slice of size {{{},{}}}", width, height);
 		this->slices.push_back(slice);
 	}
 }
@@ -87,7 +87,7 @@ sp<VoxelSlice> LOFTemps::getSlice(unsigned int idx)
 {
 	if (idx >= this->slices.size())
 	{
-		LogError("Requested slice %d - only %zu in file", idx, this->slices.size());
+		LogError("Requested slice {} - only {} in file", idx, this->slices.size());
 		return nullptr;
 	}
 	return this->slices[idx];

--- a/framework/apocresources/pck.cpp
+++ b/framework/apocresources/pck.cpp
@@ -365,7 +365,7 @@ sp<ImageSet> PCKLoader::loadStrat(Data &data, UString PckFilename, UString TabFi
 		}
 		if (img->size != Vec2<unsigned int>{8, 8})
 		{
-			LogError("Invalid size of {{},{}} in stratmap image", img->size.x, img->size.y);
+			LogError("Invalid size of {{{},{}}} in stratmap image", img->size.x, img->size.y);
 			return nullptr;
 		}
 		imageSet->images.push_back(img);

--- a/framework/apocresources/pck.cpp
+++ b/framework/apocresources/pck.cpp
@@ -53,7 +53,7 @@ static sp<PaletteImage> readPckCompression1(std::istream &input, Vec2<unsigned> 
 
 		if (col != header.column)
 		{
-			LogWarning("Header column %u doesn't match skip column %u (%u %% %u)",
+			LogWarning("Header column {} doesn't match skip column {} ({} %% {})",
 			           (unsigned)header.column, col, (unsigned)header.pixelSkip, IMAGE_STRIDE);
 			return nullptr;
 		}
@@ -113,7 +113,7 @@ static sp<PaletteImage> readPckCompression3(std::istream &input, Vec2<unsigned> 
 		}
 		blkSize = blkFile.size();
 		blkData = std::move(blkFile.readAll());
-		LogInfo("Loaded %zu bytes of xcom.blk", blkSize);
+		LogInfo("Loaded {} bytes of xcom.blk", blkSize);
 	}
 
 	auto img = mksp<PaletteImage>(size);
@@ -145,7 +145,7 @@ static sp<PaletteImage> readPckCompression3(std::istream &input, Vec2<unsigned> 
 			{
 				if (blkOffset >= blkSize)
 				{
-					LogWarning("BLKOffset %u too large for xcom.blk size", blkOffset);
+					LogWarning("BLKOffset {} too large for xcom.blk size", blkOffset);
 				}
 				else
 				{
@@ -155,7 +155,7 @@ static sp<PaletteImage> readPckCompression3(std::istream &input, Vec2<unsigned> 
 					}
 					else
 					{
-						LogWarning("{%d,%d} out of bounds", col, row);
+						LogWarning("{{{},{}}} out of bounds", col, row);
 					}
 				}
 				blkOffset++;
@@ -176,7 +176,7 @@ static unsigned int guessTabMultiplier(IFile &pckFile, IFile &tabFile)
 	auto tabSize = tabFile.size();
 	if (tabSize < 4)
 	{
-		LogWarning("Tab size %zu too small for a single entry?", tabSize);
+		LogWarning("Tab size {} too small for a single entry?", tabSize);
 		return 0;
 	}
 
@@ -207,24 +207,24 @@ sp<ImageSet> PCKLoader::load(Data &d, UString PckFilename, UString TabFilename)
 	auto pck = d.fs.open(PckFilename);
 	if (!pck)
 	{
-		LogError("Failed to open PCK file \"%s\"", PckFilename);
+		LogError("Failed to open PCK file \"{}\"", PckFilename);
 		return nullptr;
 	}
 	auto tab = d.fs.open(TabFilename);
 	if (!tab)
 	{
-		LogError("Failed to open TAB file \"%s\"", TabFilename);
+		LogError("Failed to open TAB file \"{}\"", TabFilename);
 		return nullptr;
 	}
 
 	auto tabMultiplier = guessTabMultiplier(pck, tab);
 	if (tabMultiplier == 0)
 	{
-		LogWarning("Failed to guess tab file type for \"%s\"", TabFilename);
+		LogWarning("Failed to guess tab file type for \"{}\"", TabFilename);
 		return nullptr;
 	}
 
-	LogInfo("Reading \"%s\" with tab multiplier %u", TabFilename, tabMultiplier);
+	LogInfo("Reading \"{}\" with tab multiplier {}", TabFilename, tabMultiplier);
 
 	unsigned int endIdx = (tab.size() / 4);
 
@@ -238,7 +238,7 @@ sp<ImageSet> PCKLoader::load(Data &d, UString PckFilename, UString TabFilename)
 		tab.read(reinterpret_cast<char *>(&pckOffset), sizeof(pckOffset));
 		if (!tab)
 		{
-			LogWarning("Reached EOF reading tab index %u", i);
+			LogWarning("Reached EOF reading tab index {}", i);
 			return nullptr;
 		}
 		pckOffset *= tabMultiplier;
@@ -247,7 +247,7 @@ sp<ImageSet> PCKLoader::load(Data &d, UString PckFilename, UString TabFilename)
 		pck.read(reinterpret_cast<char *>(&header), sizeof(header));
 		if (!pck)
 		{
-			LogInfo("Reached EOF reading PCK header at tab index %u", i);
+			LogInfo("Reached EOF reading PCK header at tab index {}", i);
 			break;
 		}
 		sp<PaletteImage> img;
@@ -265,12 +265,12 @@ sp<ImageSet> PCKLoader::load(Data &d, UString PckFilename, UString TabFilename)
 				img = readPckCompression3(pck, {header.rightClip, header.bottomClip});
 				break;
 			default:
-				LogWarning("Unknown compression mode %u", (unsigned)header.compressionMode);
+				LogWarning("Unknown compression mode {}", (unsigned)header.compressionMode);
 				break;
 		}
 		if (!img)
 		{
-			LogInfo("No image at PCK index %u", i);
+			LogInfo("No image at PCK index {}", i);
 			continue;
 		}
 		img->calculateBounds();
@@ -317,7 +317,7 @@ static sp<PaletteImage> loadStrategy(IFile &file)
 
 			if (x >= 8 || y >= 8)
 			{
-				LogInfo("Writing to {%d,%d} in 8x8 stratmap image", x, y);
+				LogInfo("Writing to {{{},{}}} in 8x8 stratmap image", x, y);
 			}
 			else
 			{
@@ -337,13 +337,13 @@ sp<ImageSet> PCKLoader::loadStrat(Data &data, UString PckFilename, UString TabFi
 	auto tabFile = data.fs.open(TabFilename);
 	if (!tabFile)
 	{
-		LogWarning("Failed to open tab \"%s\"", TabFilename);
+		LogWarning("Failed to open tab \"{}\"", TabFilename);
 		return nullptr;
 	}
 	auto pckFile = data.fs.open(PckFilename);
 	if (!pckFile)
 	{
-		LogWarning("Failed to open tab \"%s\"", TabFilename);
+		LogWarning("Failed to open tab \"{}\"", TabFilename);
 		return nullptr;
 	}
 
@@ -354,7 +354,7 @@ sp<ImageSet> PCKLoader::loadStrat(Data &data, UString PckFilename, UString TabFi
 		pckFile.seekg(offset, std::ios::beg);
 		if (!pckFile)
 		{
-			LogError("Failed to seek to offset %u", offset);
+			LogError("Failed to seek to offset {}", offset);
 			return nullptr;
 		}
 		auto img = loadStrategy(pckFile);
@@ -365,7 +365,7 @@ sp<ImageSet> PCKLoader::loadStrat(Data &data, UString PckFilename, UString TabFi
 		}
 		if (img->size != Vec2<unsigned int>{8, 8})
 		{
-			LogError("Invalid size of {%d,%d} in stratmap image", img->size.x, img->size.y);
+			LogError("Invalid size of {{},{}} in stratmap image", img->size.x, img->size.y);
 			return nullptr;
 		}
 		imageSet->images.push_back(img);
@@ -376,7 +376,7 @@ sp<ImageSet> PCKLoader::loadStrat(Data &data, UString PckFilename, UString TabFi
 
 	imageSet->maxSize = {8, 8};
 
-	LogInfo("Loaded %u images", static_cast<unsigned>(imageSet->images.size()));
+	LogInfo("Loaded {} images", static_cast<unsigned>(imageSet->images.size()));
 
 	return imageSet;
 }
@@ -465,13 +465,13 @@ sp<ImageSet> PCKLoader::loadShadow(Data &data, UString PckFilename, UString TabF
 	auto tabFile = data.fs.open(TabFilename);
 	if (!tabFile)
 	{
-		LogWarning("Failed to open tab \"%s\"", TabFilename);
+		LogWarning("Failed to open tab \"{}\"", TabFilename);
 		return nullptr;
 	}
 	auto pckFile = data.fs.open(PckFilename);
 	if (!pckFile)
 	{
-		LogWarning("Failed to open tab \"%s\"", TabFilename);
+		LogWarning("Failed to open tab \"{}\"", TabFilename);
 		return nullptr;
 	}
 	imageSet->maxSize = {0, 0};
@@ -484,7 +484,7 @@ sp<ImageSet> PCKLoader::loadShadow(Data &data, UString PckFilename, UString TabF
 		pckFile.seekg(offset, std::ios::beg);
 		if (!pckFile)
 		{
-			LogError("Failed to seek to offset %u", offset);
+			LogError("Failed to seek to offset {}", offset);
 			return nullptr;
 		}
 		auto img = loadShadowImage(pckFile, shadedIdx);
@@ -503,7 +503,7 @@ sp<ImageSet> PCKLoader::loadShadow(Data &data, UString PckFilename, UString TabF
 			imageSet->maxSize.y = img->size.y;
 	}
 
-	LogInfo("Loaded %u images", static_cast<unsigned>(imageSet->images.size()));
+	LogInfo("Loaded {} images", static_cast<unsigned>(imageSet->images.size()));
 
 	return imageSet;
 }

--- a/framework/apocresources/rawimage.cpp
+++ b/framework/apocresources/rawimage.cpp
@@ -17,7 +17,7 @@ sp<PaletteImage> RawImage::load(Data &data, const UString &filename, const Vec2<
 	}
 	if (size.x <= 0 || size.y <= 0)
 	{
-		LogWarning("Trying to read image of invalid size {{},{}}", size.x, size.y);
+		LogWarning("Trying to read image of invalid size {{{},{}}}", size.x, size.y);
 		return nullptr;
 	}
 
@@ -38,7 +38,7 @@ sp<PaletteImage> RawImage::load(Data &data, const UString &filename, const Vec2<
 			uint8_t idx;
 			if (!infile.read(reinterpret_cast<char *>(&idx), 1))
 			{
-				LogError("Unexpected EOF in file \"{}\" at {{},{}}", filename, x, y);
+				LogError("Unexpected EOF in file \"{}\" at {{{},{}}}", filename, x, y);
 				return nullptr;
 			}
 			l.set(Vec2<unsigned int>{x, y}, idx);

--- a/framework/apocresources/rawimage.cpp
+++ b/framework/apocresources/rawimage.cpp
@@ -12,18 +12,18 @@ sp<PaletteImage> RawImage::load(Data &data, const UString &filename, const Vec2<
 	auto infile = data.fs.open(filename);
 	if (!infile)
 	{
-		LogWarning("Failed to open file \"%s\"", filename);
+		LogWarning("Failed to open file \"{}\"", filename);
 		return nullptr;
 	}
 	if (size.x <= 0 || size.y <= 0)
 	{
-		LogWarning("Trying to read image of invalid size {%d,%d}", size.x, size.y);
+		LogWarning("Trying to read image of invalid size {{},{}}", size.x, size.y);
 		return nullptr;
 	}
 
 	if (infile.size() != static_cast<size_t>(size.x * size.y))
 	{
-		LogWarning("File \"%s\" has incorrect size for raw image of size %s", filename, size);
+		LogWarning("File \"{}\" has incorrect size for raw image of size {}", filename, size);
 	}
 
 	auto image = mksp<PaletteImage>(size);
@@ -38,7 +38,7 @@ sp<PaletteImage> RawImage::load(Data &data, const UString &filename, const Vec2<
 			uint8_t idx;
 			if (!infile.read(reinterpret_cast<char *>(&idx), 1))
 			{
-				LogError("Unexpected EOF in file \"%s\" at {%d,%d}", filename, x, y);
+				LogError("Unexpected EOF in file \"{}\" at {{},{}}", filename, x, y);
 				return nullptr;
 			}
 			l.set(Vec2<unsigned int>{x, y}, idx);
@@ -53,18 +53,18 @@ sp<ImageSet> RawImage::loadSet(Data &data, const UString &filename, const Vec2<i
 	auto infile = data.fs.open(filename);
 	if (!infile)
 	{
-		LogWarning("Failed to open file \"%s\"", filename);
+		LogWarning("Failed to open file \"{}\"", filename);
 		return nullptr;
 	}
 	if (size.x <= 0 || size.y <= 0)
 	{
-		LogWarning("Trying to read images of invalid size %s", size);
+		LogWarning("Trying to read images of invalid size {}", size);
 		return nullptr;
 	}
 
 	if (infile.size() % static_cast<size_t>(size.x * size.y) != 0)
 	{
-		LogWarning("File \"%s\" has incorrect size for raw images of size %s", filename, size);
+		LogWarning("File \"{}\" has incorrect size for raw images of size {}", filename, size);
 	}
 
 	size_t numImages = infile.size() / (size.x * size.y);
@@ -87,7 +87,7 @@ sp<ImageSet> RawImage::loadSet(Data &data, const UString &filename, const Vec2<i
 				uint8_t idx;
 				if (!infile.read(reinterpret_cast<char *>(&idx), 1))
 				{
-					LogError("Unexpected EOF in file \"%s\" at {%zu:%d,%d}", filename, i, x, y);
+					LogError("Unexpected EOF in file \"{}\" at {{}:{},{}}", filename, i, x, y);
 					return nullptr;
 				}
 				l.set(Vec2<unsigned int>{x, y}, idx);

--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -144,7 +144,7 @@ class ConfigFileImpl
 			auto unknown_options = po::collect_unrecognized(parsed.options, po::include_positional);
 			for (const auto &unknown : unknown_options)
 			{
-				LogWarning("Ignoring option \"%s\"", unknown);
+				LogWarning("Ignoring option \"{}\"", unknown);
 			}
 		}
 		catch (po::error &err)
@@ -216,7 +216,7 @@ class ConfigFileImpl
 			auto splitString = optionPair.first.split(".");
 			if (splitString.size() < 1)
 			{
-				LogError("Invalid option string \"%s\"", optionPair.first.cStr());
+				LogError("Invalid option string \"{}\"", optionPair.first.cStr());
 				continue;
 			}
 			UString sectionName;
@@ -289,7 +289,7 @@ class ConfigFileImpl
 		}
 		if (!this->get(key))
 		{
-			LogError("Option \"%s\" not set", key.cStr());
+			LogError("Option \"{}\" not set", key.cStr());
 			throw std::exception();
 		}
 		auto it = this->modifiedOptions.find(key);

--- a/framework/data.cpp
+++ b/framework/data.cpp
@@ -118,10 +118,10 @@ DataImpl::DataImpl(std::vector<UString> paths) : Data(paths)
 		if (l)
 		{
 			this->imageLoaders.emplace_back(l);
-			LogInfo("Initialised image loader %s", t);
+			LogInfo("Initialised image loader {}", t);
 		}
 		else
-			LogWarning("Failed to load image loader %s", t);
+			LogWarning("Failed to load image loader {}", t);
 	}
 
 	registeredImageWriters["lodepng"].reset(getLodePNGImageWriterFactory());
@@ -133,10 +133,10 @@ DataImpl::DataImpl(std::vector<UString> paths) : Data(paths)
 		if (l)
 		{
 			this->imageWriters.emplace_back(l);
-			LogInfo("Initialised image writer %s", t);
+			LogInfo("Initialised image writer {}", t);
 		}
 		else
-			LogWarning("Failed to load image writer %s", t);
+			LogWarning("Failed to load image writer {}", t);
 	}
 
 	registeredSampleLoaders["raw"].reset(getRAWSampleLoaderFactory());
@@ -148,10 +148,10 @@ DataImpl::DataImpl(std::vector<UString> paths) : Data(paths)
 		if (s)
 		{
 			this->sampleLoaders.emplace_back(s);
-			LogInfo("Initialised sample loader %s", t);
+			LogInfo("Initialised sample loader {}", t);
 		}
 		else
-			LogWarning("Failed to load sample loader %s", t);
+			LogWarning("Failed to load sample loader {}", t);
 	}
 
 	registeredMusicLoaders["raw"].reset(getRAWMusicLoaderFactory());
@@ -162,10 +162,10 @@ DataImpl::DataImpl(std::vector<UString> paths) : Data(paths)
 		if (m)
 		{
 			this->musicLoaders.emplace_back(m);
-			LogInfo("Initialised music loader %s", t);
+			LogInfo("Initialised music loader {}", t);
 		}
 		else
-			LogWarning("Failed to load music loader %s", t);
+			LogWarning("Failed to load music loader {}", t);
 	}
 	for (int i = 0; i < Options::imageCacheSize.get(); i++)
 		pinnedImages.push(nullptr);
@@ -190,7 +190,7 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 	auto alias = this->voxelAliases.find(path);
 	if (alias != this->voxelAliases.end())
 	{
-		LogInfo("Using alias \"%s\" for \"%s\"", path, alias->second);
+		LogInfo("Using alias \"{}\" for \"{}\"", path, alias->second);
 		return this->loadVoxelSlice(alias->second);
 	}
 
@@ -203,7 +203,7 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 		// "LOFTEMPS:DATFILE:TABFILE:INDEX:X:Y"
 		if (splitString.size() != 4)
 		{
-			LogError("Invalid LOFTEMPS string \"%s\"", path);
+			LogError("Invalid LOFTEMPS string \"{}\"", path);
 			return nullptr;
 		}
 		// Cut off the index to get the LOFTemps file
@@ -216,13 +216,13 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 			auto datFile = this->fs.open(splitString[1]);
 			if (!datFile)
 			{
-				LogError("Failed to open LOFTemps dat file \"%s\"", splitString[1]);
+				LogError("Failed to open LOFTemps dat file \"{}\"", splitString[1]);
 				return nullptr;
 			}
 			auto tabFile = this->fs.open(splitString[2]);
 			if (!tabFile)
 			{
-				LogError("Failed to open LOFTemps tab file \"%s\"", splitString[2]);
+				LogError("Failed to open LOFTemps tab file \"{}\"", splitString[2]);
 				return nullptr;
 			}
 			lofTemps = mksp<LOFTemps>(datFile, tabFile);
@@ -234,7 +234,7 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 		slice = lofTemps->getSlice(idx);
 		if (!slice)
 		{
-			LogError("Invalid idx %d", idx);
+			LogError("Invalid idx {}", idx);
 		}
 	}
 	else
@@ -262,7 +262,7 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 
 	if (!slice)
 	{
-		LogError("Failed to load VoxelSlice \"%s\"", path);
+		LogError("Failed to load VoxelSlice \"{}\"", path);
 		return nullptr;
 	}
 	slice->path = path;
@@ -276,7 +276,7 @@ sp<ImageSet> DataImpl::loadImageSet(const UString &path)
 	auto alias = this->imageSetAliases.find(path);
 	if (alias != this->imageSetAliases.end())
 	{
-		LogInfo("Using alias \"%s\" for \"%s\"", path, alias->second);
+		LogInfo("Using alias \"{}\" for \"{}\"", path, alias->second);
 		return this->loadImageSet(alias->second);
 	}
 
@@ -315,7 +315,7 @@ sp<ImageSet> DataImpl::loadImageSet(const UString &path)
 	}
 	else
 	{
-		LogError("Unknown image set format \"%s\"", path);
+		LogError("Unknown image set format \"{}\"", path);
 		return nullptr;
 	}
 
@@ -334,7 +334,7 @@ sp<Sample> DataImpl::loadSample(UString path)
 	auto alias = this->sampleAliases.find(path);
 	if (alias != this->sampleAliases.end())
 	{
-		LogInfo("Using alias \"%s\" for \"%s\"", path, alias->second);
+		LogInfo("Using alias \"{}\" for \"{}\"", path, alias->second);
 		return this->loadSample(alias->second);
 	}
 
@@ -352,7 +352,7 @@ sp<Sample> DataImpl::loadSample(UString path)
 	}
 	if (!sample)
 	{
-		LogInfo("Failed to load sample \"%s\"", path);
+		LogInfo("Failed to load sample \"{}\"", path);
 		return nullptr;
 	}
 	this->sampleCache[cacheKey] = sample;
@@ -367,7 +367,7 @@ sp<MusicTrack> DataImpl::loadMusic(const UString &path)
 	auto alias = this->musicAliases.find(path);
 	if (alias != this->musicAliases.end())
 	{
-		LogInfo("Using alias \"%s\" for \"%s\"", path, alias->second);
+		LogInfo("Using alias \"{}\" for \"{}\"", path, alias->second);
 		return this->loadMusic(alias->second);
 	}
 
@@ -381,7 +381,7 @@ sp<MusicTrack> DataImpl::loadMusic(const UString &path)
 			return track;
 		}
 	}
-	LogInfo("Failed to load music track \"%s\"", path);
+	LogInfo("Failed to load music track \"{}\"", path);
 	return nullptr;
 }
 
@@ -396,7 +396,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 	auto alias = this->imageAliases.find(path);
 	if (alias != this->imageAliases.end())
 	{
-		LogInfo("Using alias \"%s\" for \"%s\"", path, alias->second);
+		LogInfo("Using alias \"{}\" for \"{}\"", path, alias->second);
 		return this->loadImage(alias->second, lazy);
 	}
 
@@ -431,7 +431,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 		//"RAW:PATH:WIDTH:HEIGHT:INDEX[:PALETTE]" (for imagesets)
 		if (splitString.size() != 4 && splitString.size() != 5 && splitString.size() != 6)
 		{
-			LogError("Invalid RAW resource string: \"%s\"", path);
+			LogError("Invalid RAW resource string: \"{}\"", path);
 			return nullptr;
 		}
 
@@ -458,7 +458,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 		}
 		if (!pImg)
 		{
-			LogError("Failed to load RAW image: \"%s\"", path);
+			LogError("Failed to load RAW image: \"{}\"", path);
 			return nullptr;
 		}
 		if (splitString.size() > palettePos)
@@ -466,7 +466,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 			auto pal = this->loadPalette(splitString[palettePos]);
 			if (!pal)
 			{
-				LogError("Failed to load palette for RAW image: \"%s\"", path);
+				LogError("Failed to load palette for RAW image: \"{}\"", path);
 				return nullptr;
 			}
 			img = pImg->toRGBImage(pal);
@@ -481,7 +481,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 		auto splitString = path.split(':');
 		if (splitString.size() != 3 && splitString.size() != 4 && splitString.size() != 5)
 		{
-			LogError("Invalid PCK resource string: \"%s\"", path);
+			LogError("Invalid PCK resource string: \"{}\"", path);
 			return nullptr;
 		}
 		auto imageSet =
@@ -517,7 +517,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 				break;
 			}
 			default:
-				LogError("Invalid PCK resource string \"%s\"", path);
+				LogError("Invalid PCK resource string \"{}\"", path);
 				return nullptr;
 		}
 	}
@@ -526,7 +526,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 		auto splitString = path.split(':');
 		if (splitString.size() != 3 && splitString.size() != 4 && splitString.size() != 5)
 		{
-			LogError("Invalid PCKSTRAT resource string: \"%s\"", path);
+			LogError("Invalid PCKSTRAT resource string: \"{}\"", path);
 			return nullptr;
 		}
 		auto imageSet =
@@ -557,7 +557,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 				break;
 			}
 			default:
-				LogError("Invalid PCKSTRAT resource string \"%s\"", path);
+				LogError("Invalid PCKSTRAT resource string \"{}\"", path);
 				return nullptr;
 		}
 	}
@@ -566,7 +566,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 		auto splitString = path.split(':');
 		if (splitString.size() != 3 && splitString.size() != 4 && splitString.size() != 5)
 		{
-			LogError("Invalid PCKSHADOW resource string: \"%s\"", path);
+			LogError("Invalid PCKSHADOW resource string: \"{}\"", path);
 			return nullptr;
 		}
 		auto imageSet =
@@ -597,13 +597,13 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 				break;
 			}
 			default:
-				LogError("Invalid PCKSHADOW resource string \"%s\"", path);
+				LogError("Invalid PCKSHADOW resource string \"{}\"", path);
 				return nullptr;
 		}
 	}
 	else if (path.substr(0, 9) == "LOFTEMPS:")
 	{
-		LogInfo("Loading LOFTEMPS \"%s\" as image", path);
+		LogInfo("Loading LOFTEMPS \"{}\" as image", path);
 		auto voxelSlice = this->loadVoxelSlice(path);
 		if (!voxelSlice)
 		{
@@ -640,14 +640,14 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 		}
 		if (!img)
 		{
-			LogInfo("Failed to load image \"%s\"", path);
+			LogInfo("Failed to load image \"{}\"", path);
 			return nullptr;
 		}
 	}
 
 	if (!img)
 	{
-		LogInfo("Failed to load image \"%s\"", path);
+		LogInfo("Failed to load image \"{}\"", path);
 		return nullptr;
 	}
 
@@ -674,7 +674,7 @@ sp<Palette> DataImpl::loadPalette(const UString &path)
 	auto alias = this->paletteAliases.find(path);
 	if (alias != this->paletteAliases.end())
 	{
-		LogInfo("Using alias \"%s\" for \"%s\"", path, alias->second);
+		LogInfo("Using alias \"{}\" for \"{}\"", path, alias->second);
 		return this->loadPalette(alias->second);
 	}
 
@@ -690,7 +690,7 @@ sp<Palette> DataImpl::loadPalette(const UString &path)
 	pal = loadPCXPalette(*this, path);
 	if (pal)
 	{
-		LogInfo("Read \"%s\" as PCX palette", path);
+		LogInfo("Read \"{}\" as PCX palette", path);
 		this->paletteCache[cacheKey] = pal;
 		this->pinnedPalettes.push(pal);
 		this->pinnedPalettes.pop();
@@ -699,7 +699,7 @@ sp<Palette> DataImpl::loadPalette(const UString &path)
 	pal = loadPNGPalette(*this, path);
 	if (pal)
 	{
-		LogInfo("Read \"%s\" as PNG palette", path);
+		LogInfo("Read \"{}\" as PNG palette", path);
 		this->paletteCache[cacheKey] = pal;
 		this->pinnedPalettes.push(pal);
 		this->pinnedPalettes.pop();
@@ -721,7 +721,7 @@ sp<Palette> DataImpl::loadPalette(const UString &path)
 				idx++;
 			}
 		}
-		LogInfo("Read \"%s\" as Image palette", path);
+		LogInfo("Read \"{}\" as Image palette", path);
 		this->paletteCache[cacheKey] = pal;
 		this->pinnedPalettes.push(pal);
 		this->pinnedPalettes.pop();
@@ -731,13 +731,13 @@ sp<Palette> DataImpl::loadPalette(const UString &path)
 	pal = loadApocPalette(*this, path);
 	if (pal)
 	{
-		LogInfo("Read \"%s\" as RAW palette", path);
+		LogInfo("Read \"{}\" as RAW palette", path);
 		this->paletteCache[cacheKey] = pal;
 		this->pinnedPalettes.push(pal);
 		this->pinnedPalettes.pop();
 		return pal;
 	}
-	LogError("Failed to open palette \"%s\"", path);
+	LogError("Failed to open palette \"{}\"", path);
 	return nullptr;
 }
 
@@ -749,18 +749,18 @@ sp<Video> DataImpl::loadVideo(const UString &path)
 		auto splitString = path.split(':');
 		if (splitString.size() != 2)
 		{
-			LogError("Invalid SMK string: \"%s\"", path);
+			LogError("Invalid SMK string: \"{}\"", path);
 			return nullptr;
 		}
 		auto file = this->fs.open(splitString[1]);
 		if (!file)
 		{
-			LogWarning("Failed to open SMK file \"%s\"", splitString[1]);
+			LogWarning("Failed to open SMK file \"{}\"", splitString[1]);
 			return nullptr;
 		}
 		return loadSMKVideo(file);
 	}
-	LogError("Unknown video string \"%s\"", path);
+	LogError("Unknown video string \"{}\"", path);
 	return nullptr;
 }
 
@@ -779,19 +779,19 @@ bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palet
 			// Just catch any problem and continue anyway?
 			catch (fs::filesystem_error &e)
 			{
-				LogWarning("create_directories failed with \"%s\"", e.what());
+				LogWarning("create_directories failed with \"{}\"", e.what());
 			}
 		}
 		else if (!fs::is_directory(outDir))
 		{
-			LogWarning("Cannot open %s: %s is not a directory", outPath, outDir);
+			LogWarning("Cannot open {}: {} is not a directory", outPath, outDir);
 			return false;
 		}
 	}
 	std::ofstream outFile(systemPath.str(), std::ios::binary);
 	if (!outFile)
 	{
-		LogWarning("Failed to open \"%s\" for writing", systemPath);
+		LogWarning("Failed to open \"{}\" for writing", systemPath);
 		return false;
 	}
 
@@ -804,7 +804,7 @@ bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palet
 			if (!palette)
 			{
 				UString defaultPalettePath = "xcom3/ufodata/pal_01.dat";
-				LogInfo("Loading default palette \"%s\"", defaultPalettePath);
+				LogInfo("Loading default palette \"{}\"", defaultPalettePath);
 				palette = this->loadPalette(defaultPalettePath);
 				if (!palette)
 				{
@@ -815,13 +815,13 @@ bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palet
 			}
 			if (writer->writeImage(palImg, outFile, palette))
 			{
-				LogInfo("Successfully wrote palette image \"%s\" using \"%s\"", systemPath,
+				LogInfo("Successfully wrote palette image \"{}\" using \"{}\"", systemPath,
 				        writer->getName());
 				return true;
 			}
 			else
 			{
-				LogWarning("Failed to write palette image \"%s\" using \"%s\"", systemPath,
+				LogWarning("Failed to write palette image \"{}\" using \"{}\"", systemPath,
 				           writer->getName());
 				continue;
 			}
@@ -830,13 +830,13 @@ bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palet
 		{
 			if (writer->writeImage(rgbImg, outFile))
 			{
-				LogInfo("Successfully wrote RGB image \"%s\" using \"%s\"", systemPath,
+				LogInfo("Successfully wrote RGB image \"{}\" using \"{}\"", systemPath,
 				        writer->getName());
 				return true;
 			}
 			else
 			{
-				LogWarning("Failed to write RGB image \"%s\" using \"%s\"", systemPath,
+				LogWarning("Failed to write RGB image \"{}\" using \"{}\"", systemPath,
 				           writer->getName());
 				continue;
 			}
@@ -848,7 +848,7 @@ bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palet
 		}
 	}
 
-	LogWarning("No writes succeeded for image \"%s\"", systemPath);
+	LogWarning("No writes succeeded for image \"{}\"", systemPath);
 	return false;
 }
 
@@ -895,7 +895,7 @@ void DataImpl::addSampleAlias(const UString &name, const UString &value)
 	auto current = this->sampleAliases.find(name);
 	if (current != this->sampleAliases.end() && current->second != value)
 	{
-		LogWarning("Replacing alias \"%s\" - was \"%s\" now \"%s\"", name, current->second, value);
+		LogWarning("Replacing alias \"{}\" - was \"{}\" now \"{}\"", name, current->second, value);
 	}
 	this->sampleAliases[name] = value;
 }
@@ -906,7 +906,7 @@ void DataImpl::addMusicAlias(const UString &name, const UString &value)
 	auto current = this->musicAliases.find(name);
 	if (current != this->musicAliases.end() && current->second != value)
 	{
-		LogWarning("Replacing alias \"%s\" - was \"%s\" now \"%s\"", name, current->second, value);
+		LogWarning("Replacing alias \"{}\" - was \"{}\" now \"{}\"", name, current->second, value);
 	}
 	this->musicAliases[name] = value;
 }
@@ -917,7 +917,7 @@ void DataImpl::addImageAlias(const UString &name, const UString &value)
 	auto current = this->imageAliases.find(name);
 	if (current != this->imageAliases.end() && current->second != value)
 	{
-		LogWarning("Replacing alias \"%s\" - was \"%s\" now \"%s\"", name, current->second, value);
+		LogWarning("Replacing alias \"{}\" - was \"{}\" now \"{}\"", name, current->second, value);
 	}
 	this->imageAliases[name] = value;
 }
@@ -928,7 +928,7 @@ void DataImpl::addImageSetAlias(const UString &name, const UString &value)
 	auto current = this->imageSetAliases.find(name);
 	if (current != this->imageSetAliases.end() && current->second != value)
 	{
-		LogWarning("Replacing alias \"%s\" - was \"%s\" now \"%s\"", name, current->second, value);
+		LogWarning("Replacing alias \"{}\" - was \"{}\" now \"{}\"", name, current->second, value);
 	}
 	this->imageSetAliases[name] = value;
 }
@@ -939,7 +939,7 @@ void DataImpl::addPaletteAlias(const UString &name, const UString &value)
 	auto current = this->paletteAliases.find(name);
 	if (current != this->paletteAliases.end() && current->second != value)
 	{
-		LogWarning("Replacing alias \"%s\" - was \"%s\" now \"%s\"", name, current->second, value);
+		LogWarning("Replacing alias \"{}\" - was \"{}\" now \"{}\"", name, current->second, value);
 	}
 	this->paletteAliases[name] = value;
 }
@@ -950,7 +950,7 @@ void DataImpl::addVoxelSliceAlias(const UString &name, const UString &value)
 	auto current = this->voxelAliases.find(name);
 	if (current != this->voxelAliases.end() && current->second != value)
 	{
-		LogWarning("Replacing alias \"%s\" - was \"%s\" now \"%s\"", name, current->second, value);
+		LogWarning("Replacing alias \"{}\" - was \"{}\" now \"{}\"", name, current->second, value);
 	}
 	this->voxelAliases[name] = value;
 }
@@ -965,19 +965,19 @@ void DataImpl::readAliases()
 }
 void DataImpl::readAliasFile(const UString &path)
 {
-	LogInfo("Reading aliases from \"%s\"", path);
+	LogInfo("Reading aliases from \"{}\"", path);
 
 	auto file = this->fs.open(path);
 	if (!file)
 	{
-		LogWarning("Failed to open alias file \"%s\"", path);
+		LogWarning("Failed to open alias file \"{}\"", path);
 		return;
 	}
 
 	auto data = file.readAll();
 	if (!data)
 	{
-		LogWarning("Failed to read data from alias file \"%s\"", path);
+		LogWarning("Failed to read data from alias file \"{}\"", path);
 		return;
 	}
 
@@ -985,14 +985,14 @@ void DataImpl::readAliasFile(const UString &path)
 	auto parseResult = doc.load_buffer(data.get(), file.size());
 	if (!parseResult)
 	{
-		LogWarning("Failed to parse alias file at \"%s\" - \"%s\" at \"%llu\"", path,
+		LogWarning("Failed to parse alias file at \"{}\" - \"{}\" at \"{}\"", path,
 		           parseResult.description(), (unsigned long long)parseResult.offset);
 		return;
 	}
 	auto openapocNode = doc.child("openapoc");
 	if (!openapocNode)
 	{
-		LogWarning("Failed to find \"openapoc\" root node in alias file at \"%s\"", path);
+		LogWarning("Failed to find \"openapoc\" root node in alias file at \"{}\"", path);
 		return;
 	}
 	for (auto aliasNode = openapocNode.child("alias"); aliasNode;
@@ -1001,19 +1001,19 @@ void DataImpl::readAliasFile(const UString &path)
 		UString name = aliasNode.attribute("id").value();
 		if (name.empty())
 		{
-			LogWarning("Alias with missing 'id' attribute in \"%s\"", path);
+			LogWarning("Alias with missing 'id' attribute in \"{}\"", path);
 			continue;
 		}
 		UString type = aliasNode.attribute("type").value();
 		if (type.empty())
 		{
-			LogWarning("Alias \"%s\" with missing 'type' attribute in \"%s\"", name, path);
+			LogWarning("Alias \"{}\" with missing 'type' attribute in \"{}\"", name, path);
 			continue;
 		}
 		UString value = aliasNode.text().get();
 		if (value.empty())
 		{
-			LogWarning("Alias \"%s\" with missing value in \"%s\"", name, path);
+			LogWarning("Alias \"{}\" with missing value in \"{}\"", name, path);
 			continue;
 		}
 		if (type == "sample")
@@ -1042,7 +1042,7 @@ void DataImpl::readAliasFile(const UString &path)
 		}
 		else
 		{
-			LogWarning("Alias \"%s\" with unknown type \"%s\"  in \"%s\"", name, type, path);
+			LogWarning("Alias \"{}\" with unknown type \"{}\"  in \"{}\"", name, type, path);
 			continue;
 		}
 	}

--- a/framework/font.cpp
+++ b/framework/font.cpp
@@ -66,7 +66,7 @@ sp<PaletteImage> BitmapFont::getGlyph(UniChar codepoint)
 	{
 		// FIXME: Hack - assume all missing glyphs are spaces
 		// TODO: Fallback fonts?
-		LogWarning("Font %s missing glyph for character \"%s\" (codepoint %u)", this->getName(),
+		LogWarning("Font {} missing glyph for character \"{}\" (codepoint {})", this->getName(),
 		           UString(codepoint), codepoint);
 		auto missingGlyph = this->getGlyph(UString::u8Char(' '));
 		fontbitmaps.emplace(codepoint, missingGlyph);
@@ -96,13 +96,13 @@ sp<BitmapFont> BitmapFont::loadFont(const std::map<UniChar, UString> &glyphMap, 
 		auto fontImage = fw().data->loadImage(p.second);
 		if (!fontImage)
 		{
-			LogError("Failed to read glyph image \"%s\"", p.second);
+			LogError("Failed to read glyph image \"{}\"", p.second);
 			continue;
 		}
 		auto paletteImage = std::dynamic_pointer_cast<PaletteImage>(fontImage);
 		if (!paletteImage)
 		{
-			LogError("Glyph image \"%s\" doesn't look like a PaletteImage", p.second);
+			LogError("Glyph image \"{}\" doesn't look like a PaletteImage", p.second);
 			continue;
 		}
 		unsigned int maxWidth = 0;
@@ -176,7 +176,7 @@ std::list<UString> BitmapFont::wordWrapText(const UString &Text, int MaxWidth)
 				{
 					if (currentLine == "")
 					{
-						LogWarning("No break in line \"%s\" found - this will probably overflow "
+						LogWarning("No break in line \"{}\" found - this will probably overflow "
 						           "the control",
 						           currentTestLine);
 						currentLine = currentTestLine;

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -242,12 +242,12 @@ Framework::Framework(const UString programName, bool createWindow)
 		// which is unlikely in terminal use, so use that?
 		if (fs::current_path() == "/")
 		{
-			LogWarning("Setting working directory to \"%s\"", basePath);
+			LogWarning("Setting working directory to \"{}\"", basePath);
 			chdir(basePath);
 		}
 		else
 		{
-			LogWarning("Leaving default working directory \"%s\"", fs::current_path());
+			LogWarning("Leaving default working directory \"{}\"", fs::current_path());
 		}
 		SDL_free(basePath);
 	}
@@ -872,7 +872,7 @@ void Framework::displayInitialise()
 	if (scrW < 640 || scrH < 480)
 	{
 		LogError(
-		    "Requested display size of {{},{}} is lower than {640,480} and probably won't work",
+		    "Requested display size of {{{},{}}} is lower than {{640,480}} and probably won't work",
 		    scrW, scrH);
 	}
 

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -118,7 +118,7 @@ class JukeBoxImpl : public JukeBox
 		{
 			auto musicTrack = fw.data->loadMusic(track);
 			if (!musicTrack)
-				LogError("Failed to load music track \"%s\" - skipping", track);
+				LogError("Failed to load music track \"{}\" - skipping", track);
 			else
 				this->trackList.push_back(musicTrack);
 		}
@@ -141,7 +141,7 @@ class JukeBoxImpl : public JukeBox
 			LogInfo("End of jukebox playlist");
 			return;
 		}
-		LogInfo("Playing track %u (%s)", jukebox->position,
+		LogInfo("Playing track {} ({})", jukebox->position,
 		        jukebox->trackList[jukebox->position]->getName());
 		jukebox->fw.soundBackend->setTrack(jukebox->trackList[jukebox->position]);
 
@@ -203,17 +203,17 @@ class FrameworkPrivate
 		int threadPoolSize = Options::threadPoolSizeOption.get();
 		if (threadPoolSize > 0)
 		{
-			LogInfo("Set thread pool size to %d", threadPoolSize);
+			LogInfo("Set thread pool size to {}", threadPoolSize);
 		}
 		else if (std::thread::hardware_concurrency() != 0)
 		{
 			threadPoolSize = std::thread::hardware_concurrency();
-			LogInfo("Set thread pool size to reported HW concurrency of %d", threadPoolSize);
+			LogInfo("Set thread pool size to reported HW concurrency of {}", threadPoolSize);
 		}
 		else
 		{
 			threadPoolSize = 2;
-			LogInfo("Failed to get HW concurrency, falling back to pool size %d", threadPoolSize);
+			LogInfo("Failed to get HW concurrency, falling back to pool size {}", threadPoolSize);
 		}
 
 		this->threadPool.reset(new ThreadPool(threadPoolSize));
@@ -258,7 +258,7 @@ Framework::Framework(const UString programName, bool createWindow)
 		if (PHYSFS_init(programName.cStr()) == 0)
 		{
 			PHYSFS_ErrorCode error = PHYSFS_getLastErrorCode();
-			LogError("Failed to init code %i PHYSFS: %s", (int)error, PHYSFS_getErrorByCode(error));
+			LogError("Failed to init code %i PHYSFS: {}", (int)error, PHYSFS_getErrorByCode(error));
 		}
 	}
 #ifdef ANDROID
@@ -268,7 +268,7 @@ Framework::Framework(const UString programName, bool createWindow)
 	if (SDL_Init(SDL_INIT_EVENTS | SDL_INIT_TIMER) < 0)
 	{
 		LogError("Cannot init SDL2");
-		LogError("SDL error: %s", SDL_GetError());
+		LogError("SDL error: {}", SDL_GetError());
 		p->quitProgram = true;
 		return;
 	}
@@ -276,7 +276,7 @@ Framework::Framework(const UString programName, bool createWindow)
 	{
 		if (SDL_InitSubSystem(SDL_INIT_VIDEO) < 0)
 		{
-			LogError("Cannot init SDL_VIDEO - \"%s\"", SDL_GetError());
+			LogError("Cannot init SDL_VIDEO - \"{}\"", SDL_GetError());
 			p->quitProgram = true;
 			return;
 		}
@@ -307,7 +307,7 @@ Framework::Framework(const UString programName, bool createWindow)
 		desiredLanguageName = Options::languageOption.get();
 	}
 
-	LogInfo("Setting up locale \"%s\"", desiredLanguageName);
+	LogInfo("Setting up locale \"{}\"", desiredLanguageName);
 
 	boost::locale::generator gen;
 
@@ -318,14 +318,14 @@ Framework::Framework(const UString programName, bool createWindow)
 	for (auto &path : resourcePaths)
 	{
 		auto langPath = path + "/languages";
-		LogInfo("Adding \"%s\" to language path", langPath);
+		LogInfo("Adding \"{}\" to language path", langPath);
 		gen.add_messages_path(langPath.str());
 	}
 
 	std::vector<UString> translationDomains = {"paedia_string", "ufo_string"};
 	for (auto &domain : translationDomains)
 	{
-		LogInfo("Adding \"%s\" to translation domains", domain);
+		LogInfo("Adding \"{}\" to translation domains", domain);
 		gen.add_messages_domain(domain.str());
 	}
 
@@ -339,8 +339,8 @@ Framework::Framework(const UString programName, bool createWindow)
 	auto localeEncoding = std::use_facet<boost::locale::info>(loc).encoding();
 	auto isUTF8 = std::use_facet<boost::locale::info>(loc).utf8();
 
-	LogInfo("Locale info: Name \"%s\" language \"%s\" country \"%s\" variant \"%s\" encoding "
-	        "\"%s\" utf8:%s",
+	LogInfo("Locale info: Name \"{}\" language \"{}\" country \"{}\" variant \"{}\" encoding "
+	        "\"{}\" utf8:{}",
 	        localeName.c_str(), localeLang.c_str(), localeCountry.c_str(), localeVariant.c_str(),
 	        localeEncoding.c_str(), isUTF8 ? "true" : "false");
 
@@ -440,7 +440,7 @@ void Framework::run(sp<Stage> initialStage)
 			auto time_to_sleep = expected_frame_time - frame_time_now;
 			auto time_to_sleep_us =
 			    std::chrono::duration_cast<std::chrono::microseconds>(time_to_sleep);
-			LogDebug("sleeping for %d us", time_to_sleep_us.count());
+			LogDebug("sleeping for {} us", time_to_sleep_us.count());
 			std::this_thread::sleep_for(time_to_sleep);
 			continue;
 		}
@@ -529,7 +529,7 @@ void Framework::run(sp<Stage> initialStage)
 		}
 		if (frameCount && frame == frameCount)
 		{
-			LogWarning("Quitting hitting frame count limit of %llu", (unsigned long long)frame);
+			LogWarning("Quitting hitting frame count limit of {}", (unsigned long long)frame);
 			p->quitProgram = true;
 		}
 	}
@@ -572,7 +572,7 @@ void Framework::processEvents()
 					screenshotName = format("screenshot%03d.png", screenshotId);
 					screenshotId++;
 				} while (fs::exists(fs::path(screenshotName.str())));
-				LogWarning("Writing screenshot to \"%s\"", screenshotName);
+				LogWarning("Writing screenshot to \"{}\"", screenshotName);
 				if (!p->defaultSurface->rendererPrivateData)
 				{
 					LogWarning("No renderer data on surface - nothing drawn yet?");
@@ -594,7 +594,7 @@ void Framework::processEvents()
 							}
 							else
 							{
-								LogWarning("Wrote screenshot to \"%s\"", screenshotName);
+								LogWarning("Wrote screenshot to \"{}\"", screenshotName);
 							}
 						});
 					}
@@ -872,7 +872,7 @@ void Framework::displayInitialise()
 	if (scrW < 640 || scrH < 480)
 	{
 		LogError(
-		    "Requested display size of {%d,%d} is lower than {640,480} and probably won't work",
+		    "Requested display size of {{},{}} is lower than {640,480} and probably won't work",
 		    scrW, scrH);
 	}
 
@@ -886,21 +886,21 @@ void Framework::displayInitialise()
 
 	if (!p->window)
 	{
-		LogError("Failed to create window \"%s\"", SDL_GetError());
+		LogError("Failed to create window \"{}\"", SDL_GetError());
 		exit(1);
 	}
 
 	p->context = SDL_GL_CreateContext(p->window);
 	if (!p->context)
 	{
-		LogWarning("Could not create GL context! [SDLError: %s]", SDL_GetError());
+		LogWarning("Could not create GL context! [SDLError: {}]", SDL_GetError());
 		LogWarning("Attempting to create context by lowering the requested version");
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 2);
 		SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 		p->context = SDL_GL_CreateContext(p->window);
 		if (!p->context)
 		{
-			LogError("Failed to create GL context! [SDLerror: %s]", SDL_GetError());
+			LogError("Failed to create GL context! [SDLerror: {}]", SDL_GetError());
 			SDL_DestroyWindow(p->window);
 			exit(1);
 		}
@@ -924,17 +924,17 @@ void Framework::displayInitialise()
 		default:
 			profileType = "Unknown";
 	}
-	LogInfo("  Context profile: %s", profileType);
+	LogInfo("  Context profile: {}", profileType);
 	int ctxMajor, ctxMinor;
 	SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &ctxMajor);
 	SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &ctxMinor);
-	LogInfo("  Context version: %d.%d", ctxMajor, ctxMinor);
+	LogInfo("  Context version: {}.{}", ctxMajor, ctxMinor);
 	int bitsRed, bitsGreen, bitsBlue, bitsAlpha;
 	SDL_GL_GetAttribute(SDL_GL_RED_SIZE, &bitsRed);
 	SDL_GL_GetAttribute(SDL_GL_GREEN_SIZE, &bitsGreen);
 	SDL_GL_GetAttribute(SDL_GL_BLUE_SIZE, &bitsBlue);
 	SDL_GL_GetAttribute(SDL_GL_ALPHA_SIZE, &bitsAlpha);
-	LogInfo("  RGBA bits: %d-%d-%d-%d", bitsRed, bitsGreen, bitsBlue, bitsAlpha);
+	LogInfo("  RGBA bits: {}-{}-{}-{}", bitsRed, bitsGreen, bitsBlue, bitsAlpha);
 	SDL_GL_MakeCurrent(p->window, p->context); // for good measure?
 	SDL_ShowCursor(SDL_DISABLE);
 
@@ -948,17 +948,17 @@ void Framework::displayInitialise()
 		auto rendererFactory = p->registeredRenderers.find(rendererName);
 		if (rendererFactory == p->registeredRenderers.end())
 		{
-			LogInfo("Renderer \"%s\" not in supported list", rendererName);
+			LogInfo("Renderer \"{}\" not in supported list", rendererName);
 			continue;
 		}
 		Renderer *r = rendererFactory->second->create();
 		if (!r)
 		{
-			LogInfo("Renderer \"%s\" failed to init", rendererName);
+			LogInfo("Renderer \"{}\" failed to init", rendererName);
 			continue;
 		}
 		this->renderer.reset(r);
-		LogInfo("Using renderer: %s", this->renderer->getName());
+		LogInfo("Using renderer: {}", this->renderer->getName());
 		break;
 	}
 	if (!this->renderer)
@@ -985,13 +985,13 @@ void Framework::displayInitialise()
 		p->displaySize.y = (int)((float)p->windowSize.y * scaleYFloat);
 		if (p->displaySize.x < 640 || p->displaySize.y < 480)
 		{
-			LogWarning("Requested scaled size of %s is lower than {640,480} and probably "
+			LogWarning("Requested scaled size of {} is lower than {640,480} and probably "
 			           "won't work, so forcing 640x480",
 			           p->displaySize.x);
 			p->displaySize.x = std::max(640, p->displaySize.x);
 			p->displaySize.y = std::max(480, p->displaySize.y);
 		}
-		LogInfo("Scaling from %s to %s", p->displaySize, p->windowSize);
+		LogInfo("Scaling from {} to {}", p->displaySize, p->windowSize);
 		p->scaleSurface = mksp<Surface>(p->displaySize);
 	}
 	else
@@ -1077,17 +1077,17 @@ void Framework::audioInitialise()
 		auto backendFactory = p->registeredSoundBackends.find(soundBackendName);
 		if (backendFactory == p->registeredSoundBackends.end())
 		{
-			LogInfo("Sound backend %s not in supported list", soundBackendName);
+			LogInfo("Sound backend {} not in supported list", soundBackendName);
 			continue;
 		}
 		SoundBackend *backend = backendFactory->second->create();
 		if (!backend)
 		{
-			LogInfo("Sound backend %s failed to init", soundBackendName);
+			LogInfo("Sound backend {} failed to init", soundBackendName);
 			continue;
 		}
 		this->soundBackend.reset(backend);
-		LogInfo("Using sound backend %s", soundBackendName);
+		LogInfo("Using sound backend {}", soundBackendName);
 		break;
 	}
 	if (!this->soundBackend)
@@ -1193,19 +1193,19 @@ void Framework::setupModDataPaths()
 	auto mods = Options::modList.get().split(":");
 	for (const auto &modString : mods)
 	{
-		LogWarning("loading mod \"%s\"", modString);
+		LogWarning("loading mod \"{}\"", modString);
 		auto modPath = Options::modPath.get() + "/" + modString;
 		auto modInfo = ModInfo::getInfo(modPath);
 		if (!modInfo)
 		{
-			LogError("Failed to load ModInfo for mod \"%s\"", modString);
+			LogError("Failed to load ModInfo for mod \"{}\"", modString);
 			continue;
 		}
 		auto modDataPath = modPath + "/" + modInfo->getDataPath();
-		LogWarning("Loaded modinfo for mod ID \"%s\"", modInfo->getID());
+		LogWarning("Loaded modinfo for mod ID \"{}\"", modInfo->getID());
 		if (modInfo->getDataPath() != "")
 		{
-			LogWarning("Appending data path \"%s\"", modDataPath);
+			LogWarning("Appending data path \"{}\"", modDataPath);
 			this->data->fs.addPath(modDataPath);
 		}
 	}

--- a/framework/fs/physfs_archiver_cue.cpp
+++ b/framework/fs/physfs_archiver_cue.cpp
@@ -77,7 +77,7 @@ class CueParser
 		UString cmd(command);
 		if (cmd.toUpper() != "FILE")
 		{
-			LogInfo("Encountered unexpected command: \"%s\", ignoring", cmd);
+			LogInfo("Encountered unexpected command: \"{}\", ignoring", cmd);
 			return false;
 		}
 		// auto matchIter = std::sregex_iterator(arg.begin(), arg.end(), fileArgRegex);
@@ -104,7 +104,7 @@ class CueParser
 			}
 			if (last_char == arg.size())
 			{
-				LogError("Malformed argument for FILE command (arguments are: \"%s\")",
+				LogError("Malformed argument for FILE command (arguments are: \"{}\")",
 				         arg.c_str());
 				return false;
 			}
@@ -113,11 +113,11 @@ class CueParser
 		if (last_char >= first_char)
 		{
 			dataFileName = arg.substr(first_char, last_char - first_char + 1);
-			LogInfo("Reading from \"%s\"", dataFileName);
+			LogInfo("Reading from \"{}\"", dataFileName);
 		}
 		else
 		{
-			LogError("Bad file name for FILE command (arguments are: \"%s\")", arg.c_str());
+			LogError("Bad file name for FILE command (arguments are: \"{}\")", arg.c_str());
 			return false;
 		}
 
@@ -129,7 +129,7 @@ class CueParser
 		}
 		if (first_char == arg.size())
 		{
-			LogError("File type not specified for \"%s\" (arguments are: \"%s\")", dataFileName,
+			LogError("File type not specified for \"{}\" (arguments are: \"{}\")", dataFileName,
 			         arg.c_str());
 			return false;
 		}
@@ -143,7 +143,7 @@ class CueParser
 
 		if (fileTypeStr.toUpper() != "BINARY")
 		{
-			LogError("Unsupported file type: \"%s\"", fileTypeStr);
+			LogError("Unsupported file type: \"{}\"", fileTypeStr);
 			parserState = PARSER_ERROR;
 			fileType = CueFileType::FT_UNDEFINED;
 			return false;
@@ -161,7 +161,7 @@ class CueParser
 			// According to
 			// https://www.gnu.org/software/ccd2cue/manual/html_node/FILE-_0028CUE-Command_0029.html#FILE-_0028CUE-Command_0029
 			// only TRACK is allowed after FILE
-			LogError("Encountered unexpected command: \"%s\" (only TRACK is allowed)", cmd);
+			LogError("Encountered unexpected command: \"{}\" (only TRACK is allowed)", cmd);
 			parserState = PARSER_ERROR;
 			fileType = CueFileType::FT_UNDEFINED;
 			return false;
@@ -182,7 +182,7 @@ class CueParser
 
 		if (trackNumber > 1)
 		{
-			LogWarning("First track is not numbered 1 (actual number is %d)", trackNumber);
+			LogWarning("First track is not numbered 1 (actual number is {})", trackNumber);
 		}
 
 		// Read track mode
@@ -213,7 +213,7 @@ class CueParser
 			trackMode = CueTrackMode::MODE2_2352;
 		if (trackMode == CueTrackMode::MODE_UNDEFINED)
 		{
-			LogError("Unknown/unimplemented mode \"%s\"", modeStr);
+			LogError("Unknown/unimplemented mode \"{}\"", modeStr);
 			parserState = PARSER_ERROR;
 			return false;
 		}
@@ -228,7 +228,7 @@ class CueParser
 		// valid
 		if (cmd.toUpper() != "INDEX")
 		{
-			LogInfo("Encountered unexpected/unknown command: \"%s\", ignoring", cmd);
+			LogInfo("Encountered unexpected/unknown command: \"{}\", ignoring", cmd);
 			return false;
 		}
 		// FIXME: I seriously could not make heads or tails of these indices.
@@ -877,7 +877,7 @@ class CueArchiver
 		parent.offset = location;
 		parent.timestamp = d_datetime.toUnixTime();
 #if 0 // Stop archiver from being extremely chatty
-        LogInfo("Adding entry: %s", parent.name);
+        LogInfo("Adding entry: {}", parent.name);
         LogInfo("  Location %" PRIu64, parent.offset);
         LogInfo("  Length: %" PRIu64, parent.length);
 #endif
@@ -889,7 +889,7 @@ class CueArchiver
 		parent.type = FSEntry::FS_DIRECTORY;
 		IsoDirRecord_hdr childDirRecord;
 #if 0
-        LogInfo("Recursing into: %s (location: %d)", parent.name, location);
+        LogInfo("Recursing into: {} (location: {})", parent.name, location);
 #endif
 		cio->seek(cio->blockSize() * location + readpos);
 		do
@@ -959,7 +959,7 @@ class CueArchiver
 		// FIXME: This fsize is completely and utterly wrong - unless you're reading an actual iso
 		// (mode1_2048)
 		uint64_t fsize = fs::file_size(filePath);
-		LogInfo("Opening file %s of size %" PRIu64, fileName, fsize);
+		LogInfo("Opening file {} of size %" PRIu64, fileName, fsize);
 		cio = new CueIO(fileName, 0, fsize, ftype, tmode);
 		if (!cio->fileStream)
 		{
@@ -976,11 +976,11 @@ class CueArchiver
 		{
 			LogError("Bad CD magic!");
 		}
-		LogInfo("Descriptor type: %d", (int)descriptor.type);
+		LogInfo("Descriptor type: {}", (int)descriptor.type);
 		IsoDirRecord_hdr rootRecord;
 		std::memcpy(&rootRecord, descriptor.primary.rootDirEnt, 34);
-		LogInfo("Volume ID: %s", descriptor.primary.volIdentifier);
-		LogInfo("Root dirent length: %d", (int)rootRecord.length);
+		LogInfo("Volume ID: {}", descriptor.primary.volIdentifier);
+		LogInfo("Root dirent length: {}", (int)rootRecord.length);
 		readDir(rootRecord, root);
 	}
 	~CueArchiver() { delete cio; }
@@ -1077,7 +1077,7 @@ class CueArchiver
   public:
 	static void *cueOpenArchive(PHYSFS_Io *, const char *filename, int forWriting, int *claimed)
 	{
-		LogWarning("Opening \"%s\"", filename);
+		LogWarning("Opening \"{}\"", filename);
 		// FIXME: Here we assume the filename actually points to the actual .cue file,
 		// ignoring the PHYSFS_Io (though how would we even read the accompanying file?)
 		// TODO: Actually read from PHYSFS_Io to allow mounting non-CUE images?
@@ -1096,7 +1096,7 @@ class CueArchiver
 		CueParser parser(filename);
 		if (!parser.isValid())
 		{
-			LogError("Could not parse file \"%s\"", filename);
+			LogError("Could not parse file \"{}\"", filename);
 			return nullptr;
 		}
 
@@ -1110,7 +1110,7 @@ class CueArchiver
 
 		if (!fs::exists(dataFilePath))
 		{
-			LogWarning("Could not find binary file \"%s\" referenced in the cuesheet",
+			LogWarning("Could not find binary file \"{}\" referenced in the cuesheet",
 			           parser.getDataFileName());
 			LogWarning("Trying case-insensitive search...");
 			UString ucBin(parser.getDataFileName());
@@ -1121,7 +1121,7 @@ class CueArchiver
 			     dirent_it != fs::directory_iterator(); dirent_it++)
 			{
 				auto dirent = *dirent_it;
-				LogInfo("Trying %s", dirent.path().string());
+				LogInfo("Trying {}", dirent.path().string());
 				UString ucDirent(dirent.path().filename().string());
 				ucDirent = ucDirent.toLower();
 				if (ucDirent == ucBin)
@@ -1132,10 +1132,10 @@ class CueArchiver
 			}
 			if (!fs::exists(dataFilePath))
 			{
-				LogError("Binary file does not exist: \"%s\"", dataFilePath.string());
+				LogError("Binary file does not exist: \"{}\"", dataFilePath.string());
 				return nullptr;
 			}
-			LogWarning("Using \"%s\" as a binary file source", dataFilePath.string());
+			LogWarning("Using \"{}\" as a binary file source", dataFilePath.string());
 		}
 
 		return new CueArchiver(dataFilePath.string(), parser.getDataFileType(),
@@ -1229,10 +1229,10 @@ namespace OpenApoc
 void parseCueFile(UString fileName)
 {
 	CueParser parser(fileName);
-	LogInfo("Parser status: %d", parser.isValid());
-	LogInfo("Data file: %s", parser.getDataFileName());
-	LogInfo("Track mode: %d", (int)parser.getTrackMode());
-	LogInfo("File mode: %d", (int)parser.getDataFileType());
+	LogInfo("Parser status: {}", parser.isValid());
+	LogInfo("Data file: {}", parser.getDataFileName());
+	LogInfo("Track mode: {}", (int)parser.getTrackMode());
+	LogInfo("File mode: {}", (int)parser.getDataFileType());
 }
 
 PHYSFS_Archiver *getCueArchiver() { return CueArchiver::createArchiver(); }

--- a/framework/imageloader/lodepng_image.cpp
+++ b/framework/imageloader/lodepng_image.cpp
@@ -21,7 +21,7 @@ sp<Palette> OpenApoc::loadPNGPalette(Data &d, const UString fileName)
 	auto f = d.fs.open(fileName);
 	if (!f)
 	{
-		LogInfo("Failed to open file \"%s\" - skipping", fileName);
+		LogInfo("Failed to open file \"{}\" - skipping", fileName);
 		return nullptr;
 	}
 	auto data = f.readAll();
@@ -32,14 +32,14 @@ sp<Palette> OpenApoc::loadPNGPalette(Data &d, const UString fileName)
 	                           reinterpret_cast<unsigned char *>(data.get()), dataSize);
 	if (err)
 	{
-		LogInfo("Failed to read PNG headers from \"%s\" (%u) : %s - skipping", f.systemPath(), err,
+		LogInfo("Failed to read PNG headers from \"{}\" ({}) : {} - skipping", f.systemPath(), err,
 		        lodepng_error_text(err));
 		return nullptr;
 	}
 	if (width * height != 256)
 	{
 
-		LogWarning("PNG \"%s\" size {%u,%u} too large for palette (must be 256 pixels total)",
+		LogWarning("PNG \"{}\" size {{{},{}}} too large for palette (must be 256 pixels total)",
 		           f.systemPath(), width, height);
 		return nullptr;
 	}
@@ -48,7 +48,7 @@ sp<Palette> OpenApoc::loadPNGPalette(Data &d, const UString fileName)
 	                             reinterpret_cast<unsigned char *>(data.get()), dataSize);
 	if (error)
 	{
-		LogInfo("Failed to read PNG \"%s\" (%u) : %s", f.systemPath(), err,
+		LogInfo("Failed to read PNG \"{}\" ({}) : {}", f.systemPath(), err,
 		        lodepng_error_text(err));
 		return nullptr;
 	}
@@ -88,12 +88,12 @@ class LodepngImageLoader : public OpenApoc::ImageLoader
 		                                   reinterpret_cast<unsigned char *>(data.get()), dataSize);
 		if (err)
 		{
-			LogInfo("Failed to read PNG headers from \"%s\" (%u) : %s", file.systemPath(), err,
+			LogInfo("Failed to read PNG headers from \"{}\" ({}) : {}", file.systemPath(), err,
 			        lodepng_error_text(err));
 			return nullptr;
 		}
 
-		LogInfo("Loading PNG \"%s\" size {%u,%d} - colour mode %d depth %u", file.systemPath(),
+		LogInfo("Loading PNG \"{}\" size {{{},{}}} - colour mode {} depth {}", file.systemPath(),
 		        width, height, png_state.info_png.color.colortype,
 		        png_state.info_png.color.bitdepth);
 
@@ -105,11 +105,11 @@ class LodepngImageLoader : public OpenApoc::ImageLoader
 		    image, width, height, reinterpret_cast<unsigned char *>(data.get()), file.size());
 		if (error)
 		{
-			LogInfo("LodePNG error code: %d: %s", error, lodepng_error_text(error));
+			LogInfo("LodePNG error code: {}: {}", error, lodepng_error_text(error));
 		}
 		if (!image.size())
 		{
-			LogInfo("Failed to load image %s (not a PNG?)", file.systemPath());
+			LogInfo("Failed to load image {} (not a PNG?)", file.systemPath());
 			return nullptr;
 		}
 		OpenApoc::Vec2<int> size(width, height);
@@ -149,7 +149,7 @@ class LodepngImageWriter : public OpenApoc::ImageWriter
 	{
 		if (pal->colours.size() != 256)
 		{
-			LogWarning("Only 256 colour palettes supported (got %u)",
+			LogWarning("Only 256 colour palettes supported (got {})",
 			           (unsigned)pal->colours.size());
 			return false;
 		}
@@ -167,7 +167,7 @@ class LodepngImageWriter : public OpenApoc::ImageWriter
 			auto err = lodepng_palette_add(&state.info_raw, c.r, c.g, c.b, c.a);
 			if (err)
 			{
-				LogWarning("Failed to add palette index %u to PNG: %d: %s", i, err,
+				LogWarning("Failed to add palette index {} to PNG: {}: {}", i, err,
 				           lodepng_error_text(err));
 				return false;
 			}
@@ -179,13 +179,13 @@ class LodepngImageWriter : public OpenApoc::ImageWriter
 		                           img->size.x, img->size.y, state);
 		if (err)
 		{
-			LogWarning("Failed to encode PNG: %d: %s", err, lodepng_error_text(err));
+			LogWarning("Failed to encode PNG: {}: {}", err, lodepng_error_text(err));
 			return false;
 		}
 		outStream.write(reinterpret_cast<char *>(outBuf.data()), outBuf.size());
 		if (!outStream)
 		{
-			LogWarning("Failed to write %zu bytes to stream", outBuf.size());
+			LogWarning("Failed to write {} bytes to stream", outBuf.size());
 			return false;
 		}
 
@@ -202,13 +202,13 @@ class LodepngImageWriter : public OpenApoc::ImageWriter
 		                           img->size.x, img->size.y);
 		if (err)
 		{
-			LogWarning("Failed to encode PNG: %d: %s", err, lodepng_error_text(err));
+			LogWarning("Failed to encode PNG: {}: {}", err, lodepng_error_text(err));
 			return false;
 		}
 		outStream.write(reinterpret_cast<char *>(outBuf.data()), outBuf.size());
 		if (!outStream)
 		{
-			LogWarning("Failed to write %zu bytes to stream", outBuf.size());
+			LogWarning("Failed to write {} bytes to stream", outBuf.size());
 			return false;
 		}
 		LogInfo("Successfully wrote RGB PNG image");

--- a/framework/imageloader/pcx.cpp
+++ b/framework/imageloader/pcx.cpp
@@ -50,7 +50,7 @@ class PCXImageLoader : public OpenApoc::ImageLoader
 		auto data = file.readAll();
 		if (size < sizeof(struct PcxHeader) + 256 * 3)
 		{
-			LogInfo("File \"%s\" size %u too small for PCX header + palette\n", path,
+			LogInfo("File \"{}\" size {} too small for PCX header + palette\n", path,
 			        static_cast<unsigned>(size));
 			return nullptr;
 		}
@@ -58,28 +58,28 @@ class PCXImageLoader : public OpenApoc::ImageLoader
 
 		if (header->Identifier != PcxIdentifier)
 		{
-			LogInfo("File \"%s\" had invalid PCX identifier 0x%02x", path,
+			LogInfo("File \"{}\" had invalid PCX identifier 0x%02x", path,
 			        static_cast<unsigned>(header->Identifier));
 			return nullptr;
 		}
 
 		if (header->Encoding != 1)
 		{
-			LogWarning("File \"%s\" had invalid PCX Encoding 0x%02x", path,
+			LogWarning("File \"{}\" had invalid PCX Encoding 0x%02x", path,
 			           static_cast<unsigned>(header->Encoding));
 			return nullptr;
 		}
 
 		if (header->BitsPerPixel != 8)
 		{
-			LogWarning("File \"%s\" had invalid PCX BitsPerPixel 0x%02x", path,
+			LogWarning("File \"{}\" had invalid PCX BitsPerPixel 0x%02x", path,
 			           static_cast<unsigned>(header->BitsPerPixel));
 			return nullptr;
 		}
 
 		if (header->NumBitPlanes != 1)
 		{
-			LogWarning("File \"%s\" had invalid PCX NumBitPlanes 0x%02x", path,
+			LogWarning("File \"{}\" had invalid PCX NumBitPlanes 0x%02x", path,
 			           static_cast<unsigned>(header->NumBitPlanes));
 			return nullptr;
 		}
@@ -87,7 +87,7 @@ class PCXImageLoader : public OpenApoc::ImageLoader
 		uint8_t pal = data[size - (256 * 3) - 1];
 		if (pal != 0x0C)
 		{
-			LogWarning("File \"%s\" had invalid PCX palette identifier byte 0x%02x", path,
+			LogWarning("File \"{}\" had invalid PCX palette identifier byte 0x%02x", path,
 			           static_cast<unsigned>(pal));
 			return nullptr;
 		}
@@ -124,7 +124,7 @@ class PCXImageLoader : public OpenApoc::ImageLoader
 					uint8_t idx;
 					if (img_data >= reinterpret_cast<uint8_t *>(&data[size]))
 					{
-						LogWarning("Unexpected EOF reading PCX file \"%s\" ", path);
+						LogWarning("Unexpected EOF reading PCX file \"{}\" ", path);
 						return nullptr;
 					}
 					b = *img_data++;
@@ -134,7 +134,7 @@ class PCXImageLoader : public OpenApoc::ImageLoader
 						run_length = b & 0x3F;
 						if (img_data >= reinterpret_cast<uint8_t *>(&data[size]))
 						{
-							LogWarning("Unexpected EOF reading PCX file \"%s\" ", path);
+							LogWarning("Unexpected EOF reading PCX file \"{}\" ", path);
 							return nullptr;
 						}
 						idx = *img_data++;

--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -7,8 +7,8 @@
 #include "framework/configfile.h"
 #include "framework/framework.h"
 #include "library/sp.h"
-#include <mutex>
 #include <iostream>
+#include <mutex>
 #ifdef BACKTRACE_LIBUNWIND
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -104,7 +104,7 @@ std::list<UString> getBacktrace()
 	for (unsigned int frame = 0; frame < frames; frame++)
 	{
 		SymFromAddr(process, (DWORD64)(ip[frame]), 0, sym);
-		backtrace.push_back(format("  0x%p {}+0x%Ix\n", ip[frame], sym->Name,
+		backtrace.push_back(format("  0x{} {}+0x%Ix\n", ip[frame], sym->Name,
 		                           (uintptr_t)ip[frame] - (uintptr_t)sym->Address));
 	}
 

--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -8,6 +8,7 @@
 #include "framework/framework.h"
 #include "library/sp.h"
 #include <mutex>
+#include <iostream>
 #ifdef BACKTRACE_LIBUNWIND
 #ifndef _GNU_SOURCE
 #define _GNU_SOURCE
@@ -46,7 +47,7 @@ std::list<UString> getBacktrace()
 		if (info.dli_sname)
 		{
 			backtrace.push_back(
-			    format("  0x%zx %s+0x%zx (%s)\n", static_cast<uintptr_t>(ip), info.dli_sname,
+			    format("  0x%zx {}+0x%zx ({})\n", static_cast<uintptr_t>(ip), info.dli_sname,
 			           static_cast<uintptr_t>(ip) - reinterpret_cast<uintptr_t>(info.dli_saddr),
 			           info.dli_fname));
 			continue;
@@ -56,7 +57,7 @@ std::list<UString> getBacktrace()
 		char fnName[MAX_SYMBOL_LENGTH];
 		if (!unw_get_proc_name(&cursor, fnName, MAX_SYMBOL_LENGTH, &offsetInFn))
 		{
-			backtrace.push_back(format("  0x%zx %s+0x%zx (%s)\n", static_cast<uintptr_t>(ip),
+			backtrace.push_back(format("  0x%zx {}+0x%zx ({})\n", static_cast<uintptr_t>(ip),
 			                           fnName, offsetInFn, info.dli_fname));
 			continue;
 		}
@@ -103,7 +104,7 @@ std::list<UString> getBacktrace()
 	for (unsigned int frame = 0; frame < frames; frame++)
 	{
 		SymFromAddr(process, (DWORD64)(ip[frame]), 0, sym);
-		backtrace.push_back(format("  0x%p %s+0x%Ix\n", ip[frame], sym->Name,
+		backtrace.push_back(format("  0x%p {}+0x%Ix\n", ip[frame], sym->Name,
 		                           (uintptr_t)ip[frame] - (uintptr_t)sym->Address));
 	}
 
@@ -158,7 +159,7 @@ void Log(LogLevel level, UString prefix, const UString &text)
 
 void _logAssert(UString prefix, UString string, int line, UString file)
 {
-	Log(LogLevel::Error, prefix, format("%s:%d Assertion failed %s", file, line, string));
+	Log(LogLevel::Error, prefix, format("{}:{} Assertion failed {}", file, line, string));
 	exit(1);
 }
 

--- a/framework/logger_file.cpp
+++ b/framework/logger_file.cpp
@@ -43,7 +43,7 @@ void FileLogFunction(LogLevel level, UString prefix, const UString &text)
 				levelPrefix = "U";
 				break;
 		}
-		const auto message = OpenApoc::format("%s %s: %s", levelPrefix, prefix, text);
+		const auto message = OpenApoc::format("{} {}: {}", levelPrefix, prefix, text);
 		logFile << message << std::endl;
 	}
 
@@ -68,7 +68,7 @@ void enableFileLogger(const char *outputFile)
 	logFile.open(outputFile);
 	if (!logFile.good())
 	{
-		LogError("File logger failed to open file \"%s\"", outputFile);
+		LogError("File logger failed to open file \"{}\"", outputFile);
 	}
 	fileLogLevel = (LogLevel)Options::fileLogLevelOption.get();
 	backtraceLogLevel = (LogLevel)Options::backtraceLogLevelOption.get();

--- a/framework/logger_sdldialog.cpp
+++ b/framework/logger_sdldialog.cpp
@@ -24,7 +24,7 @@ void SDLDialogLogFunction(LogLevel level, UString prefix, const UString &text)
 	{
 		return;
 	}
-	auto message = OpenApoc::format("%s: %s", prefix, text);
+	auto message = OpenApoc::format("{}: {}", prefix, text);
 	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenApoc error", message.cStr(), parentWindow);
 }
 

--- a/framework/luaframework.h
+++ b/framework/luaframework.h
@@ -73,7 +73,7 @@ template <typename T> void getFromLua(lua_State *L, int argNum, const T &v [[may
 	int idx = argNum;
 	if (argNum < 0)
 		argNum = lua_gettop(L) + argNum + 1;
-	luaL_error(L, "this member (#%d) cannot be set directly", argNum);
+	luaL_error(L, "this member (#{}) cannot be set directly", argNum);
 	LogError("Invalid Lua function");
 }
 

--- a/framework/modinfo.cpp
+++ b/framework/modinfo.cpp
@@ -26,14 +26,14 @@ std::optional<ModInfo> ModInfo::getInfo(const UString &path)
 	auto parseResult = doc.load_file(filePath.cStr());
 	if (!parseResult)
 	{
-		LogWarning("Failed to parse ModInfo at \"%s\": %s at offset %u", filePath,
+		LogWarning("Failed to parse ModInfo at \"{}\": {} at offset {}", filePath,
 		           parseResult.description(), parseResult.offset);
 		return {};
 	}
 	auto infoNode = doc.child("openapoc_modinfo");
 	if (!infoNode)
 	{
-		LogWarning("ModInfo at \"%s\" doesn't have an \"openapoc_modinfo\" root node", filePath);
+		LogWarning("ModInfo at \"{}\" doesn't have an \"openapoc_modinfo\" root node", filePath);
 		return {};
 	}
 
@@ -98,7 +98,7 @@ bool ModInfo::writeInfo(const UString &path)
 	auto saveResult = doc.save_file(filePath.cStr());
 	if (!saveResult)
 	{
-		LogWarning("Failed to save ModInfo to \"%s\"", filePath);
+		LogWarning("Failed to save ModInfo to \"{}\"", filePath);
 		return false;
 	}
 

--- a/framework/musicloader/music.cpp
+++ b/framework/musicloader/music.cpp
@@ -46,19 +46,19 @@ class RawMusicTrack : public MusicTrack
 	{
 		if (!file)
 		{
-			LogError("Failed to open file \"%s\"", fileName);
+			LogError("Failed to open file \"{}\"", fileName);
 			return;
 		}
 		if (file.size() < fileOffset + (numSamples * MusicChannels * MusicBytesPerSample))
 		{
-			LogError("File \"%s\" insufficient size for offset %u + size %u - returned size %zu",
+			LogError("File \"{}\" insufficient size for offset {} + size {} - returned size {}",
 			         fileName, fileOffset, numSamples * MusicChannels * MusicBytesPerSample,
 			         file.size());
 			return;
 		}
 		if (!file.seekg(fileOffset))
 		{
-			LogError("Failed to seek to offset %u", fileOffset);
+			LogError("Failed to seek to offset {}", fileOffset);
 			return;
 		}
 
@@ -79,7 +79,7 @@ class RawMusicTrack : public MusicTrack
 	{
 		if (!valid)
 		{
-			LogError("Playing invalid file \"%s\"", file.fileName());
+			LogError("Playing invalid file \"{}\"", file.fileName());
 			*returnedSamples = 0;
 			return MusicCallbackReturn::End;
 		}
@@ -91,7 +91,7 @@ class RawMusicTrack : public MusicTrack
 		if (!file.read(reinterpret_cast<char *>(sampleBuffer),
 		               samples * MusicBytesPerSample * MusicChannels))
 		{
-			LogError("Failed to read sample data in \"%s\"", file.fileName());
+			LogError("Failed to read sample data in \"{}\"", file.fileName());
 			this->valid = false;
 			samples = 0;
 		}
@@ -101,7 +101,7 @@ class RawMusicTrack : public MusicTrack
 			// Prepare this track to be reused
 			if (!file.seekg(startingPosition))
 			{
-				LogWarning("Could not rewind track %s", name);
+				LogWarning("Could not rewind track {}", name);
 			}
 			samplePosition = 0;
 			return MusicCallbackReturn::End;
@@ -133,20 +133,20 @@ class RawMusicLoader : public MusicLoader
 		auto strings = path.split(':');
 		if (strings.size() != 2)
 		{
-			LogInfo("Invalid raw music path string \"%s\"", path);
+			LogInfo("Invalid raw music path string \"{}\"", path);
 			return nullptr;
 		}
 
 		if (!Strings::isInteger(strings[1]))
 		{
-			LogInfo("Raw music track \"%s\" doesn't look like a number", strings[1]);
+			LogInfo("Raw music track \"{}\" doesn't look like a number", strings[1]);
 			return nullptr;
 		}
 
 		unsigned int track = Strings::toInteger(strings[1]);
 		if (track > lengths.size())
 		{
-			LogInfo("Raw music track %d out of bounds", track);
+			LogInfo("Raw music track {} out of bounds", track);
 			return nullptr;
 		}
 		return mksp<RawMusicTrack>(data, path, strings[0], offsets[track],

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -6,19 +6,19 @@ namespace
 using namespace OpenApoc;
 void dumpOption(const ConfigOptionInt &opt)
 {
-	LogInfo("OPTION \"%s.%s\" = %d", opt.getSection(), opt.getName(), opt.get());
+	LogInfo("OPTION \"{}.{}\" = {}", opt.getSection(), opt.getName(), opt.get());
 }
 void dumpOption(const ConfigOptionBool &opt)
 {
-	LogInfo("OPTION \"%s.%s\" = %s", opt.getSection(), opt.getName(), opt.get() ? "true" : "false");
+	LogInfo("OPTION \"{}.{}\" = {}", opt.getSection(), opt.getName(), opt.get() ? "true" : "false");
 }
 void dumpOption(const ConfigOptionFloat &opt)
 {
-	LogInfo("OPTION \"%s.%s\" = %f", opt.getSection(), opt.getName(), opt.get());
+	LogInfo("OPTION \"{}.{}\" = {}", opt.getSection(), opt.getName(), opt.get());
 }
 void dumpOption(const ConfigOptionString &opt)
 {
-	LogInfo("OPTION \"%s.%s\" = \"%s\"", opt.getSection(), opt.getName(), opt.get());
+	LogInfo("OPTION \"{}.{}\" = \"{}\"", opt.getSection(), opt.getName(), opt.get());
 }
 
 } // anonymous namespace

--- a/framework/physfs_fs.cpp
+++ b/framework/physfs_fs.cpp
@@ -54,7 +54,7 @@ class PhysfsIFileImpl : public std::streambuf, public IFileImpl
 		file = PHYSFS_openRead(path.cStr());
 		if (!file)
 		{
-			LogError("Failed to open file \"%s\" : \"%s\"", path,
+			LogError("Failed to open file \"{}\" : \"{}\"", path,
 			         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 			return;
 		}
@@ -97,7 +97,7 @@ class PhysfsIFileImpl : public std::streambuf, public IFileImpl
 				PHYSFS_seek(file, PHYSFS_fileLength(file) + pos);
 				break;
 			default:
-				LogError("Unknown direction in seekoff (%d)", dir);
+				LogError("Unknown direction in seekoff ({})", dir);
 				LogAssert(0);
 		}
 
@@ -108,7 +108,7 @@ class PhysfsIFileImpl : public std::streambuf, public IFileImpl
 
 		if (mode & std::ios_base::out)
 		{
-			LogError("ios::out set on read-only IFile \"%s\"", this->systemPath);
+			LogError("ios::out set on read-only IFile \"{}\"", this->systemPath);
 			LogAssert(0);
 			setp(buffer.get(), buffer.get());
 		}
@@ -126,7 +126,7 @@ class PhysfsIFileImpl : public std::streambuf, public IFileImpl
 
 		if (mode & std::ios_base::out)
 		{
-			LogError("ios::out set on read-only IFile \"%s\"", this->systemPath);
+			LogError("ios::out set on read-only IFile \"{}\"", this->systemPath);
 			LogAssert(0);
 			setp(buffer.get(), buffer.get());
 		}
@@ -136,7 +136,7 @@ class PhysfsIFileImpl : public std::streambuf, public IFileImpl
 
 	int_type overflow(int_type) override
 	{
-		LogError("overflow called on read-only IFile \"%s\"", this->systemPath);
+		LogError("overflow called on read-only IFile \"{}\"", this->systemPath);
 		LogAssert(0);
 		return 0;
 	}
@@ -202,7 +202,7 @@ std::unique_ptr<char[]> IFile::readAll()
 	std::unique_ptr<char[]> mem(new char[memsize]);
 	if (!mem)
 	{
-		LogError("Failed to allocate memory for %llu bytes",
+		LogError("Failed to allocate memory for {} bytes",
 		         static_cast<long long unsigned>(memsize));
 		return nullptr;
 	}
@@ -225,13 +225,13 @@ bool FileSystem::addPath(const UString &newPath)
 {
 	if (!PHYSFS_mount(newPath.cStr(), "/", 0))
 	{
-		LogInfo("Failed to add resource dir \"%s\", error: %s", newPath,
+		LogInfo("Failed to add resource dir \"{}\", error: {}", newPath,
 		        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 		return false;
 	}
 	else
 	{
-		LogInfo("Resource dir \"%s\" mounted to \"%s\"", newPath,
+		LogInfo("Resource dir \"{}\" mounted to \"{}\"", newPath,
 		        PHYSFS_getMountPoint(newPath.cStr()));
 		return true;
 	}
@@ -248,28 +248,28 @@ FileSystem::FileSystem(std::vector<UString> paths)
 	{
 		if (!PHYSFS_mount(p.cStr(), "/", 0))
 		{
-			LogInfo("Failed to add resource dir \"%s\", error: %s", p,
+			LogInfo("Failed to add resource dir \"{}\", error: {}", p,
 			        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 			continue;
 		}
 		else
-			LogInfo("Resource dir \"%s\" mounted to \"%s\"", p, PHYSFS_getMountPoint(p.cStr()));
+			LogInfo("Resource dir \"{}\" mounted to \"{}\"", p, PHYSFS_getMountPoint(p.cStr()));
 	}
 	auto current_path = fs::current_path();
 	auto canonical_current_path = fs::canonical(current_path);
 
-	LogInfo("Current path: \"%s\"", canonical_current_path);
+	LogInfo("Current path: \"{}\"", canonical_current_path);
 
 	LogInfo("Physfs search dirs:");
 	char **search_paths = PHYSFS_getSearchPath();
 	int index = 0;
 	for (char **i = search_paths; *i != NULL; i++)
-		LogInfo("%d: \"%s\"", index++, *i);
+		LogInfo("{}: \"{}\"", index++, *i);
 
 	PHYSFS_freeList(search_paths);
 
 	this->writeDir = PHYSFS_getPrefDir(PROGRAM_ORGANISATION, PROGRAM_NAME);
-	LogInfo("Setting write directory to \"%s\"", this->writeDir);
+	LogInfo("Setting write directory to \"{}\"", this->writeDir);
 	PHYSFS_setWriteDir(this->writeDir.cStr());
 	// Finally, the write directory trumps all
 	PHYSFS_mount(this->writeDir.cStr(), "/", 0);
@@ -285,18 +285,18 @@ IFile FileSystem::open(const UString &path) const
 	auto lowerPath = path.toLower();
 	if (path != lowerPath)
 	{
-		LogError("Path \"%s\" contains CAPITAL - cut it out!", path);
+		LogError("Path \"{}\" contains CAPITAL - cut it out!", path);
 	}
 
 	if (!PHYSFS_exists(path.cStr()))
 	{
-		LogInfo("Failed to find \"%s\"", path);
+		LogInfo("Failed to find \"{}\"", path);
 		LogAssert(!f);
 		return f;
 	}
 	f.f.reset(new PhysfsIFileImpl(path));
 	f.rdbuf(dynamic_cast<PhysfsIFileImpl *>(f.f.get()));
-	LogInfo("Loading \"%s\" from \"%s\"", path, f.systemPath());
+	LogInfo("Loading \"{}\" from \"{}\"", path, f.systemPath());
 	return f;
 }
 

--- a/framework/render/gl20/ogl_2_0_renderer.cpp
+++ b/framework/render/gl20/ogl_2_0_renderer.cpp
@@ -50,7 +50,7 @@ class Program
 		std::unique_ptr<char[]> log(new char[logLength]);
 		gl20::GetShaderInfoLog(shader, logLength, NULL, log.get());
 
-		LogError("Shader compile error: %s", log.get());
+		LogError("Shader compile error: {}", log.get());
 
 		gl20::DeleteShader(shader);
 		return 0;
@@ -91,7 +91,7 @@ class Program
 		std::unique_ptr<char[]> log(new char[logLength]);
 		gl20::GetProgramInfoLog(prog, logLength, NULL, log.get());
 
-		LogError("Program link error: %s", log.get());
+		LogError("Program link error: {}", log.get());
 
 		gl20::DeleteProgram(prog);
 		prog = 0;
@@ -484,7 +484,7 @@ class BindTexture
 			case gl20::TEXTURE_3D:
 				return gl20::TEXTURE_BINDING_3D;
 			default:
-				LogError("Unknown texture enum %d", static_cast<int>(e));
+				LogError("Unknown texture enum {}", static_cast<int>(e));
 				return gl20::TEXTURE_BINDING_2D;
 		}
 	}
@@ -711,7 +711,7 @@ class OGL20Renderer : public Renderer
 		this->bound_thread = std::this_thread::get_id();
 		GLint viewport[4];
 		gl20::GetIntegerv(gl20::VIEWPORT, viewport);
-		LogInfo("Viewport {%d,%d,%d,%d}", viewport[0], viewport[1], viewport[2], viewport[3]);
+		LogInfo("Viewport {{},{},{},{}}", viewport[0], viewport[1], viewport[2], viewport[3]);
 		LogAssert(viewport[0] == 0 && viewport[1] == 0);
 		this->defaultSurface = mksp<Surface>(Vec2<int>{viewport[2], viewport[3]});
 		this->defaultSurface->rendererPrivateData.reset(
@@ -720,7 +720,7 @@ class OGL20Renderer : public Renderer
 
 		GLint maxTexUnits;
 		gl20::GetIntegerv(gl20::MAX_COMBINED_TEXTURE_IMAGE_UNITS, &maxTexUnits);
-		LogInfo("MAX_COMBINED_TEXTURE_IMAGE_UNITS: %d", maxTexUnits);
+		LogInfo("MAX_COMBINED_TEXTURE_IMAGE_UNITS: {}", maxTexUnits);
 		gl20::Enable(gl20::BLEND);
 		gl20::BlendFuncSeparate(gl20::SRC_ALPHA, gl20::ONE_MINUS_SRC_ALPHA, gl20::SRC_ALPHA,
 		                        gl20::DST_ALPHA);
@@ -1078,12 +1078,12 @@ class OGL20RendererFactory : public OpenApoc::RendererFactory
 			}
 			if (success.GetNumMissing())
 			{
-				LogInfo("GL implementation missing %d functions", success.GetNumMissing());
+				LogInfo("GL implementation missing {} functions", success.GetNumMissing());
 				return nullptr;
 			}
 			if (!gl20::sys::IsVersionGEQ(2, 0))
 			{
-				LogInfo("GL version not at least 2.0, got %d.%d", gl20::sys::GetMajorVersion(),
+				LogInfo("GL version not at least 2.0, got {}.{}", gl20::sys::GetMajorVersion(),
 				        gl20::sys::GetMinorVersion());
 				return nullptr;
 			}

--- a/framework/render/gl20/ogl_2_0_renderer.cpp
+++ b/framework/render/gl20/ogl_2_0_renderer.cpp
@@ -711,7 +711,7 @@ class OGL20Renderer : public Renderer
 		this->bound_thread = std::this_thread::get_id();
 		GLint viewport[4];
 		gl20::GetIntegerv(gl20::VIEWPORT, viewport);
-		LogInfo("Viewport {{},{},{},{}}", viewport[0], viewport[1], viewport[2], viewport[3]);
+		LogInfo("Viewport {{{},{},{},{}}}", viewport[0], viewport[1], viewport[2], viewport[3]);
 		LogAssert(viewport[0] == 0 && viewport[1] == 0);
 		this->defaultSurface = mksp<Surface>(Vec2<int>{viewport[2], viewport[3]});
 		this->defaultSurface->rendererPrivateData.reset(

--- a/framework/render/gles30_v2/gleswrap_gles3.cpp
+++ b/framework/render/gles30_v2/gleswrap_gles3.cpp
@@ -78,7 +78,7 @@ class Gles3::Gles3Loader
 			this->dlfcn_handle = dlopen(lib_name.c_str(), RTLD_NOW | RTLD_LOCAL);
 			if (!this->dlfcn_handle)
 			{
-				LogInfo("Failed to load library \"%s\" : \"%s\"", lib_name.c_str(), dlerror());
+				LogInfo("Failed to load library \"{}\" : \"{}\"", lib_name.c_str(), dlerror());
 			}
 #elif defined(GLESWRAP_PLATFORM_WGL)
 			this->win32_handle = LoadLibraryA("opengl32.dll");
@@ -177,7 +177,7 @@ bool Gles3::supported(bool desktop_extension, std::string lib_name)
 	if (desktop_extension)
 	{
 		std::string extension_list = reinterpret_cast<const char *>(LocalGetString(EXTENSIONS));
-		LogInfo("GL_EXTENSIONS: \"%s\"", extension_list.c_str());
+		LogInfo("GL_EXTENSIONS: \"{}\"", extension_list.c_str());
 		if (extension_list.find("GL_ARB_ES3_compatibility ") != extension_list.npos)
 		{
 			return true;
@@ -482,12 +482,12 @@ Gles3::KhrDebug::KhrDebug(const Gles3 *parent) : supported(false), name("GL_KHR_
 		return;
 	if (parent->Extensions.count(name))
 	{
-		LogInfo("Extension %s supported", name.c_str());
+		LogInfo("Extension {} supported", name.c_str());
 		this->supported = true;
 	}
 	else
 	{
-		LogInfo("Extension %s not supported", name.c_str());
+		LogInfo("Extension {} not supported", name.c_str());
 		return;
 	}
 	std::string func_suffix;

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -62,7 +62,7 @@ GL::GLuint CreateShader(GL::GLenum type, const UString &source)
 	std::unique_ptr<char[]> log(new char[logLength]);
 	gl->GetShaderInfoLog(shader, logLength, NULL, log.get());
 
-	LogError("Shader compile error: %s", log.get());
+	LogError("Shader compile error: {}", log.get());
 
 	gl->DeleteShader(shader);
 	return 0;
@@ -105,7 +105,7 @@ GL::GLuint CompileProgram(const UString &vertexSource, const UString &fragmentSo
 	std::unique_ptr<char[]> log(new char[logLength]);
 	gl->GetProgramInfoLog(prog, logLength, NULL, log.get());
 
-	LogError("Program link error: %s", log.get());
+	LogError("Program link error: {}", log.get());
 
 	gl->DeleteProgram(prog);
 	return 0;
@@ -241,7 +241,7 @@ class Spritesheet
 		else if (format == GL::R8UI)
 			data_format = GL::RED_INTEGER;
 		else
-			LogError("Unknown GL internal format 0x%x", format);
+			LogError("Unknown GL internal format 0x{:x}", format);
 
 		gl->TexImage3D(GL::TEXTURE_2D_ARRAY, 0, this->format, this->page_size.x, this->page_size.y,
 		               this->pages.size(), 0, data_format, GL::UNSIGNED_BYTE, nullptr);
@@ -317,7 +317,7 @@ class Spritesheet
 		pages.clear();
 		while (!validEntries.empty())
 		{
-			LogInfo("Repack: creating sheet %d", (int)pages.size());
+			LogInfo("Repack: creating sheet {}", (int)pages.size());
 			auto page = mksp<SpritesheetPage>((int)pages.size(), page_size, node_count);
 			pages.push_back(page);
 			page->addMultiple(validEntries);
@@ -349,12 +349,12 @@ class Spritesheet
 			}
 		}
 		// Required a new page
-		LogInfo("Creating spritesheet page %d", (int)pages.size());
+		LogInfo("Creating spritesheet page {}", (int)pages.size());
 		auto page = mksp<SpritesheetPage>((int)pages.size(), page_size, node_count);
 		auto ret = page->addEntry(entry);
 		if (!ret)
 		{
-			LogError("Failed to pack a %s sized sprite in a new page of size %s?", entry->size,
+			LogError("Failed to pack a {} sized sprite in a new page of size {}?", entry->size,
 			         page_size);
 		}
 		this->pages.push_back(page);
@@ -1331,7 +1331,7 @@ class OGLES30Renderer final : public Renderer
 	unsigned int maxColouredBuffers = 0;
 	~OGLES30Renderer() override
 	{
-		LogInfo("Max %u sprite buffers %u textured buffers %u coloured buffers",
+		LogInfo("Max {} sprite buffers {} textured buffers {} coloured buffers",
 		        this->maxSpriteBuffers, this->maxTexturedBuffers, this->maxColouredBuffers);
 		renderer_dead = true;
 	}
@@ -1340,17 +1340,17 @@ class OGLES30Renderer final : public Renderer
 	{
 		if (this->spriteMachine->used_buffers > this->maxSpriteBuffers)
 		{
-			LogInfo("New max sprite buffers: %u", this->spriteMachine->used_buffers);
+			LogInfo("New max sprite buffers: {}", this->spriteMachine->used_buffers);
 			this->maxSpriteBuffers = this->spriteMachine->used_buffers;
 		}
 		if (this->texturedMachine->used_buffers > this->maxTexturedBuffers)
 		{
-			LogInfo("New max textured buffers: %u", this->texturedMachine->used_buffers);
+			LogInfo("New max textured buffers: {}", this->texturedMachine->used_buffers);
 			this->maxTexturedBuffers = this->texturedMachine->used_buffers;
 		}
 		if (this->colouredDrawMachine->used_buffers > this->maxColouredBuffers)
 		{
-			LogInfo("New max coloured buffers: %u", this->colouredDrawMachine->used_buffers);
+			LogInfo("New max coloured buffers: {}", this->colouredDrawMachine->used_buffers);
 			this->maxColouredBuffers = this->colouredDrawMachine->used_buffers;
 		}
 		this->spriteMachine->used_buffers = 0;
@@ -1706,12 +1706,12 @@ void GLESWRAP_APIENTRY debug_message_proc(GL::KhrDebug::GLenum, GL::KhrDebug::GL
 		case GL::KhrDebug::DEBUG_SEVERITY_HIGH:
 		case GL::KhrDebug::DEBUG_SEVERITY_MEDIUM:
 		{
-			LogWarning("Debug message: \"%s\"", message);
+			LogWarning("Debug message: \"{}\"", message);
 			break;
 		}
 		default:
 		{
-			LogInfo("Debug message: \"%s\"", message);
+			LogInfo("Debug message: \"{}\"", message);
 			break;
 		}
 	}
@@ -1727,7 +1727,7 @@ OGLES30Renderer::OGLES30Renderer() : state(State::Idle)
 	this->colouredDrawMachine.reset(new ColouredDrawMachine{quadBufferCount});
 	GL::GLint viewport[4];
 	gl->GetIntegerv(GL::VIEWPORT, viewport);
-	LogInfo("Viewport {%d,%d,%d,%d}", viewport[0], viewport[1], viewport[2], viewport[3]);
+	LogInfo("Viewport {{},{},{},{}}", viewport[0], viewport[1], viewport[2], viewport[3]);
 	this->default_surface = mksp<Surface>(Vec2<int>{viewport[2], viewport[3]});
 	this->default_surface->rendererPrivateData =
 	    mksp<GLSurface>(0, Vec2<int>{viewport[2], viewport[3]}, this);
@@ -1742,12 +1742,12 @@ OGLES30Renderer::OGLES30Renderer() : state(State::Idle)
 	if (spritesheetPageSize.x > (unsigned int)max_texture_size ||
 	    spritesheetPageSize.y > (unsigned int)max_texture_size)
 	{
-		LogWarning("Default spritesheet size %s larger than HW limit %d - clamping...",
+		LogWarning("Default spritesheet size {} larger than HW limit {} - clamping...",
 		           spritesheetPageSize, max_texture_size);
 		spritesheetPageSize.x = std::min(spritesheetPageSize.x, (unsigned int)max_texture_size);
 		spritesheetPageSize.y = std::min(spritesheetPageSize.y, (unsigned int)max_texture_size);
 	}
-	LogInfo("Set spritesheet size to %s", spritesheetPageSize);
+	LogInfo("Set spritesheet size to {}", spritesheetPageSize);
 
 	bool use_debug = false;
 

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -1727,7 +1727,7 @@ OGLES30Renderer::OGLES30Renderer() : state(State::Idle)
 	this->colouredDrawMachine.reset(new ColouredDrawMachine{quadBufferCount});
 	GL::GLint viewport[4];
 	gl->GetIntegerv(GL::VIEWPORT, viewport);
-	LogInfo("Viewport {{},{},{},{}}", viewport[0], viewport[1], viewport[2], viewport[3]);
+	LogInfo("Viewport {{{},{},{},{}}}", viewport[0], viewport[1], viewport[2], viewport[3]);
 	this->default_surface = mksp<Surface>(Vec2<int>{viewport[2], viewport[3]});
 	this->default_surface->rendererPrivateData =
 	    mksp<GLSurface>(0, Vec2<int>{viewport[2], viewport[3]}, this);

--- a/framework/sampleloader/rawsound.cpp
+++ b/framework/sampleloader/rawsound.cpp
@@ -30,25 +30,25 @@ class RawSampleLoader : public SampleLoader
 		auto splitString = path.split(':');
 		if (splitString.size() != 3)
 		{
-			LogInfo("String \"%s\" doesn't look like a rawsample - need 3 elements (got %zu)", path,
+			LogInfo("String \"{}\" doesn't look like a rawsample - need 3 elements (got {})", path,
 			        splitString.size());
 			return nullptr;
 		}
 		if (splitString[0] != "RAWSOUND")
 		{
-			LogInfo("String \"%s\" doesn't look like a rawsample - no RAWSOUND prefix", path);
+			LogInfo("String \"{}\" doesn't look like a rawsample - no RAWSOUND prefix", path);
 			return nullptr;
 		}
 		int frequency = Strings::toInteger(splitString[2]);
 		if (allowedSampleRates.find(frequency) == allowedSampleRates.end())
 		{
-			LogWarning("Rawsound \"%s\" has invalid sample rate of %d", path, frequency);
+			LogWarning("Rawsound \"{}\" has invalid sample rate of {}", path, frequency);
 			return nullptr;
 		}
 		auto file = data.fs.open(splitString[1]);
 		if (!file)
 		{
-			LogWarning("Rawsound \"%s\" failed to open file \"%s\"", path, splitString[1]);
+			LogWarning("Rawsound \"{}\" failed to open file \"{}\"", path, splitString[1]);
 			return nullptr;
 		}
 

--- a/framework/sampleloader/wavsound.cpp
+++ b/framework/sampleloader/wavsound.cpp
@@ -40,19 +40,19 @@ class WavSampleLoader : public SampleLoader
 		const auto splitString = path.split(':');
 		if (splitString.size() != 2)
 		{
-			LogInfo("String \"%s\" doesn't look like a rawsample - need 2 elements (got %zu)", path,
+			LogInfo("String \"{}\" doesn't look like a rawsample - need 2 elements (got {})", path,
 			        splitString.size());
 			return nullptr;
 		}
 		if (splitString[0] != "WAV")
 		{
-			LogInfo("String \"%s\" doesn't look like a wav - no WAV prefix", path);
+			LogInfo("String \"{}\" doesn't look like a wav - no WAV prefix", path);
 			return nullptr;
 		}
 		const auto file = data.fs.open(splitString[1]);
 		if (!file)
 		{
-			LogWarning("wav \"%s\" failed to open file \"%s\"", path, splitString[1]);
+			LogWarning("wav \"{}\" failed to open file \"{}\"", path, splitString[1]);
 			return nullptr;
 		}
 
@@ -66,13 +66,13 @@ class WavSampleLoader : public SampleLoader
 		const auto *returnedSpec = SDL_LoadWAV(fullPath.cStr(), &spec, &buf, &bufSize);
 		if (returnedSpec == nullptr)
 		{
-			LogWarning("Failed to open WAV file at \"%s\" - \"%s\"", fullPath, SDL_GetError());
+			LogWarning("Failed to open WAV file at \"{}\" - \"{}\"", fullPath, SDL_GetError());
 			return nullptr;
 		}
 
 		if (spec.channels != 1)
 		{
-			LogWarning("Failed to open WAV file at \"%s\" - only single channel samples supported",
+			LogWarning("Failed to open WAV file at \"{}\" - only single channel samples supported",
 			           fullPath);
 			SDL_FreeWAV(buf);
 			return nullptr;
@@ -81,7 +81,7 @@ class WavSampleLoader : public SampleLoader
 		const auto format = sdlFormatToSampleFormat(spec.format);
 		if (!format)
 		{
-			LogWarning("Failed to open WAV file at \"%s\" - unsupported SDL format 0x%08x",
+			LogWarning("Failed to open WAV file at \"{}\" - unsupported SDL format 0x%08x",
 			           fullPath, spec.format);
 			SDL_FreeWAV(buf);
 			return nullptr;

--- a/framework/serialization/providers/filedataprovider.cpp
+++ b/framework/serialization/providers/filedataprovider.cpp
@@ -12,7 +12,7 @@ bool FileDataProvider::openArchive(const UString &path, bool write)
 	archivePath = path;
 	if (!write && !fs::exists(path.str()))
 	{
-		LogWarning("Attempt to open not existing directory \"%s\"", path);
+		LogWarning("Attempt to open not existing directory \"{}\"", path);
 		return false;
 	}
 	return true;
@@ -35,7 +35,7 @@ bool FileDataProvider::saveDocument(const UString &path, const UString &contents
 	{
 		if (!fs::create_directories(directoryPath))
 		{
-			LogWarning("Failed to create directory \"%s\"", directoryPath.string());
+			LogWarning("Failed to create directory \"{}\"", directoryPath.string());
 			return false;
 		}
 	}

--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -70,7 +70,7 @@ static UString calculateChecksum(const UString &type, const std::string &str)
 	}
 	else
 	{
-		LogWarning("Unknown checksum type \"%s\"", type);
+		LogWarning("Unknown checksum type \"{}\"", type);
 		return "";
 	}
 }
@@ -107,7 +107,7 @@ bool ProviderWithChecksum::parseManifest(const std::string &manifestData)
 	auto parse_result = manifestDoc.load(ss);
 	if (!parse_result)
 	{
-		LogWarning("Failed to parse checksum.xml : \"%s\" at \"%llu\"", parse_result.description(),
+		LogWarning("Failed to parse checksum.xml : \"{}\" at \"{}\"", parse_result.description(),
 		           (unsigned long long)parse_result.offset);
 		return false;
 	}
@@ -124,7 +124,7 @@ bool ProviderWithChecksum::parseManifest(const std::string &manifestData)
 
 		if (this->checksums.find(fileName) != this->checksums.end())
 		{
-			LogWarning("Multiple manifest entries for path \"%s\"", fileName);
+			LogWarning("Multiple manifest entries for path \"{}\"", fileName);
 		}
 
 		this->checksums[fileName] = {};
@@ -157,7 +157,7 @@ bool ProviderWithChecksum::openArchive(const UString &path, bool write)
 		UString result;
 		if (!inner->readDocument("checksum.xml", result))
 		{
-			LogInfo("Missing manifest file in \"%s\"", path);
+			LogInfo("Missing manifest file in \"{}\"", path);
 			return true;
 		}
 		parseManifest(result.str());
@@ -174,12 +174,12 @@ bool ProviderWithChecksum::readDocument(const UString &path, UString &result)
 			auto calculatedCSum = calculateChecksum(csum.first, result.str());
 			if (expectedCSum != calculatedCSum)
 			{
-				LogWarning("File \"%s\" has incorrect \"%s\" checksum \"%s\", expected \"%s\"",
+				LogWarning("File \"{}\" has incorrect \"{}\" checksum \"{}\", expected \"{}\"",
 				           path, csum.first, calculatedCSum, expectedCSum);
 			}
 			else
 			{
-				LogDebug("File \"%s\" matches \"%s\" checksum \"%s\"", path, csum.first,
+				LogDebug("File \"{}\" matches \"{}\" checksum \"{}\"", path, csum.first,
 				         calculatedCSum);
 			}
 		}
@@ -195,7 +195,7 @@ bool ProviderWithChecksum::saveDocument(const UString &path, const UString &cont
 	{
 		if (this->checksums.find(path) != this->checksums.end())
 		{
-			LogWarning("Multiple document entries for path \"%s\"", path);
+			LogWarning("Multiple document entries for path \"{}\"", path);
 		}
 		this->checksums[path.str()] = {};
 		if (Options::useCRCChecksum.get())

--- a/framework/serialization/providers/zipdataprovider.cpp
+++ b/framework/serialization/providers/zipdataprovider.cpp
@@ -36,7 +36,7 @@ bool ZipDataProvider::openArchive(const UString &path, bool write)
 		}
 		if (!mz_zip_writer_init_file(&archive, path.cStr(), 0))
 		{
-			LogWarning("Failed to init zip file \"%s\" for writing", path);
+			LogWarning("Failed to init zip file \"{}\" for writing", path);
 			return false;
 		}
 	}
@@ -44,7 +44,7 @@ bool ZipDataProvider::openArchive(const UString &path, bool write)
 	{
 		if (!mz_zip_reader_init_file(&archive, path.cStr(), 0))
 		{
-			LogWarning("Failed to init zip file \"%s\" for reading", path);
+			LogWarning("Failed to init zip file \"{}\" for reading", path);
 			return false;
 		}
 
@@ -67,7 +67,7 @@ bool ZipDataProvider::readDocument(const UString &filename, UString &result)
 	auto it = fileLookup.find(filename.str());
 	if (it == fileLookup.end())
 	{
-		LogInfo("File \"%s\" not found in zip in zip \"%s\"", filename, zipPath);
+		LogInfo("File \"{}\" not found in zip in zip \"{}\"", filename, zipPath);
 		return false;
 	}
 	unsigned int fileId = it->second;
@@ -75,22 +75,22 @@ bool ZipDataProvider::readDocument(const UString &filename, UString &result)
 	memset(&stat, 0, sizeof(stat));
 	if (!mz_zip_reader_file_stat(&archive, fileId, &stat))
 	{
-		LogWarning("Failed to stat file \"%s\" in zip \"%s\"", filename, zipPath);
+		LogWarning("Failed to stat file \"{}\" in zip \"{}\"", filename, zipPath);
 		return false;
 	}
 	if (stat.m_uncomp_size == 0)
 	{
-		LogInfo("Skipping %s - possibly a directory?", filename);
+		LogInfo("Skipping {} - possibly a directory?", filename);
 		return false;
 	}
 
-	LogInfo("Reading %lu bytes for file \"%s\" in zip \"%s\"", (unsigned long)stat.m_uncomp_size,
+	LogInfo("Reading %lu bytes for file \"{}\" in zip \"{}\"", (unsigned long)stat.m_uncomp_size,
 	        filename, zipPath);
 
 	up<char[]> data(new char[(unsigned int)stat.m_uncomp_size]);
 	if (!mz_zip_reader_extract_to_mem(&archive, fileId, data.get(), (size_t)stat.m_uncomp_size, 0))
 	{
-		LogWarning("Failed to extract file \"%s\" in zip \"%s\"", filename, zipPath);
+		LogWarning("Failed to extract file \"{}\" in zip \"{}\"", filename, zipPath);
 		return false;
 	}
 
@@ -102,7 +102,7 @@ bool ZipDataProvider::saveDocument(const UString &path, const UString &contents)
 	if (!mz_zip_writer_add_mem(&archive, path.cStr(), contents.cStr(), contents.cStrLength(),
 	                           MZ_DEFAULT_COMPRESSION))
 	{
-		LogWarning("Failed to insert \"%s\" into zip file \"%s\"", path, this->zipPath);
+		LogWarning("Failed to insert \"{}\" into zip file \"{}\"", path, this->zipPath);
 		return false;
 	}
 	return true;
@@ -113,7 +113,7 @@ bool ZipDataProvider::finalizeSave()
 	{
 		if (!mz_zip_writer_finalize_archive(&archive))
 		{
-			LogWarning("Failed to finalize archive \"%s\"", zipPath);
+			LogWarning("Failed to finalize archive \"{}\"", zipPath);
 			return false;
 		}
 	}

--- a/framework/serialization/serialize.cpp
+++ b/framework/serialization/serialize.cpp
@@ -21,7 +21,7 @@ SerializationNode *SerializationNode::getNodeReq(const char *name)
 	auto node = this->getNodeOpt(name);
 	if (!node)
 	{
-		throw SerializationException(format("Missing node \"%s\"", name), this);
+		throw SerializationException(format("Missing node \"{}\"", name), this);
 	}
 	return node;
 }
@@ -31,7 +31,7 @@ SerializationNode *SerializationNode::getSectionReq(const char *name)
 	auto node = this->getSectionOpt(name);
 	if (!node)
 	{
-		throw SerializationException(format("Missing section \"%s\"", name), this);
+		throw SerializationException(format("Missing section \"{}\"", name), this);
 	}
 	return node;
 }
@@ -41,7 +41,7 @@ SerializationNode *SerializationNode::getNextSiblingReq(const char *name)
 	auto node = this->getNextSiblingOpt(name);
 	if (!node)
 	{
-		throw SerializationException(format("Missing sibling of \"%s\"", name), this);
+		throw SerializationException(format("Missing sibling of \"{}\"", name), this);
 	}
 	return node;
 }
@@ -164,10 +164,10 @@ up<SerializationArchive> SerializationArchive::readArchive(const UString &path)
 	up<SerializationDataProvider> dataProvider = getProvider(!fs::is_directory(path.str()));
 	if (!dataProvider->openArchive(path, false))
 	{
-		LogWarning("Failed to open archive at \"%s\"", path);
+		LogWarning("Failed to open archive at \"{}\"", path);
 		return nullptr;
 	}
-	LogInfo("Opened archive \"%s\"", path);
+	LogInfo("Opened archive \"{}\"", path);
 
 	return mkup<XMLSerializationArchive>(std::move(dataProvider));
 }
@@ -189,7 +189,7 @@ SerializationNode *XMLSerializationArchive::getRoot(const UString &prefix, const
 	auto path = prefix + name + ".xml";
 	if (dataProvider == nullptr)
 	{
-		LogWarning("Reading from not opened archive: %s!", path);
+		LogWarning("Reading from not opened archive: {}!", path);
 		return nullptr;
 	}
 
@@ -206,12 +206,12 @@ SerializationNode *XMLSerializationArchive::getRoot(const UString &prefix, const
 			auto parse_result = doc.load_string(content.cStr());
 			if (!parse_result)
 			{
-				LogInfo("Failed to parse \"%s\" : \"%s\" at \"%llu\"", path,
+				LogInfo("Failed to parse \"{}\" : \"{}\" at \"{}\"", path,
 				        parse_result.description(), (unsigned long long)parse_result.offset);
 				return nullptr;
 			}
 			it = this->docRoots.find(path);
-			LogInfo("Parsed \"%s\"", path);
+			LogInfo("Parsed \"{}\"", path);
 		}
 	}
 	if (it == this->docRoots.end())
@@ -222,7 +222,7 @@ SerializationNode *XMLSerializationArchive::getRoot(const UString &prefix, const
 	auto root = it->second.child(name);
 	if (!root)
 	{
-		LogWarning("Failed to find root with name \"%s\" in \"%s\"", name, path);
+		LogWarning("Failed to find root with name \"{}\" in \"{}\"", name, path);
 		return nullptr;
 	}
 	const UString *newPrefix = &this->prefixes.emplace_back(prefix + name + "/");
@@ -237,7 +237,7 @@ bool XMLSerializationArchive::write(const UString &path, bool pack, bool pretty)
 	auto dataProvider = getProvider(pack);
 	if (!dataProvider->openArchive(path, true))
 	{
-		LogWarning("Failed to open archive at \"%s\"", path);
+		LogWarning("Failed to open archive at \"{}\"", path);
 		return false;
 	}
 
@@ -324,7 +324,7 @@ unsigned char XMLSerializationNode::getValueUChar()
 	auto uint = node.text().as_uint();
 	if (uint > std::numeric_limits<unsigned char>::max())
 	{
-		throw SerializationException(format("Value %u is out of range of unsigned char type", uint),
+		throw SerializationException(format("Value {} is out of range of unsigned char type", uint),
 		                             this);
 	}
 	return static_cast<unsigned char>(uint);

--- a/framework/sound.cpp
+++ b/framework/sound.cpp
@@ -42,7 +42,7 @@ void SoundBackend::playSample(sp<Sample> sample, Vec3<float> position, float gai
 			distance -= lutDistance;
 		}
 	}
-	LogInfo("Playing sample at {%f,%f,%f} - distance to camera %f, gain %f", position.x, position.y,
+	LogInfo("Playing sample at {{},{},{}} - distance to camera {}, gain {}", position.x, position.y,
 	        position.z, distance, gain);
 	// Anything within CLOSE_RANGE is at full volume
 	this->playSample(sample, gain * gainMultiplier);

--- a/framework/sound.cpp
+++ b/framework/sound.cpp
@@ -42,7 +42,7 @@ void SoundBackend::playSample(sp<Sample> sample, Vec3<float> position, float gai
 			distance -= lutDistance;
 		}
 	}
-	LogInfo("Playing sample at {{},{},{}} - distance to camera {}, gain {}", position.x, position.y,
+	LogInfo("Playing sample at {{{},{},{}}} - distance to camera {}, gain {}", position.x, position.y,
 	        position.z, distance, gain);
 	// Anything within CLOSE_RANGE is at full volume
 	this->playSample(sample, gain * gainMultiplier);

--- a/framework/sound/sdlraw_backend.cpp
+++ b/framework/sound/sdlraw_backend.cpp
@@ -324,7 +324,7 @@ class SDLRawBackend : public SoundBackend
 			std::lock_guard<std::recursive_mutex> l(this->audio_lock);
 			this->live_samples.emplace_back(sample, gain);
 		}
-		LogInfo("Placed sound %p on queue", static_cast<void*>(sample.get()));
+		LogInfo("Placed sound {} on queue", static_cast<void *>(sample.get()));
 	}
 
 	void playMusic(std::function<void(void *)> finishedCallback, void *callbackData) override
@@ -343,7 +343,7 @@ class SDLRawBackend : public SoundBackend
 	void setTrack(sp<MusicTrack> track) override
 	{
 		std::lock_guard<std::recursive_mutex> l(this->audio_lock);
-		LogInfo("Setting track to %p", static_cast<void*>(track.get()));
+		LogInfo("Setting track to {}", static_cast<void *>(track.get()));
 		this->track = track;
 		while (!music_queue.empty())
 			music_queue.pop();

--- a/framework/sound/sdlraw_backend.cpp
+++ b/framework/sound/sdlraw_backend.cpp
@@ -71,7 +71,7 @@ static bool ConvertAudio(AudioFormat input_format, SDL_AudioSpec &output_spec, i
 		size_t neededSize = std::max(1, cvt.len_mult) * cvt.len;
 		if (samples.size() < neededSize)
 		{
-			LogInfo("Expanding sample output buffer from %zu to %zu bytes", samples.size(),
+			LogInfo("Expanding sample output buffer from {} to {} bytes", samples.size(),
 			        neededSize);
 			samples.resize(neededSize);
 		}
@@ -277,18 +277,18 @@ class SDLRawBackend : public SoundBackend
 		preferred_format.channels = 2;
 		preferred_format.format = AudioFormat::SampleFormat::PCM_SINT16;
 		preferred_format.frequency = 22050;
-		LogInfo("Current audio driver: %s", SDL_GetCurrentAudioDriver());
+		LogInfo("Current audio driver: {}", SDL_GetCurrentAudioDriver());
 		LogWarning("Changing audio drivers is not currently implemented!");
 		int numDevices = SDL_GetNumAudioDevices(0); // Request playback devices only
-		LogInfo("Number of audio devices: %d", numDevices);
+		LogInfo("Number of audio devices: {}", numDevices);
 		for (int i = 0; i < numDevices; ++i)
 		{
-			LogInfo("Device %d: %s", i, SDL_GetAudioDeviceName(i, 0));
+			LogInfo("Device {}: {}", i, SDL_GetAudioDeviceName(i, 0));
 		}
 		LogWarning(
 		    "Selecting audio devices not currently implemented! Selecting first available device.");
 		const char *deviceName = SDL_GetAudioDeviceName(0, 0);
-		LogInfo("Using audio device: %s", deviceName);
+		LogInfo("Using audio device: {}", deviceName);
 		SDL_AudioSpec wantFormat;
 		wantFormat.channels = 2;
 		wantFormat.format = AUDIO_S16LSB;
@@ -304,7 +304,7 @@ class SDLRawBackend : public SoundBackend
 		    SDL_AUDIO_ALLOW_ANY_CHANGE); // hopefully we'll get a sane output format
 		SDL_PauseAudioDevice(devID, 0);  // Run at once?
 
-		LogWarning("Audio output format: Channels %d, format: %s %s %s %dbit, freq %d, samples %d",
+		LogWarning("Audio output format: Channels {}, format: {} {} {} {}bit, freq {}, samples {}",
 		           (int)output_spec.channels,
 		           SDL_AUDIO_ISSIGNED(output_spec.format) ? "signed" : "unsigned",
 		           SDL_AUDIO_ISFLOAT(output_spec.format) ? "float" : "int",
@@ -324,7 +324,7 @@ class SDLRawBackend : public SoundBackend
 			std::lock_guard<std::recursive_mutex> l(this->audio_lock);
 			this->live_samples.emplace_back(sample, gain);
 		}
-		LogInfo("Placed sound %p on queue", sample.get());
+		LogInfo("Placed sound %p on queue", static_cast<void*>(sample.get()));
 	}
 
 	void playMusic(std::function<void(void *)> finishedCallback, void *callbackData) override
@@ -343,7 +343,7 @@ class SDLRawBackend : public SoundBackend
 	void setTrack(sp<MusicTrack> track) override
 	{
 		std::lock_guard<std::recursive_mutex> l(this->audio_lock);
-		LogInfo("Setting track to %p", track.get());
+		LogInfo("Setting track to %p", static_cast<void*>(track.get()));
 		this->track = track;
 		while (!music_queue.empty())
 			music_queue.pop();
@@ -430,7 +430,7 @@ class SDLRawBackendFactory : public SoundBackendFactory
 		int ret = SDL_InitSubSystem(SDL_INIT_AUDIO);
 		if (ret < 0)
 		{
-			LogWarning("Failed to init SDL_AUDIO (%d) - %s", ret, SDL_GetError());
+			LogWarning("Failed to init SDL_AUDIO ({}) - {}", ret, SDL_GetError());
 			return nullptr;
 		}
 		return new SDLRawBackend();

--- a/framework/trace.cpp
+++ b/framework/trace.cpp
@@ -104,7 +104,7 @@ class TraceManager
 	{
 		if (!outFile)
 		{
-			LogError("Failed to open trace file \"%s\"", OpenApoc::Options::traceFile.get());
+			LogError("Failed to open trace file \"{}\"", OpenApoc::Options::traceFile.get());
 			return;
 		}
 	}
@@ -216,7 +216,7 @@ void Trace::enable()
 {
 	if (!traceInited)
 		initTrace();
-	LogWarning("Enabling tracing - sizeof(TraceEvent) = %u", (unsigned)sizeof(TraceEvent));
+	LogWarning("Enabling tracing - sizeof(TraceEvent) = {}", (unsigned)sizeof(TraceEvent));
 	LogAssert(!trace_manager);
 	trace_manager.reset(new TraceManager);
 #if defined(BROKEN_THREAD_LOCAL)

--- a/framework/video/smk.cpp
+++ b/framework/video/smk.cpp
@@ -249,7 +249,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		}
 
 		this->frame_size = {width, height};
-		LogInfo("Video frame size {{},{}}", this->frame_size.x, this->frame_size.y);
+		LogInfo("Video frame size {{{},{}}}", this->frame_size.x, this->frame_size.y);
 
 		auto ret = smk_enable_video(this->smk_ctx, 1);
 		if (ret == SMK_ERROR)

--- a/framework/video/smk.cpp
+++ b/framework/video/smk.cpp
@@ -127,26 +127,26 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 
 		if (ret == SMK_ERROR)
 		{
-			LogWarning("Error decoding frame %u", this->current_frame_read);
+			LogWarning("Error decoding frame {}", this->current_frame_read);
 			return false;
 		}
 
 		if (ret == SMK_LAST)
 		{
-			LogInfo("Last frame %u", this->current_frame_read);
+			LogInfo("Last frame {}", this->current_frame_read);
 			this->stopped = true;
 		}
 
 		const unsigned char *palette_data = smk_get_palette(this->smk_ctx);
 		if (!palette_data)
 		{
-			LogWarning("Failed to get palette data for frame %u", this->current_frame_read);
+			LogWarning("Failed to get palette data for frame {}", this->current_frame_read);
 			return false;
 		}
 		const unsigned char *image_data = smk_get_video(this->smk_ctx);
 		if (!image_data)
 		{
-			LogWarning("Failed to get image data for frame %u", this->current_frame_read);
+			LogWarning("Failed to get image data for frame {}", this->current_frame_read);
 			return false;
 		}
 
@@ -174,7 +174,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		unsigned long audio_bytes = smk_get_audio_size(this->smk_ctx, 0);
 		if (audio_bytes == 0)
 		{
-			LogWarning("Error reading audio size for frame %u", this->current_frame_read);
+			LogWarning("Error reading audio size for frame {}", this->current_frame_read);
 			return false;
 		}
 
@@ -185,17 +185,17 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		auto sample_pointer = smk_get_audio(this->smk_ctx, 0);
 		if (!sample_pointer)
 		{
-			LogWarning("Error reading audio data for frame %u", this->current_frame_read);
+			LogWarning("Error reading audio data for frame {}", this->current_frame_read);
 			return false;
 		}
 		memcpy(audio_frame->samples.get(), sample_pointer, audio_bytes);
 
-		LogInfo("Read %lu samples bytes, %u samples", audio_bytes, audio_frame->sample_count);
+		LogInfo("Read %lu samples bytes, {} samples", audio_bytes, audio_frame->sample_count);
 
 		this->image_queue.push(frame);
 		this->audio_queue.push(audio_frame);
 
-		LogInfo("read frame %u", this->current_frame_read);
+		LogInfo("read frame {}", this->current_frame_read);
 		this->current_frame_read++;
 		return true;
 	}
@@ -212,14 +212,14 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		auto video_path = file.systemPath();
 		this->file_path = video_path;
 
-		LogInfo("Read %llu bytes from video",
+		LogInfo("Read {} bytes from video",
 		        static_cast<unsigned long long>(this->video_data_size));
 
 		this->smk_ctx = smk_open_memory(reinterpret_cast<unsigned char *>(this->video_data.get()),
 		                                static_cast<unsigned long>(this->video_data_size));
 		if (!this->smk_ctx)
 		{
-			LogWarning("Failed to read SMK file \"%s\"", video_path);
+			LogWarning("Failed to read SMK file \"{}\"", video_path);
 			this->video_data.reset();
 			return false;
 		}
@@ -227,7 +227,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 
 		if (smk_info_all(this->smk_ctx, nullptr, &this->frame_count, &usf))
 		{
-			LogWarning("Failed to read SMK file info from \"%s\"", video_path);
+			LogWarning("Failed to read SMK file info from \"{}\"", video_path);
 			this->video_data.reset();
 			smk_close(this->smk_ctx);
 			this->smk_ctx = nullptr;
@@ -236,13 +236,13 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 
 		this->frame_time = std::chrono::nanoseconds((unsigned int)(usf * 1000));
 
-		LogInfo("Video frame count %lu, ns per frame = %u (USF: %f)", this->frame_count,
+		LogInfo("Video frame count %lu, ns per frame = {} (USF: {})", this->frame_count,
 		        this->frame_time.count(), usf);
 
 		unsigned long height, width;
 		if (smk_info_video(this->smk_ctx, &width, &height, nullptr))
 		{
-			LogWarning("Failed to read SMK video info from \"%s\"", video_path);
+			LogWarning("Failed to read SMK video info from \"{}\"", video_path);
 			this->video_data.reset();
 			smk_close(this->smk_ctx);
 			this->smk_ctx = nullptr;
@@ -250,12 +250,12 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		}
 
 		this->frame_size = {width, height};
-		LogInfo("Video frame size {%u,%u}", this->frame_size.x, this->frame_size.y);
+		LogInfo("Video frame size {{},{}}", this->frame_size.x, this->frame_size.y);
 
 		auto ret = smk_enable_video(this->smk_ctx, 1);
 		if (ret == SMK_ERROR)
 		{
-			LogWarning("Error enabling video for \"%s\"", video_path);
+			LogWarning("Error enabling video for \"{}\"", video_path);
 			return false;
 		}
 
@@ -267,19 +267,19 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		ret = smk_info_audio(this->smk_ctx, &audio_track_mask, channels, bitdepth, audio_rate);
 		if (ret == SMK_ERROR)
 		{
-			LogWarning("Error reading audio info for \"%s\"", video_path);
+			LogWarning("Error reading audio info for \"{}\"", video_path);
 			return false;
 		}
 
 		if (audio_track_mask & SMK_AUDIO_TRACK_0)
 		{
 			// WE only support a single track
-			LogInfo("Audio track: channels %u depth %u rate %lu", (unsigned)channels[0],
+			LogInfo("Audio track: channels {} depth {} rate %lu", (unsigned)channels[0],
 			        (unsigned)bitdepth[0], audio_rate[0]);
 		}
 		else
 		{
-			LogWarning("Unsupported audio track mask 0x%02x for \"%s\"", (unsigned)audio_track_mask,
+			LogWarning("Unsupported audio track mask 0x%02x for \"{}\"", (unsigned)audio_track_mask,
 			           video_path);
 			return false;
 		}
@@ -295,7 +295,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 				this->audio_format.channels = 2;
 				break;
 			default:
-				LogWarning("Unsupported audio channel count %u for \"%s\"", (unsigned)channels[0],
+				LogWarning("Unsupported audio channel count {} for \"{}\"", (unsigned)channels[0],
 				           video_path);
 				return false;
 		}
@@ -310,7 +310,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 				this->audio_bytes_per_sample = 2;
 				break;
 			default:
-				LogWarning("Unsupported audio bit depth %u for \"%s\"", (unsigned)bitdepth[0],
+				LogWarning("Unsupported audio bit depth {} for \"{}\"", (unsigned)bitdepth[0],
 				           video_path);
 				return false;
 		}
@@ -320,7 +320,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 
 		if (ret == SMK_ERROR)
 		{
-			LogWarning("Error enabling audio track 0 for \"%s\"", video_path);
+			LogWarning("Error enabling audio track 0 for \"{}\"", video_path);
 		}
 
 		// Everything looks  good

--- a/framework/video/smk.cpp
+++ b/framework/video/smk.cpp
@@ -212,8 +212,7 @@ class SMKVideo : public Video, public std::enable_shared_from_this<SMKVideo>
 		auto video_path = file.systemPath();
 		this->file_path = video_path;
 
-		LogInfo("Read {} bytes from video",
-		        static_cast<unsigned long long>(this->video_data_size));
+		LogInfo("Read {} bytes from video", static_cast<unsigned long long>(this->video_data_size));
 
 		this->smk_ctx = smk_open_memory(reinterpret_cast<unsigned char *>(this->video_data.get()),
 		                                static_cast<unsigned long>(this->video_data_size));

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -15,7 +15,7 @@ int main(int argc, char *argv[])
 	{
 		return EXIT_FAILURE;
 	}
-	LogInfo("Starting OpenApoc \"%s\"", OPENAPOC_VERSION);
+	LogInfo("Starting OpenApoc \"{}\"", OPENAPOC_VERSION);
 
 	{
 		Trace::setThreadName("main");

--- a/game/state/battle/ai/aidecision.cpp
+++ b/game/state/battle/ai/aidecision.cpp
@@ -20,37 +20,37 @@ UString AIAction::getName()
 	switch (type)
 	{
 		case AIAction::Type::AttackGrenade:
-			return format("Attack %s with grenade %s ", targetUnit->id, item->type->id);
+			return format("Attack {} with grenade {} ", targetUnit->id, item->type->id);
 		case AIAction::Type::AttackWeaponTile:
 			if (item)
 			{
-				return format("Attack %s with weapon %s ", targetLocation, item->type->id);
+				return format("Attack {} with weapon {} ", targetLocation, item->type->id);
 			}
 			else
 			{
-				return format("Attack %s with weapon(s)", targetLocation);
+				return format("Attack {} with weapon(s)", targetLocation);
 			}
 		case AIAction::Type::AttackWeaponUnit:
 			if (item)
 			{
-				return format("Attack %s with weapon %s ", targetUnit->id, item->type->id);
+				return format("Attack {} with weapon {} ", targetUnit->id, item->type->id);
 			}
 			else
 			{
-				return format("Attack %s with weapon(s)", targetUnit->id);
+				return format("Attack {} with weapon(s)", targetUnit->id);
 			}
 		case AIAction::Type::AttackPsiMC:
-			return format("Attack %s with psi MC using %s ", targetUnit->id, item->type->id);
+			return format("Attack {} with psi MC using {} ", targetUnit->id, item->type->id);
 		case AIAction::Type::AttackPsiStun:
-			return format("Attack %s with psi stun using %s ", targetUnit->id, item->type->id);
+			return format("Attack {} with psi stun using {} ", targetUnit->id, item->type->id);
 		case AIAction::Type::AttackPsiPanic:
-			return format("Attack %s with psi panic using %s ", targetUnit->id, item->type->id);
+			return format("Attack {} with psi panic using {} ", targetUnit->id, item->type->id);
 		case AIAction::Type::AttackBrainsucker:
-			return format("Attack %s with brainsucker", targetUnit->id);
+			return format("Attack {} with brainsucker", targetUnit->id);
 		case AIAction::Type::AttackSuicide:
-			return format("Attack (suicide) %s  ", targetUnit->id);
+			return format("Attack (suicide) {}  ", targetUnit->id);
 	}
-	LogError("Unimplemented getName for AIAction %d", (int)type);
+	LogError("Unimplemented getName for AIAction {}", (int)type);
 	return "";
 }
 
@@ -109,21 +109,21 @@ UString AIMovement::getName()
 		case AIMovement::Type::ChangeStance:
 			return format("Change Stance");
 		case AIMovement::Type::Patrol:
-			return format("Move to %s", targetLocation);
+			return format("Move to {}", targetLocation);
 		case AIMovement::Type::Advance:
-			return format("Advance on target to %s", targetLocation);
+			return format("Advance on target to {}", targetLocation);
 		case AIMovement::Type::Pursue:
-			return format("Pursue target to %s", targetLocation);
+			return format("Pursue target to {}", targetLocation);
 		case AIMovement::Type::GetInRange:
-			return format("Get in range, moving to %s", targetLocation);
+			return format("Get in range, moving to {}", targetLocation);
 		case AIMovement::Type::Retreat:
-			return format("Retreat to %s", targetLocation);
+			return format("Retreat to {}", targetLocation);
 		case AIMovement::Type::TakeCover:
-			return format("Taking cover, moving to %s", targetLocation);
+			return format("Taking cover, moving to {}", targetLocation);
 		case AIMovement::Type::Turn:
-			return format("Turn to %s", targetLocation);
+			return format("Turn to {}", targetLocation);
 	}
-	LogError("Unimplemented getName for AIMovement %d", (int)type);
+	LogError("Unimplemented getName for AIMovement {}", (int)type);
 	return "";
 }
 
@@ -198,7 +198,7 @@ bool AIMovement::isFinished(BattleUnit &u) { return !inProgress(u) && executed; 
 
 UString AIDecision::getName()
 {
-	return format("Action: [%s] Movement: [%s]", action ? action->getName() : "NULL",
+	return format("Action: [{}] Movement: [{}]", action ? action->getName() : "NULL",
 	              movement ? movement->getName() : "NULL");
 }
 

--- a/game/state/battle/ai/tacticalai.cpp
+++ b/game/state/battle/ai/tacticalai.cpp
@@ -15,7 +15,7 @@ const UString TacticalAI::getName()
 		case Type::Vanilla:
 			return "TacticalAIVanilla";
 	}
-	LogError("Unimplemented getName for Tactical AI Type %d", (int)type);
+	LogError("Unimplemented getName for Tactical AI Type {}", (int)type);
 	return "";
 }
 

--- a/game/state/battle/ai/unitai.cpp
+++ b/game/state/battle/ai/unitai.cpp
@@ -28,7 +28,7 @@ const UString UnitAI::getName()
 		case Type::Hardcore:
 			return "UnitAIHardcore";
 	}
-	LogError("Unimplemented getName for Unit AI Type %d", (int)type);
+	LogError("Unimplemented getName for Unit AI Type {}", (int)type);
 	return "";
 }
 

--- a/game/state/battle/ai/unitailowmorale.cpp
+++ b/game/state/battle/ai/unitailowmorale.cpp
@@ -222,7 +222,7 @@ std::tuple<AIDecision, bool> UnitAILowMorale::think(GameState &state, BattleUnit
 				return std::make_tuple(decision, true);
 			}
 			default:
-				LogError("Unsupported LowMorale AI type %d", (int)u.getAIType());
+				LogError("Unsupported LowMorale AI type {}", (int)u.getAIType());
 				break;
 		}
 	}

--- a/game/state/battle/ai/unitaivanilla.cpp
+++ b/game/state/battle/ai/unitaivanilla.cpp
@@ -91,7 +91,7 @@ UnitAIVanilla::getWeaponDecision(GameState &state, BattleUnit &u, sp<AEquipment>
                                  StateRef<BattleUnit> target)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: getWeaponDecision()", u.id);
+	LogWarning("VANILLA AI {}: getWeaponDecision()", u.id);
 #endif
 	auto action = mksp<AIAction>();
 	action->item = e;
@@ -163,7 +163,7 @@ UnitAIVanilla::getPsiDecision(GameState &state, BattleUnit &u, sp<AEquipment> e,
                               StateRef<BattleUnit> target, PsiStatus status)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: getPsiDecision()", u.id);
+	LogWarning("VANILLA AI {}: getPsiDecision()", u.id);
 #endif
 	std::ignore = state;
 
@@ -195,7 +195,7 @@ UnitAIVanilla::getPsiDecision(GameState &state, BattleUnit &u, sp<AEquipment> e,
 			priority *= 16.0f;
 			break;
 		default:
-			LogError("Invalid psi attack state for getPsiDecision %d", (int)status);
+			LogError("Invalid psi attack state for getPsiDecision {}", (int)status);
 			return NULLTUPLE3;
 	}
 	action->psiEnergySnapshot = u.agent->modified_stats.psi_energy;
@@ -217,7 +217,7 @@ UnitAIVanilla::getGrenadeDecision(GameState &state, BattleUnit &u, sp<AEquipment
                                   StateRef<BattleUnit> target)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: getGrenadeDecision()", u.id);
+	LogWarning("VANILLA AI {}: getGrenadeDecision()", u.id);
 #endif
 	auto action = mksp<AIAction>();
 	action->item = e;
@@ -304,7 +304,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::getBrainsuckerDecision(Ga
                                                                               BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: getBrainsuckerDecision()", u.id);
+	LogWarning("VANILLA AI {}: getBrainsuckerDecision()", u.id);
 #endif
 	auto action = mksp<AIAction>();
 	action->type = AIAction::Type::AttackBrainsucker;
@@ -359,7 +359,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::getSuicideDecision(GameSt
                                                                           BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: getSuicideDecision()", u.id);
+	LogWarning("VANILLA AI {}: getSuicideDecision()", u.id);
 #endif
 	std::tuple<AIDecision, float, unsigned> decision = NULLTUPLE3;
 
@@ -408,7 +408,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::getAttackDecision(GameSta
                                                                          BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s getAttackDecision()", u.id);
+	LogWarning("VANILLA AI {} getAttackDecision()", u.id);
 #endif
 	std::tuple<AIDecision, float, unsigned> decision = NULLTUPLE3;
 
@@ -577,7 +577,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::getAttackDecision(GameSta
 std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkGreen(GameState &state, BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: thinkGreen()", u.id);
+	LogWarning("VANILLA AI {}: thinkGreen()", u.id);
 #endif
 
 	bool isMoving = lastDecision.movement && u.isMoving();
@@ -596,7 +596,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkGreen(GameState &sta
 	if (isUnderAttack)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: getTakeCoverMovement()", u.id);
+		LogWarning("VANILLA AI {}: getTakeCoverMovement()", u.id);
 #endif
 		auto takeCover = UnitAIHelper::getTakeCoverMovement(state, u);
 		if (takeCover)
@@ -608,7 +608,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkGreen(GameState &sta
 	if (wasEnemyVisible)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: getPursueMovement()", u.id);
+		LogWarning("VANILLA AI {}: getPursueMovement()", u.id);
 #endif
 		auto pursue = UnitAIHelper::getPursueMovement(state, u, flagLastSeenPosition);
 		if (pursue)
@@ -627,7 +627,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkGreen(GameState &sta
 		if (u.missions.empty() || u.missions.front()->type != BattleUnitMission::Type::Turn)
 		{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-			LogWarning("VANILLA AI %s: getTurnMovement()", u.id);
+			LogWarning("VANILLA AI {}: getTurnMovement()", u.id);
 #endif
 			auto turn = UnitAIHelper::getTurnMovement(state, u, flagLastAttackerPosition);
 			return std::make_tuple(AIDecision(nullptr, turn), 0.0f, 0);
@@ -635,7 +635,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkGreen(GameState &sta
 	}
 
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: getFallbackMovement()", u.id);
+	LogWarning("VANILLA AI {}: getFallbackMovement()", u.id);
 #endif
 
 	auto fallback = UnitAIHelper::getFallbackMovement(state, u);
@@ -651,7 +651,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkGreen(GameState &sta
 std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkRed(GameState &state, BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLAAI %s: thinkRed()", u.id);
+	LogWarning("VANILLAAI {}: thinkRed()", u.id);
 #endif
 	bool isUnderAttack = flagLastAttackerPosition != NONE;
 	bool isInterrupted =
@@ -660,7 +660,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkRed(GameState &state
 	if (isUnderAttack)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: getFallbackMovement()", u.id);
+		LogWarning("VANILLA AI {}: getFallbackMovement()", u.id);
 #endif
 		auto fallback = UnitAIHelper::getFallbackMovement(state, u);
 		if (fallback)
@@ -669,7 +669,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkRed(GameState &state
 		}
 
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: getTakeCoverMovement()", u.id);
+		LogWarning("VANILLA AI {}: getTakeCoverMovement()", u.id);
 #endif
 		auto takeCover = UnitAIHelper::getTakeCoverMovement(state, u);
 		if (takeCover)
@@ -678,7 +678,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkRed(GameState &state
 		}
 
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: getKneelMovement()", u.id);
+		LogWarning("VANILLA AI {}: getKneelMovement()", u.id);
 #endif
 		auto kneel = UnitAIHelper::getKneelMovement(state, u);
 		if (kneel)
@@ -698,7 +698,7 @@ std::tuple<AIDecision, float, unsigned> UnitAIVanilla::thinkRed(GameState &state
 AIDecision UnitAIVanilla::thinkInternal(GameState &state, BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: thinkInternal()", u.id);
+	LogWarning("VANILLA AI {}: thinkInternal()", u.id);
 #endif
 	switch (u.getAIType())
 	{
@@ -756,7 +756,7 @@ AIDecision UnitAIVanilla::thinkInternal(GameState &state, BattleUnit &u)
 	if (!u.missions.empty() && u.missions.front()->type == BattleUnitMission::Type::ThrowItem)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: RETHINK PRENVENTED", u.id);
+		LogWarning("VANILLA AI {}: RETHINK PRENVENTED", u.id);
 #endif
 		return {};
 	}
@@ -789,7 +789,7 @@ AIDecision UnitAIVanilla::thinkInternal(GameState &state, BattleUnit &u)
 	if (!reThink)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: RETHINK DENIED", u.id);
+		LogWarning("VANILLA AI {}: RETHINK DENIED", u.id);
 #endif
 		return lastDecision;
 	}
@@ -803,12 +803,12 @@ AIDecision UnitAIVanilla::thinkInternal(GameState &state, BattleUnit &u)
 	if (decision.isEmpty())
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: RETHINK EMPTY", u.id);
+		LogWarning("VANILLA AI {}: RETHINK EMPTY", u.id);
 #endif
 		return {};
 	}
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: RETHINK SUCCESS", u.id);
+	LogWarning("VANILLA AI {}: RETHINK SUCCESS", u.id);
 #endif
 
 	ticksLastThink = state.gameTime.getTicks();
@@ -828,7 +828,7 @@ std::tuple<AIDecision, bool> UnitAIVanilla::think(GameState &state, BattleUnit &
 	}
 
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: think()", u.id);
+	LogWarning("VANILLA AI {}: think()", u.id);
 #endif
 
 	raiseFlags(state, u);
@@ -926,26 +926,26 @@ void UnitAIVanilla::routine(GameState &state, BattleUnit &u)
 void UnitAIVanilla::raiseFlags(GameState &state [[maybe_unused]], BattleUnit &u)
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: raiseFlags()", u.id);
+	LogWarning("VANILLA AI {}: raiseFlags()", u.id);
 #endif
 	if (!u.visibleEnemies.empty() && !enemySpottedPrevious)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: RAISED ENEMY SPOTTED", u.id);
+		LogWarning("VANILLA AI {}: RAISED ENEMY SPOTTED", u.id);
 #endif
 		flagEnemySpotted = enemySpotted;
 	}
 	if (lastSeenEnemyPosition != NONE)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: RAISED LAST SEEN", u.id);
+		LogWarning("VANILLA AI {}: RAISED LAST SEEN", u.id);
 #endif
 		flagLastSeenPosition = lastSeenEnemyPosition;
 	}
 	if (attackerPosition != NONE)
 	{
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-		LogWarning("VANILLA AI %s: RAISED LAST ATTACKER", u.id);
+		LogWarning("VANILLA AI {}: RAISED LAST ATTACKER", u.id);
 #endif
 		flagLastAttackerPosition = attackerPosition;
 	}
@@ -954,7 +954,7 @@ void UnitAIVanilla::raiseFlags(GameState &state [[maybe_unused]], BattleUnit &u)
 void UnitAIVanilla::clearFlags(GameState &state [[maybe_unused]], BattleUnit &u [[maybe_unused]])
 {
 #ifdef VANILLA_AI_DEBUG_OUTPUT
-	LogWarning("VANILLA AI %s: clearFlags()", u.id);
+	LogWarning("VANILLA AI {}: clearFlags()", u.id);
 #endif
 	flagEnemySpotted = false;
 	flagLastSeenPosition = NONE;

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -350,7 +350,7 @@ bool Battle::initialMapCheck(GameState &state, std::list<StateRef<Agent>> agents
 			{
 				continue;
 			}
-			LogWarning("Los block center %s visible from %s", ePos, sPos);
+			LogWarning("Los block center {} visible from {}", ePos, sPos);
 			enemySpawn->low_priority = true;
 		}
 	}
@@ -448,7 +448,7 @@ void Battle::initialMapPartRemoval(GameState &state)
 					}
 					for (auto &p : partsToKill)
 					{
-						LogWarning("Removing MP %s at %s as it's blocking unit %s",
+						LogWarning("Removing MP {} at {} as it's blocking unit {}",
 						           p->getOwner()->type.id, p->getPosition(), u.first);
 						auto mp = p->getOwner();
 						mp->destroyed = true;
@@ -510,7 +510,7 @@ void Battle::initialMapPartLinkUp()
 		if (mp->willCollapse())
 		{
 			auto pos = mp->tileObject->getOwningTile()->position;
-			LogWarning("MP %s SBT %d at %s is UNLINKED", mp->type.id,
+			LogWarning("MP {} SBT {} at {} is UNLINKED", mp->type.id,
 			           (int)mp->type->getVanillaSupportedById(), pos);
 		}
 	}
@@ -545,7 +545,7 @@ void Battle::initialMapPartLinkUp()
 		if (mp->willCollapse())
 		{
 			auto pos = mp->tileObject->getOwningTile()->position;
-			LogWarning("MP %s SBT %d at %s is going to fall", mp->type.id,
+			LogWarning("MP {} SBT {} at {} is going to fall", mp->type.id,
 			           (int)mp->type->getVanillaSupportedById(), pos);
 		}
 	}
@@ -2418,7 +2418,7 @@ void Battle::giveInterruptChanceToUnit(GameState &state, StateRef<BattleUnit> gi
 		}
 		else
 		{
-			LogWarning("Interrupting AI %s for unit %s decided to %s", decision.ai, receiver->id,
+			LogWarning("Interrupting AI {} for unit {} decided to {}", decision.ai, receiver->id,
 			           decision.getName());
 			receiver->aiList.reset(state, *receiver);
 			if (interruptQueue.empty())
@@ -3591,16 +3591,16 @@ void Battle::loadImagePacks(GameState &state)
 		if (imagePackName.length() == 0)
 			continue;
 		auto imagePackPath = BattleUnitImagePack::getImagePackPath() + "/" + imagePackName;
-		LogInfo("Loading image pack \"%s\" from \"%s\"", imagePackName, imagePackPath);
+		LogInfo("Loading image pack \"{}\" from \"{}\"", imagePackName, imagePackPath);
 		auto imagePack = mksp<BattleUnitImagePack>();
 		if (!imagePack->loadImagePack(state, imagePackPath))
 		{
-			LogError("Failed to load image pack \"%s\" from \"%s\"", imagePackName, imagePackPath);
+			LogError("Failed to load image pack \"{}\" from \"{}\"", imagePackName, imagePackPath);
 			continue;
 		}
-		state.battle_unit_image_packs[format("%s%s", BattleUnitImagePack::getPrefix(),
+		state.battle_unit_image_packs[format("{}{}", BattleUnitImagePack::getPrefix(),
 		                                     imagePackName)] = imagePack;
-		LogInfo("Loaded image pack \"%s\" from \"%s\"", imagePackName, imagePackPath);
+		LogInfo("Loaded image pack \"{}\" from \"{}\"", imagePackName, imagePackPath);
 	}
 }
 
@@ -3694,17 +3694,17 @@ void Battle::loadAnimationPacks(GameState &state)
 	{
 		auto animationPackPath =
 		    BattleUnitAnimationPack::getAnimationPackPath() + "/" + animationPackName;
-		LogInfo("Loading animation pack \"%s\" from \"%s\"", animationPackName, animationPackPath);
+		LogInfo("Loading animation pack \"{}\" from \"{}\"", animationPackName, animationPackPath);
 		auto animationPack = mksp<BattleUnitAnimationPack>();
 		if (!animationPack->loadAnimationPack(state, animationPackPath))
 		{
-			LogError("Failed to load animation pack \"%s\" from \"%s\"", animationPackName,
+			LogError("Failed to load animation pack \"{}\" from \"{}\"", animationPackName,
 			         animationPackPath);
 			continue;
 		}
-		state.battle_unit_animation_packs[format("%s%s", BattleUnitAnimationPack::getPrefix(),
+		state.battle_unit_animation_packs[format("{}{}", BattleUnitAnimationPack::getPrefix(),
 		                                         animationPackName)] = animationPack;
-		LogInfo("Loaded animation pack \"%s\" from \"%s\"", animationPackName, animationPackPath);
+		LogInfo("Loaded animation pack \"{}\" from \"{}\"", animationPackName, animationPackPath);
 	}
 }
 

--- a/game/state/battle/battledoor.cpp
+++ b/game/state/battle/battledoor.cpp
@@ -19,7 +19,7 @@ template <> sp<BattleDoor> StateObject<BattleDoor>::get(const GameState &state, 
 	auto it = state.current_battle->doors.find(id);
 	if (it == state.current_battle->doors.end())
 	{
-		LogError("No agent_type matching ID \"%s\"", id);
+		LogError("No agent_type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -44,7 +44,7 @@ const UString &StateObject<BattleDoor>::getId(const GameState &state, const sp<B
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleDoor matching pointer %p", ptr.get());
+	LogError("No BattleDoor matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/battle/battledoor.cpp
+++ b/game/state/battle/battledoor.cpp
@@ -44,7 +44,7 @@ const UString &StateObject<BattleDoor>::getId(const GameState &state, const sp<B
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleDoor matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No BattleDoor matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/battle/battleexplosion.cpp
+++ b/game/state/battle/battleexplosion.cpp
@@ -320,7 +320,7 @@ void BattleExplosion::expand(GameState &state, const TileMap &map, const Vec3<in
 				}
 			}
 			doodadType = {&state,
-			              format("DOODAD_BATTLE_EXPLOSION_%d%d", velocity.x + 1, velocity.y + 1)};
+			              format("DOODAD_BATTLE_EXPLOSION_{}{}", velocity.x + 1, velocity.y + 1)};
 		}
 		Vec3<float> doodadPos = to;
 		doodadPos += Vec3<float>{0.5f, 0.5f, 0.5f};

--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -247,7 +247,7 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 				               std::min(newPosition.z, previousPosition.z)};
 				break;
 			default:
-				LogError("What the hell is this item colliding with? Type is %d",
+				LogError("What the hell is this item colliding with? Type is {}",
 				         (int)c.obj->getType());
 				break;
 		}
@@ -278,7 +278,7 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 		// Fell below 0???
 		if (newPosition.z < 0)
 		{
-			LogError("Item at %f %f fell off the end of the world!?", newPosition.x, newPosition.y);
+			LogError("Item at {} {} fell off the end of the world!?", newPosition.x, newPosition.y);
 			die(state, false);
 			return;
 		}

--- a/game/state/battle/battlemappart.cpp
+++ b/game/state/battle/battlemappart.cpp
@@ -884,7 +884,7 @@ bool BattleMapPart::findSupport(bool allowClinging)
 				}
 				if (!mp)
 				{
-					LogError("Map part disappeared? %d %d %d", x, y, z);
+					LogError("Map part disappeared? {} {} {}", x, y, z);
 					return false;
 				}
 				mp->supportedParts.emplace_back(position, type->type);
@@ -963,7 +963,7 @@ bool BattleMapPart::findSupport(bool allowClinging)
 				}
 				if (!mp)
 				{
-					LogError("Map part disappeared? %d %d %d", x, y, z);
+					LogError("Map part disappeared? {} {} {}", x, y, z);
 					return false;
 				}
 				mp->supportedParts.emplace_back(position, type->type);

--- a/game/state/battle/battlescanner.cpp
+++ b/game/state/battle/battlescanner.cpp
@@ -28,7 +28,7 @@ sp<BattleScanner> StateObject<BattleScanner>::get(const GameState &state, const 
 	auto it = state.current_battle->scanners.find(id);
 	if (it == state.current_battle->scanners.end())
 	{
-		LogError("No scanner type matching ID \"%s\"", id);
+		LogError("No scanner type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -52,7 +52,7 @@ template <> sp<BattleUnit> StateObject<BattleUnit>::get(const GameState &state, 
 	auto it = state.current_battle->units.find(id);
 	if (it == state.current_battle->units.end())
 	{
-		LogError("No agent_type matching ID \"%s\"", id);
+		LogError("No agent_type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -77,7 +77,7 @@ const UString &StateObject<BattleUnit>::getId(const GameState &state, const sp<B
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No battleUnit matching pointer %p", ptr.get());
+	LogError("No battleUnit matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -1057,7 +1057,7 @@ bool BattleUnit::startAttackPsiInternal(GameState &state, StateRef<BattleUnit> t
 	int roll = randBoundsExclusive(state.rng, 0, 100);
 	experiencePoints.psi_attack++;
 	experiencePoints.psi_energy++;
-	LogWarning("Psi Attack #%d Roll %d Chance %d %s Attacker %s Target %s", (int)status, roll,
+	LogWarning("Psi Attack #{} Roll {} Chance {} {} Attacker {} Target {}", (int)status, roll,
 	           chance, roll < chance ? (UString) "SUCCESS" : (UString) "FAILURE", id, target->id);
 	if (roll >= chance)
 	{
@@ -2403,11 +2403,11 @@ void BattleUnit::updateIdling(GameState &state)
 		// Sanity checks
 		if (goalFacing != facing)
 		{
-			LogError("Unit %s (%s) turning without a mission, wtf?", id, agent->type->id);
+			LogError("Unit {} ({}) turning without a mission, wtf?", id, agent->type->id);
 		}
 		if (target_body_state != current_body_state)
 		{
-			LogError("Unit %s (%s) changing body state without a mission, wtf?", id,
+			LogError("Unit {} ({}) changing body state without a mission, wtf?", id,
 			         agent->type->id);
 		}
 
@@ -2704,7 +2704,7 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 				               std::min(newPosition.z, previousPosition.z)};
 				break;
 			default:
-				LogError("What the hell is this unit colliding with? Type is %d",
+				LogError("What the hell is this unit colliding with? Type is {}",
 				         (int)c.obj->getType());
 				break;
 		}
@@ -2744,7 +2744,7 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 		// Fell below 0???
 		if (newPosition.z < 0)
 		{
-			LogError("Unit at %f %f fell off the end of the world!?", newPosition.x, newPosition.y);
+			LogError("Unit at {} {} fell off the end of the world!?", newPosition.x, newPosition.y);
 			die(state, nullptr, false);
 			destroyed = true;
 			return;
@@ -3670,7 +3670,7 @@ void BattleUnit::updateAI(GameState &state, unsigned int)
 	auto decision = aiList.think(state, *this);
 	if (!decision.isEmpty())
 	{
-		LogWarning("AI %s for unit %s decided to %s", decision.ai, id, decision.getName());
+		LogWarning("AI {} for unit {} decided to {}", decision.ai, id, decision.getName());
 		executeAIDecision(state, decision);
 	}
 }
@@ -4968,7 +4968,7 @@ bool BattleUnit::useItem(GameState &state, sp<AEquipment> item)
 	if (item->ownerAgent != agent || (item->equippedSlotType != EquipmentSlotType::RightHand &&
 	                                  item->equippedSlotType != EquipmentSlotType::LeftHand))
 	{
-		LogError("Unit %s attempting to use item that is not in hand or does not belong to us?",
+		LogError("Unit {} attempting to use item that is not in hand or does not belong to us?",
 		         id);
 		return false;
 	}
@@ -5071,7 +5071,7 @@ void BattleUnit::setBodyState(GameState &state, BodyState bodyState)
 {
 	if (!agent->isBodyStateAllowed(bodyState))
 	{
-		LogError("SetBodyState called on %s (%s) (%s) with bodyState %d", id, agent->name,
+		LogError("SetBodyState called on {} ({}) ({}) with bodyState {}", id, agent->name,
 		         agent->type->id, (int)bodyState);
 		return;
 	}
@@ -5248,7 +5248,7 @@ void BattleUnit::setMovementState(MovementState state)
 		}
 		else
 		{
-			LogError("setMovementState %d incompatible with current body states %d to %d",
+			LogError("setMovementState {} incompatible with current body states {} to {}",
 			         (int)state, (int)current_body_state, (int)target_body_state);
 			return;
 		}
@@ -5458,7 +5458,7 @@ bool BattleUnit::popFinishedMissions(GameState &state)
 	bool popped = false;
 	while (missions.size() > 0 && missions.front()->isFinished(state, *this))
 	{
-		LogWarning("Unit %s mission \"%s\" finished", id, missions.front()->getName());
+		LogWarning("Unit {} mission \"{}\" finished", id, missions.front()->getName());
 		missions.pop_front();
 		popped = true;
 		// We may have retreated as a result of finished mission

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -77,7 +77,7 @@ const UString &StateObject<BattleUnit>::getId(const GameState &state, const sp<B
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No battleUnit matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No battleUnit matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -150,17 +150,17 @@ bool BattleUnitTileHelper::canEnterTile(Tile *from, Tile *to, bool allowJumping,
 	Vec3<int> fromPos = from->position;
 	if (fromPos == toPos)
 	{
-		LogError("FromPos == ToPos %s", toPos);
+		LogError("FromPos == ToPos {}", toPos);
 		return false;
 	}
 	if (!map.tileIsValid(fromPos))
 	{
-		LogError("FromPos %s is not on the map", fromPos);
+		LogError("FromPos {} is not on the map", fromPos);
 		return false;
 	}
 	if (!map.tileIsValid(toPos))
 	{
-		LogError("ToPos %s is not on the map", toPos);
+		LogError("ToPos {} is not on the map", toPos);
 		return false;
 	}
 
@@ -1470,7 +1470,7 @@ bool BattleUnitMission::getNextBodyState(GameState &state, BattleUnit &u, BodySt
 				}
 				else
 				{
-					LogError("Unit %s (%s) (%s) lost capability to attain bodyState %d?", u.id,
+					LogError("Unit {} ({}) ({}) lost capability to attain bodyState {}?", u.id,
 					         u.agent->name, u.agent->type->id, (int)targetBodyState);
 				}
 			}
@@ -1537,7 +1537,7 @@ MovementState BattleUnitMission::getNextMovementState(GameState &, BattleUnit &u
 						break;
 					}
 				default:
-					LogError("Invalid facingDelta %d", facingDelta);
+					LogError("Invalid facingDelta {}", facingDelta);
 					break;
 			}
 			break;
@@ -1763,7 +1763,7 @@ bool BattleUnitMission::isFinishedInternal(GameState &, BattleUnit &u)
 
 void BattleUnitMission::start(GameState &state, BattleUnit &u)
 {
-	LogWarning("Unit %s mission \"%s\" starting", u.id, getName());
+	LogWarning("Unit {} mission \"{}\" starting", u.id, getName());
 
 	switch (this->type)
 	{
@@ -1789,7 +1789,7 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 				}
 				if (item->type->type != AEquipmentType::Type::Teleporter)
 				{
-					LogError("Unit is trying to teleport using non-teleporter item %s!?",
+					LogError("Unit is trying to teleport using non-teleporter item {}!?",
 					         item->type->name);
 					cancelled = true;
 					return;
@@ -1975,7 +1975,7 @@ void BattleUnitMission::setPathTo(GameState &state, BattleUnit &u, Vec3<int> tar
 			// If unit cannot move at all - cancel
 			if (!u.canMove())
 			{
-				LogInfo("Cannot move to %d %d %d, unit has no movement ability", target.x, target.y,
+				LogInfo("Cannot move to {} {} {}, unit has no movement ability", target.x, target.y,
 				        target.z);
 				cancelled = true;
 				return;
@@ -2006,7 +2006,7 @@ void BattleUnitMission::setPathTo(GameState &state, BattleUnit &u, Vec3<int> tar
 							    !targetTile->getUnitIfPresent(true, true, false, u.tileObject,
 							                                  false, u.isLarge()))
 							{
-								LogInfo("Cannot move to %d %d %d, found an adjacent free tile, "
+								LogInfo("Cannot move to {} {} {}, found an adjacent free tile, "
 								        "moving to an adjacent tile",
 								        target.x, target.y, target.z);
 								approachOnly = true;
@@ -2025,7 +2025,7 @@ void BattleUnitMission::setPathTo(GameState &state, BattleUnit &u, Vec3<int> tar
 				}
 				if (!approachOnly)
 				{
-					LogInfo("Cannot move to %d %d %d, impassable", target.x, target.y, target.z);
+					LogInfo("Cannot move to {} {} {}, impassable", target.x, target.y, target.z);
 					cancelled = true;
 					return;
 				}
@@ -2040,7 +2040,7 @@ void BattleUnitMission::setPathTo(GameState &state, BattleUnit &u, Vec3<int> tar
 				target.z--;
 				if (target.z == -1)
 				{
-					LogError("Solid ground missing on level 0? Reached %d %d %d", target.x,
+					LogError("Solid ground missing on level 0? Reached {} {} {}", target.x,
 					         target.y, target.z);
 					cancelled = true;
 					return;
@@ -2066,7 +2066,7 @@ void BattleUnitMission::setPathTo(GameState &state, BattleUnit &u, Vec3<int> tar
 	}
 	else
 	{
-		LogError("Mission %s: Unit without tileobject attempted pathfinding!", getName());
+		LogError("Mission {}: Unit without tileobject attempted pathfinding!", getName());
 		cancelled = true;
 		return;
 	}
@@ -2512,38 +2512,38 @@ UString BattleUnitMission::getName()
 			name = "AcquireTUs";
 			break;
 		case Type::GotoLocation:
-			name = "GotoLocation " + format(" %s", targetLocation);
+			name = "GotoLocation " + format(" {}", targetLocation);
 			break;
 		case Type::Teleport:
-			name = "Teleport to " + format(" %s", targetLocation);
+			name = "Teleport to " + format(" {}", targetLocation);
 			break;
 		case Type::RestartNextMission:
 			name = "Restart next mission";
 			break;
 		case Type::Snooze:
-			name = "Snooze " + format(" for %u ticks", timeToSnooze);
+			name = "Snooze " + format(" for {} ticks", timeToSnooze);
 			break;
 		case Type::ChangeBodyState:
-			name = "ChangeBodyState " + format("%d", (int)this->targetBodyState);
+			name = "ChangeBodyState " + format("{}", (int)this->targetBodyState);
 			break;
 		case Type::ThrowItem:
 			name = "ThrowItem " +
-			       format("%s at %s", item ? item->type->name : "(item is gone)", targetLocation);
+			       format("{} at {}", item ? item->type->name : "(item is gone)", targetLocation);
 			break;
 		case Type::DropItem:
-			name = "DropItem " + format("%s", item ? item->type->name : "(item is gone)");
+			name = "DropItem " + format("{}", item ? item->type->name : "(item is gone)");
 			break;
 		case Type::ReachGoal:
 			name = "ReachGoal";
 			break;
 		case Type::Turn:
-			name = "Turn " + format(" %s", targetFacing);
+			name = "Turn " + format(" {}", targetFacing);
 			break;
 		case Type::Brainsuck:
-			name = "Brainsuck " + format(" %s", targetUnit.id);
+			name = "Brainsuck " + format(" {}", targetUnit.id);
 			break;
 		case Type::Jump:
-			name = "Jump to " + format(" %s", jumpTarget);
+			name = "Jump to " + format(" {}", jumpTarget);
 			break;
 	}
 	return name;

--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -53,12 +53,12 @@ bool AgentTileHelper::canEnterTile(Tile *from, Tile *to, bool, bool &, float &co
 	Vec3<int> toPos = to->position;
 	if (fromPos == toPos)
 	{
-		LogError("FromPos == ToPos %s", toPos);
+		LogError("FromPos == ToPos {}", toPos);
 		return false;
 	}
 	if (!map.tileIsValid(toPos))
 	{
-		LogError("ToPos %s is not on the map", toPos);
+		LogError("ToPos {} is not on the map", toPos);
 		return false;
 	}
 
@@ -484,7 +484,7 @@ void AgentMission::setPathTo(GameState &state [[maybe_unused]], Agent &a, StateR
 	auto key = Vec3<int>{(Vec3<int>)a.position * map.size + b->crewQuarters};
 	if (map.agentPathCache.find(key) != map.agentPathCache.end())
 	{
-		LogWarning("Found cached path from %s to %s, using it", a.position, b->crewQuarters);
+		LogWarning("Found cached path from {} to {}, using it", a.position, b->crewQuarters);
 		path = map.agentPathCache[key];
 	}
 	else
@@ -584,7 +584,7 @@ UString AgentMission::getName()
 			name += " " + this->targetBuilding.id;
 			break;
 		case MissionType::Snooze:
-			name += format(" for %u ticks", this->timeToSnooze);
+			name += format(" for {} ticks", this->timeToSnooze);
 			break;
 		case MissionType::Teleport:
 			name += " " + this->targetBuilding.id;

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -49,7 +49,7 @@ template <> const UString &StateObject<Base>::getId(const GameState &state, cons
 		if (b.second == ptr)
 			return b.first;
 	}
-	LogError("No base matching pointer %p", ptr.get());
+	LogError("No base matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -69,7 +69,7 @@ Base::Base(GameState &state, StateRef<Building> building) : building(building)
 	StateRef<FacilityType> type = {&state, FacilityType::getPrefix() + "ACCESS_LIFT"};
 	if (canBuildFacility(type, building->base_layout->baseLift, true) != BuildError::NoError)
 	{
-		LogError("Building %s has invalid lift location", building->name);
+		LogError("Building {} has invalid lift location", building->name);
 	}
 	else
 	{
@@ -189,7 +189,7 @@ static bool randomlyPlaceFacility(GameState &state, Base &base, StateRef<Facilit
 	}
 	else
 	{
-		LogError("Position %s in base in possible list but failed to build", position);
+		LogError("Position {} in base in possible list but failed to build", position);
 		return false;
 	}
 }

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -25,7 +25,7 @@ template <> sp<Base> StateObject<Base>::get(const GameState &state, const UStrin
 	auto it = state.player_bases.find(id);
 	if (it == state.player_bases.end())
 	{
-		LogError("No baseas matching ID \"%s\"", id);
+		LogError("No baseas matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -23,7 +23,7 @@ sp<BuildingFunction> StateObject<BuildingFunction>::get(const GameState &state, 
 	auto it = state.building_functions.find(id);
 	if (it == state.building_functions.end())
 	{
-		LogError("No building_function matching ID \"%s\"", id);
+		LogError("No building_function matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -49,7 +49,7 @@ template <> sp<Building> StateObject<Building>::get(const GameState &state, cons
 			return it->second;
 	}
 
-	LogError("No building type matching ID \"%s\"", id);
+	LogError("No building type matching ID \"{}\"", id);
 	return nullptr;
 }
 
@@ -76,7 +76,7 @@ const UString &StateObject<Building>::getId(const GameState &state, const sp<Bui
 				return b.first;
 		}
 	}
-	LogError("No building matching pointer %p", ptr.get());
+	LogError("No building matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -234,7 +234,7 @@ void Building::updateCargo(GameState &state)
 				}
 				if (ferries.empty())
 				{
-					LogError("There is no ferry type for cargo with bio = %s in the game!?",
+					LogError("There is no ferry type for cargo with bio = {} in the game!?",
 					         needBio);
 					return;
 				}
@@ -244,7 +244,7 @@ void Building::updateCargo(GameState &state)
 				v->provideService(state, true);
 				spawnedFerry = true;
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
-				LogWarning("Spawned cargo ferry %s owned by %s at %s", v->type.id, ferryCompany.id,
+				LogWarning("Spawned cargo ferry {} owned by {} at {}", v->type.id, ferryCompany.id,
 				           thisRef.id);
 #endif
 				break;
@@ -293,7 +293,7 @@ void Building::updateCargo(GameState &state)
 				v->provideService(state, true);
 				spawnedFerry = true;
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
-				LogWarning("Spawned passenger ferry %s owned by %s at %s", v->type.id,
+				LogWarning("Spawned passenger ferry {} owned by {} at {}", v->type.id,
 				           ferryCompany.id, thisRef.id);
 #endif
 				break;
@@ -332,7 +332,7 @@ void Building::updateCargo(GameState &state)
 		if (c.type == Cargo::Type::Bio)
 		{
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
-			LogWarning("BIOCARGO: %s needs to deliver %d to %s", thisRef.id,
+			LogWarning("BIOCARGO: {} needs to deliver {} to {}", thisRef.id,
 			           c.count * c.space / c.divisor, c.destination.id);
 #endif
 			spaceNeeded[c.destination][sourceOrg][0] += std::max(1, c.count * c.space / c.divisor);
@@ -340,7 +340,7 @@ void Building::updateCargo(GameState &state)
 		else
 		{
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
-			LogWarning("CARGO: %s needs to deliver %d to %s", thisRef.id,
+			LogWarning("CARGO: {} needs to deliver {} to {}", thisRef.id,
 			           c.count * c.space / c.divisor, c.destination.id);
 #endif
 			spaceNeeded[c.destination][sourceOrg][1] += std::max(1, c.count * c.space / c.divisor);
@@ -358,7 +358,7 @@ void Building::updateCargo(GameState &state)
 			continue;
 		}
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
-		LogWarning("AGENT: %s needs to deliver to %s", thisRef.id,
+		LogWarning("AGENT: {} needs to deliver to {}", thisRef.id,
 		           a->missions.front()->targetBuilding.id);
 #endif
 		spaceNeeded[a->missions.front()->targetBuilding][a->owner].resize(3);
@@ -582,7 +582,7 @@ void Building::updateCargo(GameState &state)
 					{
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
 						LogWarning(
-						    "Ordered ferry %s name %s in %s type %s owned by %s bound for %s",
+						    "Ordered ferry {} name {} in {} type {} owned by {} bound for {}",
 						    DEBUG_CARGO && DEBUG_PASS ? "CA" : (DEBUG_CARGO ? "C" : "A"), v.first,
 						    !v.second->currentBuilding ? "" : v.second->currentBuilding.id,
 						    v.second->type.id, v.second->owner.id, bld.first.id);

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -76,7 +76,7 @@ const UString &StateObject<Building>::getId(const GameState &state, const sp<Bui
 				return b.first;
 		}
 	}
-	LogError("No building matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No building matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -769,7 +769,7 @@ template <> const UString &StateObject<City>::getId(const GameState &state, cons
 			return c.first;
 		}
 	}
-	LogError("No city matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No city matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -102,7 +102,7 @@ void City::initMap(GameState &state)
 		{
 			if (s->building->carEntranceLocation.x != -1)
 			{
-				LogWarning("Building has multiple car entrances? %s", s->building->name);
+				LogWarning("Building has multiple car entrances? {}", s->building->name);
 			}
 			s->building->carEntranceLocation = s->initialPosition;
 			// crew quarters is the closest to camera spot with vehicle access
@@ -121,22 +121,22 @@ void City::initMap(GameState &state)
 	{
 		if (b.second->landingPadLocations.empty())
 		{
-			LogError("Building %s has no landing pads", b.first);
+			LogError("Building {} has no landing pads", b.first);
 		}
-		LogInfo("Building %s has %u landing pads:", b.first,
+		LogInfo("Building {} has {} landing pads:", b.first,
 		        (unsigned)b.second->landingPadLocations.size());
 		for (auto &loc : b.second->landingPadLocations)
 		{
-			LogInfo("Pad: %s", loc);
+			LogInfo("Pad: {}", loc);
 		}
-		LogInfo("Car: %s", b.second->carEntranceLocation);
+		LogInfo("Car: {}", b.second->carEntranceLocation);
 		if (b.second->crewQuarters == Vec3<int>{-1, -1, -1})
 		{
-			LogWarning("Building %s has no car exit?", b.first);
+			LogWarning("Building {} has no car exit?", b.first);
 			b.second->crewQuarters = {(b.second->bounds.p0.x + b.second->bounds.p1.x) / 2,
 			                          (b.second->bounds.p0.y + b.second->bounds.p1.y) / 2, 2};
 		}
-		LogInfo("Crew Quarters: %s", b.second->crewQuarters);
+		LogInfo("Crew Quarters: {}", b.second->crewQuarters);
 		if (b.second->function.id == "BUILDINGFUNCTION_SPACE_PORT")
 		{
 			spaceports.emplace_back(&state, b.first);
@@ -625,7 +625,7 @@ void City::initialSceneryLinkUp()
 		if (mp->willCollapse())
 		{
 			auto pos = mp->tileObject->getOwningTile()->position;
-			LogWarning("SC %s at %s is UNLINKED", mp->type.id, pos);
+			LogWarning("SC {} at {} is UNLINKED", mp->type.id, pos);
 		}
 	}
 
@@ -653,7 +653,7 @@ void City::initialSceneryLinkUp()
 		if (mp->willCollapse())
 		{
 			auto pos = mp->tileObject->getOwningTile()->position;
-			LogWarning("SC %s at %s is going to fall", mp->type.id, pos);
+			LogWarning("SC {} at {} is going to fall", mp->type.id, pos);
 		}
 	}
 
@@ -674,7 +674,7 @@ sp<Vehicle> City::createVehicle(GameState &state, StateRef<VehicleType> type,
 {
 	auto v = mksp<Vehicle>();
 	v->type = type;
-	v->name = format("%s %d", type->name, ++type->numCreated);
+	v->name = format("{} {}", type->name, ++type->numCreated);
 	v->city = {&state, id};
 	v->owner = owner;
 	v->health = type->health;
@@ -742,7 +742,7 @@ template <> sp<City> StateObject<City>::get(const GameState &state, const UStrin
 	auto it = state.cities.find(id);
 	if (it == state.cities.end())
 	{
-		LogError("No citymap matching ID \"%s\"", id);
+		LogError("No citymap matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -769,7 +769,7 @@ template <> const UString &StateObject<City>::getId(const GameState &state, cons
 			return c.first;
 		}
 	}
-	LogError("No city matching pointer %p", ptr.get());
+	LogError("No city matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/research.cpp
+++ b/game/state/city/research.cpp
@@ -182,7 +182,7 @@ const UString &StateObject<ResearchTopic>::getId(const GameState &state,
 		if (r.second == ptr)
 			return r.first;
 	}
-	LogError("No research matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No research matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 
@@ -216,7 +216,7 @@ template <> const UString &StateObject<Lab>::getId(const GameState &state, const
 		if (l.second == ptr)
 			return l.first;
 	}
-	LogError("No lab matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No lab matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/research.cpp
+++ b/game/state/city/research.cpp
@@ -156,7 +156,7 @@ sp<ResearchTopic> StateObject<ResearchTopic>::get(const GameState &state, const 
 	auto it = state.research.topics.find(id);
 	if (it == state.research.topics.end())
 	{
-		LogError("No research topic matching ID \"%s\"", id);
+		LogError("No research topic matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -182,7 +182,7 @@ const UString &StateObject<ResearchTopic>::getId(const GameState &state,
 		if (r.second == ptr)
 			return r.first;
 	}
-	LogError("No research matching pointer %p", ptr.get());
+	LogError("No research matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -191,7 +191,7 @@ template <> sp<Lab> StateObject<Lab>::get(const GameState &state, const UString 
 	auto it = state.research.labs.find(id);
 	if (it == state.research.labs.end())
 	{
-		LogError("No lab matching ID \"%s\"", id);
+		LogError("No lab matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -216,7 +216,7 @@ template <> const UString &StateObject<Lab>::getId(const GameState &state, const
 		if (l.second == ptr)
 			return l.first;
 	}
-	LogError("No lab matching pointer %p", ptr.get());
+	LogError("No lab matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -855,7 +855,7 @@ bool Scenery::findSupport(bool allowClinging)
 								}
 								if (!mp)
 								{
-									LogError("Map part disappeared? %d %d %d", x, y, z);
+									LogError("Map part disappeared? {} {} {}", x, y, z);
 									return false;
 								}
 							}
@@ -912,7 +912,7 @@ bool Scenery::findSupport(bool allowClinging)
 								}
 								if (!mp)
 								{
-									LogError("Map part disappeared? %d %d %d", x, y, z);
+									LogError("Map part disappeared? {} {} {}", x, y, z);
 									return false;
 								}
 							}
@@ -1060,7 +1060,7 @@ bool Scenery::findSupport(bool allowClinging)
 					}
 					if (!mp)
 					{
-						LogError("Map part disappeared? %d %d %d", x, y, z);
+						LogError("Map part disappeared? {} {} {}", x, y, z);
 						return false;
 					}
 					mp->supportedParts.insert(lastMp->currentPosition);
@@ -1144,7 +1144,7 @@ UString Scenery::getId() const { return type.id; }
 
 int Scenery::getType() const { return (int)0; }
 
-UString Scenery::getSupportString() const { return format("%d", supportHardness); }
+UString Scenery::getSupportString() const { return format("{}", supportHardness); }
 
 void Scenery::setPosition(const Vec3<float> &pos)
 {
@@ -1427,11 +1427,11 @@ void Scenery::collapse(GameState &state)
 	if (this->initialPosition.z <= 1)
 	{
 		this->damaged = true;
-		LogWarning("Scenery at %s  type %s can't fall as below 2", currentPosition, type.id);
+		LogWarning("Scenery at {}  type {} can't fall as below 2", currentPosition, type.id);
 	}
 	else
 	{
-		LogWarning("Scenery at %s type %s now falling", currentPosition, type.id);
+		LogWarning("Scenery at {} type {} now falling", currentPosition, type.id);
 		falling = true;
 		// state.current_battle->queueVisionRefresh(position);
 		// state.current_battle->queuePathfindingRefresh(position);

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -87,7 +87,7 @@ const UString &StateObject<Vehicle>::getId(const GameState &state, const sp<Vehi
 		if (v.second == ptr)
 			return v.first;
 	}
-	LogError("No vehicle matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No vehicle matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -87,7 +87,7 @@ const UString &StateObject<Vehicle>::getId(const GameState &state, const sp<Vehi
 		if (v.second == ptr)
 			return v.first;
 	}
-	LogError("No vehicle matching pointer %p", ptr.get());
+	LogError("No vehicle matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -1272,7 +1272,7 @@ void Vehicle::leaveDimensionGate(GameState &state)
 	auto initialPosition = (*portal)->getPosition();
 	auto initialFacing = 0.0f;
 
-	LogInfo("Leaving dimension gate %s", this->name);
+	LogInfo("Leaving dimension gate {}", this->name);
 	LogAssert(this->betweenDimensions == true);
 	if (this->tileObject)
 	{
@@ -1333,7 +1333,7 @@ void Vehicle::enterDimensionGate(GameState &state)
 
 void Vehicle::leaveBuilding(GameState &state, Vec3<float> initialPosition, float initialFacing)
 {
-	LogInfo("Launching %s", this->name);
+	LogInfo("Launching {}", this->name);
 	if (this->tileObject)
 	{
 		LogError("Trying to launch already-launched vehicle");
@@ -3235,12 +3235,12 @@ bool Vehicle::popFinishedMissions(GameState &state)
 		{
 			return false;
 		}
-		LogInfo("Vehicle %s mission \"%s\" finished", name, missions.front()->getName());
+		LogInfo("Vehicle {} mission \"{}\" finished", name, missions.front()->getName());
 		missions.pop_front();
 		popped = true;
 		if (!missions.empty())
 		{
-			LogInfo("Vehicle %s mission \"%s\" starting", name, missions.front()->getName());
+			LogInfo("Vehicle {} mission \"{}\" starting", name, missions.front()->getName());
 			missions.front()->start(state, *this);
 			continue;
 		}
@@ -3274,12 +3274,12 @@ bool Vehicle::getNewGoal(GameState &state, int &turboTiles)
 	} while (popped && !acquired && debug_deadlock_preventor > 0);
 	if (debug_deadlock_preventor <= 0)
 	{
-		LogWarning("Vehicle %s at %s", name, position);
+		LogWarning("Vehicle {} at {}", name, position);
 		for (auto &m : missions)
 		{
-			LogWarning("Mission %s", m->getName());
+			LogWarning("Mission {}", m->getName());
 		}
-		LogError("Vehicle %s deadlocked, please send log to developers. Vehicle will self-destruct "
+		LogError("Vehicle {} deadlocked, please send log to developers. Vehicle will self-destruct "
 		         "now...",
 		         name);
 		die(state);
@@ -3583,7 +3583,7 @@ sp<VEquipment> Vehicle::addEquipment(GameState &state, Vec2<int> pos,
 	// layouts
 	// if (!this->canAddEquipment(pos, type))
 	//{
-	//	LogError("Trying to add \"%s\" at {%d,%d} on vehicle \"%s\" failed", type.id, pos.x,
+	//	LogError("Trying to add \"{}\" at {{},{}} on vehicle \"{}\" failed", type.id, pos.x,
 	//	         pos.y, this->name);
 	//}
 	Vec2<int> slotOrigin;
@@ -3601,7 +3601,7 @@ sp<VEquipment> Vehicle::addEquipment(GameState &state, Vec2<int> pos,
 	// If this was not within a slow fail
 	if (!slotFound)
 	{
-		LogError("Equipping \"%s\" on \"%s\" at %s failed: No valid slot", equipmentType->name,
+		LogError("Equipping \"{}\" on \"{}\" at {} failed: No valid slot", equipmentType->name,
 		         this->name, pos);
 		return nullptr;
 	}
@@ -3614,7 +3614,7 @@ sp<VEquipment> Vehicle::addEquipment(GameState &state, Vec2<int> pos,
 			engine->type = equipmentType;
 			this->equipment.emplace_back(engine);
 			engine->equippedPosition = slotOrigin;
-			LogInfo("Equipped \"%s\" with engine \"%s\"", this->name, equipmentType->name);
+			LogInfo("Equipped \"{}\" with engine \"{}\"", this->name, equipmentType->name);
 			return engine;
 		}
 		case EquipmentSlotType::VehicleWeapon:
@@ -3625,21 +3625,21 @@ sp<VEquipment> Vehicle::addEquipment(GameState &state, Vec2<int> pos,
 			weapon->owner = thisRef;
 			this->equipment.emplace_back(weapon);
 			weapon->equippedPosition = slotOrigin;
-			LogInfo("Equipped \"%s\" with weapon \"%s\"", this->name, equipmentType->name);
+			LogInfo("Equipped \"{}\" with weapon \"{}\"", this->name, equipmentType->name);
 			return weapon;
 		}
 		case EquipmentSlotType::VehicleGeneral:
 		{
 			auto equipment = mksp<VEquipment>();
 			equipment->type = equipmentType;
-			LogInfo("Equipped \"%s\" with general equipment \"%s\"", this->name,
+			LogInfo("Equipped \"{}\" with general equipment \"{}\"", this->name,
 			        equipmentType->name);
 			equipment->equippedPosition = slotOrigin;
 			this->equipment.emplace_back(equipment);
 			return equipment;
 		}
 		default:
-			LogError("Equipment \"%s\" for \"%s\" at pos (%d,%d} has invalid type",
+			LogError("Equipment \"{}\" for \"{}\" at pos ({},{}} has invalid type",
 			         equipmentType->name, this->name, pos.x, pos.y);
 			return nullptr;
 	}
@@ -3695,7 +3695,7 @@ void Vehicle::equipDefaultEquipment(GameState &state)
 {
 	equipment.clear();
 	loot.clear();
-	LogInfo("Equipping \"%s\" with default equipment", this->type->name);
+	LogInfo("Equipping \"{}\" with default equipment", this->type->name);
 	auto alien = owner == state.getAliens();
 	for (auto &pair : this->type->initial_equipment_list)
 	{
@@ -3733,7 +3733,7 @@ template <> sp<Vehicle> StateObject<Vehicle>::get(const GameState &state, const 
 	auto it = state.vehicles.find(id);
 	if (it == state.vehicles.end())
 	{
-		LogError("No vehicle matching ID \"%s\"", id);
+		LogError("No vehicle matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -3972,7 +3972,7 @@ void Cargo::seize(GameState &state, StateRef<Organisation> org [[maybe_unused]])
 	}
 	int worth = cost * count / divisor;
 	// FIXME: Adjust relationship accordingly to seized cargo's worth
-	LogWarning("Adjust relationship accordingly to worth: %d", worth);
+	LogWarning("Adjust relationship accordingly to worth: {}", worth);
 	if (destination->owner == state.getPlayer())
 	{
 		fw().pushEvent(

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -113,12 +113,12 @@ bool FlyingVehicleTileHelper::canEnterTile(Tile *from, Tile *to, bool, bool &, f
 	Vec3<int> toPos = to->position;
 	if (fromPos == toPos)
 	{
-		LogError("FromPos == ToPos %s", toPos);
+		LogError("FromPos == ToPos {}", toPos);
 		return false;
 	}
 	if (!map.tileIsValid(toPos))
 	{
-		LogError("ToPos %s is not on the map", toPos);
+		LogError("ToPos {} is not on the map", toPos);
 		return false;
 	}
 
@@ -887,13 +887,13 @@ VehicleTargetHelper::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 		{
 			break;
 		}
-		LogInfo("Cannot move to %d %d %d, contains scenery that is not a landing pad", target.x,
+		LogInfo("Cannot move to {} {} {}, contains scenery that is not a landing pad", target.x,
 		        target.y, target.z);
 		reachability = Reachability::BlockedByScenery;
 		target.z++;
 		if (target.z >= map.size.z)
 		{
-			LogError("No space in the sky? Reached %d %d %d", target.x, target.y, target.z);
+			LogError("No space in the sky? Reached {} {} {}", target.x, target.y, target.z);
 			return {reachability, false};
 		}
 		targetTile = map.getTile(target);
@@ -970,7 +970,7 @@ VehicleTargetHelper::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 		}
 		if (foundNewTarget)
 		{
-			LogWarning("Target %d,%d,%d was unreachable, found new closest target %d,%d,%d",
+			LogWarning("Target {},{},{} was unreachable, found new closest target {},{},{}",
 			           target.x, target.y, target.z, newTarget.x, newTarget.y, newTarget.z);
 			target = newTarget;
 		}
@@ -1000,13 +1000,13 @@ VehicleTargetHelper::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 		if (!sideStepLocations.empty())
 		{
 			auto newTarget = pickRandom(state.rng, sideStepLocations);
-			LogWarning("Target %s was unreachable, side-stepping to  %s.", target, newTarget);
+			LogWarning("Target {} was unreachable, side-stepping to  {}.", target, newTarget);
 			target = newTarget;
 		}
 	}
 	else
 	{
-		LogError("Unknown value for vehicleAvoidance: %d", static_cast<int>(vehicleAvoidance));
+		LogError("Unknown value for vehicleAvoidance: {}", static_cast<int>(vehicleAvoidance));
 	}
 	return {reachability, true};
 }
@@ -1031,7 +1031,7 @@ VehicleTargetHelper::adjustTargetToClosest(GameState &state, Vehicle &v, Vec3<in
 			}
 			return adjustTargetToClosestFlying(state, v, target, vehicleAvoidance);
 		default:
-			LogError("Vehicle [%s] has unknown type [%s]", v.name, v.type->name);
+			LogError("Vehicle [{}] has unknown type [{}]", v.name, v.type->name);
 	}
 }
 
@@ -1152,7 +1152,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 							angleToTarget = (float)angleToTargetInt * (float)M_PI / 4.0f;
 							if (destFacing != angleToTarget)
 							{
-								LogWarning("Vehicle %s facing target", v.name);
+								LogWarning("Vehicle {} facing target", v.name);
 								destFacing = angleToTarget;
 								return true;
 							}
@@ -1242,7 +1242,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 								angleToTarget = (float)angleToTargetInt * (float)M_PI / 4.0f;
 								if (destFacing != angleToTarget)
 								{
-									LogWarning("Vehicle %s facing target", v.name);
+									LogWarning("Vehicle {} facing target", v.name);
 									destFacing = angleToTarget;
 									return true;
 								}
@@ -1282,7 +1282,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 			if (v.currentBuilding != this->targetBuilding)
 			{
 				auto name = this->getName();
-				LogError("Vehicle mission %s: getNextDestination() shouldn't be called unless "
+				LogError("Vehicle mission {}: getNextDestination() shouldn't be called unless "
 				         "you've reached the target?",
 				         name);
 			}
@@ -1680,14 +1680,14 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					auto exitTile = map.getTile(exitLocation);
 					if (!exitTile)
 					{
-						LogError("Invalid entrance location %s - outside map?", exitLocation.x);
+						LogError("Invalid entrance location {} - outside map?", exitLocation.x);
 						snoozeTicks = TICKS_PER_HOUR / 2;
 						continue;
 					}
 					auto scenery = exitTile->presentScenery;
 					if (!scenery)
 					{
-						LogInfo("Tried exit %s - destroyed", exitLocation);
+						LogInfo("Tried exit {} - destroyed", exitLocation);
 						snoozeTicks = TICKS_PER_HOUR / 2;
 						continue;
 					}
@@ -1711,7 +1711,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					{
 						continue;
 					}
-					LogInfo("Launching vehicle from building \"%s\" at exit %s", b.id,
+					LogInfo("Launching vehicle from building \"{}\" at exit {}", b.id,
 					        exitLocation);
 					Vec3<float> leaveLocation = exitTile->getRestingPosition();
 					float facing = 0.0f;
@@ -1736,7 +1736,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						leaveLocation += Vec3<float>{0.49f, 0.0f, 0.0f};
 					}
 					v.leaveBuilding(state, leaveLocation, facing);
-					LogInfo("Launching vehicle from building \"%s\" at pad %s", b.id,
+					LogInfo("Launching vehicle from building \"{}\" at pad {}", b.id,
 					        leaveLocation);
 					this->currentPlannedPath = {exitLocation, exitLocation};
 					return;
@@ -1758,7 +1758,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					auto tileAbovePad = map.getTile(abovePadLocation);
 					if (!padTile || !tileAbovePad)
 					{
-						LogError("Invalid landing pad location %s - outside map?", padLocation.x);
+						LogError("Invalid landing pad location {} - outside map?", padLocation.x);
 						continue;
 					}
 					FlyingVehicleTileHelper tileHelper(map, v);
@@ -1782,14 +1782,14 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					{
 						continue;
 					}
-					LogInfo("Launching vehicle from building \"%s\" at pad %s", b.id, padLocation);
+					LogInfo("Launching vehicle from building \"{}\" at pad {}", b.id, padLocation);
 					this->currentPlannedPath = {belowPadLocation, belowPadLocation, padLocation,
 					                            abovePadLocation};
 					v.leaveBuilding(state, belowPadLocation);
 					return;
 				}
 			}
-			LogInfo("No free exit in building \"%s\" free - waiting", b.id);
+			LogInfo("No free exit in building \"{}\" free - waiting", b.id);
 			v.addMission(state, snooze(state, v, snoozeTicks));
 			return;
 		}
@@ -1817,7 +1817,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						auto vehiclePosition = vehicleTile->getOwningTile()->position;
 						if (vehiclePosition != targetBuilding->carEntranceLocation)
 						{
-							LogError("Vehicle at %s not inside vehicle entrance for building %s",
+							LogError("Vehicle at {} not inside vehicle entrance for building {}",
 							         vehiclePosition, b.id);
 							return;
 						}
@@ -1832,7 +1832,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						auto vehiclePosition = vehicleTile->getOwningTile()->position;
 						if (vehiclePosition.z < 2)
 						{
-							LogError("Vehicle trying to land off bottom of map %s",
+							LogError("Vehicle trying to land off bottom of map {}",
 							         vehiclePosition);
 							cancelled = true;
 							return;
@@ -1851,8 +1851,8 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						}
 						if (!padFound)
 						{
-							LogError("Vehicle at %s not directly above a landing pad for "
-							         "building %s",
+							LogError("Vehicle at {} not directly above a landing pad for "
+							         "building {}",
 							         vehiclePosition, b.id);
 							cancelled = true;
 							return;
@@ -1877,7 +1877,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				}
 				default:
 				{
-					LogError("Unhandled missionCounter in %s", getName());
+					LogError("Unhandled missionCounter in {}", getName());
 					return;
 				}
 			}
@@ -1901,7 +1901,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			}
 			if (!isFinished(state, v))
 			{
-				LogInfo("Vehicle mission %s: Pathing to %s", getName(), targetLocation);
+				LogInfo("Vehicle mission {}: Pathing to {}", getName(), targetLocation);
 				v.addMission(state, VehicleMission::gotoLocation(state, v, targetLocation,
 				                                                 allowTeleporter, pickNearest));
 			}
@@ -2031,8 +2031,8 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				randomNearbyPos.x = clamp(randomNearbyPos.x, 0, map.size.x - 1);
 				randomNearbyPos.y = clamp(randomNearbyPos.y, 0, map.size.y - 1);
 				randomNearbyPos.z = clamp(randomNearbyPos.z, 0, map.size.z - 1);
-				LogInfo("Vehicle mission %s: Can't find place to land, moving to random location "
-				        "at %s",
+				LogInfo("Vehicle mission {}: Can't find place to land, moving to random location "
+				        "at {}",
 				        getName(), randomNearbyPos);
 				v.addMission(
 				    state, VehicleMission::gotoLocation(state, v, randomNearbyPos, false, true, 1));
@@ -2046,16 +2046,16 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 		case MissionType::AttackVehicle:
 		{
 			auto name = this->getName();
-			LogInfo("Vehicle mission %s checking state", name);
+			LogInfo("Vehicle mission {} checking state", name);
 			if (isFinished(state, v))
 			{
-				LogInfo("Vehicle mission %s became finished", name);
+				LogInfo("Vehicle mission {} became finished", name);
 				return;
 			}
 			auto t = this->targetVehicle;
 			if (v.shared_from_this() == t.getSp())
 			{
-				LogError("Vehicle mission %s: Targeting itself", name);
+				LogError("Vehicle mission {}: Targeting itself", name);
 				return;
 			}
 			auto vehicleTile = v.tileObject;
@@ -2074,7 +2074,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				return;
 			}
 			auto name = this->getName();
-			LogInfo("Vehicle mission %s checking state", name);
+			LogInfo("Vehicle mission {} checking state", name);
 			auto b = this->targetBuilding;
 			if (!b)
 			{
@@ -2083,7 +2083,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			}
 			if (b == v.currentBuilding)
 			{
-				LogInfo("Vehicle mission %s: Already at building", name);
+				LogInfo("Vehicle mission {}: Already at building", name);
 				return;
 			}
 			if (allowTeleporter)
@@ -2109,12 +2109,12 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				auto position = vehicleTile->getOwningTile()->position;
 				if (position == targetBuilding->carEntranceLocation)
 				{
-					LogInfo("Mission %s: Entering depot on entrance %s", name, position);
+					LogInfo("Mission {}: Entering depot on entrance {}", name, position);
 					v.addMission(state, VehicleMission::land(v, b));
 					return;
 				}
 
-				LogInfo("Vehicle mission %s: Pathing to entrance at %s", name,
+				LogInfo("Vehicle mission {}: Pathing to entrance at {}", name,
 				        b->carEntranceLocation);
 				v.addMission(state, VehicleMission::gotoLocation(state, v, b->carEntranceLocation,
 				                                                 allowTeleporter, false, 1));
@@ -2131,7 +2131,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			{
 				/* Am I already above a landing pad? If so land */
 				auto position = vehicleTile->getOwningTile()->position;
-				LogInfo("Vehicle mission %s: at position %s", name, position);
+				LogInfo("Vehicle mission {}: at position {}", name, position);
 				for (auto &padLocation : b->landingPadLocations)
 				{
 					auto padTile = b->city->map->getTile(padLocation);
@@ -2144,7 +2144,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					abovePadLocation.z += 1;
 					if (abovePadLocation == position)
 					{
-						LogInfo("Mission %s: Landing on pad %s", name, padLocation);
+						LogInfo("Mission {}: Landing on pad {}", name, padLocation);
 						v.addMission(state, VehicleMission::land(v, b));
 						return;
 					}
@@ -2212,7 +2212,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				}
 				if (shortestPathCost != FLT_MAX)
 				{
-					LogInfo("Vehicle mission %s: Pathing to pad at %s", name, shortestPathPad);
+					LogInfo("Vehicle mission {}: Pathing to pad at {}", name, shortestPathPad);
 					v.addMission(state, VehicleMission::gotoLocation(state, v, shortestPathPad,
 					                                                 allowTeleporter, false, 1));
 					// If we can't path to building's pad then snooze
@@ -2225,7 +2225,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				}
 				else
 				{
-					LogInfo("Vehicle mission %s: No pads, pathing to random location near building",
+					LogInfo("Vehicle mission {}: No pads, pathing to random location near building",
 					        name);
 					std::uniform_int_distribution<int> xPos(targetBuilding->bounds.p0.x - 2,
 					                                        targetBuilding->bounds.p1.x + 2);
@@ -2415,7 +2415,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				}
 				default:
 				{
-					LogError("Unhandled missionCounter in %s", getName());
+					LogError("Unhandled missionCounter in {}", getName());
 					return;
 				}
 			}
@@ -2506,7 +2506,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						{
 							goodPos.z = glm::min(goodPos.z + 1, map.size.z - 1);
 
-							LogInfo("Vehicle mission %s: Pathing to infiltration spot %s", name,
+							LogInfo("Vehicle mission {}: Pathing to infiltration spot {}", name,
 							        goodPos);
 							v.addMission(state, VehicleMission::gotoLocation(state, v, goodPos,
 							                                                 false, true));
@@ -2519,7 +2519,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						}
 					}
 
-					LogInfo("Vehicle mission %s: Infiltrating from {%f,%f,%f}", name, pos.x, pos.y,
+					LogInfo("Vehicle mission {}: Infiltrating from {{},{},{}}", name, pos.x, pos.y,
 					        pos.z);
 
 					// If arrived to a location above building, deposit aliens or subvert
@@ -2580,7 +2580,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				}
 				default:
 				{
-					LogError("Unhandled missionCounter in %s", getName());
+					LogError("Unhandled missionCounter in {}", getName());
 					return;
 				}
 			}
@@ -2615,7 +2615,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				}
 				default:
 				{
-					LogError("Unhandled missionCounter in %s", getName());
+					LogError("Unhandled missionCounter in {}", getName());
 					return;
 				}
 			}
@@ -2637,7 +2637,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			// No setup
 			return;
 		default:
-			LogError("TODO: Implement start %s", getName());
+			LogError("TODO: Implement start {}", getName());
 			return;
 	}
 }
@@ -2649,7 +2649,7 @@ void VehicleMission::setPathTo(GameState &state, Vehicle &v, Vec3<int> target, i
 	auto vehicleTile = v.tileObject;
 	if (!vehicleTile)
 	{
-		LogError("Mission %s: Take off before pathfinding!", this->getName());
+		LogError("Mission {}: Take off before pathfinding!", this->getName());
 		return;
 	}
 	const auto avoidance =
@@ -3103,12 +3103,12 @@ UString VehicleMission::getName()
 		case MissionType::DepartToSpace:
 		case MissionType::Crash:
 		case MissionType::Teleport:
-			name += format(" %s", this->targetLocation);
+			name += format(" {}", this->targetLocation);
 			break;
 		case MissionType::FollowVehicle:
 		case MissionType::RecoverVehicle:
 		case MissionType::AttackVehicle:
-			name += format(" %s", this->targetVehicle.id);
+			name += format(" {}", this->targetVehicle.id);
 			break;
 		case MissionType::GotoBuilding:
 		case MissionType::AttackBuilding:
@@ -3120,7 +3120,7 @@ UString VehicleMission::getName()
 		case MissionType::ArriveFromDimensionGate:
 		case MissionType::SelfDestruct:
 		case MissionType::Snooze:
-			name += format(" %u ticks", this->timeToSnooze);
+			name += format(" {} ticks", this->timeToSnooze);
 			break;
 		case MissionType::InfiltrateSubvert:
 			name += " " + this->targetBuilding.id + " " + (subvert ? "[Subvert]" : "[Infiltrate]");
@@ -3169,12 +3169,12 @@ bool GroundVehicleTileHelper::canEnterTile(Tile *from, Tile *to, bool, bool &, f
 	Vec3<int> toPos = to->position;
 	if (fromPos == toPos)
 	{
-		LogError("FromPos == ToPos %s", toPos);
+		LogError("FromPos == ToPos {}", toPos);
 		return false;
 	}
 	if (!map.tileIsValid(toPos))
 	{
-		LogError("ToPos %s is not on the map", toPos);
+		LogError("ToPos {} is not on the map", toPos);
 		return false;
 	}
 

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -2519,7 +2519,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						}
 					}
 
-					LogInfo("Vehicle mission {}: Infiltrating from {{},{},{}}", name, pos.x, pos.y,
+					LogInfo("Vehicle mission {}: Infiltrating from {{{},{},{}}}", name, pos.x, pos.y,
 					        pos.z);
 
 					// If arrived to a location above building, deposit aliens or subvert

--- a/game/state/city/vequipment.cpp
+++ b/game/state/city/vequipment.cpp
@@ -57,7 +57,7 @@ bool VEquipment::fire(GameState &state, Vec3<float> targetPosition, Vec3<float> 
 		const auto it = WeaponStateMap.find(this->weaponState);
 		if (it != WeaponStateMap.end())
 			stateName = it->second;
-		LogWarning("Trying to fire weapon in state %s", stateName);
+		LogWarning("Trying to fire weapon in state {}", stateName);
 		return false;
 	}
 	if (this->ammo <= 0 && this->type->max_ammo != 0)
@@ -150,11 +150,11 @@ void VEquipment::noAmmoToReload(const GameState &state [[maybe_unused]],
 	switch (equipment->type->type)
 	{
 		case EquipmentSlotType::VehicleEngine:
-			LogInfo("Failed to refuel engine: %s", owner->name);
+			LogInfo("Failed to refuel engine: {}", owner->name);
 			fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughFuel, owner));
 			break;
 		case EquipmentSlotType::VehicleWeapon:
-			LogInfo("Failed to rearm weapon: %s", owner->name);
+			LogInfo("Failed to rearm weapon: {}", owner->name);
 			fw().pushEvent(new GameVehicleEvent(GameEventType::NotEnoughAmmo, owner));
 			break;
 		case EquipmentSlotType::VehicleGeneral:

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -86,35 +86,35 @@ UString GameVehicleEvent::message()
 		case GameEventType::UfoSpotted:
 			return tr("UFO spotted.");
 		case GameEventType::UfoCrashed:
-			return format("%s %s", tr("UFO crash landed:"), vehicle->name);
+			return format("{} {}", tr("UFO crash landed:"), vehicle->name);
 		case GameEventType::UfoRecoveryUnmanned:
-			return format("%s %s", tr("Unmanned UFO recovered:"), vehicle->name);
+			return format("{} {}", tr("Unmanned UFO recovered:"), vehicle->name);
 		case GameEventType::VehicleRecovered:
-			return format("%s %s", tr("Vehicle successfully recovered:"), vehicle->name);
+			return format("{} {}", tr("Vehicle successfully recovered:"), vehicle->name);
 		case GameEventType::VehicleNoFuel:
-			return format("%s %s", tr("Vehicle out of fuel:"), vehicle->name);
+			return format("{} {}", tr("Vehicle out of fuel:"), vehicle->name);
 		case GameEventType::UfoRecoveryBegin:
 			return "";
 		case GameEventType::VehicleLightDamage:
-			return format("%s %s", tr("Vehicle lightly damaged:"), vehicle->name);
+			return format("{} {}", tr("Vehicle lightly damaged:"), vehicle->name);
 		case GameEventType::VehicleModerateDamage:
-			return format("%s %s", tr("Vehicle moderately damaged:"), vehicle->name);
+			return format("{} {}", tr("Vehicle moderately damaged:"), vehicle->name);
 		case GameEventType::VehicleHeavyDamage:
-			return format("%s %s", tr("Vehicle heavily damaged:"), vehicle->name);
+			return format("{} {}", tr("Vehicle heavily damaged:"), vehicle->name);
 		case GameEventType::VehicleEscaping:
-			return format("%s %s", tr("Vehicle returning to base as damaged:"), vehicle->name);
+			return format("{} {}", tr("Vehicle returning to base as damaged:"), vehicle->name);
 		case GameEventType::VehicleNoAmmo:
-			return format("%s %s", vehicle->name, tr(": Weapon out of ammo:"));
+			return format("{} {}", vehicle->name, tr(": Weapon out of ammo:"));
 		case GameEventType::VehicleLowFuel:
-			return format("%s %s", tr("Vehicle low on fuel:"), vehicle->name);
+			return format("{} {}", tr("Vehicle low on fuel:"), vehicle->name);
 		case GameEventType::VehicleRepaired:
-			return format("%s %s", tr("Vehicle Repaired:"), vehicle->name);
+			return format("{} {}", tr("Vehicle Repaired:"), vehicle->name);
 		case GameEventType::VehicleRearmed:
-			return format("%s %s", tr("Vehicle Rearmed:"), vehicle->name);
+			return format("{} {}", tr("Vehicle Rearmed:"), vehicle->name);
 		case GameEventType::VehicleRefuelled:
-			return format("%s %s", tr("Vehicle Refuelled:"), vehicle->name);
+			return format("{} {}", tr("Vehicle Refuelled:"), vehicle->name);
 		case GameEventType::VehicleNoEngine:
-			return format("%s %s", tr("Vehicle has no engine:"), vehicle->name);
+			return format("{} {}", tr("Vehicle has no engine:"), vehicle->name);
 		case GameEventType::UnauthorizedVehicle:
 			if (vehicle->type->isGround())
 			{
@@ -125,9 +125,9 @@ UString GameVehicleEvent::message()
 				return tr("An illegal flyer has been detected.");
 			}
 		case GameEventType::NotEnoughAmmo:
-			return format("%s %s", tr("Not enough ammo to rearm vehicle:"), vehicle->name);
+			return format("{} {}", tr("Not enough ammo to rearm vehicle:"), vehicle->name);
 		case GameEventType::NotEnoughFuel:
-			return format("%s %s", tr("Not enough fuel to refuel vehicle"), vehicle->name);
+			return format("{} {}", tr("Not enough fuel to refuel vehicle"), vehicle->name);
 		default:
 			LogError("Invalid vehicle event type");
 			break;
@@ -142,55 +142,55 @@ UString GameAgentEvent::message()
 		case GameEventType::AgentArrived:
 			if (flag)
 			{
-				return format("%s %s", tr("New transfer arrived:"), agent->name);
+				return format("{} {}", tr("New transfer arrived:"), agent->name);
 			}
 			else
 			{
-				return format("%s %s", tr("New recruit arrived:"), agent->name);
+				return format("{} {}", tr("New recruit arrived:"), agent->name);
 			}
 		case GameEventType::AgentUnableToReach:
 			return format(
-			    "%s%s", agent->name,
+			    "{}{}", agent->name,
 			    tr(": Unable to reach destination due to damaged people tube network and / or "
 			       "poor diplomatic relations with Transtellar."));
 		case GameEventType::HostileSpotted:
-			return format("%s", tr("Hostile unit spotted"));
+			return format("{}", tr("Hostile unit spotted"));
 		case GameEventType::AgentBrainsucked:
-			return format("%s %s", tr("Unit Brainsucked:"), agent->name);
+			return format("{} {}", tr("Unit Brainsucked:"), agent->name);
 		case GameEventType::AgentDiedBattle:
-			return format("%s %s", tr("Unit has died:"), agent->name);
+			return format("{} {}", tr("Unit has died:"), agent->name);
 		case GameEventType::HostileDied:
-			return format("%s %s", tr("Hostile unit has died"), agent->name);
+			return format("{} {}", tr("Hostile unit has died"), agent->name);
 		case GameEventType::UnknownDied:
-			return format("%s", tr("Unknown Unit has died"));
+			return format("{}", tr("Unknown Unit has died"));
 		case GameEventType::AgentCriticallyWounded:
-			return format("%s: %s", tr("Unit critically wounded"), agent->name);
+			return format("{}: {}", tr("Unit critically wounded"), agent->name);
 		case GameEventType::AgentBadlyInjured:
-			return format("%s %s", tr("Unit badly injured:"), agent->name);
+			return format("{} {}", tr("Unit badly injured:"), agent->name);
 		case GameEventType::AgentInjured:
-			return format("%s %s", tr("Unit injured:"), agent->name);
+			return format("{} {}", tr("Unit injured:"), agent->name);
 		case GameEventType::AgentUnderFire:
-			return format("%s %s", tr("Unit under fire:"), agent->name);
+			return format("{} {}", tr("Unit under fire:"), agent->name);
 		case GameEventType::AgentUnconscious:
-			return format("%s %s", tr("Unit has lost consciousness:"), agent->name);
+			return format("{} {}", tr("Unit has lost consciousness:"), agent->name);
 		case GameEventType::AgentLeftCombat:
-			return format("%s %s", tr("Unit has left combat zone:"), agent->name);
+			return format("{} {}", tr("Unit has left combat zone:"), agent->name);
 		case GameEventType::AgentFrozen:
-			return format("%s %s", tr("Unit has frozen:"), agent->name);
+			return format("{} {}", tr("Unit has frozen:"), agent->name);
 		case GameEventType::AgentBerserk:
-			return format("%s %s", tr("Unit has gone berserk:"), agent->name);
+			return format("{} {}", tr("Unit has gone berserk:"), agent->name);
 		case GameEventType::AgentPanicked:
-			return format("%s %s", tr("Unit has panicked:"), agent->name);
+			return format("{} {}", tr("Unit has panicked:"), agent->name);
 		case GameEventType::AgentPanicOver:
-			return format("%s %s", tr("Unit has stopped panicking:"), agent->name);
+			return format("{} {}", tr("Unit has stopped panicking:"), agent->name);
 		case GameEventType::AgentPsiAttacked:
-			return format("%s %s", tr("Psionic attack on unit:"), agent->name);
+			return format("{} {}", tr("Psionic attack on unit:"), agent->name);
 		case GameEventType::AgentPsiControlled:
-			return format("%s %s", tr("Unit under Psionic control:"), agent->name);
+			return format("{} {}", tr("Unit under Psionic control:"), agent->name);
 		case GameEventType::AgentPsiOver:
-			return format("%s %s", tr("Unit freed from Psionic control:"), agent->name);
+			return format("{} {}", tr("Unit freed from Psionic control:"), agent->name);
 		case GameEventType::NoLOF:
-			return format("%s", tr("No line of fire"));
+			return format("{}", tr("No line of fire"));
 		case GameEventType::AgentPsiProbed:
 			return "";
 		default:
@@ -205,16 +205,16 @@ UString GameBuildingEvent::message()
 	switch (type)
 	{
 		case GameEventType::MissionCompletedBuildingNormal:
-			return format("%s %s", tr("X-COM returning from mission at:"), building->name);
+			return format("{} {}", tr("X-COM returning from mission at:"), building->name);
 		case GameEventType::MissionCompletedBuildingRaid:
-			return format("%s %s", tr("X-COM returning from raid at:"), building->name);
+			return format("{} {}", tr("X-COM returning from raid at:"), building->name);
 		case GameEventType::BuildingAttacked:
-			return format("%s %s %s %s", tr("Building under attack :"), building->name,
+			return format("{} {} {} {}", tr("Building under attack :"), building->name,
 			              tr("Attacked by:"), actor->name);
 		case GameEventType::AlienSpotted:
 			return tr("Live Alien spotted.");
 		case GameEventType::CargoExpiresSoon:
-			return format("%s %s", tr("Cargo expires soon:"), building->name);
+			return format("{} {}", tr("Cargo expires soon:"), building->name);
 		case GameEventType::CommenceInvestigation:
 			return "";
 		default:
@@ -288,7 +288,7 @@ UString GameBattleEvent::message()
 	switch (type)
 	{
 		case GameEventType::NewTurn:
-			return tr("Turn:") + " " + format("%d", battle->currentTurn) + "   " + tr("Side:") +
+			return tr("Turn:") + " " + format("{}", battle->currentTurn) + "   " + tr("Side:") +
 			       "  " + tr(battle->currentActiveOrganisation->name);
 		default:
 			LogError("Invalid battle event type");
@@ -363,7 +363,7 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 	switch (type)
 	{
 		case GameEventType::AgentDiedCity:
-			messageInner = format("%s %s", tr("Agent has died:"), name);
+			messageInner = format("{} {}", tr("Agent has died:"), name);
 			break;
 		case GameEventType::BaseDestroyed:
 			if (actor.length() > 0)
@@ -378,20 +378,20 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 		case GameEventType::VehicleDestroyed:
 			if (actor.length() > 0)
 			{
-				messageInner = format("%s %s %s: %s", tr("Vehicle destroyed:"), name,
+				messageInner = format("{} {} {}: {}", tr("Vehicle destroyed:"), name,
 				                      tr("destroyed by"), actor);
 			}
 			else
 			{
-				messageInner = format("%s %s", tr("Vehicle destroyed:"), name);
+				messageInner = format("{} {}", tr("Vehicle destroyed:"), name);
 			}
 			break;
 		case GameEventType::VehicleRecovered:
 			messageInner =
-			    format("%s %s", tr("Scrapped vehicle recovered in irreparable condition:"), name);
+			    format("{} {}", tr("Scrapped vehicle recovered in irreparable condition:"), name);
 			break;
 		case GameEventType::VehicleNoFuel:
-			messageInner = format("%s %s", tr("Vehicle out of fuel:"), name);
+			messageInner = format("{} {}", tr("Vehicle out of fuel:"), name);
 			break;
 	}
 }

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1367,7 +1367,7 @@ void GameState::loadMods()
 
 		if (!modLoadScript.empty())
 		{
-			LogInfo("Executing modLoad script \"%s\" for mod \"%s\"", modLoadScript,
+			LogInfo("Executing modLoad script \"{}\" for mod \"{}\"", modLoadScript,
 			        modInfo->getID());
 			this->luaGameState.runScript(modLoadScript);
 		}
@@ -1376,11 +1376,11 @@ void GameState::loadMods()
 
 bool GameState::appendGameState(const UString &gamestatePath)
 {
-	LogInfo("Appending gamestate \"%s\"", gamestatePath);
+	LogInfo("Appending gamestate \"{}\"", gamestatePath);
 	auto file = fw().data->fs.open(gamestatePath);
 	if (!file)
 	{
-		LogWarning("Failed to open gamestate file \"%s\"", gamestatePath);
+		LogWarning("Failed to open gamestate file \"{}\"", gamestatePath);
 		return false;
 	}
 	return this->loadGame(file.systemPath());

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -250,7 +250,7 @@ void GameState::validateResearch()
 		{
 			if (t.second->itemId.length() == 0)
 			{
-				LogError("EMPTY REFERENCE resulting item for %s", t.first);
+				LogError("EMPTY REFERENCE resulting item for {}", t.first);
 			}
 			else
 			{
@@ -284,7 +284,7 @@ void GameState::validateResearch()
 				}
 				if (fail)
 				{
-					LogError("%s DOES NOT EXIST: referenced as manufactured by %s",
+					LogError("{} DOES NOT EXIST: referenced as manufactured by {}",
 					         t.second->itemId, t.first);
 				}
 			}
@@ -295,11 +295,11 @@ void GameState::validateResearch()
 			{
 				if (topic.id.length() == 0)
 				{
-					LogError("EMPTY REFERENCE required topic for %s", t.first);
+					LogError("EMPTY REFERENCE required topic for {}", t.first);
 				}
 				else if (research.topics.find(topic.id) == research.topics.end())
 				{
-					LogError("%s DOES NOT EXIST: referenced as required topic for %s", topic.id,
+					LogError("{} DOES NOT EXIST: referenced as required topic for {}", topic.id,
 					         t.first);
 				}
 			}
@@ -308,11 +308,11 @@ void GameState::validateResearch()
 		{
 			if (entry.first.id.length() == 0)
 			{
-				LogError("EMPTY REFERENCE required item for %s", t.first);
+				LogError("EMPTY REFERENCE required item for {}", t.first);
 			}
 			else if (agent_equipment.find(entry.first.id) == agent_equipment.end())
 			{
-				LogError("%s DOES NOT EXIST: referenced as required item for %s", entry.first.id,
+				LogError("{} DOES NOT EXIST: referenced as required item for {}", entry.first.id,
 				         t.first);
 			}
 		}
@@ -320,11 +320,11 @@ void GameState::validateResearch()
 		{
 			if (entry.first.id.length() == 0)
 			{
-				LogError("EMPTY REFERENCE consumed item for %s", t.first);
+				LogError("EMPTY REFERENCE consumed item for {}", t.first);
 			}
 			else if (agent_equipment.find(entry.first.id) == agent_equipment.end())
 			{
-				LogError("%s DOES NOT EXIST: referenced as consumed item for %s", entry.first.id,
+				LogError("{} DOES NOT EXIST: referenced as consumed item for {}", entry.first.id,
 				         t.first);
 			}
 		}
@@ -332,11 +332,11 @@ void GameState::validateResearch()
 		{
 			if (entry.first.id.length() == 0)
 			{
-				LogError("EMPTY REFERENCE required item for %s", t.first);
+				LogError("EMPTY REFERENCE required item for {}", t.first);
 			}
 			else if (vehicle_equipment.find(entry.first.id) == vehicle_equipment.end())
 			{
-				LogError("%s DOES NOT EXIST: referenced as required item for %s", entry.first.id,
+				LogError("{} DOES NOT EXIST: referenced as required item for {}", entry.first.id,
 				         t.first);
 			}
 		}
@@ -344,11 +344,11 @@ void GameState::validateResearch()
 		{
 			if (entry.first.id.length() == 0)
 			{
-				LogError("EMPTY REFERENCE consumed item for %s", t.first);
+				LogError("EMPTY REFERENCE consumed item for {}", t.first);
 			}
 			else if (vehicle_equipment.find(entry.first.id) == vehicle_equipment.end())
 			{
-				LogError("%s DOES NOT EXIST: referenced as consumed item for %s", entry.first.id,
+				LogError("{} DOES NOT EXIST: referenced as consumed item for {}", entry.first.id,
 				         t.first);
 			}
 		}
@@ -357,12 +357,12 @@ void GameState::validateResearch()
 			if (t.second->dependencies.items.agentItemsRequired.find(entry.first) ==
 			    t.second->dependencies.items.agentItemsRequired.end())
 			{
-				LogError("Consumed agent item %s not in required list for topic %s", entry.first.id,
+				LogError("Consumed agent item {} not in required list for topic {}", entry.first.id,
 				         t.first);
 			}
 			else if (t.second->dependencies.items.agentItemsRequired.at(entry.first) < entry.second)
 			{
-				LogError("Consumed agent items %s has bigger count than required for topic %s",
+				LogError("Consumed agent items {} has bigger count than required for topic {}",
 				         entry.first.id, t.first);
 			}
 		}
@@ -371,13 +371,13 @@ void GameState::validateResearch()
 			if (t.second->dependencies.items.vehicleItemsRequired.find(entry.first) ==
 			    t.second->dependencies.items.vehicleItemsRequired.end())
 			{
-				LogError("Consumed vehicle item %s not in required list for topic %s",
+				LogError("Consumed vehicle item {} not in required list for topic {}",
 				         entry.first.id, t.first);
 			}
 			else if (t.second->dependencies.items.vehicleItemsRequired.at(entry.first) <
 			         entry.second)
 			{
-				LogError("Consumed vehicle item %s has bigger count than required for topic %s",
+				LogError("Consumed vehicle item {} has bigger count than required for topic {}",
 				         entry.first.id, t.first);
 			}
 		}
@@ -426,8 +426,8 @@ void GameState::validateScenery()
 				}
 				if (newRoad || (roadAlive && roadDead))
 				{
-					LogError("ROAD MUTATION: In %s when damaged from %s to %s roads go [%d%d%d%d] "
-					         "to [%d%d%d%d]",
+					LogError("ROAD MUTATION: In {} when damaged from {} to {} roads go [{}{}{}{}] "
+					         "to [{}{}{}{}]",
 					         sc.first, thisSc.id, thisSc->damagedTile.id,
 					         (int)thisSc->connection[0], (int)thisSc->connection[1],
 					         (int)thisSc->connection[2], (int)thisSc->connection[3],
@@ -455,12 +455,12 @@ void GameState::validateAgentEquipment()
 			if (ae.second->max_ammo == 0)
 			{
 				LogError(
-				    "%s ZERO MAX AMMO: equipment of type ammo must always have non-zero max ammo",
+				    "{} ZERO MAX AMMO: equipment of type ammo must always have non-zero max ammo",
 				    ae.first);
 			}
 			if (ae.second->max_ammo != 1 && ae.second->bioStorage)
 			{
-				LogError("%s BIO AMMO CLIP: equipment stored in alien containment must never have "
+				LogError("{} BIO AMMO CLIP: equipment stored in alien containment must never have "
 				         "max ammo other than 1",
 				         ae.first);
 			}
@@ -773,11 +773,11 @@ void GameState::invasion()
 	// Select a random mission type
 	int week = this->gameTime.getWeek();
 	auto preference =
-	    this->ufo_mission_preference.find(format("%s%d", UFOMissionPreference::getPrefix(), week));
+	    this->ufo_mission_preference.find(format("{}{}", UFOMissionPreference::getPrefix(), week));
 	if (preference == this->ufo_mission_preference.end())
 	{
 		preference = this->ufo_mission_preference.find(
-		    format("%s%s", UFOMissionPreference::getPrefix(), "DEFAULT"));
+		    format("{}{}", UFOMissionPreference::getPrefix(), "DEFAULT"));
 	}
 	auto missionType = pickRandom(rng, preference->second->missionList);
 	// Compile list of missions rated by priority
@@ -1343,23 +1343,23 @@ void GameState::loadMods()
 	auto mods = Options::modList.get().split(":");
 	for (const auto &modString : mods)
 	{
-		LogWarning("loading mod \"%s\"", modString);
+		LogWarning("loading mod \"{}\"", modString);
 		auto modPath = Options::modPath.get() + "/" + modString;
 		auto modInfo = ModInfo::getInfo(modPath);
 		if (!modInfo)
 		{
-			LogError("Failed to load ModInfo for mod \"%s\"", modString);
+			LogError("Failed to load ModInfo for mod \"{}\"", modString);
 			continue;
 		}
-		LogWarning("Loaded modinfo for mod ID \"%s\"", modInfo->getID());
+		LogWarning("Loaded modinfo for mod ID \"{}\"", modInfo->getID());
 		if (modInfo->getStatePath() != "")
 		{
 			auto modStatePath = modPath + "/" + modInfo->getStatePath();
-			LogWarning("Loading mod gamestate \"%s\"", modStatePath);
+			LogWarning("Loading mod gamestate \"{}\"", modStatePath);
 
 			if (!this->loadGame(modStatePath))
 			{
-				LogError("Failed to load mod ID \"%s\"", modInfo->getID());
+				LogError("Failed to load mod ID \"{}\"", modInfo->getID());
 			}
 		}
 

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -257,6 +257,12 @@ class GameState : public std::enable_shared_from_this<GameState>
 	// appends a GameState package from "submodPath", relative to the currently set data directories
 	// Returns true on success, false on failure
 	bool appendGameState(const UString &gamestatePath);
+
+	// BIT OF A HACK - we (ab)use the serializeIn generate code to dump translation strings
+	// This should probably be tweaked to generate code to allow a visitor to be called each object?
+	// Mutable as serializeIn takes a const GameState
+	mutable std::set<UString> translateable_strings;
+	bool populate_translateable_strings = false;
 };
 
 }; // namespace OpenApoc

--- a/game/state/gamestate_serialize.cpp
+++ b/game/state/gamestate_serialize.cpp
@@ -389,7 +389,7 @@ bool operator==(const UnitAI &a, const UnitAI &b)
 			return ca == cb;
 		}
 	}
-	LogError("Unsupported comparison for UserAI type %d", (int)a.type);
+	LogError("Unsupported comparison for UserAI type {}", (int)a.type);
 	return false;
 }
 bool operator!=(const UnitAI &a, const UnitAI &b) { return !(a == b); }
@@ -426,7 +426,7 @@ bool operator==(const TacticalAI &a, const TacticalAI &b)
 			return ca == cb;
 		}
 	}
-	LogError("Unsupported comparison for Tactical type %d", (int)a.type);
+	LogError("Unsupported comparison for Tactical type {}", (int)a.type);
 	return false;
 }
 bool operator!=(const TacticalAI &a, const TacticalAI &b) { return !(a == b); }
@@ -463,7 +463,7 @@ bool GameState::loadGame(const UString &path)
 	auto archive = SerializationArchive::readArchive(path);
 	if (!archive)
 	{
-		LogError("Failed to read \"%s\"", path);
+		LogError("Failed to read \"{}\"", path);
 		return false;
 	}
 
@@ -481,7 +481,7 @@ bool GameState::serialize(SerializationArchive *archive) const
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -497,7 +497,7 @@ bool GameState::serialize(SerializationArchive *archive, const GameState &refere
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -511,7 +511,7 @@ bool GameState::deserialize(SerializationArchive *archive)
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -526,7 +526,7 @@ static bool serialize(const BattleMapTileset &tileSet, SerializationArchive *arc
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -541,7 +541,7 @@ static bool deserialize(BattleMapTileset &tileSet, const GameState &state,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -566,7 +566,7 @@ bool BattleMapTileset::loadTileset(GameState &state, const UString &path)
 	auto archive = SerializationArchive::readArchive(path);
 	if (!archive)
 	{
-		LogError("Failed to read \"%s\"", path);
+		LogError("Failed to read \"{}\"", path);
 		return false;
 	}
 
@@ -582,7 +582,7 @@ static bool serialize(const BattleUnitImagePack &imagePack, SerializationArchive
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -597,7 +597,7 @@ static bool deserialize(BattleUnitImagePack &imagePack, const GameState &state,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -621,7 +621,7 @@ bool BattleUnitImagePack::loadImagePack(GameState &state, const UString &path)
 	auto file = fw().data->fs.open(path);
 	if (!file)
 	{
-		LogError("Failed to open image pack \"%s\"", path);
+		LogError("Failed to open image pack \"{}\"", path);
 		return false;
 	}
 	auto fullPath = file.systemPath();
@@ -630,7 +630,7 @@ bool BattleUnitImagePack::loadImagePack(GameState &state, const UString &path)
 	auto archive = SerializationArchive::readArchive(fullPath);
 	if (!archive)
 	{
-		LogError("Failed to read \"%s\"", fullPath);
+		LogError("Failed to read \"{}\"", fullPath);
 		return false;
 	}
 
@@ -646,7 +646,7 @@ static bool serialize(const BattleUnitAnimationPack &animationPack, Serializatio
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -661,7 +661,7 @@ static bool deserialize(BattleUnitAnimationPack &animationPack, const GameState 
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -684,7 +684,7 @@ bool BattleUnitAnimationPack::loadAnimationPack(GameState &state, const UString 
 	auto file = fw().data->fs.open(path);
 	if (!file)
 	{
-		LogError("Failed to open animation pack \"%s\"", path);
+		LogError("Failed to open animation pack \"{}\"", path);
 	}
 	const auto fullPath = file.systemPath();
 
@@ -692,7 +692,7 @@ bool BattleUnitAnimationPack::loadAnimationPack(GameState &state, const UString 
 	auto archive = SerializationArchive::readArchive(fullPath);
 	if (!archive)
 	{
-		LogError("Failed to read \"%s\"", fullPath);
+		LogError("Failed to read \"{}\"", fullPath);
 		return false;
 	}
 
@@ -708,7 +708,7 @@ static bool serialize(const BattleMapSectorTiles &mapSector, SerializationArchiv
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -723,7 +723,7 @@ static bool deserialize(BattleMapSectorTiles &mapSector, const GameState &state,
 	}
 	catch (SerializationException &e)
 	{
-		LogError("Serialization failed: \"%s\"", e.what());
+		LogError("Serialization failed: \"{}\"", e.what());
 		return false;
 	}
 	return true;
@@ -748,7 +748,7 @@ bool BattleMapSectorTiles::loadSector(GameState &state, const UString &path)
 	auto archive = SerializationArchive::readArchive(path);
 	if (!archive)
 	{
-		LogError("Failed to read \"%s\"", path);
+		LogError("Failed to read \"{}\"", path);
 		return false;
 	}
 

--- a/game/state/gamestate_serialize.h
+++ b/game/state/gamestate_serialize.h
@@ -210,7 +210,7 @@ void serializeIn(const GameState *, SerializationNode *node, T &val,
 			return;
 		}
 	}
-	throw SerializationException(format("Invalid enum value for %s: \"%s\"", typeid(T).name(), str),
+	throw SerializationException(format("Invalid enum value for {}: \"{}\"", typeid(T).name(), str),
 	                             node);
 }
 
@@ -334,7 +334,7 @@ void serializeOut(SerializationNode *node, const T &val, const T &,
 	auto it = valueMap.find(val);
 	if (it == valueMap.end())
 	{
-		LogError("Invalid enum value for %s: %d", typeid(T).name(), (int)val);
+		LogError("Invalid enum value for {}: {}", typeid(T).name(), (int)val);
 	}
 	node->setValue(it->second);
 }

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -111,7 +111,7 @@
 	<object>
 		<name>AgentType</name>
 		<member>id</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>role</member>
 		<member>possible_genders</member>
 		<member>gender_chance</member>
@@ -282,9 +282,9 @@
 	</object>
 	<object>
 		<name>ResearchTopic</name>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>order</member>
-		<member>description</member>
+		<member translate="true">description</member>
 		<member>man_hours</member>
 		<member>type</member>
 		<member>required_lab_size</member>
@@ -314,8 +314,8 @@
 	</object>
 	<object>
 		<name>UfopaediaCategory</name>
-		<member>title</member>
-		<member>description</member>
+		<member translate="true">title</member>
+		<member translate="true">description</member>
 		<member>background</member>
 		<member>entries</member>
 	</object>
@@ -425,7 +425,7 @@
 		<name>Vehicle</name>
 		<member>type</member>
 		<member>owner</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>attackMode</member>
 		<member>altitude</member>
 		<member>missions</member>
@@ -1044,14 +1044,14 @@
 	</object>
 	<object>
 		<name>BuildingFunction</name>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>infiltrationSpeed</member>
 		<member>detectionWeight</member>
 		<member>ufopaedia_entry</member>
 	</object>
 	<object>
 		<name>Building</name>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>city</member>
 		<member>function</member>
 		<member>owner</member>
@@ -1126,7 +1126,7 @@
 	<object>
 		<name>VAmmoType</name>
 		<member>id</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>weight</member>
 		<member>ammo_id</member>
 		<member>manufacturer</member>
@@ -1161,7 +1161,7 @@
 	</enum>
 	<object>
 		<name>DamageType</name>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>icon_sprite</member>
 		<member>ignore_shield</member>
 		<member>non_violent</member>
@@ -1177,7 +1177,7 @@
 		<name>AEquipmentType</name>
 		<member>type</member>
 		<member>id</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>weight</member>
 		<member>held_image_pack</member>
 		<member>dropped_sprite</member>
@@ -1229,7 +1229,7 @@
 		<name>VEquipmentType</name>
 		<member>type</member>
 		<member>id</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>weight</member>
 		<member>max_ammo</member>
 		<member>ammo_type</member>
@@ -1277,7 +1277,7 @@
 	</object>
 	<object>
 		<name>FacilityType</name>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>fixed</member>
 		<member>buildCost</member>
 		<member>buildTime</member>
@@ -1324,7 +1324,7 @@
 	<object>
 		<name>Organisation</name>
 		<member>id</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>balance</member>
 		<member>income</member>
 		<member>infiltrationValue</member>
@@ -1349,7 +1349,7 @@
 		<name>VehicleType</name>
 		<member>numCreated</member>
 		<member>type</member>
-		<member>name</member>
+		<member translate="true">name</member>
 		<member>manufacturer</member>
 		<member>image_offset</member>
 		<member>acceleration</member>
@@ -1390,8 +1390,8 @@
 	</object>
 	<object>
 		<name>UfopaediaEntry</name>
-		<member>title</member>
-		<member>description</member>
+		<member translate="true">title</member>
+		<member translate="true">description</member>
 		<member>background</member>
 		<member>data_id</member>
 		<member>data_type</member>

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -129,7 +129,7 @@ UString GameTime::getShortDateString() const
 	return ss.str();
 }
 
-UString GameTime::getWeekString() const { return format("%s %d", tr("Week"), getWeek()); }
+UString GameTime::getWeekString() const { return format("{} {}", tr("Week"), getWeek()); }
 
 unsigned int GameTime::getWeek() const
 {

--- a/game/state/luagamestate.cpp
+++ b/game/state/luagamestate.cpp
@@ -106,16 +106,16 @@ int LuaGameState::callHook(const UString &hookName, int nresults, int nargs)
 
 bool LuaGameState::runScript(const UString &scriptPath)
 {
-	LogInfo("Running script \"%s\"", scriptPath);
+	LogInfo("Running script \"{}\"", scriptPath);
 	auto scriptFile = fw().data->fs.open(scriptPath);
 	if (!scriptFile)
 	{
-		LogWarning("Failed to open script \"%s\"", scriptPath);
+		LogWarning("Failed to open script \"{}\"", scriptPath);
 		return false;
 	}
 
 	const auto &fullPath = scriptFile.systemPath();
-	LogInfo("Loading script from \"%s\"", fullPath);
+	LogInfo("Loading script from \"{}\"", fullPath);
 
 	bool ret = true;
 	pushLuaDebugTraceback(L);
@@ -123,11 +123,11 @@ bool LuaGameState::runScript(const UString &scriptPath)
 	if (luaL_loadfile(L, fullPath.cStr()) || lua_pcall(L, 0, 0, -2))
 	{
 		handleLuaError(L);
-		LogWarning("Script \"%s\" failed", scriptPath);
+		LogWarning("Script \"{}\" failed", scriptPath);
 		ret = false;
 	}
 	lua_pop(L, 1); // pop debug.traceback function
-	LogInfo("Script run %s", ret ? "success" : "fail");
+	LogInfo("Script run {}", ret ? "success" : "fail");
 	return ret;
 }
 

--- a/game/state/rules/aequipmenttype.cpp
+++ b/game/state/rules/aequipmenttype.cpp
@@ -25,7 +25,7 @@ sp<AEquipmentType> StateObject<AEquipmentType>::get(const GameState &state, cons
 	auto it = state.agent_equipment.find(id);
 	if (it == state.agent_equipment.end())
 	{
-		LogError("No aequipement type matching ID \"%s\"", id);
+		LogError("No aequipement type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -52,7 +52,7 @@ sp<EquipmentSet> StateObject<EquipmentSet>::get(const GameState &state, const US
 		it = state.equipment_sets_by_level.find(id);
 		if (it == state.equipment_sets_by_level.end())
 		{
-			LogError("No equipment set (score) matching ID \"%s\"", id);
+			LogError("No equipment set (score) matching ID \"{}\"", id);
 			return nullptr;
 		}
 	}
@@ -102,7 +102,7 @@ sp<EquipmentSet> EquipmentSet::getByScore(const GameState &state, const int scor
 		if (es.second->isAppropriate(score))
 			return es.second;
 	}
-	LogError("No equipment set matching score %d", score);
+	LogError("No equipment set matching score {}", score);
 	return nullptr;
 }
 
@@ -113,7 +113,7 @@ sp<EquipmentSet> EquipmentSet::getByLevel(const GameState &state, const int leve
 		if (es.second->isAppropriate(level))
 			return es.second;
 	}
-	LogError("No equipment set matching level %d", level);
+	LogError("No equipment set matching level {}", level);
 	return nullptr;
 }
 

--- a/game/state/rules/agenttype.cpp
+++ b/game/state/rules/agenttype.cpp
@@ -27,7 +27,7 @@ template <> sp<AgentType> StateObject<AgentType>::get(const GameState &state, co
 	auto it = state.agent_types.find(id);
 	if (it == state.agent_types.end())
 	{
-		LogError("No agent_type matching ID \"%s\"", id);
+		LogError("No agent_type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -53,7 +53,7 @@ const UString &StateObject<AgentType>::getId(const GameState &state, const sp<Ag
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", ptr.get());
+	LogError("No agent_type matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -63,7 +63,7 @@ sp<AgentBodyType> StateObject<AgentBodyType>::get(const GameState &state, const 
 	auto it = state.agent_body_types.find(id);
 	if (it == state.agent_body_types.end())
 	{
-		LogError("No agent_body_type matching ID \"%s\"", id);
+		LogError("No agent_body_type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -90,7 +90,7 @@ const UString &StateObject<AgentBodyType>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", ptr.get());
+	LogError("No agent_type matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -101,7 +101,7 @@ sp<AgentEquipmentLayout> StateObject<AgentEquipmentLayout>::get(const GameState 
 	auto it = state.agent_equipment_layouts.find(id);
 	if (it == state.agent_equipment_layouts.end())
 	{
-		LogError("No agent_body_type matching ID \"%s\"", id);
+		LogError("No agent_body_type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -128,7 +128,7 @@ const UString &StateObject<AgentEquipmentLayout>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", ptr.get());
+	LogError("No agent_type matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/agenttype.cpp
+++ b/game/state/rules/agenttype.cpp
@@ -53,7 +53,7 @@ const UString &StateObject<AgentType>::getId(const GameState &state, const sp<Ag
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No agent_type matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 
@@ -90,7 +90,7 @@ const UString &StateObject<AgentBodyType>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No agent_type matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 
@@ -128,7 +128,7 @@ const UString &StateObject<AgentEquipmentLayout>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No agent_type matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -93,7 +93,7 @@ template <> sp<BattleMap> StateObject<BattleMap>::get(const GameState &state, co
 	auto it = state.battle_maps.find(id);
 	if (it == state.battle_maps.end())
 	{
-		LogError("No battle_map matching ID \"%s\"", id);
+		LogError("No battle_map matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -117,7 +117,7 @@ const UString &StateObject<BattleMap>::getId(const GameState &state, const sp<Ba
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No battle_map matching pointer %p", ptr.get());
+	LogError("No battle_map matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -616,7 +616,7 @@ bool BattleMap::generateMap(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int>
 		}
 		else
 		{
-			LogWarning("Cannot generate a map %s with gen size %d since generating large maps is "
+			LogWarning("Cannot generate a map {} with gen size {} since generating large maps is "
 			           "disabled",
 			           id, (int)genSize);
 			return false;
@@ -774,8 +774,8 @@ bool BattleMap::generateMap(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int>
 		// then we cannot create a map of such size
 		if (mandatorySectorLost && !mandatorySectorRemaining)
 		{
-			LogWarning("Failed to place mandatory sectors for map %s with size %d, %d, %d at "
-			           "attempt %d",
+			LogWarning("Failed to place mandatory sectors for map {} with size {}, {}, {} at "
+			           "attempt {}",
 			           id, size.x, size.y, size.z, attempt_make_map);
 			continue;
 		}
@@ -800,8 +800,8 @@ bool BattleMap::generateMap(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int>
 		// then we cannot create a map of such size
 		if (failed)
 		{
-			LogWarning("Failed to place mandatory sectors for map %s with size %d, %d, %d at "
-			           "attempt %d",
+			LogWarning("Failed to place mandatory sectors for map {} with size {}, {}, {} at "
+			           "attempt {}",
 			           id, size.x, size.y, size.z, attempt_make_map);
 			continue;
 		}
@@ -899,17 +899,17 @@ bool BattleMap::generateMap(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int>
 		// If we failed at filling a map at this point, then there's nothing else we can do
 		if (!isMapComplete(sec_map, size))
 		{
-			LogWarning("Failed to complete map %s with size %d, %d, %d at attempt %d", id, size.x,
+			LogWarning("Failed to complete map {} with size {}, {}, {} at attempt {}", id, size.x,
 			           size.y, size.z, attempt_make_map);
 			continue;
 		}
 
-		LogWarning("Successfully completed map %s with size %d, %d, %d at attempt %d", id, size.x,
+		LogWarning("Successfully completed map {} with size {}, {}, {} at attempt {}", id, size.x,
 		           size.y, size.z, attempt_make_map);
 		return true;
 	}
 
-	LogWarning("Failed (totally) to generate a map %s with gen size %d", id, (int)genSize);
+	LogWarning("Failed (totally) to generate a map {} with gen size {}", id, (int)genSize);
 	return false;
 }
 
@@ -928,7 +928,7 @@ bool BattleMap::generateBase(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int
 	}
 	if (!base)
 	{
-		LogError("Failed to find base in building %s", mission_location_id);
+		LogError("Failed to find base in building {}", mission_location_id);
 		return false;
 	}
 
@@ -1007,17 +1007,17 @@ BattleMap::fillMap(std::vector<std::list<std::pair<Vec3<int>, sp<BattleMapPart>>
 					continue;
 				if (!sec->tiles)
 				{
-					LogInfo("Loading sector tiles \"%s\"", sec->sectorTilesName);
+					LogInfo("Loading sector tiles \"{}\"", sec->sectorTilesName);
 					sec->tiles.reset(new BattleMapSectorTiles());
 					if (!sec->tiles->loadSector(state, BattleMapSectorTiles::getMapSectorPath() +
 					                                       "/" + sec->sectorTilesName))
 					{
-						LogError("Failed to load sector tiles \"%s\"", sec->sectorTilesName);
+						LogError("Failed to load sector tiles \"{}\"", sec->sectorTilesName);
 					}
 				}
 				else
 				{
-					LogInfo("Using already-loaded sector tiles \"%s\"", sec->sectorTilesName);
+					LogInfo("Using already-loaded sector tiles \"{}\"", sec->sectorTilesName);
 				}
 				auto &tiles = *sec->tiles;
 				Vec3<int> shift = {x * chunk_size.x, y * chunk_size.y, z * chunk_size.z};
@@ -1534,11 +1534,11 @@ void BattleMap::loadTilesets(GameState &state) const
 	{
 		unsigned count = 0;
 		auto tilesetPath = BattleMapTileset::getTilesetPath() + "/" + tilesetName;
-		LogInfo("Loading tileset \"%s\" from \"%s\"", tilesetName, tilesetPath);
+		LogInfo("Loading tileset \"{}\" from \"{}\"", tilesetName, tilesetPath);
 		BattleMapTileset tileset;
 		if (!tileset.loadTileset(state, tilesetPath))
 		{
-			LogError("Failed to load tileset \"%s\" from \"%s\"", tilesetName, tilesetPath);
+			LogError("Failed to load tileset \"{}\" from \"{}\"", tilesetName, tilesetPath);
 			continue;
 		}
 
@@ -1574,13 +1574,13 @@ void BattleMap::loadTilesets(GameState &state) const
 			// Sanity check
 			if (state.battleMapTiles.find(tileName) != state.battleMapTiles.end())
 			{
-				LogError("Duplicate tile with ID \"%s\"", tileName);
+				LogError("Duplicate tile with ID \"{}\"", tileName);
 				continue;
 			}
 			state.battleMapTiles.emplace(tileName, tile);
 			count++;
 		}
-		LogInfo("Loaded %u tiles from tileset \"%s\"", count, tilesetName);
+		LogInfo("Loaded {} tiles from tileset \"{}\"", count, tilesetName);
 	}
 }
 

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -117,7 +117,7 @@ const UString &StateObject<BattleMap>::getId(const GameState &state, const sp<Ba
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No battle_map matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No battle_map matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/battlemapparttype.cpp
+++ b/game/state/rules/battle/battlemapparttype.cpp
@@ -13,7 +13,7 @@ sp<BattleMapPartType> StateObject<BattleMapPartType>::get(const GameState &state
 	auto it = state.battleMapTiles.find(id);
 	if (it != state.battleMapTiles.end())
 		return it->second;
-	LogError("No battle map part type matching ID \"%s\"", id);
+	LogError("No battle map part type matching ID \"{}\"", id);
 
 	return nullptr;
 }

--- a/game/state/rules/battle/battleunitanimationpack.cpp
+++ b/game/state/rules/battle/battleunitanimationpack.cpp
@@ -42,7 +42,7 @@ const UString &StateObject<BattleUnitAnimationPack>::getId(const GameState &stat
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleUnitAnimationPack matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No BattleUnitAnimationPack matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/battleunitanimationpack.cpp
+++ b/game/state/rules/battle/battleunitanimationpack.cpp
@@ -16,7 +16,7 @@ sp<BattleUnitAnimationPack> StateObject<BattleUnitAnimationPack>::get(const Game
 	auto it = state.battle_unit_animation_packs.find(id);
 	if (it == state.battle_unit_animation_packs.end())
 	{
-		LogError("No BattleUnitAnimationPack matching ID \"%s\"", id);
+		LogError("No BattleUnitAnimationPack matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -42,7 +42,7 @@ const UString &StateObject<BattleUnitAnimationPack>::getId(const GameState &stat
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleUnitAnimationPack matching pointer %p", ptr.get());
+	LogError("No BattleUnitAnimationPack matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -52,7 +52,7 @@ const UString BattleUnitAnimationPack::getNameFromID(UString id)
 	auto plen = getPrefix().length();
 	if (id.length() > plen)
 		return id.substr(plen, id.length() - plen);
-	LogError("Invalid BattleUnitAnimationPack ID %s", id);
+	LogError("Invalid BattleUnitAnimationPack ID {}", id);
 	return emptyString;
 }
 
@@ -165,7 +165,7 @@ void BattleUnitAnimationPack::drawShadow(
 		e = hand_state_animations[key][facing];
 		if (!e)
 		{
-			LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+			LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 			           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 			return;
 		}
@@ -180,7 +180,7 @@ void BattleUnitAnimationPack::drawShadow(
 		e = body_state_animations[key][facing];
 		if (!e)
 		{
-			LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+			LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 			           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 			return;
 		}
@@ -196,7 +196,7 @@ void BattleUnitAnimationPack::drawShadow(
 		e = standart_animations[key][facing];
 		if (!e)
 		{
-			LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+			LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 			           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 			return;
 		}
@@ -262,7 +262,7 @@ void BattleUnitAnimationPack::drawUnit(
 		e = hand_state_animations[key][facing];
 		if (!e)
 		{
-			LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+			LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 			           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 			return;
 		}
@@ -287,7 +287,7 @@ void BattleUnitAnimationPack::drawUnit(
 		e = body_state_animations[key][facing];
 		if (!e)
 		{
-			LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+			LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 			           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 			return;
 		}
@@ -304,7 +304,7 @@ void BattleUnitAnimationPack::drawUnit(
 			                         currentHands, firingAngle, movement, currentBody}][facing];
 			if (!e)
 			{
-				LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+				LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 				           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 				return;
 			}
@@ -318,7 +318,7 @@ void BattleUnitAnimationPack::drawUnit(
 			e = standart_animations[key][facing];
 			if (!e)
 			{
-				LogWarning("Body %d %d Hands %d %d Movement %d Frame missing!", (int)currentBody,
+				LogWarning("Body {} {} Hands {} {} Movement {} Frame missing!", (int)currentBody,
 				           (int)targetBody, (int)currentHands, (int)targetHands, (int)movement);
 				return;
 			}
@@ -380,7 +380,7 @@ void BattleUnitAnimationPack::drawUnit(
 					continue;
 				if ((int)body->images.size() <= b->index)
 				{
-					LogError("Missing image: body %s size %u index %d", body.id,
+					LogError("Missing image: body {} size {} index {}", body.id,
 					         body->images.size(), b->index);
 					break;
 				}
@@ -392,7 +392,7 @@ void BattleUnitAnimationPack::drawUnit(
 					continue;
 				if ((int)legs->images.size() <= b->index)
 				{
-					LogError("Missing image: legs %s size %u index %d", legs.id,
+					LogError("Missing image: legs {} size {} index {}", legs.id,
 					         legs->images.size(), b->index);
 					break;
 				}
@@ -404,7 +404,7 @@ void BattleUnitAnimationPack::drawUnit(
 					continue;
 				if ((int)helmet->images.size() <= b->index)
 				{
-					LogError("Missing image: helmet %s size %u index %d", helmet.id,
+					LogError("Missing image: helmet {} size {} index {}", helmet.id,
 					         helmet->images.size(), b->index);
 					break;
 				}
@@ -416,7 +416,7 @@ void BattleUnitAnimationPack::drawUnit(
 					continue;
 				if ((int)leftHand->images.size() <= b->index)
 				{
-					LogError("Missing image: leftHand %s size %u index %d", leftHand.id,
+					LogError("Missing image: leftHand {} size {} index {}", leftHand.id,
 					         leftHand->images.size(), b->index);
 					break;
 				}
@@ -428,7 +428,7 @@ void BattleUnitAnimationPack::drawUnit(
 					continue;
 				if ((int)rightHand->images.size() <= b->index)
 				{
-					LogError("Missing image: rightHand %s size %u index %d", rightHand.id,
+					LogError("Missing image: rightHand {} size {} index {}", rightHand.id,
 					         rightHand->images.size(), b->index);
 					break;
 				}
@@ -440,7 +440,7 @@ void BattleUnitAnimationPack::drawUnit(
 					continue;
 				if ((int)heldItem->held_image_pack->images.size() <= b->index)
 				{
-					LogError("Missing image: heldItem %s pack %s size %u index %d", heldItem.id,
+					LogError("Missing image: heldItem {} pack {} size {} index {}", heldItem.id,
 					         heldItem->held_image_pack.id, heldItem->held_image_pack->images.size(),
 					         b->index);
 					break;

--- a/game/state/rules/battle/battleunitimagepack.cpp
+++ b/game/state/rules/battle/battleunitimagepack.cpp
@@ -14,7 +14,7 @@ sp<BattleUnitImagePack> StateObject<BattleUnitImagePack>::get(const GameState &s
 	auto it = state.battle_unit_image_packs.find(id);
 	if (it == state.battle_unit_image_packs.end())
 	{
-		LogError("No BattleUnitImagePack matching ID \"%s\"", id);
+		LogError("No BattleUnitImagePack matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -40,7 +40,7 @@ const UString &StateObject<BattleUnitImagePack>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleUnitImagePack matching pointer %p", ptr.get());
+	LogError("No BattleUnitImagePack matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -52,7 +52,7 @@ const UString BattleUnitImagePack::getNameFromID(UString id)
 	auto plen = getPrefix().length();
 	if (id.length() > plen)
 		return id.substr(plen, id.length() - plen);
-	LogError("Invalid BattleUnitImagePack ID %s", id);
+	LogError("Invalid BattleUnitImagePack ID {}", id);
 	return emptyString;
 }
 } // namespace OpenApoc

--- a/game/state/rules/battle/battleunitimagepack.cpp
+++ b/game/state/rules/battle/battleunitimagepack.cpp
@@ -40,7 +40,7 @@ const UString &StateObject<BattleUnitImagePack>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleUnitImagePack matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No BattleUnitImagePack matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/damage.cpp
+++ b/game/state/rules/battle/damage.cpp
@@ -22,7 +22,7 @@ template <> sp<HazardType> StateObject<HazardType>::get(const GameState &state, 
 	auto it = state.hazard_types.find(id);
 	if (it == state.hazard_types.end())
 	{
-		LogError("No hazard type matching ID \"%s\"", id);
+		LogError("No hazard type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -46,7 +46,7 @@ sp<DamageModifier> StateObject<DamageModifier>::get(const GameState &state, cons
 	auto it = state.damage_modifiers.find(id);
 	if (it == state.damage_modifiers.end())
 	{
-		LogError("No damage modifier type matching ID \"%s\"", id);
+		LogError("No damage modifier type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -69,7 +69,7 @@ template <> sp<DamageType> StateObject<DamageType>::get(const GameState &state, 
 	auto it = state.damage_types.find(id);
 	if (it == state.damage_types.end())
 	{
-		LogError("No damage type type matching ID \"%s\"", id);
+		LogError("No damage type type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -79,7 +79,7 @@ int DamageType::dealDamage(int damage, StateRef<DamageModifier> modifier) const
 {
 	if (modifiers.find(modifier) == modifiers.end())
 	{
-		LogError("Do not know how to deal damage type to modifier %s!", modifier.id);
+		LogError("Do not know how to deal damage type to modifier {}!", modifier.id);
 		return damage;
 	}
 	else

--- a/game/state/rules/city/baselayout.cpp
+++ b/game/state/rules/city/baselayout.cpp
@@ -9,7 +9,7 @@ template <> sp<BaseLayout> StateObject<BaseLayout>::get(const GameState &state, 
 	auto it = state.base_layouts.find(id);
 	if (it == state.base_layouts.end())
 	{
-		LogError("No base layout type matching ID \"%s\"", id);
+		LogError("No base layout type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/city/facilitytype.cpp
+++ b/game/state/rules/city/facilitytype.cpp
@@ -18,7 +18,7 @@ sp<FacilityType> StateObject<FacilityType>::get(const GameState &state, const US
 	auto it = state.facility_types.find(id);
 	if (it == state.facility_types.end())
 	{
-		LogError("No facility type matching ID \"%s\"", id);
+		LogError("No facility type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/city/scenerytiletype.cpp
+++ b/game/state/rules/city/scenerytiletype.cpp
@@ -14,7 +14,7 @@ sp<SceneryTileType> StateObject<SceneryTileType>::get(const GameState &state, co
 		if (it != pair.second->tile_types.end())
 			return it->second;
 	}
-	LogError("No scenery tile type matching ID \"%s\"", id);
+	LogError("No scenery tile type matching ID \"{}\"", id);
 	return nullptr;
 }
 

--- a/game/state/rules/city/ufogrowth.cpp
+++ b/game/state/rules/city/ufogrowth.cpp
@@ -9,7 +9,7 @@ template <> sp<UFOGrowth> StateObject<UFOGrowth>::get(const GameState &state, co
 	auto it = state.ufo_growth_lists.find(id);
 	if (it == state.ufo_growth_lists.end())
 	{
-		LogError("No ufo growth matching ID \"%s\"", id);
+		LogError("No ufo growth matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/city/ufoincursion.cpp
+++ b/game/state/rules/city/ufoincursion.cpp
@@ -10,7 +10,7 @@ sp<UFOIncursion> StateObject<UFOIncursion>::get(const GameState &state, const US
 	auto it = state.ufo_incursions.find(id);
 	if (it == state.ufo_incursions.end())
 	{
-		LogError("No incursion rule matching ID \"%s\"", id);
+		LogError("No incursion rule matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/city/ufomissionpreference.cpp
+++ b/game/state/rules/city/ufomissionpreference.cpp
@@ -11,7 +11,7 @@ sp<UFOMissionPreference> StateObject<UFOMissionPreference>::get(const GameState 
 	auto it = state.ufo_mission_preference.find(id);
 	if (it == state.ufo_mission_preference.end())
 	{
-		LogError("No UFOMissionPreference matching ID \"%s\"", id);
+		LogError("No UFOMissionPreference matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/city/ufopaedia.cpp
+++ b/game/state/rules/city/ufopaedia.cpp
@@ -18,7 +18,7 @@ sp<UfopaediaEntry> StateObject<UfopaediaEntry>::get(const GameState &state, cons
 		if (entry != cat.second->entries.end())
 			return entry->second;
 	}
-	LogError("No UFOPaedia entry matching ID \"%s\"", id);
+	LogError("No UFOPaedia entry matching ID \"{}\"", id);
 	return nullptr;
 }
 

--- a/game/state/rules/city/vammotype.cpp
+++ b/game/state/rules/city/vammotype.cpp
@@ -21,7 +21,7 @@ template <> sp<VAmmoType> StateObject<VAmmoType>::get(const GameState &state, co
 	auto it = state.vehicle_ammo.find(id);
 	if (it == state.vehicle_ammo.end())
 	{
-		LogError("No vammo type matching ID \"%s\"", id);
+		LogError("No vammo type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/city/vehicletype.cpp
+++ b/game/state/rules/city/vehicletype.cpp
@@ -77,7 +77,7 @@ const UString &StateObject<VehicleType>::getId(const GameState &state, const sp<
 		if (v.second == ptr)
 			return v.first;
 	}
-	LogError("No vehicle type matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No vehicle type matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/city/vehicletype.cpp
+++ b/game/state/rules/city/vehicletype.cpp
@@ -39,7 +39,7 @@ const Vec3<float> &VehicleType::directionToVector(Direction d)
 	auto it = DirectionVectors.find(d);
 	if (it == DirectionVectors.end())
 	{
-		LogError("Failed to find a direction vector for %d", (int)d);
+		LogError("Failed to find a direction vector for {}", (int)d);
 		return fallback;
 	}
 	return it->second;
@@ -52,7 +52,7 @@ template <> sp<VehicleType> StateObject<VehicleType>::get(const GameState &state
 	auto it = state.vehicle_types.find(id);
 	if (it == state.vehicle_types.end())
 	{
-		LogError("No vehicle type matching ID \"%s\"", id);
+		LogError("No vehicle type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -77,7 +77,7 @@ const UString &StateObject<VehicleType>::getId(const GameState &state, const sp<
 		if (v.second == ptr)
 			return v.first;
 	}
-	LogError("No vehicle type matching pointer %p", ptr.get());
+	LogError("No vehicle type matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/city/vequipmenttype.cpp
+++ b/game/state/rules/city/vequipmenttype.cpp
@@ -23,7 +23,7 @@ sp<VEquipmentType> StateObject<VEquipmentType>::get(const GameState &state, cons
 	auto it = state.vehicle_equipment.find(id);
 	if (it == state.vehicle_equipment.end())
 	{
-		LogError("No vequipement type matching ID \"%s\"", id);
+		LogError("No vequipement type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/doodadtype.cpp
+++ b/game/state/rules/doodadtype.cpp
@@ -11,7 +11,7 @@ sp<DoodadType> StateObject<DoodadType>::get(const GameState &state, const UStrin
 	auto it = state.doodad_types.find(id);
 	if (it == state.doodad_types.end())
 	{
-		LogError("No doodad type matching ID \"%s\"", id);
+		LogError("No doodad type matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/rules/supportedmappart.cpp
+++ b/game/state/rules/supportedmappart.cpp
@@ -38,13 +38,13 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 	do
 	{
 #ifdef MAP_PART_LINK_DEBUG_OUTPUT
-		LogWarning("%s", log);
+		LogWarning("{}", log);
 		log = "";
-		log += format("\nIteration begins. List contains %d items:", (int)currentSet->size());
+		log += format("\nIteration begins. List contains {} items:", (int)currentSet->size());
 		for (auto &mp : *currentSet)
 		{
 			auto pos = mp->getTilePosition();
-			log += format("\n %s at %d %d %d", mp->getId(), pos.x, pos.y, pos.z);
+			log += format("\n {} at {} {} {}", mp->getId(), pos.x, pos.y, pos.z);
 		}
 		log += format("\n");
 #endif
@@ -78,7 +78,7 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 			{
 #ifdef MAP_PART_LINK_DEBUG_OUTPUT
 				auto pos = curSetPart->getTilePosition();
-				log += format("\n Processing %s at %d %d %d: OK %s", curSetPart->getId(), pos.x,
+				log += format("\n Processing {} at {} {} {}: OK {}", curSetPart->getId(), pos.x,
 				              pos.y, pos.z, curSetPart->getSupportString());
 				{
 					auto &map = curSetPart->getMap();
@@ -110,7 +110,7 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 											    p.second ==
 											        (BattleMapPartType::Type)curSetPart->getType())
 											{
-												log += format("\n - Supported by %s at %d %d %d",
+												log += format("\n - Supported by {} at {} {} {}",
 												              mp2->type.id, x - pos.x, y - pos.y,
 												              z - pos.z);
 											}
@@ -124,7 +124,7 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 										{
 											if (p == pos)
 											{
-												log += format("\n - Supported by %s at %d %d %d",
+												log += format("\n - Supported by {} at {} {} {}",
 												              mp2->type.id, x - pos.x, y - pos.y,
 												              z - pos.z);
 											}
@@ -151,7 +151,7 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 			{
 #ifdef MAP_PART_LINK_DEBUG_OUTPUT
 				auto pos = curSetPart->getTilePosition();
-				log += format("\n Processing %s at %s: FAIL, remains in next iteration",
+				log += format("\n Processing {} at {}: FAIL, remains in next iteration",
 				              curSetPart->getId(), pos);
 #endif
 				// Step 4: Failure [If no support is found]
@@ -161,7 +161,7 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 				{
 #ifdef MAP_PART_LINK_DEBUG_OUTPUT
 					auto newpos = supportedPart->getTilePosition();
-					log += format("\n - %s at %s added to next iteration", supportedPart->getId(),
+					log += format("\n - {} at {} added to next iteration", supportedPart->getId(),
 					              newpos);
 #endif
 					supportedPart->ceaseBeingSupported();
@@ -183,9 +183,9 @@ void SupportedMapPart::attemptReLinkSupports(sp<std::set<SupportedMapPart *>> cu
 	for (auto &sp : *currentSet)
 	{
 		log += format("\nAttempt over");
-		log += format("\n%s at %s will fall", sp->getId(), sp->getTilePosition());
+		log += format("\n{} at {} will fall", sp->getId(), sp->getTilePosition());
 	}
-	LogWarning("%s", log);
+	LogWarning("{}", log);
 #endif
 }
 

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -49,7 +49,7 @@ std::shared_future<void> SaveManager::loadGame(const UString &savePath, sp<GameS
 	auto loadTask = fw().threadPoolEnqueue([saveArchiveLocation, state]() -> void {
 		if (!state->loadGame(saveArchiveLocation))
 		{
-			LogError("Failed to load '%s'", saveArchiveLocation);
+			LogError("Failed to load '{}'", saveArchiveLocation);
 			return;
 		}
 		state->initState();
@@ -119,7 +119,7 @@ bool writeArchiveWithBackup(SerializationArchive *archive, const UString &path, 
 
 		if (!haveNewName)
 		{
-			LogError("Unable to create temporary file at \"%s\"", tempPath.string());
+			LogError("Unable to create temporary file at \"{}\"", tempPath.string());
 			return false;
 		}
 
@@ -154,7 +154,7 @@ bool writeArchiveWithBackup(SerializationArchive *archive, const UString &path, 
 			fs::rename(tempPath, savePath);
 		}
 
-		LogError("Unable to save game: \"%s\"", exception.what());
+		LogError("Unable to save game: \"{}\"", exception.what());
 	}
 
 	return false;
@@ -174,7 +174,7 @@ bool SaveManager::findFreePath(UString &path, const UString &name) const
 			}
 		}
 
-		LogError("Unable to generate filename for save %s", name);
+		LogError("Unable to generate filename for save {}", name);
 		return false;
 	}
 
@@ -211,7 +211,7 @@ bool SaveManager::overrideGame(const SaveMetadata &metadata, const UString &newN
 			}
 			catch (fs::filesystem_error &error)
 			{
-				LogWarning("Error while removing renamed save: \"%s\"", error.what());
+				LogWarning("Error while removing renamed save: \"{}\"", error.what());
 			}
 		}
 	}
@@ -265,7 +265,7 @@ std::vector<SaveMetadata> SaveManager::getSaveList() const
 	{
 		if (!fs::exists(saveDirectory) && !fs::create_directories(saveDirectory))
 		{
-			LogWarning("Save directory \"%s\" not found, and could not be created!", saveDirectory);
+			LogWarning("Save directory \"{}\" not found, and could not be created!", saveDirectory);
 			return saveList;
 		}
 
@@ -296,7 +296,7 @@ std::vector<SaveMetadata> SaveManager::getSaveList() const
 	}
 	catch (fs::filesystem_error &er)
 	{
-		LogError("Error while enumerating directory: \"%s\"", er.what());
+		LogError("Error while enumerating directory: \"{}\"", er.what());
 	}
 
 	sort(saveList.begin(), saveList.end(), [](const SaveMetadata &lhs, const SaveMetadata &rhs) {
@@ -321,7 +321,7 @@ bool SaveManager::deleteGame(const sp<SaveMetadata> &slot) const
 	}
 	catch (fs::filesystem_error &exception)
 	{
-		LogError("Unable to delete saved gane: \"%s\"", exception.what());
+		LogError("Unable to delete saved gane: \"{}\"", exception.what());
 		return false;
 	}
 }

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -55,7 +55,7 @@ template <> const UString &StateObject<Agent>::getId(const GameState &state, con
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent matching pointer %p", static_cast<void*>(ptr.get()));
+	LogError("No agent matching pointer {}", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -31,7 +31,7 @@ template <> sp<Agent> StateObject<Agent>::get(const GameState &state, const UStr
 	auto it = state.agents.find(id);
 	if (it == state.agents.end())
 	{
-		LogError("No agent matching ID \"%s\"", id);
+		LogError("No agent matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;
@@ -55,7 +55,7 @@ template <> const UString &StateObject<Agent>::getId(const GameState &state, con
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent matching pointer %p", ptr.get());
+	LogError("No agent matching pointer %p", static_cast<void*>(ptr.get()));
 	return emptyString;
 }
 
@@ -94,7 +94,7 @@ StateRef<Agent> AgentGenerator::createAgent(GameState &state, StateRef<Organisat
 
 		auto firstName = pickRandom(state.rng, firstNameList->second);
 		auto secondName = pickRandom(state.rng, this->second_names);
-		agent->name = format("%s %s", firstName, secondName);
+		agent->name = format("{} {}", firstName, secondName);
 	}
 	else
 	{
@@ -281,7 +281,7 @@ UString Agent::getRankName() const
 		case Rank::Commander:
 			return tr("Commander");
 	}
-	LogError("Unknown rank %d", (int)rank);
+	LogError("Unknown rank {}", (int)rank);
 	return "";
 }
 
@@ -489,7 +489,7 @@ bool Agent::canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> equipmentTyp
 		        }
 		        if (!validSlot)
 		        {
-		            LogInfo("Equipping \"%s\" on \"%s\" at {%d,%d} failed: Armor intersecting both
+		            LogInfo("Equipping \"{}\" on \"{}\" at {{},{}} failed: Armor intersecting both
 		armor and non-armor slot",
 		                type->name, this->name, pos.x, pos.y);
 		            return false;
@@ -647,7 +647,7 @@ sp<AEquipment> Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentTy
 	{
 		if (!allowFailure)
 		{
-			LogError("Trying to add \"%s\" on agent \"%s\" failed: no valid slot found",
+			LogError("Trying to add \"{}\" on agent \"{}\" failed: no valid slot found",
 			         equipmentType.id, this->name);
 		}
 		return nullptr;
@@ -672,7 +672,7 @@ sp<AEquipment> Agent::addEquipmentByType(GameState &state, StateRef<AEquipmentTy
 	{
 		if (!allowFailure)
 		{
-			LogError("Trying to add \"%s\" on agent \"%s\" failed: no valid slot found",
+			LogError("Trying to add \"{}\" on agent \"{}\" failed: no valid slot found",
 			         equipmentType.id, this->name);
 		}
 		return nullptr;
@@ -720,7 +720,7 @@ void Agent::addEquipment(GameState &state, sp<AEquipment> object, EquipmentSlotT
 	Vec2<int> pos = findFirstSlotByType(slotType, object->type);
 	if (pos.x == -1)
 	{
-		LogError("Trying to add \"%s\" on agent \"%s\" failed: no valid slot found", type.id,
+		LogError("Trying to add \"{}\" on agent \"{}\" failed: no valid slot found", type.id,
 		         this->name);
 		return;
 	}
@@ -733,11 +733,11 @@ void Agent::addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object)
 	EquipmentSlotType slotType;
 	if (!canAddEquipment(pos, object->type, slotType))
 	{
-		LogError("Trying to add \"%s\" at %s on agent  \"%s\" failed", object->type.id, pos,
+		LogError("Trying to add \"{}\" at {} on agent  \"{}\" failed", object->type.id, pos,
 		         this->name);
 	}
 
-	LogInfo("Equipped \"%s\" with equipment \"%s\"", this->name, object->type->name);
+	LogInfo("Equipped \"{}\" with equipment \"{}\"", this->name, object->type->name);
 	// Proper position
 	for (auto &slot : type->equipment_layout->slots)
 	{
@@ -874,12 +874,12 @@ bool Agent::popFinishedMissions(GameState &state)
 	bool popped = false;
 	while (missions.size() > 0 && missions.front()->isFinished(state, *this))
 	{
-		LogWarning("Agent %s mission \"%s\" finished", name, missions.front()->getName());
+		LogWarning("Agent {} mission \"{}\" finished", name, missions.front()->getName());
 		missions.pop_front();
 		popped = true;
 		if (!missions.empty())
 		{
-			LogWarning("Agent %s mission \"%s\" starting", name, missions.front()->getName());
+			LogWarning("Agent {} mission \"{}\" starting", name, missions.front()->getName());
 			missions.front()->start(state, *this);
 			continue;
 		}

--- a/game/state/shared/doodad.cpp
+++ b/game/state/shared/doodad.cpp
@@ -73,7 +73,7 @@ sp<Image> Doodad::getSprite()
 		if (animTime > age)
 			return frame;
 	}
-	LogWarning("Doodad reached age %d with no frame", age);
+	LogWarning("Doodad reached age {} with no frame", age);
 	return frame;
 }
 

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -161,7 +161,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	int price = 0;
 	if (state.economy.find(vehicleEquipment.id) == state.economy.end())
 	{
-		LogError("Economy not found for %s: How are we buying it then!?", vehicleEquipment.id);
+		LogError("Economy not found for {}: How are we buying it then!?", vehicleEquipment.id);
 	}
 	else
 	{
@@ -172,7 +172,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 			economy.currentStock -= count;
 			if (economy.currentStock < 0)
 			{
-				LogInfo("Economy went into negative stock for %s: Was it because we used economy "
+				LogInfo("Economy went into negative stock for {}: Was it because we used economy "
 				        "to transfer?",
 				        vehicleEquipment.id);
 			}
@@ -183,7 +183,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	auto building = buyer->owner->id == id ? buyer : getPurchaseBuilding(state, buyer);
 	building->cargo.emplace_back(state, vehicleEquipment, count, price,
 	                             StateRef<Organisation>{&state, id}, buyer);
-	LogWarning("PURCHASE: %s bought %dx%s at %s to %s ", buyer->owner.id, count,
+	LogWarning("PURCHASE: {} bought {}x{} at {} to {} ", buyer->owner.id, count,
 	           vehicleEquipment.id, building.id, buyer.id);
 	auto owner = buyer->owner;
 	owner->balance -= count * price;
@@ -195,7 +195,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	int price = 0;
 	if (state.economy.find(vehicleAmmo.id) == state.economy.end())
 	{
-		LogError("Economy not found for %s: How are we buying it then!?", vehicleAmmo.id);
+		LogError("Economy not found for {}: How are we buying it then!?", vehicleAmmo.id);
 	}
 	else
 	{
@@ -206,7 +206,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 			economy.currentStock -= count;
 			if (economy.currentStock < 0)
 			{
-				LogInfo("Economy went into negative stock for %s: Was it because we used economy "
+				LogInfo("Economy went into negative stock for {}: Was it because we used economy "
 				        "to transfer?",
 				        vehicleAmmo.id);
 			}
@@ -217,7 +217,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	auto building = buyer->owner->id == id ? buyer : getPurchaseBuilding(state, buyer);
 	building->cargo.emplace_back(state, vehicleAmmo, count, price,
 	                             StateRef<Organisation>{&state, id}, buyer);
-	LogWarning("PURCHASE: %s bought %dx%s at %s to %s ", buyer->owner.id, count, vehicleAmmo.id,
+	LogWarning("PURCHASE: {} bought {}x{} at {} to {} ", buyer->owner.id, count, vehicleAmmo.id,
 	           building.id, buyer.id);
 	auto owner = buyer->owner;
 	owner->balance -= count * price;
@@ -229,7 +229,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	int price = 0;
 	if (state.economy.find(agentEquipment.id) == state.economy.end())
 	{
-		LogError("Economy not found for %s: How are we buying it then!?", agentEquipment.id);
+		LogError("Economy not found for {}: How are we buying it then!?", agentEquipment.id);
 	}
 	else
 	{
@@ -240,7 +240,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 			economy.currentStock -= count;
 			if (economy.currentStock < 0)
 			{
-				LogInfo("Economy went into negative stock for %s: Was it because we used economy "
+				LogInfo("Economy went into negative stock for {}: Was it because we used economy "
 				        "to transfer?",
 				        agentEquipment.id);
 			}
@@ -253,7 +253,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	    state, agentEquipment,
 	    count * (agentEquipment->type == AEquipmentType::Type::Ammo ? agentEquipment->max_ammo : 1),
 	    price, StateRef<Organisation>{&state, id}, buyer);
-	LogWarning("PURCHASE: %s bought %dx%s at %s to %s ", buyer->owner.id, count, agentEquipment.id,
+	LogWarning("PURCHASE: {} bought {}x{} at {} to {} ", buyer->owner.id, count, agentEquipment.id,
 	           building.id, buyer.id);
 	auto owner = buyer->owner;
 	owner->balance -= count * price;
@@ -265,7 +265,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 	int price = 0;
 	if (state.economy.find(vehicleType.id) == state.economy.end())
 	{
-		LogError("Economy not found for %s: How are we buying it then!?", vehicleType.id);
+		LogError("Economy not found for {}: How are we buying it then!?", vehicleType.id);
 	}
 	else
 	{
@@ -276,7 +276,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 			economy.currentStock -= count;
 			if (economy.currentStock < 0)
 			{
-				LogError("Economy went into negative stock for %s: How the hell?", vehicleType.id);
+				LogError("Economy went into negative stock for {}: How the hell?", vehicleType.id);
 			}
 		}
 	}
@@ -288,7 +288,7 @@ void Organisation::purchase(GameState &state, const StateRef<Building> &buyer,
 		v->homeBuilding = buyer;
 		v->setMission(state, VehicleMission::gotoBuilding(state, *v));
 	}
-	LogWarning("PURCHASE: %s bought %dx%s at %s to %s ", buyer->owner.id, count, vehicleType.id,
+	LogWarning("PURCHASE: {} bought {}x{} at {} to {} ", buyer->owner.id, count, vehicleType.id,
 	           building.id, buyer.id);
 	auto owner = buyer->owner;
 	owner->balance -= count * price;
@@ -770,7 +770,7 @@ sp<Organisation> StateObject<Organisation>::get(const GameState &state, const US
 	auto it = state.organisations.find(id);
 	if (it == state.organisations.end())
 	{
-		LogError("No organisation matching ID \"%s\"", id);
+		LogError("No organisation matching ID \"{}\"", id);
 		return nullptr;
 	}
 	return it->second;

--- a/game/state/stateobject.h
+++ b/game/state/stateobject.h
@@ -67,13 +67,13 @@ template <typename T> class StateRef
 		auto idPrefix = id.substr(0, prefix.length());
 		if (prefix != idPrefix)
 		{
-			LogWarning("%s object has invalid prefix - expected \"%s\" ID \"%s\"", T::getTypeName(),
+			LogWarning("{} object has invalid prefix - expected \"{}\" ID \"{}\"", T::getTypeName(),
 			           T::getPrefix(), id);
 		}
 		obj = T::get(*state, id);
 		if (!obj)
 		{
-			LogError("No %s object matching ID \"%s\" found", T::getTypeName(), id);
+			LogError("No {} object matching ID \"{}\" found", T::getTypeName(), id);
 		}
 	}
 

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -159,7 +159,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 	// Approach Only makes no sense with pathing into a block, but we'll fix it anyway
 	if (approachOnly && !destinationIsSingleTile)
 	{
-		LogWarning("Trying to route from %s to %s-%s in approachOnly mode? Extending destination's "
+		LogWarning("Trying to route from {} to {}-{} in approachOnly mode? Extending destination's "
 		           "xy boundaries by 1.",
 		           origin, destinationStart, destinationEnd);
 		approachOnly = false;
@@ -171,28 +171,28 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 
 	if (destinationIsSingleTile)
 	{
-		LogInfo("Trying to route from %s to %s", origin, destinationStart);
+		LogInfo("Trying to route from {} to {}", origin, destinationStart);
 	}
 	else
 	{
-		LogInfo("Trying to route from %s to %s-%s", origin, destinationStart, destinationEnd);
+		LogInfo("Trying to route from {} to {}-{}", origin, destinationStart, destinationEnd);
 	}
 
 	if (!tileIsValid(origin))
 	{
-		LogError("Bad origin %s", origin);
+		LogError("Bad origin {}", origin);
 		return {};
 	}
 	if (!tileIsValid(destinationStart))
 	{
-		LogError("Bad destinationStart %s", destinationStart);
+		LogError("Bad destinationStart {}", destinationStart);
 		return {};
 	}
 	if (destinationEnd.x <= destinationStart.x || destinationEnd.x > this->size.x ||
 	    destinationEnd.y <= destinationStart.y || destinationEnd.y > this->size.y ||
 	    destinationEnd.z <= destinationStart.z || destinationEnd.z > this->size.z)
 	{
-		LogError("Bad destinationEnd %s", destinationEnd);
+		LogError("Bad destinationEnd {}", destinationEnd);
 		return {};
 	}
 
@@ -202,7 +202,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 	Tile *startTile = this->getTile(origin);
 	if (!startTile)
 	{
-		LogError("Failed to get origin tile at %s", origin);
+		LogError("Failed to get origin tile at {}", origin);
 		return {};
 	}
 
@@ -227,7 +227,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 		auto first = fringe.begin();
 		if (first == fringe.end())
 		{
-			LogInfo("No more tiles to expand after %d iterations", iterationCount);
+			LogInfo("No more tiles to expand after {} iterations", iterationCount);
 			break;
 		}
 		auto nodeToExpand = *first;
@@ -247,7 +247,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 		             nodeToExpand->thisTile->position.x] = true;
 
 #ifdef PATHFINDING_DEBUG
-		LogInfo("EXPAND %s", nodeToExpand->thisTile->position);
+		LogInfo("EXPAND {}", nodeToExpand->thisTile->position);
 		nodeToExpand->thisTile->pathfindingDebugFlag = true;
 #endif
 
@@ -342,7 +342,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 					nodesToDelete.push_back(newNode);
 
 #ifdef PATHFINDING_DEBUG
-					LogInfo("NEW ND %s [%f, %f]", nextPosition, newNode->costToGetHere,
+					LogInfo("NEW ND {} [{}, {}]", nextPosition, newNode->costToGetHere,
 					        newNode->distanceToGoal);
 #endif
 
@@ -367,15 +367,15 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 		}
 		else if (maxCost > 0.0f)
 		{
-			LogInfo("No route from %s to %s-%s found after %d iterations, returning "
-			        "closest path %s",
+			LogInfo("No route from {} to {}-{} found after {} iterations, returning "
+			        "closest path {}",
 			        origin, destinationStart, destinationEnd, iterationCount,
 			        closestNodeSoFar->thisTile->position);
 		}
 		else
 		{
-			LogInfo("No route from %s to %s-%s found after %d iterations, returning "
-			        "closest path %s",
+			LogInfo("No route from {} to {}-{} found after {} iterations, returning "
+			        "closest path {}",
 			        origin, destinationStart, destinationEnd, iterationCount,
 			        closestNodeSoFar->thisTile->position);
 		}
@@ -384,18 +384,18 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 	{
 		if (maxCost > 0.0f)
 		{
-			LogInfo("Could not find path within maxPath, returning closest path ending at %s",
+			LogInfo("Could not find path within maxPath, returning closest path ending at {}",
 			        closestNodeSoFar->thisTile->position.x);
 		}
 		else
 		{
-			LogInfo("Surprisingly, no nodes to expand! Closest path ends at %s",
+			LogInfo("Surprisingly, no nodes to expand! Closest path ends at {}",
 			        closestNodeSoFar->thisTile->position);
 		}
 	}
 	/*else
 	{
-	    LogInfo("Path of length %d found in %d iterations", (int)(closestNodeSoFar->costToGetHere *
+	    LogInfo("Path of length {} found in {} iterations", (int)(closestNodeSoFar->costToGetHere *
 	canEnterTile.pathOverheadAlloawnce() / 4.0f), iterationCount);
 	}*/
 
@@ -429,16 +429,16 @@ std::list<Vec3<int>> Battle::findShortestPath(Vec3<int> origin, Vec3<int> destin
 	// a minimum number of iterations required to pathfind between two locations
 	static const int PATH_ITERATION_LIMIT_MULTIPLIER = 2;
 
-	LogInfo("Trying to route (battle) from %s to %s", origin, destination);
+	LogInfo("Trying to route (battle) from {} to {}", origin, destination);
 
 	if (!map->tileIsValid(origin))
 	{
-		LogError("Bad origin %s", origin);
+		LogError("Bad origin {}", origin);
 		return {};
 	}
 	if (!map->tileIsValid(destination))
 	{
-		LogError("Bad destination %s", destination);
+		LogError("Bad destination {}", destination);
 		return {};
 	}
 
@@ -738,7 +738,7 @@ std::list<int> Battle::findLosBlockPath(int origin, int destination, BattleUnitT
 	std::list<LosNode *> fringe;
 	int iterationCount = 0;
 
-	LogInfo("Trying to route from lb %d to lb %d", origin, destination);
+	LogInfo("Trying to route from lb {} to lb {}", origin, destination);
 
 	if (origin == destination)
 	{
@@ -773,7 +773,7 @@ std::list<int> Battle::findLosBlockPath(int origin, int destination, BattleUnitT
 		auto first = fringe.begin();
 		if (first == fringe.end())
 		{
-			LogInfo("No more blocks to expand after %d iterations", iterationCount);
+			LogInfo("No more blocks to expand after {} iterations", iterationCount);
 			break;
 		}
 		auto nodeToExpand = *first;
@@ -828,13 +828,13 @@ std::list<int> Battle::findLosBlockPath(int origin, int destination, BattleUnitT
 
 	if (iterationCount > iterationLimit)
 	{
-		LogWarning("No route from lb %d to %d found after %d iterations, returning "
-		           "closest path ending in %d",
+		LogWarning("No route from lb {} to {} found after {} iterations, returning "
+		           "closest path ending in {}",
 		           origin, destination, iterationCount, closestNodeSoFar->block);
 	}
 	else if (closestNodeSoFar->distanceToGoal > 0)
 	{
-		LogInfo("Surprisingly, no nodes to expand! Closest path ends in %d",
+		LogInfo("Surprisingly, no nodes to expand! Closest path ends in {}",
 		        closestNodeSoFar->block);
 	}
 
@@ -963,8 +963,8 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 	}
 
 	UString log = ";";
-	log += format("\nGroup move order issued to %d, %d, %d. Looking for the leader. Total number "
-	              "of units: %d",
+	log += format("\nGroup move order issued to {}, {}, {}. Looking for the leader. Total number "
+	              "of units: {}",
 	              targetLocation.x, targetLocation.y, targetLocation.z, (int)selectedUnits.size());
 
 	// Sort units based on proximity to target and speed
@@ -986,7 +986,7 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 	while (itUnit != localUnits.end())
 	{
 		auto curUnit = *itUnit;
-		log += format("\nTrying unit %s for leader", curUnit.id);
+		log += format("\nTrying unit {} for leader", curUnit.id);
 
 		auto mission = BattleUnitMission::gotoLocation(*curUnit, targetLocation, facingDelta,
 		                                               demandGiveWay, true, 20, false);
@@ -1044,7 +1044,7 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 	if (itUnit == localUnits.end() && !leadUnit)
 	{
 		log += format("\nNoone could path to target, aborting");
-		LogWarning("%s", log);
+		LogWarning("{}", log);
 		return;
 	}
 
@@ -1080,7 +1080,7 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 	    });
 
 	// Path every other unit to areas around target
-	log += format("\nTarget location is now %d, %d, %d. Leader is %s", targetLocation.x,
+	log += format("\nTarget location is now {}, {}, {}. Leader is {}", targetLocation.x,
 	              targetLocation.y, targetLocation.z, leadUnit.id);
 
 	auto itOffset = targetOffsets.begin();
@@ -1089,10 +1089,10 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 		if (itOffset == targetOffsets.end())
 		{
 			log += format("\nRan out of location offsets, exiting");
-			LogWarning("%s", log);
+			LogWarning("{}", log);
 			return;
 		}
-		log += format("\nPathing unit %s", unit.id);
+		log += format("\nPathing unit {}", unit.id);
 		while (itOffset != targetOffsets.end())
 		{
 			auto offset = rotate(*itOffset, rotation);
@@ -1106,7 +1106,7 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 				continue;
 			}
 
-			log += format("\nTrying location %d, %d, %d at offset %d, %d, %d",
+			log += format("\nTrying location {}, {}, {} at offset {}, {}, {}",
 			              targetLocationOffsetted.x, targetLocationOffsetted.y,
 			              targetLocationOffsetted.z, offset.x, offset.y, offset.z);
 			float costLimit = 1.50f * 2.0f *
@@ -1128,7 +1128,7 @@ void Battle::groupMove(GameState &state, std::list<StateRef<BattleUnit>> &select
 		}
 	}
 	log += format("\nSuccessfully pathed everybody to target");
-	LogWarning("%s", log);
+	LogWarning("{}", log);
 }
 
 std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destination,
@@ -1172,7 +1172,7 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 	std::list<RoadSegmentNode *> fringe;
 	int iterationCount = 0;
 
-	LogInfo("Trying to route from rs %d to rs %d", originID, destinationID);
+	LogInfo("Trying to route from rs {} to rs {}", originID, destinationID);
 
 	auto startNode = new RoadSegmentNode(
 	    0.0f, GroundVehicleTileHelper::getDistanceStatic(origin, destination), nullptr, originID);
@@ -1235,7 +1235,7 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 		auto first = fringe.begin();
 		if (first == fringe.end())
 		{
-			LogInfo("No more road segments to expand after %d iterations", iterationCount);
+			LogInfo("No more road segments to expand after {} iterations", iterationCount);
 			break;
 		}
 		auto nodeToExpand = *first;
@@ -1376,13 +1376,13 @@ std::list<Vec3<int>> City::findShortestPath(Vec3<int> origin, Vec3<int> destinat
 
 	if (iterationCount > iterationLimit)
 	{
-		LogWarning("No route from lb %d to %d found after %d iterations, returning "
-		           "closest path ending at %d",
+		LogWarning("No route from lb {} to {} found after {} iterations, returning "
+		           "closest path ending at {}",
 		           origin, destination, iterationCount, closestNodeSoFar->segment);
 	}
 	else if (closestNodeSoFar->distanceToGoal > 0)
 	{
-		LogInfo("Surprisingly, no nodes to expand! Closest path ends at %d",
+		LogInfo("Surprisingly, no nodes to expand! Closest path ends at {}",
 		        closestNodeSoFar->segment);
 	}
 
@@ -1771,12 +1771,12 @@ void City::fillRoadSegmentMap(GameState &state [[maybe_unused]])
 							{
 								continue;
 							}
-							LogWarning("Pass 2: Tile %s disconnected from some exits network",
+							LogWarning("Pass 2: Tile {} disconnected from some exits network",
 							           tileToTryNext);
 							break;
 						// Anything goes, coming up OOOs!
 						case 3:
-							LogWarning("Pass 3: Tile %s disconnected from main network!",
+							LogWarning("Pass 3: Tile {} disconnected from main network!",
 							           tileToTryNext);
 							break;
 					}
@@ -1792,13 +1792,13 @@ void City::fillRoadSegmentMap(GameState &state [[maybe_unused]])
 					{
 						if (roadSegments[nextSegmentToProcess].empty())
 						{
-							LogWarning("Skipping empty segment %d", nextSegmentToProcess);
+							LogWarning("Skipping empty segment {}", nextSegmentToProcess);
 							nextSegmentToProcess++;
 							continue;
 						}
 						auto initialConnections =
 						    roadSegments[nextSegmentToProcess].connections.size();
-						LogInfo("Segment %d Connections %d First %d", nextSegmentToProcess,
+						LogInfo("Segment {} Connections {} First {}", nextSegmentToProcess,
 						        initialConnections,
 						        initialConnections == 0
 						            ? -1
@@ -1896,13 +1896,13 @@ void City::fillRoadSegmentMap(GameState &state [[maybe_unused]])
 											// Some sanity
 											if (idx == -1)
 											{
-												LogError("Linking from %s to %s: Non road, wtf?",
+												LogError("Linking from {} to {}: Non road, wtf?",
 												         currentPosition, nextPosition);
 												break;
 											}
 											if (roadSegments[idx].tilePosition.size() > 1)
 											{
-												LogWarning("Linking from %s to %s: Existing road "
+												LogWarning("Linking from {} to {}: Existing road "
 												           "segment, wtf?",
 												           currentPosition, nextPosition);
 												// break;

--- a/game/state/tilemap/tile.cpp
+++ b/game/state/tilemap/tile.cpp
@@ -44,7 +44,7 @@ Vec3<float> Tile::getRestingPosition(bool large, bool overlay)
 		if (position.x < 1 || position.y < 1)
 		{
 			LogError(
-			    "Trying to get resting position for a large unit when it can't fit! %d, %d, %d",
+			    "Trying to get resting position for a large unit when it can't fit! {}, {}, {}",
 			    position.x, position.y, position.z);
 			return Vec3<float>{position.x + 0.5, position.y + 0.5, position.z};
 		}
@@ -82,7 +82,7 @@ bool Tile::getSolidGround(bool large)
 	{
 		if (position.x < 1 || position.y < 1)
 		{
-			LogError("Trying to get solid ground for a large unit when it can't fit! %d, %d, %d",
+			LogError("Trying to get solid ground for a large unit when it can't fit! {}, {}, {}",
 			         position.x, position.y, position.z);
 			return false;
 		}
@@ -110,7 +110,7 @@ bool Tile::getCanStand(bool large)
 		if (position.x < 1 || position.y < 1)
 		{
 			LogError(
-			    "Trying to get standing ability for a large unit when it can't fit! %d, %d, %d",
+			    "Trying to get standing ability for a large unit when it can't fit! {}, {}, {}",
 			    position.x, position.y, position.z);
 			return false;
 		}
@@ -137,7 +137,7 @@ bool Tile::getHasExit(bool large)
 	{
 		if (position.x < 1 || position.y < 1)
 		{
-			LogError("Trying to get exit for a large unit when it can't fit! %d, %d, %d",
+			LogError("Trying to get exit for a large unit when it can't fit! {}, {}, {}",
 			         position.x, position.y, position.z);
 			return false;
 		}

--- a/game/state/tilemap/tilemap.cpp
+++ b/game/state/tilemap/tilemap.cpp
@@ -54,7 +54,7 @@ TileMap::TileMap(Vec3<int> size, Vec3<float> velocityScale, Vec3<int> voxelMapSi
 		{
 			if (seenTypes.find(type) != seenTypes.end())
 			{
-				LogError("Type %d appears in multiple layers", static_cast<int>(type));
+				LogError("Type {} appears in multiple layers", static_cast<int>(type));
 			}
 			seenTypes.insert(type);
 		}
@@ -217,7 +217,7 @@ unsigned int TileMap::getLayer(TileObject::Type type) const
 			return i;
 		}
 	}
-	LogError("No layer matching object type %d", static_cast<int>(type));
+	LogError("No layer matching object type {}", static_cast<int>(type));
 	return 0;
 }
 
@@ -252,9 +252,9 @@ sp<Image> TileMap::dumpVoxelView(const Rect<int> viewRect, const TileTransform &
 	int w = viewRect.p1.x - viewRect.p0.x;
 	Vec2<float> offset = {viewRect.p0.x, viewRect.p0.y};
 
-	LogWarning("ViewRect %s", viewRect);
+	LogWarning("ViewRect {}", viewRect);
 
-	LogWarning("Dumping voxels {%d,%d} voxels w/offset %s", w, h, offset);
+	LogWarning("Dumping voxels {{},{}} voxels w/offset {}", w, h, offset);
 
 	int inc = fast ? 2 : 1;
 

--- a/game/state/tilemap/tilemap.cpp
+++ b/game/state/tilemap/tilemap.cpp
@@ -254,7 +254,7 @@ sp<Image> TileMap::dumpVoxelView(const Rect<int> viewRect, const TileTransform &
 
 	LogWarning("ViewRect {}", viewRect);
 
-	LogWarning("Dumping voxels {{},{}} voxels w/offset {}", w, h, offset);
+	LogWarning("Dumping voxels {{{},{}}} voxels w/offset {}", w, h, offset);
 
 	int inc = fast ? 2 : 1;
 

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -101,7 +101,7 @@ class TileMap
 
 		if (!((x >= 0) && (x < size.x) && (y >= 0) && (y < size.y) && (z >= 0) && (z < size.z)))
 		{
-			LogError("Incorrect tile coordinates (const) %d,%d,%d", x, y, z);
+			LogError("Incorrect tile coordinates (const) {},{},{}", x, y, z);
 			return nullptr;
 		}
 		return &this->tiles[z * size.x * size.y + y * size.x + x];
@@ -110,7 +110,7 @@ class TileMap
 	{
 		if (!((x >= 0) && (x < size.x) && (y >= 0) && (y < size.y) && (z >= 0) && (z < size.z)))
 		{
-			LogError("Incorrect tile coordinates %d,%d,%d", x, y, z);
+			LogError("Incorrect tile coordinates {},{},{}", x, y, z);
 			return nullptr;
 		}
 		return &this->tiles[z * size.x * size.y + y * size.x + x];

--- a/game/state/tilemap/tileobject.cpp
+++ b/game/state/tilemap/tileobject.cpp
@@ -142,7 +142,7 @@ void TileObject::setPosition(Vec3<float> newPosition)
 				Tile *intersectingTile = map.getTile(x, y, z);
 				if (!intersectingTile)
 				{
-					LogError("Failed to get intersecting tile at {{},{},{}}", x, y, z);
+					LogError("Failed to get intersecting tile at {{{},{},{}}}", x, y, z);
 					continue;
 				}
 				this->intersectingTiles.push_back(intersectingTile);

--- a/game/state/tilemap/tileobject.cpp
+++ b/game/state/tilemap/tileobject.cpp
@@ -99,18 +99,18 @@ void TileObject::setPosition(Vec3<float> newPosition)
 	    newPosition.x > map.size.x + 1 || newPosition.y > map.size.y + 1 ||
 	    newPosition.z > map.size.z + 1)
 	{
-		LogWarning("Trying to place object at %s in map of size %s", newPosition, map.size);
+		LogWarning("Trying to place object at {} in map of size {}", newPosition, map.size);
 		newPosition.x = clamp(newPosition.x, 0.0f, (float)map.size.x + 1);
 		newPosition.y = clamp(newPosition.y, 0.0f, (float)map.size.y + 1);
 		newPosition.z = clamp(newPosition.z, 0.0f, (float)map.size.z + 1);
-		LogWarning("Clamped object to %s", newPosition);
+		LogWarning("Clamped object to {}", newPosition);
 	}
 	this->removeFromMap();
 
 	this->owningTile = map.getTile(newPosition);
 	if (!this->owningTile)
 	{
-		LogError("Failed to get tile for position %s", newPosition);
+		LogError("Failed to get tile for position {}", newPosition);
 		return;
 	}
 
@@ -142,7 +142,7 @@ void TileObject::setPosition(Vec3<float> newPosition)
 				Tile *intersectingTile = map.getTile(x, y, z);
 				if (!intersectingTile)
 				{
-					LogError("Failed to get intersecting tile at {%d,%d,%d}", x, y, z);
+					LogError("Failed to get intersecting tile at {{},{},{}}", x, y, z);
 					continue;
 				}
 				this->intersectingTiles.push_back(intersectingTile);

--- a/game/state/tilemap/tileobject_battlemappart.cpp
+++ b/game/state/tilemap/tileobject_battlemappart.cpp
@@ -65,7 +65,7 @@ TileObject::Type TileObjectBattleMapPart::convertType(BattleMapPartType::Type ty
 		case BattleMapPartType::Type::Feature:
 			return TileObject::Type::Feature;
 		default:
-			LogError("Unknown BattleMapPartType::Type %d", (int)type);
+			LogError("Unknown BattleMapPartType::Type {}", (int)type);
 			return TileObject::Type::Ground;
 	}
 }
@@ -141,7 +141,7 @@ float TileObjectBattleMapPart::getZOrder() const
 			return z + (float)map_part->type->height / 40.0f / 2.0f - 14.0f;
 		}
 		default:
-			LogError("Impossible map part type %d", (int)type);
+			LogError("Impossible map part type {}", (int)type);
 			return 0.0f;
 	}
 }

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -59,19 +59,19 @@ void BaseScreen::begin()
 	selGraphic = form->findControlTyped<Graphic>("GRAPHIC_SELECTED_FACILITY");
 	for (int i = 0; i < 3; i++)
 	{
-		auto labelName = format("LABEL_%d", i + 1);
+		auto labelName = format("LABEL_{}", i + 1);
 		auto label = form->findControlTyped<Label>(labelName);
 		if (!label)
 		{
-			LogError("Failed to find UI control matching \"%s\"", labelName);
+			LogError("Failed to find UI control matching \"{}\"", labelName);
 		}
 		statsLabels.push_back(label);
 
-		auto valueName = format("VALUE_%d", i + 1);
+		auto valueName = format("VALUE_{}", i + 1);
 		auto value = form->findControlTyped<Label>(valueName);
 		if (!value)
 		{
-			LogError("Failed to find UI control matching \"%s\"", valueName);
+			LogError("Failed to find UI control matching \"{}\"", valueName);
 		}
 		statsValues.push_back(value);
 	}
@@ -285,7 +285,7 @@ void BaseScreen::eventOccurred(Event *e)
 					}
 					if (!ufopaedia_category)
 					{
-						LogError("No UFOPaedia category found for entry %s",
+						LogError("No UFOPaedia category found for entry {}",
 						         ufopaedia_entry->title);
 					}
 					fw().stageQueueCommand(
@@ -397,11 +397,11 @@ void BaseScreen::eventOccurred(Event *e)
 		selText->setText(tr(dragFacility->name));
 		selGraphic->setImage(dragFacility->sprite);
 		statsLabels[0]->setText(tr("Cost to build"));
-		statsValues[0]->setText(format("$%d", dragFacility->buildCost));
+		statsValues[0]->setText(format("${}", dragFacility->buildCost));
 		statsLabels[1]->setText(tr("Days to build"));
-		statsValues[1]->setText(format("%d", dragFacility->buildTime));
+		statsValues[1]->setText(format("{}", dragFacility->buildTime));
 		statsLabels[2]->setText(tr("Maintenance cost"));
-		statsValues[2]->setText(format("$%d", dragFacility->weeklyCost));
+		statsValues[2]->setText(format("${}", dragFacility->weeklyCost));
 	}
 	else if (selFacility != nullptr)
 	{
@@ -410,17 +410,17 @@ void BaseScreen::eventOccurred(Event *e)
 		if (selFacility->type->capacityAmount > 0)
 		{
 			statsLabels[0]->setText(tr("Capacity"));
-			statsValues[0]->setText(format("%d", selFacility->type->capacityAmount));
+			statsValues[0]->setText(format("{}", selFacility->type->capacityAmount));
 			statsLabels[1]->setText(tr("Usage"));
 			statsValues[1]->setText(
-			    format("%d%%", state->current_base->getUsage(*state, selFacility)));
+			    format("{}%%", state->current_base->getUsage(*state, selFacility)));
 		}
 	}
 	else if (selection != NO_SELECTION)
 	{
 		int sprite = BaseGraphics::getCorridorSprite(*state->current_base, selection);
 		auto image = format(
-		    "PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:%d:xcom3/ufodata/base.pcx", sprite);
+		    "PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:{}:xcom3/ufodata/base.pcx", sprite);
 		if (sprite != 0)
 		{
 			selText->setText(tr("Corridor"));

--- a/game/ui/base/basestage.cpp
+++ b/game/ui/base/basestage.cpp
@@ -45,7 +45,7 @@ void BaseStage::begin()
 	for (auto &pair : state->player_bases)
 	{
 		auto &viewBase = pair.second;
-		auto viewName = format("BUTTON_BASE_%d", ++b);
+		auto viewName = format("BUTTON_BASE_{}", ++b);
 		auto view = form->findControlTyped<GraphicButton>(viewName);
 		if (!view)
 		{

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -94,7 +94,7 @@ void BuyAndSellScreen::updateFormValues(bool queueHighlightUpdate)
 	int balance = state->getPlayer()->balance + moneyDelta;
 	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance));
 	form->findControlTyped<Label>("TEXT_FUNDS_DELTA")
-	    ->setText(format("%s%s", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
+	    ->setText(format("{}{}", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
 }
 
 void BuyAndSellScreen::closeScreen()
@@ -248,17 +248,17 @@ void BuyAndSellScreen::closeScreen()
 		if (!badOrgs.empty())
 		{
 			UString title =
-			    format("%s%s", badOrgs.front()->name, badOrgs.size() > 1 ? " & others" : "");
+			    format("{}{}", badOrgs.front()->name, badOrgs.size() > 1 ? " & others" : "");
 
 			// If player can ferry themselves then give option
 			if (config().getBool("OpenApoc.NewFeature.AllowManualCargoFerry"))
 			{
 				UString message = transportationHostile
-				                      ? format("%s %s",
+				                      ? format("{} {}",
 				                               tr("Hostile organization refuses to carry out the "
 				                                  "requested transportation for this company."),
 				                               tr("Proceed?"))
-				                      : format("%s %s",
+				                      : format("{} {}",
 				                               tr("No free transport to carry out the requested "
 				                                  "transportation detected in the city."),
 				                               tr("Proceed?"));
@@ -272,7 +272,7 @@ void BuyAndSellScreen::closeScreen()
 			else if (!transportationHostile)
 			{
 				// FIXME: Different message maybe? Same for now
-				UString message = format("%s %s",
+				UString message = format("{} {}",
 				                         tr("No free transport to carry out the requested "
 				                            "transportation detected in the city."),
 				                         tr("Proceed?"));
@@ -356,18 +356,18 @@ void BuyAndSellScreen::closeScreen()
 		if (transportationBusy || transportationHostile)
 		{
 			UString title =
-			    format("%s%s", badOrgs.front()->name, badOrgs.size() > 1 ? " & others" : "");
+			    format("{}{}", badOrgs.front()->name, badOrgs.size() > 1 ? " & others" : "");
 
 			// If player can ferry themselves then give option
 			if (config().getBool("OpenApoc.NewFeature.AllowManualCargoFerry"))
 			{
 				UString message =
 				    transportationHostile
-				        ? format("%s %s",
+				        ? format("{} {}",
 				                 tr("This hostile organization refuses to carry out the "
 				                    "requested transfer."),
 				                 tr("Proceed?"))
-				        : format("%s %s",
+				        : format("{} {}",
 				                 tr("No free transport to carry out the requested "
 				                    "transportation detected in the city."),
 				                 tr("Proceed?"));
@@ -381,7 +381,7 @@ void BuyAndSellScreen::closeScreen()
 			else if (!transportationHostile)
 			{
 				// FIXME: Different message maybe? Same for now
-				UString message = format("%s %s",
+				UString message = format("{} {}",
 				                         tr("No free transport to carry out the requested "
 				                            "transportation detected in the city."),
 				                         tr("Proceed?"));
@@ -423,7 +423,7 @@ void BuyAndSellScreen::executeOrders()
 				if (c->itemType != TransactionControl::Type::Vehicle &&
 				    state->economy.find(c->itemId) == state->economy.end())
 				{
-					LogError("Economy not found for %s: How are we selling it then!?", c->itemId);
+					LogError("Economy not found for {}: How are we selling it then!?", c->itemId);
 					continue;
 				}
 
@@ -499,7 +499,7 @@ void BuyAndSellScreen::executeOrders()
 							}
 							case TransactionControl::Type::VehicleType:
 							{
-								LogError("How did we manage to sell a vehicle type %s!?",
+								LogError("How did we manage to sell a vehicle type {}!?",
 								         c->itemId);
 								break;
 							}
@@ -512,7 +512,7 @@ void BuyAndSellScreen::executeOrders()
 						auto org = c->manufacturer;
 						if (org->isRelatedTo(player) == Organisation::Relation::Hostile)
 						{
-							LogError("How the hell is being bought from a hostile org %s?",
+							LogError("How the hell is being bought from a hostile org {}?",
 							         c->manufacturerName);
 							continue;
 						}
@@ -521,13 +521,13 @@ void BuyAndSellScreen::executeOrders()
 						{
 							case TransactionControl::Type::Vehicle:
 							{
-								LogError("It should be impossible to buy a particular vehicle %s.",
+								LogError("It should be impossible to buy a particular vehicle {}.",
 								         c->itemId);
 								break;
 							}
 							case TransactionControl::Type::AgentEquipmentBio:
 							{
-								LogError("Alien %s: How are we buying it!?", c->itemId);
+								LogError("Alien {}: How are we buying it!?", c->itemId);
 								break;
 							}
 							case TransactionControl::Type::AgentEquipmentCargo:

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -341,7 +341,7 @@ void RecruitScreen::updateFormValues()
 	int balance = state->getPlayer()->balance + moneyDelta;
 	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance));
 	form->findControlTyped<Label>("TEXT_FUNDS_DELTA")
-	    ->setText(format("%s%s", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
+	    ->setText(format("{}{}", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
 
 	updateBaseHighlight();
 }
@@ -351,7 +351,7 @@ void RecruitScreen::updateBaseHighlight()
 	int usage = state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
 	fillBaseBar(usage);
 	auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
-	facilityLabel->setText(format("%s%%", usage));
+	facilityLabel->setText(format("{}%%", usage));
 }
 
 void RecruitScreen::fillBaseBar(int percent)
@@ -411,7 +411,7 @@ void RecruitScreen::personnelSheet(const Agent &agent, sp<Form> formPersonnelSta
 	formPersonnelStats->findControlTyped<Graphic>("SELECTED_PORTRAIT")
 	    ->setImage(agent.getPortrait().photo);
 	formPersonnelStats->findControlTyped<Label>("VALUE_SKILL")
-	    ->setText(format("%d", agent.getSkill()));
+	    ->setText(format("{}", agent.getSkill()));
 }
 
 /**
@@ -425,7 +425,7 @@ std::vector<sp<Image>> RecruitScreen::getBigUnitRanks()
 	{
 		bigUnitRanks.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/"
-		                                "tacbut.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "tacbut.tab:{}:xcom3/tacdata/tactical.pal",
 		                                i)));
 	}
 
@@ -477,10 +477,10 @@ void RecruitScreen::attemptCloseScreen()
 	if (hired != 0 || fired != 0 || transferred != 0)
 	{
 		UString message =
-		    format("%d %s\n%d %s", hired, tr("unit(s) hired"), fired, tr("unit(s) fired."));
+		    format("{} {}\n{} {}", hired, tr("unit(s) hired"), fired, tr("unit(s) fired."));
 		if (transferred > 0)
 		{
-			message = format("%s\n(%d %s)", message, transferred, tr("units(s) transferred"));
+			message = format("{}\n({} {})", message, transferred, tr("units(s) transferred"));
 		}
 		fw().stageQueueCommand(
 		    {StageCmd::Command::PUSH,

--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -129,7 +129,7 @@ void ResearchScreen::begin()
 		}
 		if (agent->assigned_to_lab)
 		{
-			LogError("Agent \"%s\" already assigned to a lab?", agent->name);
+			LogError("Agent \"{}\" already assigned to a lab?", agent->name);
 			return;
 		}
 		agent->assigned_to_lab = true;
@@ -147,7 +147,7 @@ void ResearchScreen::begin()
 		}
 		if (!agent->assigned_to_lab)
 		{
-			LogError("Agent \"%s\" not assigned to a lab?", agent->name);
+			LogError("Agent \"{}\" not assigned to a lab?", agent->name);
 			return;
 		}
 		agent->assigned_to_lab = false;
@@ -306,7 +306,7 @@ void ResearchScreen::populateUILabList(const UString &listName, std::list<sp<Fac
 		item->setData(facility);
 
 		auto label = std::static_pointer_cast<Label>(item->Controls[0]);
-		label->setText(format("%d", facility->lab->assigned_agents.size()));
+		label->setText(format("{}", facility->lab->assigned_agents.size()));
 
 		uiListLabs->addItem(item);
 		if (facility == viewFacility)
@@ -327,7 +327,7 @@ void ResearchScreen::setCurrentLabInfo()
 		assignedAgentList->clear();
 		form->findControlTyped<Label>("TEXT_LAB_TYPE")->setText("");
 		auto totalSkillLabel = form->findControlTyped<Label>("TEXT_TOTAL_SKILL");
-		totalSkillLabel->setText(format(tr("Total Skill: %d"), 0));
+		totalSkillLabel->setText(format(tr("Total Skill: {}"), 0));
 		updateProgressInfo();
 		return;
 	}
@@ -383,7 +383,7 @@ void ResearchScreen::setCurrentLabInfo()
 					this->assigned_agent_count++;
 					if (this->assigned_agent_count > this->viewFacility->type->capacityAmount)
 					{
-						LogError("Selected lab has %d assigned agents, but has a capacity of %d",
+						LogError("Selected lab has {} assigned agents, but has a capacity of {}",
 						         this->assigned_agent_count,
 						         this->viewFacility->type->capacityAmount);
 					}
@@ -411,7 +411,7 @@ void ResearchScreen::setCurrentLabInfo()
 
 	auto totalSkillLabel = form->findControlTyped<Label>("TEXT_TOTAL_SKILL");
 	totalSkillLabel->setText(
-	    format(tr("Total Skill: %d"), this->viewFacility->lab->getTotalSkill()));
+	    format(tr("Total Skill: {}"), this->viewFacility->lab->getTotalSkill()));
 
 	// update scientists quantity for selected lab
 	auto uiListLabs = form->findControlTyped<ListBox>("LIST_SMALL_LABS");
@@ -424,7 +424,7 @@ void ResearchScreen::setCurrentLabInfo()
 	if (selectedItem)
 	{
 		auto label = std::static_pointer_cast<Label>(selectedItem->Controls[0]);
-		label->setText(format("%d", this->viewFacility->lab->assigned_agents.size()));
+		label->setText(format("{}", this->viewFacility->lab->assigned_agents.size()));
 	}
 
 	updateProgressInfo();
@@ -477,7 +477,7 @@ void ResearchScreen::updateProgressInfo()
 		auto topicTitle = form->findControlTyped<Label>("TEXT_CURRENT_PROJECT");
 		topicTitle->setText(tr(topic->name));
 		auto completionPercent = form->findControlTyped<Label>("TEXT_PROJECT_COMPLETION");
-		auto completionText = format(tr("%d%%"), static_cast<int>(projectProgress * 100.0f));
+		auto completionText = format(tr("{}%%"), static_cast<int>(projectProgress * 100.0f));
 		completionPercent->setText(completionText);
 	}
 	else
@@ -508,7 +508,7 @@ void ResearchScreen::updateProgressInfo()
 		manufacturing_scroll_left->setVisible(true);
 		manufacturing_scroll_right->setVisible(true);
 		manufacturing_scrollbar->setValue(this->viewFacility->lab->getQuantity());
-		manufacturing_quantity->setText(format("%d", this->viewFacility->lab->getQuantity()));
+		manufacturing_quantity->setText(format("{}", this->viewFacility->lab->getQuantity()));
 	}
 	else
 	{

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -27,7 +27,7 @@ ResearchSelect::ResearchSelect(sp<GameState> state, sp<Lab> lab)
     : Stage(), form(ui().getForm("researchselect")), lab(lab), state(state)
 {
 	progressImage = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 63));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 63));
 }
 
 ResearchSelect::~ResearchSelect() = default;
@@ -233,7 +233,7 @@ void ResearchSelect::populateResearchList()
 		{
 			UString progress_text;
 			if (this->lab->type == ResearchTopic::Type::Engineering)
-				progress_text = format("$%d", t->cost);
+				progress_text = format("${}", t->cost);
 			else
 				progress_text = tr("Complete");
 			auto progress_label =
@@ -285,7 +285,7 @@ void ResearchSelect::populateResearchList()
 		}
 
 		auto skill_total_label =
-		    control->createChild<Label>(format("%d", skill_total), ui().getFont("smalfont"));
+		    control->createChild<Label>(format("{}", skill_total), ui().getFont("smalfont"));
 		skill_total_label->Size = {50, 18};
 		skill_total_label->Location = {328, 2};
 		skill_total_label->TextHAlign = HorizontalAlignment::Right;

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -460,7 +460,7 @@ void TransactionScreen::updateBaseHighlight()
 		int i = 0;
 		for (auto &b : state->player_bases)
 		{
-			auto viewName = format("BUTTON_BASE_%d", ++i);
+			auto viewName = format("BUTTON_BASE_{}", ++i);
 			auto view = form->findControlTyped<GraphicButton>(viewName);
 			auto viewImage = drawMiniBase(*b.second, viewHighlight, viewFacility);
 			view->setImage(viewImage);
@@ -482,7 +482,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("{}%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -496,7 +496,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("{}%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -510,7 +510,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("{}%%", usage));
 			break;
 		}
 		default:
@@ -651,7 +651,7 @@ void TransactionScreen::initViewSecondBase()
 {
 	for (int i = 1; i <= MAX_BASES; i++)
 	{
-		auto viewName = format("BUTTON_SECOND_BASE_%d", i);
+		auto viewName = format("BUTTON_SECOND_BASE_{}", i);
 		form->findControlTyped<GraphicButton>(viewName)->setVisible(false);
 	}
 	form->findControlTyped<Graphic>("FACILITY_SECOND_PIC")->setVisible(false);

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -146,7 +146,7 @@ void TransferScreen::updateBaseHighlight()
 		int i = 0;
 		for (auto &b : state->player_bases)
 		{
-			auto viewName = format("BUTTON_SECOND_BASE_%d", ++i);
+			auto viewName = format("BUTTON_SECOND_BASE_{}", ++i);
 			auto view = form->findControlTyped<GraphicButton>(viewName);
 			auto viewImage = drawMiniBase(*b.second, viewHighlight, viewFacility);
 			view->setImage(viewImage);
@@ -170,7 +170,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("{}%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -183,7 +183,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("{}%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -196,7 +196,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("{}%%", usage));
 			break;
 		}
 		default:
@@ -413,18 +413,18 @@ void TransferScreen::closeScreen()
 		if (transportationBusy || transportationHostile)
 		{
 			UString title =
-			    format("%s%s", badOrgs.front()->name, badOrgs.size() > 1 ? " & others" : "");
+			    format("{}{}", badOrgs.front()->name, badOrgs.size() > 1 ? " & others" : "");
 
 			// If player can ferry themselves then give option
 			if (config().getBool("OpenApoc.NewFeature.AllowManualCargoFerry"))
 			{
 				UString message =
 				    transportationHostile
-				        ? format("%s %s",
+				        ? format("{} {}",
 				                 tr("This hostile organization refuses to carry out the "
 				                    "requested transfer."),
 				                 tr("Proceed?"))
-				        : format("%s %s",
+				        : format("{} {}",
 				                 tr("No free transport to carry out the requested "
 				                    "transportation detected in the city."),
 				                 tr("Proceed?"));
@@ -438,7 +438,7 @@ void TransferScreen::closeScreen()
 			else if (!transportationHostile)
 			{
 				// FIXME: Different message maybe? Same for now
-				UString message = format("%s %s",
+				UString message = format("{} {}",
 				                         tr("No free transport to carry out the requested "
 				                            "transportation detected in the city."),
 				                         tr("Proceed?"));
@@ -652,7 +652,7 @@ void TransferScreen::initViewSecondBase()
 	int i = 0;
 	for (auto &b : state->player_bases)
 	{
-		auto viewName = format("BUTTON_SECOND_BASE_%d", ++i);
+		auto viewName = format("BUTTON_SECOND_BASE_{}", ++i);
 		auto view = form->findControlTyped<GraphicButton>(viewName);
 		view->setVisible(true);
 		if (second_base == b.second)

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -344,7 +344,7 @@ void VEquipScreen::eventOccurred(Event *e)
 			{
 				if (base->inventoryVehicleEquipment[draggedEquipment->id] <= 0)
 				{
-					LogError("Trying to equip item \"%s\" with zero inventory",
+					LogError("Trying to equip item \"{}\" with zero inventory",
 					         this->draggedEquipment->id);
 				}
 				auto e =
@@ -387,7 +387,7 @@ void VEquipScreen::render()
 			break;
 		default:
 			LogError(
-			    "Trying to draw equipment screen of unsupported vehicle type for vehicle \"%s\"",
+			    "Trying to draw equipment screen of unsupported vehicle type for vehicle \"{}\"",
 			    this->selected->name);
 			allowedEquipmentUser = VEquipmentType::User::Air;
 			break;
@@ -432,7 +432,7 @@ void VEquipScreen::render()
 				// Not in stock
 				continue;
 			}
-			auto countImage = labelFont->getString(format("%d", count));
+			auto countImage = labelFont->getString(format("{}", count));
 			auto &equipmentImage = equipmentType->equipscreen_sprite;
 			fw().renderer->draw(equipmentImage, inventoryPosition);
 
@@ -494,12 +494,12 @@ void VEquipScreen::setSelectedVehicle(sp<Vehicle> vehicle)
 		LogError("Trying to set invalid selected vehicle");
 		return;
 	}
-	LogInfo("Selecting vehicle \"%s\"", vehicle->name);
+	LogInfo("Selecting vehicle \"{}\"", vehicle->name);
 	this->selected = vehicle;
 	auto backgroundImage = vehicle->type->equipment_screen;
 	if (!backgroundImage)
 	{
-		LogError("Trying to view equipment screen of vehicle \"%s\" which has no equipment screen "
+		LogError("Trying to view equipment screen of vehicle \"{}\" which has no equipment screen "
 		         "background",
 		         vehicle->type->name);
 	}

--- a/game/ui/battle/battlebriefing.cpp
+++ b/game/ui/battle/battlebriefing.cpp
@@ -38,7 +38,7 @@ BattleBriefing::BattleBriefing(sp<GameState> state,
 {
 
 	menuform->findControlTyped<Label>("TEXT_DATE")
-	    ->setText(format("%s      %s", state->gameTime.getLongDateString(),
+	    ->setText(format("{}      {}", state->gameTime.getLongDateString(),
 	                     state->gameTime.getShortTimeString()));
 
 	// FIXME: Read and store briefing text and image properly
@@ -83,7 +83,7 @@ BattleBriefing::BattleBriefing(sp<GameState> state,
 				int briefingID = alienFunctionMap.at(building->function->name);
 				menuform->findControlTyped<Graphic>("BRIEFING_IMAGE")
 				    ->setImage(
-				        fw().data->loadImage(format("xcom3/tacdata/alienm%d.pcx", briefingID)));
+				        fw().data->loadImage(format("xcom3/tacdata/alienm{}.pcx", briefingID)));
 				switch (briefingID)
 				{
 					case 1:

--- a/game/ui/battle/battledebriefing.cpp
+++ b/game/ui/battle/battledebriefing.cpp
@@ -25,28 +25,28 @@ BattleDebriefing::BattleDebriefing(sp<GameState> state)
 	    });
 
 	menuform->findControlTyped<Label>("TEXT_SCORE_COMBAT_RATING")
-	    ->setText(format("%d", state->current_battle->score.combatRating));
+	    ->setText(format("{}", state->current_battle->score.combatRating));
 	menuform->findControlTyped<Label>("TEXT_SCORE_CASUALTY_PENALTY")
-	    ->setText(format("%d", state->current_battle->score.casualtyPenalty));
+	    ->setText(format("{}", state->current_battle->score.casualtyPenalty));
 	menuform->findControlTyped<Label>("TEXT_SCORE_LEADERSHIP_BONUS")
-	    ->setText(format("%d", state->current_battle->score.getLeadershipBonus()));
+	    ->setText(format("{}", state->current_battle->score.getLeadershipBonus()));
 	menuform->findControlTyped<Label>("TEXT_SCORE_LIVE_ALIENS_CAPTURED")
-	    ->setText(format("%d", state->current_battle->score.liveAlienCaptured));
+	    ->setText(format("{}", state->current_battle->score.liveAlienCaptured));
 	menuform->findControlTyped<Label>("TEXT_SCORE_EQUIPMENT_CAPTURED")
-	    ->setText(format("%d", state->current_battle->score.equipmentCaptured));
+	    ->setText(format("{}", state->current_battle->score.equipmentCaptured));
 	menuform->findControlTyped<Label>("TEXT_SCORE_EQUIPMENT_LOST")
-	    ->setText(format("%d", state->current_battle->score.equipmentLost));
+	    ->setText(format("{}", state->current_battle->score.equipmentLost));
 	menuform->findControlTyped<Label>("TEXT_SCORE_TOTAL")
-	    ->setText(format("%d", state->current_battle->score.getTotal()));
+	    ->setText(format("{}", state->current_battle->score.getTotal()));
 	menuform->findControlTyped<Label>("TEXT_MISSION_PERFORMANCE")
-	    ->setText(format("%s", state->current_battle->score.getText()));
+	    ->setText(format("{}", state->current_battle->score.getText()));
 
 	int idx = 1;
 	for (auto &u : state->current_battle->unitsPromoted)
 	{
-		menuform->findControlTyped<Label>(format("PROMOTION_%d", idx++))
+		menuform->findControlTyped<Label>(format("PROMOTION_{}", idx++))
 		    ->setText(
-		        format("%s %s %s", u->agent->name, tr("promoted to"), u->agent->getRankName()));
+		        format("{} {} {}", u->agent->name, tr("promoted to"), u->agent->getRankName()));
 	}
 }
 

--- a/game/ui/battle/battleprestart.cpp
+++ b/game/ui/battle/battleprestart.cpp
@@ -75,7 +75,7 @@ BattlePreStart::BattlePreStart(sp<GameState> state)
 	{
 		bigUnitRanks.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/"
-		                                "tacbut.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "tacbut.tab:{}:xcom3/tacdata/tactical.pal",
 		                                i)));
 	}
 }

--- a/game/ui/boot.cpp
+++ b/game/ui/boot.cpp
@@ -54,11 +54,11 @@ void BootUp::update()
 		loadTask = fw().threadPoolEnqueue([loadedState, path]() {
 			auto &ui_instance = ui();
 			std::ignore = ui_instance;
-			LogWarning("Loading save \"%s\"", path);
+			LogWarning("Loading save \"{}\"", path);
 
 			if (!loadedState->loadGame(path))
 			{
-				LogError("Failed to load supplied game \"%s\"", path);
+				LogError("Failed to load supplied game \"{}\"", path);
 			}
 			loadedState->initState();
 		});

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -40,7 +40,7 @@ void BaseBuyScreen::begin()
 	form->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 
 	auto text = form->findControlTyped<Label>("TEXT_PRICE");
-	text->setText(format(tr("This Building will cost $%d"), price));
+	text->setText(format(tr("This Building will cost ${}"), price));
 
 	form->findControlTyped<Graphic>("GRAPHIC_MINIMAP")
 	    ->setImage(BaseGraphics::drawMinimap(state, *base->building));
@@ -87,7 +87,7 @@ void BaseBuyScreen::eventOccurred(Event *e)
 				}
 				if (!newBuilding)
 				{
-					LogError("We just bought %s's last building? WTF?",
+					LogError("We just bought {}'s last building? WTF?",
 					         base->building->owner->name);
 				}
 				base->building->owner = state->getPlayer();

--- a/game/ui/city/bribescreen.cpp
+++ b/game/ui/city/bribescreen.cpp
@@ -82,7 +82,7 @@ void BribeScreen::updateInfo()
 	}
 
 	labelFunds->setText(state->getPlayerBalance());
-	labelRelation->setText(format("%s%s X-COM", tr(organisation->name), tr(relationship)));
+	labelRelation->setText(format("{}{} X-COM", tr(organisation->name), tr(relationship)));
 	labelOffer->setText(offer);
 }
 
@@ -94,7 +94,7 @@ void BribeScreen::updateInfo()
  */
 UString BribeScreen::getOfferString(int itWillCost, const UString &newAttitude) const
 {
-	return format("%s %d  %s  %s", tr("It will cost: $"), itWillCost,
+	return format("{} {}  {}  {}", tr("It will cost: $"), itWillCost,
 	              tr("to improve relations to:"), newAttitude);
 }
 

--- a/game/ui/city/scorescreen.cpp
+++ b/game/ui/city/scorescreen.cpp
@@ -52,38 +52,38 @@ void ScoreScreen::setScoreMode()
 		formScoreFilled = true;
 
 		formScore->findControlTyped<Label>("TACTICAL_W")
-		    ->setText(format("%d", state->weekScore.tacticalMissions));
+		    ->setText(format("{}", state->weekScore.tacticalMissions));
 		formScore->findControlTyped<Label>("RESEARCH_W")
-		    ->setText(format("%d", state->weekScore.researchCompleted));
+		    ->setText(format("{}", state->weekScore.researchCompleted));
 		formScore->findControlTyped<Label>("ALIEN_W")->setText(
-		    format("%d", state->weekScore.alienIncidents));
+		    format("{}", state->weekScore.alienIncidents));
 		formScore->findControlTyped<Label>("UFO_SHOTDOWN_W")
-		    ->setText(format("%d", state->weekScore.craftShotDownUFO));
+		    ->setText(format("{}", state->weekScore.craftShotDownUFO));
 		formScore->findControlTyped<Label>("CRAFT_SHOTDOWN_W")
-		    ->setText(format("%d", state->weekScore.craftShotDownXCom));
+		    ->setText(format("{}", state->weekScore.craftShotDownXCom));
 		formScore->findControlTyped<Label>("INCURSIONS_W")
-		    ->setText(format("%d", state->weekScore.incursions));
+		    ->setText(format("{}", state->weekScore.incursions));
 		formScore->findControlTyped<Label>("DAMAGE_W")
-		    ->setText(format("%d", state->weekScore.cityDamage));
+		    ->setText(format("{}", state->weekScore.cityDamage));
 		formScore->findControlTyped<Label>("TOTAL_W")->setText(
-		    format("%d", state->weekScore.getTotal()));
+		    format("{}", state->weekScore.getTotal()));
 
 		formScore->findControlTyped<Label>("TACTICAL_T")
-		    ->setText(format("%d", state->totalScore.tacticalMissions));
+		    ->setText(format("{}", state->totalScore.tacticalMissions));
 		formScore->findControlTyped<Label>("RESEARCH_T")
-		    ->setText(format("%d", state->totalScore.researchCompleted));
+		    ->setText(format("{}", state->totalScore.researchCompleted));
 		formScore->findControlTyped<Label>("ALIEN_T")->setText(
-		    format("%d", state->totalScore.alienIncidents));
+		    format("{}", state->totalScore.alienIncidents));
 		formScore->findControlTyped<Label>("UFO_SHOTDOWN_T")
-		    ->setText(format("%d", state->totalScore.craftShotDownUFO));
+		    ->setText(format("{}", state->totalScore.craftShotDownUFO));
 		formScore->findControlTyped<Label>("CRAFT_SHOTDOWN_T")
-		    ->setText(format("%d", state->totalScore.craftShotDownXCom));
+		    ->setText(format("{}", state->totalScore.craftShotDownXCom));
 		formScore->findControlTyped<Label>("INCURSIONS_T")
-		    ->setText(format("%d", state->totalScore.incursions));
+		    ->setText(format("{}", state->totalScore.incursions));
 		formScore->findControlTyped<Label>("DAMAGE_T")
-		    ->setText(format("%d", state->totalScore.cityDamage));
+		    ->setText(format("{}", state->totalScore.cityDamage));
 		formScore->findControlTyped<Label>("TOTAL_T")->setText(
-		    format("%d", state->totalScore.getTotal()));
+		    format("{}", state->totalScore.getTotal()));
 	}
 
 	title->setText(tr("SCORE"));
@@ -122,14 +122,14 @@ void ScoreScreen::setFinanceMode()
 				}
 			}
 		}
-		formFinance->findControlTyped<Label>("AGENTS_Q")->setText(format("%d", soldiers));
-		formFinance->findControlTyped<Label>("BIOCHEMISTS_Q")->setText(format("%d", biochemists));
-		formFinance->findControlTyped<Label>("ENGINEERS_Q")->setText(format("%d", engineers));
-		formFinance->findControlTyped<Label>("PHYSICISTS_Q")->setText(format("%d", physicists));
+		formFinance->findControlTyped<Label>("AGENTS_Q")->setText(format("{}", soldiers));
+		formFinance->findControlTyped<Label>("BIOCHEMISTS_Q")->setText(format("{}", biochemists));
+		formFinance->findControlTyped<Label>("ENGINEERS_Q")->setText(format("{}", engineers));
+		formFinance->findControlTyped<Label>("PHYSICISTS_Q")->setText(format("{}", physicists));
 		formFinance->findControlTyped<Label>("TOTAL_Q")->setText(
-		    format("%d", soldiers + biochemists + engineers + physicists));
+		    format("{}", soldiers + biochemists + engineers + physicists));
 		formFinance->findControlTyped<Label>("BASES_TOTAL_Q")
-		    ->setText(format("%d", state->player_bases.size()));
+		    ->setText(format("{}", state->player_bases.size()));
 
 		soldiers *= HIRE_COST_SOLDIER;
 		biochemists *= HIRE_COST_BIO;
@@ -137,11 +137,11 @@ void ScoreScreen::setFinanceMode()
 		physicists *= HIRE_COST_PHYSIC;
 		int agentsSalary = soldiers + biochemists + engineers + physicists;
 
-		formFinance->findControlTyped<Label>("AGENTS_W")->setText(format("$%d", soldiers));
-		formFinance->findControlTyped<Label>("BIOCHEMISTS_W")->setText(format("$%d", biochemists));
-		formFinance->findControlTyped<Label>("ENGINEERS_W")->setText(format("$%d", engineers));
-		formFinance->findControlTyped<Label>("PHYSICISTS_W")->setText(format("$%d", physicists));
-		formFinance->findControlTyped<Label>("TOTAL_W")->setText(format("$%d", agentsSalary));
+		formFinance->findControlTyped<Label>("AGENTS_W")->setText(format("${}", soldiers));
+		formFinance->findControlTyped<Label>("BIOCHEMISTS_W")->setText(format("${}", biochemists));
+		formFinance->findControlTyped<Label>("ENGINEERS_W")->setText(format("${}", engineers));
+		formFinance->findControlTyped<Label>("PHYSICISTS_W")->setText(format("${}", physicists));
+		formFinance->findControlTyped<Label>("TOTAL_W")->setText(format("${}", agentsSalary));
 
 		int basesCosts = 0;
 		for (auto &b : state->player_bases)
@@ -151,16 +151,16 @@ void ScoreScreen::setFinanceMode()
 				basesCosts += f->type->weeklyCost;
 			}
 		}
-		formFinance->findControlTyped<Label>("BASES_TOTAL_W")->setText(format("$%d", basesCosts));
+		formFinance->findControlTyped<Label>("BASES_TOTAL_W")->setText(format("${}", basesCosts));
 		formFinance->findControlTyped<Label>("OVERHEADS_W")
-		    ->setText(format("$%d", agentsSalary + basesCosts));
+		    ->setText(format("${}", agentsSalary + basesCosts));
 
 		int balance = state->getPlayer()->balance;
 		formFinance->findControlTyped<Label>("INITIAL")->setText(
-		    format("%s $%d", tr("Initial funds>"), balance));
+		    format("{} ${}", tr("Initial funds>"), balance));
 		formFinance->findControlTyped<Label>("REMAINING")
 		    ->setText(
-		        format("%s $%d", tr("Remaining finds>"), balance - agentsSalary - basesCosts));
+		        format("{} ${}", tr("Remaining finds>"), balance - agentsSalary - basesCosts));
 	}
 
 	title->setText(tr("FINANCE"));

--- a/game/ui/components/basegraphics.cpp
+++ b/game/ui/components/basegraphics.cpp
@@ -67,7 +67,7 @@ void BaseGraphics::renderBase(Vec2<int> renderPos, const Base &base)
 			{
 				Vec2<int> pos = renderPos + i * TILE_SIZE;
 				auto image = format(
-				    "PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:%d:xcom3/ufodata/base.pcx",
+				    "PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:{}:xcom3/ufodata/base.pcx",
 				    sprite);
 				fw().renderer->draw(fw().data->loadImage(image), pos);
 			}
@@ -157,7 +157,7 @@ sp<RGBImage> BaseGraphics::drawMiniBase(const Base &base, FacilityHighlight high
 			}
 			Vec2<int> pos = i * MINI_SIZE;
 			auto image =
-			    format("RAW:xcom3/ufodata/minibase.dat:4:4:%d:xcom3/ufodata/base.pcx", sprite);
+			    format("RAW:xcom3/ufodata/minibase.dat:4:4:{}:xcom3/ufodata/base.pcx", sprite);
 			RGBImage::blit(std::dynamic_pointer_cast<RGBImage>(fw().data->loadImage(image)),
 			               minibase, {0, 0}, pos);
 		}

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -41,10 +41,10 @@ void ControlGenerator::init(GameState &state [[maybe_unused]])
 	{
 		battleSelect.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/"
-		                                "tacbut.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "tacbut.tab:{}:xcom3/tacdata/tactical.pal",
 		                                25 + i)));
 		citySelect.push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    37 + i)));
 	}
 
@@ -56,7 +56,7 @@ void ControlGenerator::init(GameState &state [[maybe_unused]])
 	{
 		unitRanks.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/"
-		                                "tacbut.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "tacbut.tab:{}:xcom3/tacdata/tactical.pal",
 		                                i)));
 	}
 
@@ -86,7 +86,7 @@ void ControlGenerator::init(GameState &state [[maybe_unused]])
 	for (int i = 47; i <= 50; i++)
 	{
 		icons.push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%s:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 
@@ -94,7 +94,7 @@ void ControlGenerator::init(GameState &state [[maybe_unused]])
 	for (int i = 51; i <= 63; i++)
 	{
 		vehiclePassengerCountIcons.push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%s:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 	labelFont = ui().getFont("smalfont");
@@ -534,7 +534,7 @@ sp<Control> ControlGenerator::createLargeAgentControl(GameState &state, const Ag
 	if (skill != UnitSkillState::Hidden)
 	{
 		auto skillLabel = baseControl->createChild<Label>(
-		    format(tr("Skill %s"), info.agent->getSkill()), singleton.labelFont);
+		    format(tr("Skill {}"), info.agent->getSkill()), singleton.labelFont);
 		skillLabel->Tint = {192, 192, 192};
 
 		skillLabel->Size = {nameLabel->Size.x, singleton.labelFont->getFontHeight()};

--- a/game/ui/components/equipscreen.cpp
+++ b/game/ui/components/equipscreen.cpp
@@ -149,7 +149,7 @@ void EquipmentPaperDoll::onRender()
 		auto *slot = getSlotAtPosition(pos, slotList);
 		if (!slot)
 		{
-			LogWarning("Equipment at %s not in slot", pos);
+			LogWarning("Equipment at {} not in slot", pos);
 		}
 		auto equipmentSize = equipment->getEquipmentSlotSize();
 		auto alignX = slot->align_x;

--- a/game/ui/debugtools/debugmenu.cpp
+++ b/game/ui/debugtools/debugmenu.cpp
@@ -138,7 +138,7 @@ void DebugMenu::bulkExportPcks()
 		UString pckloadstr = UString("PCK:") + pckname + UString(":") +
 		                     pckname.substr(0, pckname.length() - 3) + UString("tab");
 
-		LogInfo("Processing %s", pckloadstr);
+		LogInfo("Processing {}", pckloadstr);
 
 		sp<ImageSet> pckset = fw().data->loadImageSet(pckloadstr);
 
@@ -155,7 +155,7 @@ void DebugMenu::bulkExportPcks()
 				if (sp<RGBImage> bi = std::dynamic_pointer_cast<RGBImage>(curimg))
 				{
 
-					LogInfo("Saving %s", outputname);
+					LogInfo("Saving {}", outputname);
 					fw().data->writeImage(outputname, bi);
 				}
 				else if (sp<PaletteImage> pi = std::dynamic_pointer_cast<PaletteImage>(curimg))
@@ -166,7 +166,7 @@ void DebugMenu::bulkExportPcks()
 						outputname = UString("extracted/") + pckname + UString("/") +
 						             Strings::fromInteger(idx) + UString(".#") +
 						             Strings::fromInteger(palidx) + UString(".png");
-						LogInfo("Saving %s", outputname);
+						LogInfo("Saving {}", outputname);
 						fw().data->writeImage(outputname, pi, PaletteList.at(palidx));
 					}
 				}

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -27,11 +27,11 @@ void AEquipmentSheet::clear()
 	{
 		for (char alignment : {'L', 'C', 'R'})
 		{
-			auto labelName = format("LABEL_%d_%c", i + 1, alignment);
+			auto labelName = format("LABEL_{}_%c", i + 1, alignment);
 			auto label = form->findControlTyped<Label>(labelName);
 			if (!label)
 			{
-				LogError("Failed to find UI control matching \"%s\"", labelName);
+				LogError("Failed to find UI control matching \"{}\"", labelName);
 			}
 			else
 			{
@@ -57,7 +57,7 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 	// when possible, the actual item's weight takes precedence
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")
-	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
+	    ->setText(format("{}", item ? item->getWeight() : itemType.weight));
 
 	switch (itemType.type)
 	{
@@ -102,31 +102,31 @@ void AEquipmentSheet::displayGrenade(sp<AEquipment> item [[maybe_unused]],
 	form->findControlTyped<Label>("LABEL_2_C")->setText(itemType.damage_type->name);
 
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Power"));
-	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", itemType.damage));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("{}", itemType.damage));
 }
 
 void AEquipmentSheet::displayAmmo(sp<AEquipment> item, const AEquipmentType &itemType)
 {
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", itemType.accuracy));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("{}", itemType.accuracy));
 
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Fire rate"));
 	form->findControlTyped<Label>("LABEL_3_R")
 	    ->setText(format("%.2f", itemType.getRoundsPerSecond()));
 
 	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
-	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", itemType.getRangeInTiles()));
+	form->findControlTyped<Label>("LABEL_4_R")->setText(format("{}", itemType.getRangeInTiles()));
 
 	form->findControlTyped<Label>("LABEL_6_C")->setText(tr("Ammo Type:"));
 	form->findControlTyped<Label>("LABEL_7_C")->setText(itemType.damage_type->name);
 
 	form->findControlTyped<Label>("LABEL_8_L")->setText(tr("Power"));
-	form->findControlTyped<Label>("LABEL_8_R")->setText(format("%d", itemType.damage));
+	form->findControlTyped<Label>("LABEL_8_R")->setText(format("{}", itemType.damage));
 
 	form->findControlTyped<Label>("LABEL_9_L")->setText(tr("Rounds"));
 	form->findControlTyped<Label>("LABEL_9_R")
-	    ->setText(item ? format("%d / %d", item->ammo, itemType.max_ammo)
-	                   : format("%d", itemType.max_ammo));
+	    ->setText(item ? format("{} / {}", item->ammo, itemType.max_ammo)
+	                   : format("{}", itemType.max_ammo));
 	if (itemType.recharge > 0)
 	{
 		form->findControlTyped<Label>("LABEL_10_C")->setText(tr("(Recharges)"));
@@ -144,20 +144,20 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 
 	auto &ammoType = *itemType.ammo_types.begin();
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", ammoType->accuracy));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("{}", ammoType->accuracy));
 
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Fire rate"));
 	form->findControlTyped<Label>("LABEL_3_R")
 	    ->setText(format("%.2f", ammoType->getRoundsPerSecond()));
 
 	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
-	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", ammoType->getRangeInTiles()));
+	form->findControlTyped<Label>("LABEL_4_R")->setText(format("{}", ammoType->getRangeInTiles()));
 
 	form->findControlTyped<Label>("LABEL_5_C")->setText(tr("Ammo types:"));
 	int ammoNum = 1;
 	for (auto &ammo : itemType.ammo_types)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_C", 5 + ammoNum))->setText(ammo->name);
+		form->findControlTyped<Label>(format("LABEL_{}_C", 5 + ammoNum))->setText(ammo->name);
 		if (++ammoNum >= 4)
 		{
 			break;
@@ -169,8 +169,8 @@ void AEquipmentSheet::displayArmor(sp<AEquipment> item, const AEquipmentType &it
 {
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Protection"));
 	form->findControlTyped<Label>("LABEL_2_R")
-	    ->setText(item ? format("%d / %d", item->armor, itemType.armor)
-	                   : format("%d", itemType.armor));
+	    ->setText(item ? format("{} / {}", item->armor, itemType.armor)
+	                   : format("{}", itemType.armor));
 }
 
 void AEquipmentSheet::displayOther(sp<AEquipment> item [[maybe_unused]],
@@ -186,7 +186,7 @@ void AEquipmentSheet::displayAlien(sp<AEquipment> item, const AEquipmentType &it
 
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")
-	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
+	    ->setText(format("{}", item ? item->getWeight() : itemType.weight));
 }
 
 }; // namespace OpenApoc

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -59,7 +59,7 @@ AEquipScreen::AEquipScreen(sp<GameState> state, sp<Agent> firstAgent)
 	{
 		bigUnitRanks.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/"
-		                                "tacbut.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "tacbut.tab:{}:xcom3/tacdata/tactical.pal",
 		                                i)));
 	}
 
@@ -103,7 +103,7 @@ AEquipScreen::AEquipScreen(sp<GameState> state, sp<Agent> firstAgent)
 	    });
 
 	woundImage = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                         "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                         258));
 	FATAL_WOUND_LOCATIONS[BodyPart::Helmet] = {{310, 130}, {307, 117}, {327, 137},
 	                                           {312, 128}, {309, 118}, {317, 123}};
@@ -429,7 +429,7 @@ void AEquipScreen::render()
 		auto rect = std::get<0>(tuple);
 		auto pos = rect.p0;
 		pos.x -= inventoryPage * inventoryControl->Size.x;
-		auto countImage = count > 0 ? labelFont->getString(format("%d", count)) : nullptr;
+		auto countImage = count > 0 ? labelFont->getString(format("{}", count)) : nullptr;
 		auto &equipmentImage = item->type->equipscreen_sprite;
 
 		if (pos.x < inventoryControl->Location.x + formMain->Location.x ||
@@ -580,7 +580,7 @@ void AEquipScreen::handleItemPlacement(Vec2<int> mousePos)
 	{
 		auto message_box = mksp<MessageBox>(
 		    tr("NOT ENOUGH TU'S"),
-		    format("%s %d", tr("TU cost per item picked up:"), currentAgent->unit->getPickupCost()),
+		    format("{} {}", tr("TU cost per item picked up:"), currentAgent->unit->getPickupCost()),
 		    MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 	}
@@ -650,7 +650,7 @@ void AEquipScreen::handleItemPlacement(bool toAgent)
 	{
 		auto message_box = mksp<MessageBox>(
 		    tr("NOT ENOUGH TU'S"),
-		    format("%s %d", tr("TU cost per item picked up:"), currentAgent->unit->getPickupCost()),
+		    format("{} {}", tr("TU cost per item picked up:"), currentAgent->unit->getPickupCost()),
 		    MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 	}
@@ -1543,7 +1543,7 @@ void AEquipScreen::processTemplate(int idx, bool remember)
 				}
 				else
 				{
-					LogError("Agent %s cannot apply template, fail at pos %s item %s",
+					LogError("Agent {} cannot apply template, fail at pos {} item {}",
 					         currentAgent->name, pos, type.id);
 				}
 			}

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -44,7 +44,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.health, 100, healthColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_1")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_1")->getText() +
-	    format(": %d/%d", item.modified_stats.health, item.current_stats.health);
+	    format(": {}/{}", item.modified_stats.health, item.current_stats.health);
 
 	form->findControlTyped<Label>("LABEL_2")->setText(tr("Accuracy"));
 	form->findControlTyped<Graphic>("VALUE_2")->setImage(
@@ -52,7 +52,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.accuracy, 100, accuracyColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_2")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_2")->getText() +
-	    format(": %d/%d", item.modified_stats.accuracy, item.current_stats.accuracy);
+	    format(": {}/{}", item.modified_stats.accuracy, item.current_stats.accuracy);
 
 	form->findControlTyped<Label>("LABEL_3")->setText(tr("Reactions"));
 	form->findControlTyped<Graphic>("VALUE_3")->setImage(
@@ -60,7 +60,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.reactions, 100, reactionsColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_3")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_3")->getText() +
-	    format(": %d/%d", item.modified_stats.reactions, item.current_stats.reactions);
+	    format(": {}/{}", item.modified_stats.reactions, item.current_stats.reactions);
 
 	form->findControlTyped<Label>("LABEL_4")->setText(turnBased ? tr("Time Units") : tr("Speed"));
 	form->findControlTyped<Graphic>("VALUE_4")->ToolTipText =
@@ -71,7 +71,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 		    createStatsBar(item.initial_stats.time_units, item.current_stats.time_units,
 		                   item.modified_stats.time_units, 100, speedColour, {88, 7}));
 		form->findControlTyped<Graphic>("VALUE_4")->ToolTipText +=
-		    format("^ %d/%d", item.modified_stats.time_units, item.current_stats.time_units);
+		    format("^ {}/{}", item.modified_stats.time_units, item.current_stats.time_units);
 	}
 	else
 	{
@@ -79,7 +79,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 		    item.initial_stats.getDisplaySpeedValue(), item.current_stats.getDisplaySpeedValue(),
 		    item.modified_stats.getDisplaySpeedValue(), 100, speedColour, {88, 7}));
 		form->findControlTyped<Graphic>("VALUE_4")->ToolTipText +=
-		    format("^ %d/%d", item.modified_stats.getDisplaySpeedValue(),
+		    format("^ {}/{}", item.modified_stats.getDisplaySpeedValue(),
 		           item.current_stats.getDisplaySpeedValue());
 	}
 
@@ -89,7 +89,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    item.modified_stats.getDisplayStaminaValue(), 100, staminaColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_5")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_5")->getText() +
-	    format(": %d/%d", item.modified_stats.getDisplayStaminaValue(),
+	    format(": {}/{}", item.modified_stats.getDisplayStaminaValue(),
 	           item.current_stats.getDisplayStaminaValue());
 
 	form->findControlTyped<Label>("LABEL_6")->setText(tr("Bravery"));
@@ -98,7 +98,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.bravery, 100, braveryColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_6")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_6")->getText() +
-	    format(": %d/%d", item.modified_stats.bravery, item.current_stats.bravery);
+	    format(": {}/{}", item.modified_stats.bravery, item.current_stats.bravery);
 
 	form->findControlTyped<Label>("LABEL_7")->setText(tr("Strength"));
 	form->findControlTyped<Graphic>("VALUE_7")->setImage(
@@ -106,7 +106,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.strength, 100, strengthColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_7")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_7")->getText() +
-	    format(": %d/%d", item.modified_stats.strength, item.current_stats.strength);
+	    format(": {}/{}", item.modified_stats.strength, item.current_stats.strength);
 
 	form->findControlTyped<Label>("LABEL_8")->setText(tr("Psi-energy"));
 	form->findControlTyped<Graphic>("VALUE_8")->setImage(
@@ -114,7 +114,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.psi_energy, 100, psiEnergyColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_8")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_8")->getText() +
-	    format(": %d/%d", item.modified_stats.psi_energy, item.current_stats.psi_energy);
+	    format(": {}/{}", item.modified_stats.psi_energy, item.current_stats.psi_energy);
 
 	form->findControlTyped<Label>("LABEL_9")->setText(tr("Psi-attack"));
 	form->findControlTyped<Graphic>("VALUE_9")->setImage(
@@ -122,7 +122,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                   item.modified_stats.psi_attack, 100, psiAttackColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_9")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_9")->getText() +
-	    format(": %d/%d", item.modified_stats.psi_attack, item.current_stats.psi_attack);
+	    format(": {}/{}", item.modified_stats.psi_attack, item.current_stats.psi_attack);
 
 	form->findControlTyped<Label>("LABEL_10")->setText(tr("Psi-defence"));
 	form->findControlTyped<Graphic>("VALUE_10")
@@ -130,18 +130,18 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	                              item.modified_stats.psi_defence, 100, psiDefenceColour, {88, 7}));
 	form->findControlTyped<Graphic>("VALUE_10")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_10")->getText() +
-	    format(": %d/%d", item.modified_stats.psi_defence, item.current_stats.psi_defence);
+	    format(": {}/{}", item.modified_stats.psi_defence, item.current_stats.psi_defence);
 }
 
 void AgentSheet::clear()
 {
 	for (int i = 0; i < 10; i++)
 	{
-		auto labelName = format("LABEL_%d", i + 1);
+		auto labelName = format("LABEL_{}", i + 1);
 		auto label = form->findControlTyped<Label>(labelName);
 		if (!label)
 		{
-			LogError("Failed to find UI control matching \"%s\"", labelName);
+			LogError("Failed to find UI control matching \"{}\"", labelName);
 		}
 		else
 		{

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -76,7 +76,7 @@ void CheatOptions::updateMultiplierText(UString controlName, float multMin, floa
 	float multValue = ((double)bar->getValue() - bar->getMinimum()) /
 	                      ((double)bar->getMaximum() - bar->getMinimum()) * (multMax - multMin) +
 	                  multMin;
-	label->setText(format("%d%%", scaleScrollbarToMultiplier(bar->getValue(), multMin, multMax,
+	label->setText(format("{}%%", scaleScrollbarToMultiplier(bar->getValue(), multMin, multMax,
 	                                                         bar->getMinimum(), bar->getMaximum()) *
 	                                  100));
 }
@@ -124,16 +124,16 @@ void CheatOptions::eventOccurred(Event *e)
 		{
 			for (auto &r : this->state->research.topics)
 			{
-				LogWarning("Topic \"%s\"", r.first);
+				LogWarning("Topic \"{}\"", r.first);
 				auto &topic = r.second;
 				if (topic->isComplete())
 				{
-					LogWarning("Topic \"%s\" already complete", r.first);
+					LogWarning("Topic \"{}\" already complete", r.first);
 				}
 				else
 				{
 					topic->forceComplete();
-					LogWarning("Topic \"%s\" marked as complete", r.first);
+					LogWarning("Topic \"{}\" marked as complete", r.first);
 				}
 			}
 			this->state->research.resortTopicList();
@@ -203,7 +203,7 @@ void CheatOptions::eventOccurred(Event *e)
 			auto bar = std::dynamic_pointer_cast<ScrollBar>(e->forms().RaisedBy);
 			if (!bar)
 			{
-				LogError("Failed to cast \"%s\" control to ScrollBar", e->forms().RaisedBy->Name);
+				LogError("Failed to cast \"{}\" control to ScrollBar", e->forms().RaisedBy->Name);
 				return;
 			}
 			menuform->findControlTyped<Label>("TEXT_MODIFY_FUNDS")
@@ -218,7 +218,7 @@ void CheatOptions::eventOccurred(Event *e)
 					auto bar = std::dynamic_pointer_cast<ScrollBar>(e->forms().RaisedBy);
 					if (!bar)
 					{
-						LogError("Failed to cast \"%s\" control to ScrollBar",
+						LogError("Failed to cast \"{}\" control to ScrollBar",
 						         e->forms().RaisedBy->Name);
 						return;
 					}

--- a/game/ui/general/difficultymenu.cpp
+++ b/game/ui/general/difficultymenu.cpp
@@ -83,7 +83,7 @@ void DifficultyMenu::eventOccurred(Event *e)
 		}
 		else
 		{
-			LogWarning("Unknown button pressed: %s", e->forms().RaisedBy->Name);
+			LogWarning("Unknown button pressed: {}", e->forms().RaisedBy->Name);
 			return;
 		}
 

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -308,7 +308,7 @@ void InGameOptions::eventOccurred(Event *e)
 			fw().stageQueueCommand(
 			    {StageCmd::Command::PUSH,
 			     mksp<MessageBox>(tr("Abort Mission"),
-			                      format("%s %d", tr("Units Lost :"), unitsLost),
+			                      format("{} {}", tr("Units Lost :"), unitsLost),
 			                      MessageBox::ButtonOptions::YesNo, [this] {
 				                      state->current_battle->abortMission(*state);
 				                      Battle::finishBattle(*state);

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -111,7 +111,7 @@ void SaveMenu::begin()
 				if (timestamp != 0 && tminfo != nullptr)
 				{
 					char temp_time[1024];
-					strftime(temp_time, sizeof(temp_time), "%d/%m/%y %T", tminfo);
+					strftime(temp_time, sizeof(temp_time), "{}/%m/%y %T", tminfo);
 					ss << temp_time;
 				}
 				saveTimeLabel->setText(ss.str());

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -38,23 +38,23 @@ bool TransactionControl::resourcesInitialised = false;
 void TransactionControl::initResources()
 {
 	bgLeft = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 45));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 45));
 	bgRight = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 46));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 46));
 	purchaseBoxIcon = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 47));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 47));
 	purchaseXComIcon = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 48));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 48));
 	purchaseArrow = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 52));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 52));
 	alienContainedDetain = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 75));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 75));
 	alienContainedKill = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 76));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 76));
 	scrollLeft = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 53));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 53));
 	scrollRight = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:%d:xcom3/ufodata/research.pcx", 54));
+	    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:{}:xcom3/ufodata/research.pcx", 54));
 	transactionShade = fw().data->loadImage("city/transaction-shade.png");
 	labelFont = ui().getFont("smalfont");
 
@@ -143,10 +143,10 @@ void TransactionControl::updateValues()
 	int curDeltaRight = tradeState.getLROrder();
 	int curDeltaLeft = -curDeltaRight;
 
-	stockLeft->setText(format("%d", tradeState.getLeftStock(true)));
-	stockRight->setText(format("%d", tradeState.getRightStock(true)));
-	deltaLeft->setText(format("%s%d", curDeltaLeft > 0 ? "+" : "", curDeltaLeft));
-	deltaRight->setText(format("%s%d", curDeltaRight > 0 ? "+" : "", curDeltaRight));
+	stockLeft->setText(format("{}", tradeState.getLeftStock(true)));
+	stockRight->setText(format("{}", tradeState.getRightStock(true)));
+	deltaLeft->setText(format("{}{}", curDeltaLeft > 0 ? "+" : "", curDeltaLeft));
+	deltaRight->setText(format("{}{}", curDeltaRight > 0 ? "+" : "", curDeltaRight));
 	deltaLeft->setVisible(tradeState.getLeftIndex() != ECONOMY_IDX && curDeltaLeft != 0);
 	deltaRight->setVisible(tradeState.getRightIndex() != ECONOMY_IDX && curDeltaRight != 0);
 	setDirty();
@@ -228,7 +228,7 @@ sp<TransactionControl> TransactionControl::createControl(GameState &state, State
 			type = Type::Soldier;
 			break;
 		default:
-			LogError("Unknown type of agent %s.", agent.id);
+			LogError("Unknown type of agent {}.", agent.id);
 			return nullptr;
 	}
 
@@ -527,7 +527,7 @@ sp<TransactionControl> TransactionControl::createControl(GameState &state,
 			// Nothing, we can still sell it for parts or transfer!
 		}
 	}
-	LogInfo("Vehicle type %s starting price %d", vehicle->type.id, price);
+	LogInfo("Vehicle type {} starting price {}", vehicle->type.id, price);
 	// Add price of ammo and equipment
 	for (auto &e : vehicle->equipment)
 	{
@@ -538,7 +538,7 @@ sp<TransactionControl> TransactionControl::createControl(GameState &state,
 			{
 				price += e->ammo * state.economy[e->type->ammo_type.id].currentPrice;
 			}
-			LogInfo("Vehicle type %s price increased to %d after counting %s", vehicle->type.id,
+			LogInfo("Vehicle type {} price increased to {} after counting {}", vehicle->type.id,
 			        price, e->type.id);
 		}
 	}
@@ -548,11 +548,11 @@ sp<TransactionControl> TransactionControl::createControl(GameState &state,
 		if (state.economy.find(e.second.id) != state.economy.end())
 		{
 			price -= state.economy[e.second.id].currentPrice;
-			LogInfo("Vehicle type %s price decreased to %d after counting %s", vehicle->type.id,
+			LogInfo("Vehicle type {} price decreased to {} after counting {}", vehicle->type.id,
 			        price, e.second.id);
 		}
 	}
-	LogInfo("Vehicle type %s final price %d", vehicle->type.id, price);
+	LogInfo("Vehicle type {} final price {}", vehicle->type.id, price);
 
 	auto manufacturer = vehicle->type->manufacturer;
 	bool isAmmo = false;
@@ -637,7 +637,7 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 	// Price
 	if (price != 0 && (indexLeft == ECONOMY_IDX || indexRight == ECONOMY_IDX))
 	{
-		auto label = control->createChild<Label>(format("$%d", control->price), labelFont);
+		auto label = control->createChild<Label>(format("${}", control->price), labelFont);
 		label->Location = {290, 3};
 		label->Size = {47, 16};
 		label->TextHAlign = HorizontalAlignment::Right;

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -49,11 +49,11 @@ void VehicleSheet::clear()
 	{
 		for (char alignment : {'L', 'R'})
 		{
-			auto labelName = format("LABEL_%d_%c", i + 1, alignment);
+			auto labelName = format("LABEL_{}_%c", i + 1, alignment);
 			auto label = form->findControlTyped<Label>(labelName);
 			if (!label)
 			{
-				LogError("Failed to find UI control matching \"%s\"", labelName);
+				LogError("Failed to find UI control matching \"{}\"", labelName);
 			}
 			else
 			{
@@ -90,32 +90,32 @@ void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> ve
 
 	form->findControlTyped<Label>("LABEL_1_R")
 	    ->setText(vehicle
-	                  ? format("%d / %d", vehicle->getConstitution(), vehicle->getMaxConstitution())
-	                  : format("%d", vehicleType->getMaxConstitution(it1, it2)));
+	                  ? format("{} / {}", vehicle->getConstitution(), vehicle->getMaxConstitution())
+	                  : format("{}", vehicleType->getMaxConstitution(it1, it2)));
 
 	form->findControlTyped<Label>("LABEL_2_R")
-	    ->setText(format("%d", vehicle ? vehicle->getArmor() : vehicleType->getArmor(it1, it2)));
+	    ->setText(format("{}", vehicle ? vehicle->getArmor() : vehicleType->getArmor(it1, it2)));
 
 	form->findControlTyped<Label>("LABEL_3_R")
 	    ->setText(
-	        format("%d%%", vehicle ? vehicle->getAccuracy() : vehicleType->getAccuracy(it1, it2)));
+	        format("{}%%", vehicle ? vehicle->getAccuracy() : vehicleType->getAccuracy(it1, it2)));
 	form->findControlTyped<Label>("LABEL_4_R")
 	    ->setText(
-	        format("%d", vehicle ? vehicle->getTopSpeed() : vehicleType->getTopSpeed(it1, it2)));
+	        format("{}", vehicle ? vehicle->getTopSpeed() : vehicleType->getTopSpeed(it1, it2)));
 	form->findControlTyped<Label>("LABEL_5_R")
-	    ->setText(format("%d", vehicle ? vehicle->getAcceleration()
+	    ->setText(format("{}", vehicle ? vehicle->getAcceleration()
 	                                   : vehicleType->getAcceleration(it1, it2)));
 	form->findControlTyped<Label>("LABEL_6_R")
-	    ->setText(format("%d", vehicle ? vehicle->getWeight() : vehicleType->getWeight(it1, it2)));
+	    ->setText(format("{}", vehicle ? vehicle->getWeight() : vehicleType->getWeight(it1, it2)));
 	form->findControlTyped<Label>("LABEL_7_R")
-	    ->setText(vehicle ? format("%dk / %dk", vehicle->getFuel(), vehicle->getMaxFuel())
-	                      : format("%dk", vehicleType->getMaxFuel(it1, it2)));
+	    ->setText(vehicle ? format("{}k / {}k", vehicle->getFuel(), vehicle->getMaxFuel())
+	                      : format("{}k", vehicleType->getMaxFuel(it1, it2)));
 	form->findControlTyped<Label>("LABEL_8_R")
-	    ->setText(vehicle ? format("%d / %d", vehicle->getPassengers(), vehicle->getMaxPassengers())
-	                      : format("%d", vehicleType->getMaxPassengers(it1, it2)));
+	    ->setText(vehicle ? format("{} / {}", vehicle->getPassengers(), vehicle->getMaxPassengers())
+	                      : format("{}", vehicleType->getMaxPassengers(it1, it2)));
 	form->findControlTyped<Label>("LABEL_9_R")
-	    ->setText(vehicle ? format("%d / %d", vehicle->getCargo(), vehicle->getMaxCargo())
-	                      : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	    ->setText(vehicle ? format("{} / {}", vehicle->getCargo(), vehicle->getMaxCargo())
+	                      : format("{}", vehicleType->getMaxCargo(it1, it2)));
 }
 
 void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> type)
@@ -125,7 +125,7 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
 
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
-	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
+	form->findControlTyped<Label>("LABEL_1_R")->setText(format("{}", type->weight));
 
 	// Draw equipment stats
 	switch (type->type)
@@ -145,27 +145,27 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 void VehicleSheet::displayEngine(sp<VEquipment> item [[maybe_unused]], sp<VEquipmentType> type)
 {
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Top Speed"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->top_speed));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("{}", type->top_speed));
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Power"));
-	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->power));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("{}", type->power));
 }
 
 void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 {
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Damage"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->damage));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("{}", type->damage));
 	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Range"));
-	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->getRangeInTiles()));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("{}", type->getRangeInTiles()));
 	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d%%", type->accuracy));
+	form->findControlTyped<Label>("LABEL_4_R")->setText(format("{}%%", type->accuracy));
 
 	// Only show rounds if non-zero (IE not infinite ammo)
 	if (type->max_ammo != 0)
 	{
 		form->findControlTyped<Label>("LABEL_5_L")->setText(tr("Rounds"));
 		form->findControlTyped<Label>("LABEL_5_R")
-		    ->setText(item ? format("%d / %d", item->ammo, type->max_ammo)
-		                   : format("%d", type->max_ammo));
+		    ->setText(item ? format("{} / {}", item->ammo, type->max_ammo)
+		                   : format("{}", type->max_ammo));
 	}
 }
 
@@ -174,55 +174,55 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 	int statsCount = 2;
 	if (type->accuracy_modifier)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Accuracy"));
-		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
-		    ->setText(format("%d%%", 100 - type->accuracy_modifier));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Accuracy"));
+		form->findControlTyped<Label>(format("LABEL_{}_R", statsCount))
+		    ->setText(format("{}%%", 100 - type->accuracy_modifier));
 		statsCount++;
 	}
 	if (type->cargo_space)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Cargo"));
-		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
-		    ->setText(format("%d", type->cargo_space));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Cargo"));
+		form->findControlTyped<Label>(format("LABEL_{}_R", statsCount))
+		    ->setText(format("{}", type->cargo_space));
 		statsCount++;
 	}
 	if (type->passengers)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Passengers"));
-		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
-		    ->setText(format("%d", type->passengers));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Passengers"));
+		form->findControlTyped<Label>(format("LABEL_{}_R", statsCount))
+		    ->setText(format("{}", type->passengers));
 		statsCount++;
 	}
 	if (type->alien_space)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Aliens Held"));
-		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
-		    ->setText(format("%d", type->alien_space));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Aliens Held"));
+		form->findControlTyped<Label>(format("LABEL_{}_R", statsCount))
+		    ->setText(format("{}", type->alien_space));
 		statsCount++;
 	}
 	if (type->missile_jamming)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Jamming"));
-		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
-		    ->setText(format("%d", type->missile_jamming));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Jamming"));
+		form->findControlTyped<Label>(format("LABEL_{}_R", statsCount))
+		    ->setText(format("{}", type->missile_jamming));
 		statsCount++;
 	}
 	if (type->shielding)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Shielding"));
-		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
-		    ->setText(format("%d", type->shielding));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Shielding"));
+		form->findControlTyped<Label>(format("LABEL_{}_R", statsCount))
+		    ->setText(format("{}", type->shielding));
 		statsCount++;
 	}
 	if (type->cloaking)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))
 		    ->setText(tr("Cloaks Craft"));
 		statsCount++;
 	}
 	if (type->teleporting)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Teleports"));
+		form->findControlTyped<Label>(format("LABEL_{}_L", statsCount))->setText(tr("Teleports"));
 		statsCount++;
 	}
 }
@@ -232,7 +232,7 @@ void VehicleSheet::displayAlien(sp<VEquipmentType> type)
 	form->findControlTyped<Label>("ITEM_NAME")->setText(tr("Alien Artifact"));
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
-	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
+	form->findControlTyped<Label>("LABEL_1_R")->setText(format("{}", type->weight));
 }
 
 }; // namespace OpenApoc

--- a/game/ui/general/videoscreen.cpp
+++ b/game/ui/general/videoscreen.cpp
@@ -25,7 +25,7 @@ VideoScreen::VideoScreen(const UString &videoPath, sp<Stage> nextScreen)
 		this->video = fw().data->loadVideo(videoPath);
 		if (!this->video)
 		{
-			LogWarning("Failed to load video \"%s\"", videoPath);
+			LogWarning("Failed to load video \"{}\"", videoPath);
 		}
 		else
 		{
@@ -35,7 +35,7 @@ VideoScreen::VideoScreen(const UString &videoPath, sp<Stage> nextScreen)
 			Vec2<float> scale_factors = display_size / unscaled_frame_size;
 			float scale = std::min(scale_factors.x, scale_factors.y);
 			this->frame_size = unscaled_frame_size * scale;
-			LogInfo("Scaling video from %s to %s", this->video->getVideoSize(), this->frame_size);
+			LogInfo("Scaling video from {} to {}", this->video->getVideoSize(), this->frame_size);
 			this->frame_position = (fw().displayGetSize() / 2) - (this->frame_size / 2);
 		}
 	}

--- a/game/ui/skirmish/mapselector.cpp
+++ b/game/ui/skirmish/mapselector.cpp
@@ -60,7 +60,7 @@ sp<Control> MapSelector::createMapRowBuilding(StateRef<Building> building, sp<Ga
 	const int HEIGHT = 21;
 
 	auto text = control->createChild<Label>(
-	    format("[%s Building] %s [%s]", building->owner == state->getAliens() ? "Alien" : "Human",
+	    format("[{} Building] {} [{}]", building->owner == state->getAliens() ? "Alien" : "Human",
 	           building->name, building->battle_map.id),
 	    ui().getFont("smalfont"));
 	text->Location = {0, 0};
@@ -89,7 +89,7 @@ sp<Control> MapSelector::createMapRowVehicle(StateRef<VehicleType> vehicle, sp<G
 	const int HEIGHT = 21;
 
 	auto text = control->createChild<Label>(
-	    format("[UFO] %s [%s]", vehicle->name, vehicle->battle_map.id), ui().getFont("smalfont"));
+	    format("[UFO] {} [{}]", vehicle->name, vehicle->battle_map.id), ui().getFont("smalfont"));
 	text->Location = {0, 0};
 	text->Size = {488, HEIGHT};
 	text->TextVAlign = VerticalAlignment::Centre;
@@ -116,7 +116,7 @@ sp<Control> MapSelector::createMapRowBase(StateRef<Base> base, sp<GameState> sta
 	const int HEIGHT = 21;
 
 	auto text =
-	    control->createChild<Label>(format("[Base] %s", base->name), ui().getFont("smalfont"));
+	    control->createChild<Label>(format("[Base] {}", base->name), ui().getFont("smalfont"));
 	text->Location = {0, 0};
 	text->Size = {488, HEIGHT};
 	text->TextVAlign = VerticalAlignment::Centre;

--- a/game/ui/skirmish/selectforces.cpp
+++ b/game/ui/skirmish/selectforces.cpp
@@ -24,38 +24,38 @@ SelectForces::SelectForces(sp<GameState> state, Skirmish &skirmish,
 	menuform->findControlTyped<ScrollBar>("NUM_BSK_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_BSK")->setText(
-		        format("%d", menuform->findControlTyped<ScrollBar>("NUM_BSK_SLIDER")->getValue()));
+		        format("{}", menuform->findControlTyped<ScrollBar>("NUM_BSK_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_CHRYS_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_CHRYS")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_CHRYS_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_CHRYS_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_EGG_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_EGG")->setText(
-		        format("%d", menuform->findControlTyped<ScrollBar>("NUM_EGG_SLIDER")->getValue()));
+		        format("{}", menuform->findControlTyped<ScrollBar>("NUM_EGG_SLIDER")->getValue()));
 	    });
 
 	menuform->findControlTyped<ScrollBar>("NUM_SPITTER_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_SPITTER")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_SPITTER_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_SPITTER_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_ANTHROPOD_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_ANTHROPOD")
 		        ->setText(format(
-		            "%d",
+		            "{}",
 		            menuform->findControlTyped<ScrollBar>("NUM_ANTHROPOD_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_MULTIWORM_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_MULTIWORM")
 		        ->setText(format(
-		            "%d",
+		            "{}",
 		            menuform->findControlTyped<ScrollBar>("NUM_MULTIWORM_SLIDER")->getValue()));
 	    });
 
@@ -63,19 +63,19 @@ SelectForces::SelectForces(sp<GameState> state, Skirmish &skirmish,
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_POPPER")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_POPPER_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_POPPER_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_SKEL_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_SKEL")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_SKEL_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_SKEL_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_HYPERWORM_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_HYPERWORM")
 		        ->setText(format(
-		            "%d",
+		            "{}",
 		            menuform->findControlTyped<ScrollBar>("NUM_HYPERWORM_SLIDER")->getValue()));
 	    });
 
@@ -83,32 +83,32 @@ SelectForces::SelectForces(sp<GameState> state, Skirmish &skirmish,
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_MEGA")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_MEGA_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_MEGA_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_PSI_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_PSI")->setText(
-		        format("%d", menuform->findControlTyped<ScrollBar>("NUM_PSI_SLIDER")->getValue()));
+		        format("{}", menuform->findControlTyped<ScrollBar>("NUM_PSI_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_MICRO_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_MICRO")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_MICRO_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_MICRO_SLIDER")->getValue()));
 	    });
 
 	menuform->findControlTyped<ScrollBar>("NUM_GUARD_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_GUARD")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_GUARD_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_GUARD_SLIDER")->getValue()));
 	    });
 
 	menuform->findControlTyped<ScrollBar>("NUM_CIVILIAN_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_CIVILIAN")
 		        ->setText(format(
-		            "%d",
+		            "{}",
 		            menuform->findControlTyped<ScrollBar>("NUM_CIVILIAN_SLIDER")->getValue()));
 	    });
 

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -100,7 +100,7 @@ std::shared_future<void> loadBattleVehicle(bool hotseat, sp<VehicleType> vehicle
 		    auto v = mksp<Vehicle>();
 		    auto vID = Vehicle::generateObjectID(*state);
 		    v->type = {state, vehicle};
-		    v->name = format("%s %d", v->type->name, ++v->type->numCreated);
+		    v->name = format("{} {}", v->type->name, ++v->type->numCreated);
 
 		    state->vehicles[vID] = v;
 		    StateRef<Vehicle> ufo = {state, vID};
@@ -147,33 +147,33 @@ Skirmish::Skirmish(sp<GameState> state) : Stage(), menuform(ui().getForm("skirmi
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_HUMANS")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_HUMANS_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_HUMANS_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_HYBRIDS_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_HYBRIDS")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("NUM_HYBRIDS_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("NUM_HYBRIDS_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("NUM_ANDROIDS_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("NUM_ANDROIDS")
 		        ->setText(format(
-		            "%d",
+		            "{}",
 		            menuform->findControlTyped<ScrollBar>("NUM_ANDROIDS_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("DAYS_PHYSICAL_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("DAYS_PHYSICAL")
 		        ->setText(format(
-		            "%d",
+		            "{}",
 		            menuform->findControlTyped<ScrollBar>("DAYS_PHYSICAL_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("DAYS_PSI_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("DAYS_PSI")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("DAYS_PSI_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("DAYS_PSI_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("PLAYER_TECH_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
@@ -181,21 +181,21 @@ Skirmish::Skirmish(sp<GameState> state) : Stage(), menuform(ui().getForm("skirmi
 		        ->setText(
 		            menuform->findControlTyped<ScrollBar>("PLAYER_TECH_SLIDER")->getValue() == 0
 		                ? "NO"
-		                : format("%d", menuform->findControlTyped<ScrollBar>("PLAYER_TECH_SLIDER")
+		                : format("{}", menuform->findControlTyped<ScrollBar>("PLAYER_TECH_SLIDER")
 		                                   ->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("ALIEN_SCORE_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("ALIEN_SCORE")
 		        ->setText(format(
-		            "%dK",
+		            "{}K",
 		            menuform->findControlTyped<ScrollBar>("ALIEN_SCORE_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("ORG_SCORE_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
 		    menuform->findControlTyped<Label>("ORG_SCORE")
 		        ->setText(format(
-		            "%d", menuform->findControlTyped<ScrollBar>("ORG_SCORE_SLIDER")->getValue()));
+		            "{}", menuform->findControlTyped<ScrollBar>("ORG_SCORE_SLIDER")->getValue()));
 	    });
 	menuform->findControlTyped<ScrollBar>("ARMOR_SLIDER")
 	    ->addCallback(FormEventType::ScrollBarChange, [this](Event *) {
@@ -302,7 +302,7 @@ void Skirmish::goToBattle(bool customAliens, std::map<StateRef<AgentType>, int> 
 		f->buildTime = 0;
 	}
 
-	LogWarning("Adding new agents to base %s", playerBase.id);
+	LogWarning("Adding new agents to base {}", playerBase.id);
 	int countHumans = menuform->findControlTyped<ScrollBar>("NUM_HUMANS_SLIDER")->getValue();
 	int countHybrids = menuform->findControlTyped<ScrollBar>("NUM_HYBRIDS_SLIDER")->getValue();
 	int countAndroids = menuform->findControlTyped<ScrollBar>("NUM_ANDROIDS_SLIDER")->getValue();
@@ -601,19 +601,19 @@ void Skirmish::updateLocationLabel()
 	UString text = "[No map selected]";
 	if (locBuilding)
 	{
-		text = format("[%s Building] %s [%s]",
+		text = format("[{} Building] {} [{}]",
 		              locBuilding->owner == state.getAliens() ? "Alien" : "Human",
 		              locBuilding->name, locBuilding->battle_map.id);
 	}
 	else if (locVehicle)
 	{
-		text = format("[UFO] %s [%s]", locVehicle->name, locVehicle->battle_map.id);
+		text = format("[UFO] {} [{}]", locVehicle->name, locVehicle->battle_map.id);
 	}
 	else if (locBase)
 	{
-		text = format("[Base] %s", locBase->name);
+		text = format("[Base] {}", locBase->name);
 	}
-	menuform->findControlTyped<Label>("LOCATION")->setText(format("LOCATION: %s", text));
+	menuform->findControlTyped<Label>("LOCATION")->setText(format("LOCATION: {}", text));
 }
 
 void Skirmish::battleInBuilding(bool hotseat, StateRef<Base> playerBase,

--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -134,43 +134,43 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
 	targetTacticalThisLevel =
 
 	    fw().data->loadImage(format("PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/"
-	                                "stratico.tab:%d",
+	                                "stratico.tab:{}",
 	                                482));
 	targetTacticalOtherLevel =
 	    fw().data->loadImage(format("PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/"
-	                                "stratico.tab:%d",
+	                                "stratico.tab:{}",
 	                                483));
 	selectedTileEmptyImageBack =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                182));
 	selectedTileEmptyImageFront =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                183));
 	selectedTileFilledImageBack =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                184));
 	selectedTileFilledImageFront =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                185));
 	selectedTileFireImageBack =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                186));
 	selectedTileFireImageFront =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                187));
 	selectedTileBackgroundImageBack =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                188));
 	selectedTileBackgroundImageFront =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                189));
 	selectedTileImageOffset = {23, 42};
 	pal = fw().data->loadPalette("xcom3/tacdata/tactical.pal");
@@ -185,11 +185,11 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
 	{
 		activeUnitSelectionArrow.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 		                                167 + i)));
 		inactiveUnitSelectionArrow.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+		                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 		                                173 + i)));
 	}
 	// Alexey Andronov (Istrebitel)
@@ -201,101 +201,101 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
 
 	behaviorUnitSelectionUnderlay[BattleUnit::BehaviorMode::Evasive] =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                190));
 	behaviorUnitSelectionUnderlay[BattleUnit::BehaviorMode::Normal] =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                191));
 	behaviorUnitSelectionUnderlay[BattleUnit::BehaviorMode::Aggressive] =
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                192));
 
 	runningIcon = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                          "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                          "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                          193));
 
 	bleedingIcon = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                           "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                           "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                           194));
 
 	healingIcons.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   195)));
 	healingIcons.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   196)));
 
 	lowMoraleIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                197)));
 	lowMoraleIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                198)));
 
 	psiIcons[PsiStatus::Probe].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                199)));
 	psiIcons[PsiStatus::Probe].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                200)));
 	psiIcons[PsiStatus::Panic].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                201)));
 	psiIcons[PsiStatus::Panic].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                202)));
 	psiIcons[PsiStatus::Stun].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                203)));
 	psiIcons[PsiStatus::Stun].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                204)));
 	psiIcons[PsiStatus::Control].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                205)));
 	psiIcons[PsiStatus::Control].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                206)));
 	psiIcons[PsiStatus::NotEngaged].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                207)));
 	psiIcons[PsiStatus::NotEngaged].push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                208)));
 
 	targetLocationIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                68)));
 	targetLocationIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                69)));
 	targetLocationIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                70)));
 	targetLocationIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                69)));
 	targetLocationIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                68)));
 	targetLocationOffset = {23, 42};
 
@@ -315,7 +315,7 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
 
 	for (int i = 0; i <= 255; i++)
 	{
-		tuIndicators.push_back(font->getString(format("%d", i)));
+		tuIndicators.push_back(font->getString(format("{}", i)));
 	}
 	tuSeparator = font->getString("/");
 	pathPreviewTooFar = font->getString(tr("Too Far"));
@@ -1566,7 +1566,7 @@ void BattleTileView::render()
 		}
 		break;
 		default:
-			LogError("Unexpected tile view mode \"%d\"", (int)this->viewMode);
+			LogError("Unexpected tile view mode \"{}\"", (int)this->viewMode);
 			break;
 	}
 
@@ -1581,7 +1581,7 @@ void BattleTileView::render()
 	if (this->debugHotkeyMode)
 	{
 		auto font = ui().getFont("smallset");
-		auto cursorPositionString = font->getString(format("Cursor at %s", selectedTilePosition));
+		auto cursorPositionString = font->getString(format("Cursor at {}", selectedTilePosition));
 		r.draw(cursorPositionString, {0, 0});
 	}
 }

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -84,69 +84,69 @@ BattleView::BattleView(sp<GameState> gameState)
 {
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                88)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                89)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                90)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                91)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                92)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                93)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                94)));
 	motionScannerDirectionIcons.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                95)));
 
 	selectedItemOverlay = fw().data->loadImage("battle/battle-item-select-icon.png");
 	selectedPsiOverlay = fw().data->loadImage("battle/battle-psi-select-icon.png");
 	pauseIcon = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                        "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                        "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                        260));
 
 	squadOverlay.emplace_back();
 	squadOverlay.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   1)));
 	squadOverlay.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   0)));
 
 	unitHostiles.emplace_back();
 	unitHostiles.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   7)));
 	unitHostiles.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   8)));
 	unitHostiles.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   9)));
 	unitHostiles.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   10)));
 	unitHostiles.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   11)));
 	unitHostiles.push_back(fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                                   "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                                   "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                                   12)));
 
 	lastClickedHostile.resize(6);
@@ -155,18 +155,18 @@ BattleView::BattleView(sp<GameState> gameState)
 	squadNumber.emplace_back();
 	for (int i = 1; i <= 6; i++)
 	{
-		squadNumber.push_back(font->getString(format("%d", i)));
+		squadNumber.push_back(font->getString(format("{}", i)));
 	}
 
 	for (int i = 0; i < NUM_TABS_RT; ++i)
 	{
-		sp<Form> f = baseForm->findControlTyped<Form>(format("SUBFORM_RT_%d", i + 1));
+		sp<Form> f = baseForm->findControlTyped<Form>(format("SUBFORM_RT_{}", i + 1));
 		f->takesFocus = false;
 		uiTabsRT.push_back(f);
 	}
 	for (int i = 0; i < NUM_TABS_TB; ++i)
 	{
-		sp<Form> f = baseForm->findControlTyped<Form>(format("SUBFORM_TB_%d", i + 1));
+		sp<Form> f = baseForm->findControlTyped<Form>(format("SUBFORM_TB_{}", i + 1));
 		f->takesFocus = false;
 		uiTabsTB.push_back(f);
 	}
@@ -1361,7 +1361,7 @@ void BattleView::update()
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(
 				         "Next Turn",
-				         format("%s, it is your turn!",
+				         format("{}, it is your turn!",
 				                state->current_battle->currentActiveOrganisation->name),
 				         MessageBox::ButtonOptions::Ok, [this] {
 					         state->current_battle->currentPlayer =
@@ -2102,7 +2102,7 @@ void BattleView::updateTBButtons()
 void BattleView::updateHiddenForm()
 {
 	hideDisplay = true;
-	hiddenForm->findControlTyped<Label>("TEXT_TURN")->setText(format("%d", battle.currentTurn));
+	hiddenForm->findControlTyped<Label>("TEXT_TURN")->setText(format("{}", battle.currentTurn));
 	hiddenForm->findControlTyped<Label>("TEXT_SIDE")
 	    ->setText(battle.currentActiveOrganisation->name);
 	bool player = state->current_battle->hotseat &&
@@ -2116,7 +2116,7 @@ void BattleView::updateHiddenForm()
 void BattleView::refreshDelayText()
 {
 	int delay = primingTab->findControlTyped<ScrollBar>("DELAY_SLIDER")->getValue();
-	LogWarning("Delay %d", delay);
+	LogWarning("Delay {}", delay);
 	UString text;
 	if (delay == 0)
 	{
@@ -2132,7 +2132,7 @@ void BattleView::refreshDelayText()
 			}
 			else
 			{
-				text = format("%s %d", tr("Turns before activation:"), delay - 1);
+				text = format("{} {}", tr("Turns before activation:"), delay - 1);
 			}
 		}
 		else
@@ -2205,7 +2205,7 @@ void BattleView::updatePathPreview()
 		target.z--;
 		if (target.z == -1)
 		{
-			LogError("Solid ground missing on level 0? Reached %d %d %d", target.x, target.y,
+			LogError("Solid ground missing on level 0? Reached {} {} {}", target.x, target.y,
 			         target.z);
 			return;
 		}
@@ -2398,11 +2398,11 @@ void BattleView::orderMove(Vec3<int> target, bool strafe, bool demandGiveWay)
 
 			if (unit->setMission(*state, mission))
 			{
-				LogInfo("BattleUnit \"%s\" going to location %s", unit->agent->name, target);
+				LogInfo("BattleUnit \"{}\" going to location {}", unit->agent->name, target);
 			}
 			else
 			{
-				LogInfo("BattleUnit \"%s\" could not receive order to move", unit->agent->name);
+				LogInfo("BattleUnit \"{}\" could not receive order to move", unit->agent->name);
 			}
 		}
 	}
@@ -2414,11 +2414,11 @@ void BattleView::orderTurn(Vec3<int> target)
 	{
 		if (unit->setMission(*state, BattleUnitMission::turn(*unit, target)))
 		{
-			LogWarning("BattleUnit \"%s\" turning to face location %s", unit->agent->name, target);
+			LogWarning("BattleUnit \"{}\" turning to face location {}", unit->agent->name, target);
 		}
 		else
 		{
-			LogWarning("BattleUnit \"%s\" could not receive order to turn", unit->agent->name);
+			LogWarning("BattleUnit \"{}\" could not receive order to turn", unit->agent->name);
 		}
 	}
 }
@@ -2439,7 +2439,7 @@ void BattleView::orderThrow(Vec3<int> target, bool right)
 
 	if (unit->setMission(*state, BattleUnitMission::throwItem(*unit, item, target)))
 	{
-		LogWarning("BattleUnit \"%s\" throwing item in the %s hand", unit->agent->name,
+		LogWarning("BattleUnit \"{}\" throwing item in the {} hand", unit->agent->name,
 		           right ? "right" : "left");
 		selectionState = BattleSelectionState::Normal;
 	}
@@ -2598,7 +2598,7 @@ void BattleView::orderDrop(bool right)
 	{
 		// Special case, just add mission in front of anything and start it, no need to clear orders
 		unit->addMission(*state, BattleUnitMission::dropItem(*unit, item));
-		LogWarning("BattleUnit \"%s\" dropping item in %s hand", unit->agent->name,
+		LogWarning("BattleUnit \"{}\" dropping item in {} hand", unit->agent->name,
 		           right ? "right" : "left");
 	}
 	else // Try to pick something up
@@ -2707,14 +2707,14 @@ void BattleView::orderTeleport(Vec3<int> target, bool right)
 	auto m = BattleUnitMission::teleport(*unit, item, target);
 	if (unit->setMission(*state, m) && !m->cancelled)
 	{
-		LogWarning("BattleUnit \"%s\" teleported using item in %s hand ", unit->agent->name,
+		LogWarning("BattleUnit \"{}\" teleported using item in {} hand ", unit->agent->name,
 		           right ? "right" : "left");
 		selectionState = BattleSelectionState::Normal;
 	}
 	else
 	{
 		actionImpossibleDelay = 40;
-		LogWarning("BattleUnit \"%s\" could not teleport using item in %s hand ", unit->agent->name,
+		LogWarning("BattleUnit \"{}\" could not teleport using item in {} hand ", unit->agent->name,
 		           right ? "right" : "left");
 	}
 }
@@ -3517,7 +3517,7 @@ bool BattleView::handleMouseDown(Event *e)
 			}
 		}
 		// Determine course of action
-		LogWarning("Click at tile %d, %d, %d", t.x, t.y, t.z);
+		LogWarning("Click at tile {}, {}, {}", t.x, t.y, t.z);
 		switch (selectionState)
 		{
 			case BattleSelectionState::Normal:
@@ -3633,11 +3633,11 @@ bool BattleView::handleMouseDown(Event *e)
 				if (true)
 				{
 					UString debug = "";
-					debug += format("\nDEBUG INFORMATION ABOUT TILE %d, %d, %d", t.x, t.y, t.z);
-					debug += format("\n LOS BLOCK %d", battle.getLosBlockID(t.x, t.y, t.z));
+					debug += format("\nDEBUG INFORMATION ABOUT TILE {}, {}, {}", t.x, t.y, t.z);
+					debug += format("\n LOS BLOCK {}", battle.getLosBlockID(t.x, t.y, t.z));
 					auto &map = *battle.map;
 					auto tile = map.getTile(t);
-					debug += format("\n STAND %d PASS %d", (int)tile->canStand,
+					debug += format("\n STAND {} PASS {}", (int)tile->canStand,
 					                (int)tile->getPassable());
 					for (auto &o : tile->ownedObjects)
 					{
@@ -3649,7 +3649,7 @@ bool BattleView::handleMouseDown(Event *e)
 							auto mp =
 							    std::static_pointer_cast<TileObjectBattleMapPart>(o)->getOwner();
 							debug += format(
-							    "\n[%s] SBT %d STATUS %s\nFIRE Res=%d Tim=%d Burned=%D",
+							    "\n[{}] SBT {} STATUS {}\nFIRE Res={} Tim={} Burned=%D",
 							    mp->type.id, mp->type->getVanillaSupportedById(),
 							    !mp->isAlive()
 							        ? "DEAD "
@@ -3684,7 +3684,7 @@ bool BattleView::handleMouseDown(Event *e)
 													if (p.first == t && p.second == mp->type->type)
 													{
 														debug +=
-														    format("\nSupported by %s at %d %d %d",
+														    format("\nSupported by {} at {} {} {}",
 														           mp2->type.id, x - t.x, y - t.y,
 														           z - t.z);
 													}
@@ -3700,7 +3700,7 @@ bool BattleView::handleMouseDown(Event *e)
 							auto h =
 							    std::static_pointer_cast<TileObjectBattleHazard>(o)->getHazard();
 							debug +=
-							    format("\nHazard %s %s Pow=%d Age=%d LT=%d  ", h->damageType.id,
+							    format("\nHazard {} {} Pow={} Age={} LT={}  ", h->damageType.id,
 							           h->damageType->hazardType.id, h->power, h->age, h->lifetime);
 						}
 					}
@@ -3709,38 +3709,38 @@ bool BattleView::handleMouseDown(Event *e)
 					if (uto)
 					{
 						auto u = uto->getUnit();
-						debug += format("\nContains unit %s.", u->id.cStr());
-						debug += format("\nMorale state: %d", (int)u->moraleState);
-						debug += format("\nPosition: %f, %f, %f", u->position.x, u->position.y,
+						debug += format("\nContains unit {}.", u->id.cStr());
+						debug += format("\nMorale state: {}", (int)u->moraleState);
+						debug += format("\nPosition: {}, {}, {}", u->position.x, u->position.y,
 						                u->position.z);
-						debug += format("\nGoal: %f, %f, %f", u->goalPosition.x, u->goalPosition.y,
+						debug += format("\nGoal: {}, {}, {}", u->goalPosition.x, u->goalPosition.y,
 						                u->goalPosition.z);
-						debug += format("\nCurrent movement: %d, falling: %d",
+						debug += format("\nCurrent movement: {}, falling: {}",
 						                (int)u->current_movement_state, (int)u->falling);
-						debug += format("\nItems [%d]:", (int)u->agent->equipment.size());
+						debug += format("\nItems [{}]:", (int)u->agent->equipment.size());
 						for (auto &e : u->agent->equipment)
 						{
-							debug += format("\n%s", e->type.id);
+							debug += format("\n{}", e->type.id);
 						}
-						debug += format("\nMissions [%d]:", (int)u->missions.size());
+						debug += format("\nMissions [{}]:", (int)u->missions.size());
 						for (auto &m : u->missions)
 						{
-							debug += format("\n%s", m->getName());
+							debug += format("\n{}", m->getName());
 						}
-						debug += format("\nSeen units [%d]:", (int)u->visibleUnits.size());
+						debug += format("\nSeen units [{}]:", (int)u->visibleUnits.size());
 						for (auto &unit : u->visibleUnits)
 						{
-							debug += format("\n%s", unit.id);
+							debug += format("\n{}", unit.id);
 						}
 						/*	debug += format(
-						"\nCurrent ai state:\n  %s\n  enSp %d enSpPr %d attPos %s "
-						"lasSnEnPos %s",
+						"\nCurrent ai state:\n  {}\n  enSp {} enSpPr {} attPos {} "
+						"lasSnEnPos {}",
 						u->aiList.lastDecision.getName(), (int)u->aiState.enemySpotted,
 						(int)u->aiState.enemySpottedPrevious,
 						u->aiState.attackerPosition,
 						u->aiList.lastSeenEnemyPosition);*/
 					}
-					LogWarning("%s", debug);
+					LogWarning("{}", debug);
 				}
 				break;
 			case BattleSelectionState::FireAny:
@@ -4117,11 +4117,11 @@ void BattleView::updatePsiInfo()
 	    ->setImage(psiInfo.status == PsiStatus::Probe ? selectedPsiOverlay : nullptr);
 
 	activeTab->findControlTyped<Label>("PSI_ENERGY_LABEL")
-	    ->setText(format("%d", psiInfo.curEnergy));
+	    ->setText(format("{}", psiInfo.curEnergy));
 	activeTab->findControlTyped<Label>("PSI_ATTACK_LABEL")
-	    ->setText(format("%d", psiInfo.curAttack));
+	    ->setText(format("{}", psiInfo.curAttack));
 	activeTab->findControlTyped<Label>("PSI_DEFENSE_LABEL")
-	    ->setText(format("%d", psiInfo.curDefense));
+	    ->setText(format("{}", psiInfo.curDefense));
 
 	// FIXME: Maybe pre-draw all 100 of them?
 
@@ -4327,7 +4327,7 @@ AgentInfo BattleView::createUnitInfo(int index)
 void BattleView::updateUnitInfo(int index)
 {
 	AgentInfo info = unitInfo[index];
-	auto baseControl = baseForm->findControlTyped<Graphic>(format("UNIT_%d", index + 1));
+	auto baseControl = baseForm->findControlTyped<Graphic>(format("UNIT_{}", index + 1));
 	baseControl->Controls.clear();
 	if (!info.agent)
 	{
@@ -4341,12 +4341,12 @@ void BattleView::updateSpottedInfo(int index)
 {
 	if (spottedInfo[index] == 0)
 	{
-		baseForm->findControlTyped<Graphic>(format("UNIT_%d_HOSTILES", index + 1))
+		baseForm->findControlTyped<Graphic>(format("UNIT_{}_HOSTILES", index + 1))
 		    ->setImage(nullptr);
 	}
 	else
 	{
-		baseForm->findControlTyped<Graphic>(format("UNIT_%d_HOSTILES", index + 1))
+		baseForm->findControlTyped<Graphic>(format("UNIT_{}_HOSTILES", index + 1))
 		    ->setImage(unitHostiles[spottedInfo[index]]);
 	}
 }
@@ -4381,9 +4381,9 @@ void BattleView::updateSquadInfo(int index)
 {
 	SquadInfo info = squadInfo[index];
 
-	baseForm->findControlTyped<Graphic>(format("SQUAD_%d", index + 1))
+	baseForm->findControlTyped<Graphic>(format("SQUAD_{}", index + 1))
 	    ->setImage(squadNumber[info.units]);
-	baseForm->findControlTyped<Graphic>(format("SQUAD_%d_OVERLAY", index + 1))
+	baseForm->findControlTyped<Graphic>(format("SQUAD_{}_OVERLAY", index + 1))
 	    ->setImage(squadOverlay[info.selectedMode]);
 }
 

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -82,24 +82,24 @@ CityTileView::CityTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratT
 	for (int i = 72; i < 76; i++)
 	{
 		selectionBrackets[0].push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 	for (int i = 76; i < 80; i++)
 	{
 		selectionBrackets[2].push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 	for (int i = 80; i < 84; i++)
 	{
 		selectionBrackets[1].push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 	for (int i = 1; i <= 4; i++)
 	{
-		selectionBrackets[3].push_back(fw().data->loadImage(format("city/city-bracket-%d.png", i)));
+		selectionBrackets[3].push_back(fw().data->loadImage(format("city/city-bracket-{}.png", i)));
 	}
 
 	selectionImageFriendlySmall = fw().data->loadImage("battle/map-selection-small.png");
@@ -164,7 +164,7 @@ void CityTileView::eventOccurred(Event *e)
 						DEBUG_SHOW_ALIEN_CREW = false;
 						DEBUG_LAYER = -1;
 					}
-					LogWarning("Debug walk type display set to %s", DEBUG_SHOW_MISC_TYPE);
+					LogWarning("Debug walk type display set to {}", DEBUG_SHOW_MISC_TYPE);
 					return;
 				}
 				case SDLK_F5:
@@ -183,7 +183,7 @@ void CityTileView::eventOccurred(Event *e)
 						DEBUG_SHOW_MISC_TYPE = 0;
 						DEBUG_LAYER = -1;
 					}
-					LogWarning("Debug Alien display set to %s", DEBUG_SHOW_ALIEN_CREW);
+					LogWarning("Debug Alien display set to {}", DEBUG_SHOW_ALIEN_CREW);
 					return;
 				}
 				case SDLK_F12:
@@ -197,7 +197,7 @@ void CityTileView::eventOccurred(Event *e)
 						DEBUG_SHOW_MISC_TYPE = 0;
 						DEBUG_LAYER = -1;
 					}
-					LogWarning("Debug slopes display set to %s", DEBUG_SHOW_SLOPES);
+					LogWarning("Debug slopes display set to {}", DEBUG_SHOW_SLOPES);
 					return;
 				}
 				case SDLK_F11:
@@ -211,7 +211,7 @@ void CityTileView::eventOccurred(Event *e)
 						DEBUG_SHOW_MISC_TYPE = 0;
 						DEBUG_LAYER = -1;
 					}
-					LogWarning("Debug roads display set to %s", DEBUG_SHOW_ROADS);
+					LogWarning("Debug roads display set to {}", DEBUG_SHOW_ROADS);
 					return;
 				}
 				case SDLK_F10:
@@ -225,7 +225,7 @@ void CityTileView::eventOccurred(Event *e)
 						DEBUG_SHOW_MISC_TYPE = 0;
 						DEBUG_LAYER = -1;
 					}
-					LogWarning("Debug tube display set to %s", DEBUG_SHOW_TUBE);
+					LogWarning("Debug tube display set to {}", DEBUG_SHOW_TUBE);
 					return;
 				}
 				case SDLK_KP_0:
@@ -434,7 +434,7 @@ void CityTileView::render()
 													          DEBUG_SHOW_MISC_TYPE - 1;
 													break;
 												default:
-													LogError("Unhandled DEBUG_SHOW_WALK_TYPE %d",
+													LogError("Unhandled DEBUG_SHOW_WALK_TYPE {}",
 													         DEBUG_SHOW_MISC_TYPE);
 													DEBUG_SHOW_MISC_TYPE = 0;
 													break;
@@ -1065,7 +1065,7 @@ void CityTileView::update()
 		}
 		else
 		{
-			LogError("Unhandled hoursClamped %d", hour);
+			LogError("Unhandled hoursClamped {}", hour);
 		}
 
 		for (int i = 0; i < 256; i++)

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -431,7 +431,7 @@ void CityView::tryOpenUfopaediaEntry(StateRef<UfopaediaEntry> ufopaediaEntry)
 		}
 		if (!ufopaedia_category)
 		{
-			LogError("No UFOPaedia category found for entry %s", ufopaediaEntry->title);
+			LogError("No UFOPaedia category found for entry {}", ufopaediaEntry->title);
 		}
 		fw().stageQueueCommand(
 		    {StageCmd::Command::PUSH,
@@ -447,13 +447,13 @@ void CityView::orderGoToBase()
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
-				LogInfo("Goto base for vehicle \"%s\"", v->name);
+				LogInfo("Goto base for vehicle \"{}\"", v->name);
 				auto bld = v->homeBuilding;
 				if (!bld)
 				{
-					LogError("Vehicle \"%s\" has no building", v->name);
+					LogError("Vehicle \"{}\" has no building", v->name);
 				}
-				LogInfo("Vehicle \"%s\" goto building \"%s\"", v->name, bld->name);
+				LogInfo("Vehicle \"{}\" goto building \"{}\"", v->name, bld->name);
 				// FIXME: Don't clear missions if not replacing current mission
 				v->setMission(*this->state, VehicleMission::gotoBuilding(*this->state, *v, bld));
 			}
@@ -464,13 +464,13 @@ void CityView::orderGoToBase()
 	{
 		for (auto &a : this->state->current_city->cityViewSelectedAgents)
 		{
-			LogInfo("Goto base for vehicle \"%s\"", a->name);
+			LogInfo("Goto base for vehicle \"{}\"", a->name);
 			auto bld = a->homeBuilding;
 			if (!bld)
 			{
-				LogError("Vehicle \"%s\" has no building", a->name);
+				LogError("Vehicle \"{}\" has no building", a->name);
 			}
-			LogInfo("Vehicle \"%s\" goto building \"%s\"", a->name, bld->name);
+			LogInfo("Vehicle \"{}\" goto building \"{}\"", a->name, bld->name);
 			// FIXME: Don't clear missions if not replacing current mission
 			a->setMission(*this->state, AgentMission::gotoBuilding(*this->state, *a, bld));
 		}
@@ -513,7 +513,7 @@ void CityView::orderMove(StateRef<Building> building, bool alternative)
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
-				LogInfo("Vehicle \"%s\" goto building \"%s\"", v->name, building->name);
+				LogInfo("Vehicle \"{}\" goto building \"{}\"", v->name, building->name);
 				// FIXME: Don't clear missions if not replacing current mission
 				v->setMission(*state,
 				              VehicleMission::gotoBuilding(*state, *v, building, useTeleporter));
@@ -530,7 +530,7 @@ void CityView::orderMove(StateRef<Building> building, bool alternative)
 			{
 				continue;
 			}
-			LogInfo("Agent \"%s\" goto building \"%s\"", a->name, building->name);
+			LogInfo("Agent \"{}\" goto building \"{}\"", a->name, building->name);
 			// FIXME: Don't clear missions if not replacing current mission
 			a->setMission(*state,
 			              AgentMission::gotoBuilding(*state, *a, building, useTeleporter, useTaxi));
@@ -886,7 +886,7 @@ void CityView::setSelectedTab(int tabIndex)
 {
 	if (tabIndex < 0 || tabIndex > uiTabs.size())
 	{
-		LogError("Trying to select invalid tab: %d", tabIndex);
+		LogError("Trying to select invalid tab: {}", tabIndex);
 		return;
 	}
 	for (auto tab : uiTabs)
@@ -917,7 +917,7 @@ CityView::CityView(sp<GameState> state)
 	baseForm->findControlTyped<RadioButton>("BUTTON_SPEED1")->setChecked(true);
 	for (size_t i = 0; i < NUM_TABS; ++i)
 	{
-		sp<Form> f = baseForm->findControlTyped<Form>(format("SUBFORM_TAB_%d", i + 1));
+		sp<Form> f = baseForm->findControlTyped<Form>(format("SUBFORM_TAB_{}", i + 1));
 		f->takesFocus = false;
 		this->uiTabs.push_back(f);
 	}
@@ -928,7 +928,7 @@ CityView::CityView(sp<GameState> state)
 
 	for (size_t i = 0; i < this->uiTabs.size(); ++i)
 	{
-		this->baseForm->findControl(format("BUTTON_TAB_%d", i + 1))
+		this->baseForm->findControl(format("BUTTON_TAB_{}", i + 1))
 		    ->addCallback(FormEventType::ButtonClick,
 		                  [this, i](Event *) { this->setSelectedTab(i); });
 	}
@@ -1003,11 +1003,11 @@ CityView::CityView(sp<GameState> state)
 	auto vehicleForm = this->uiTabs[1];
 	for (int i = 0; i < weaponDisabled.size(); i++)
 	{
-		vehicleForm->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
+		vehicleForm->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_{}_DISABLED", i + 1))
 		    ->addCallback(
 		        FormEventType::CheckBoxSelected,
 		        [this, i](FormsEvent *e [[maybe_unused]]) { orderDisableWeapon(i, true); });
-		vehicleForm->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
+		vehicleForm->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_{}_DISABLED", i + 1))
 		    ->addCallback(
 		        FormEventType::CheckBoxDeSelected,
 		        [this, i](FormsEvent *e [[maybe_unused]]) { orderDisableWeapon(i, false); });
@@ -1487,8 +1487,8 @@ CityView::CityView(sp<GameState> state)
 	auto font = ui().getFont("smallset");
 	for (int i = 0; i <= state->current_city->roadSegments.size(); i++)
 	{
-		debugLabelsOK.push_back(font->getString(format("%d", i)));
-		debugLabelsDead.push_back(font->getString(format("-%d-", i)));
+		debugLabelsOK.push_back(font->getString(format("{}", i)));
+		debugLabelsDead.push_back(font->getString(format("-{}-", i)));
 	}
 
 #ifdef DEBUG_START_PAUSE
@@ -1559,11 +1559,11 @@ void CityView::refreshBaseView()
 	for (auto &pair : state->player_bases)
 	{
 		auto &viewBase = pair.second;
-		auto viewName = format("BUTTON_BASE_%d", ++b);
+		auto viewName = format("BUTTON_BASE_{}", ++b);
 		auto view = this->uiTabs[0]->findControlTyped<GraphicButton>(viewName);
 		if (!view)
 		{
-			LogError("Failed to find UI control matching \"%s\"", viewName);
+			LogError("Failed to find UI control matching \"{}\"", viewName);
 		}
 		view->setVisible(true);
 		view->setData(viewBase);
@@ -1955,25 +1955,25 @@ void CityView::update()
 				if (weaponType[i])
 				{
 					uiTabs[1]
-					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_%d", i + 1))
+					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_{}", i + 1))
 					    ->setImage(weaponType[i]->icon);
 					uiTabs[1]
-					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_%d", i + 1))
+					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_{}", i + 1))
 					    ->ToolTipText = tr(weaponType[i]->name);
 					uiTabs[1]
-					    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
+					    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_{}_DISABLED", i + 1))
 					    ->setVisible(true);
 				}
 				else
 				{
 					uiTabs[1]
-					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_%d", i + 1))
+					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_{}", i + 1))
 					    ->setImage(nullptr);
 					uiTabs[1]
-					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_%d", i + 1))
+					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_{}", i + 1))
 					    ->ToolTipText = "";
 					uiTabs[1]
-					    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
+					    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_{}_DISABLED", i + 1))
 					    ->setVisible(false);
 				}
 			}
@@ -2005,14 +2005,14 @@ void CityView::update()
 					}
 				}
 				uiTabs[1]
-				    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_%d_AMMO", i + 1))
+				    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_{}_AMMO", i + 1))
 				    ->setImage(bar);
 			}
 			if (currentDisabled != weaponDisabled[i])
 			{
 				weaponDisabled[i] = currentDisabled;
 				uiTabs[1]
-				    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
+				    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_{}_DISABLED", i + 1))
 				    ->setChecked(currentDisabled);
 			}
 		}
@@ -2114,7 +2114,7 @@ void CityView::update()
 							UString efficiency = tr("Combat training (efficiency=");
 							int usage = base->getUsage(*state, FacilityType::Capacity::Training);
 							usage = (100.0f / std::max(100, usage)) * 100;
-							efficiency += format("%d%%", usage) + UString(")");
+							efficiency += format("{}%%", usage) + UString(")");
 							agentAssignment->setText(efficiency);
 							break;
 						}
@@ -2123,7 +2123,7 @@ void CityView::update()
 							UString efficiency = tr("Psionic training (efficiency=");
 							int usage = base->getUsage(*state, FacilityType::Capacity::Psi);
 							usage = (100.0f / std::max(100, usage)) * 100;
-							efficiency += format("%d%%", usage) + UString(")");
+							efficiency += format("{}%%", usage) + UString(")");
 							agentAssignment->setText(efficiency);
 							break;
 						}
@@ -2241,7 +2241,7 @@ void CityView::update()
 								                    fac->lab->current_project->man_hours_progress) /
 								                fac->lab->current_project->man_hours) *
 								               100;
-								agentAssignment->setText(pr + format(" (%d%%)", progress));
+								agentAssignment->setText(pr + format(" ({}%%)", progress));
 							}
 							else
 								agentAssignment->setText(tr("No project assigned"));
@@ -2367,7 +2367,7 @@ void CityView::update()
 								     (fac->lab->current_project->man_hours *
 								      fac->lab->manufacture_goal)) *
 								    100;
-								agentAssignment->setText(pr + format(" (%d%%)", progress));
+								agentAssignment->setText(pr + format(" ({}%%)", progress));
 							}
 							else
 								agentAssignment->setText(tr("No project assigned"));
@@ -2490,7 +2490,7 @@ void CityView::update()
 								                    fac->lab->current_project->man_hours_progress) /
 								                fac->lab->current_project->man_hours) *
 								               100;
-								agentAssignment->setText(pr + format(" (%d%%)", progress));
+								agentAssignment->setText(pr + format(" ({}%%)", progress));
 							}
 							else
 								agentAssignment->setText(tr("No project assigned"));
@@ -2964,7 +2964,7 @@ bool CityView::handleKeyDown(Event *e)
 							stuffToRepair.insert(s);
 						}
 					}
-					LogInfo("Repairing %u tiles out of %u",
+					LogInfo("Repairing {} tiles out of {}",
 					        static_cast<unsigned>(stuffToRepair.size()),
 					        static_cast<unsigned>(state->current_city->scenery.size()));
 
@@ -3011,14 +3011,14 @@ bool CityView::handleKeyDown(Event *e)
 						if (type.second->crashed_sprite)
 						{
 							validTypes.emplace_back(state.get(), type.second);
-							LogWarning("Valid UFO type: %s", type.second->name);
+							LogWarning("Valid UFO type: {}", type.second->name);
 						}
 					}
 
 					for (int i = 0; i < 3; i++)
 					{
 						auto type = pickRandom(state->rng, validTypes);
-						LogWarning("Crashing %s", type->name);
+						LogWarning("Crashing {}", type->name);
 						pos.z = 9 + i;
 						auto ufo = state->current_city->placeVehicle(*state, {state.get(), type},
 						                                             state->getAliens(), pos);
@@ -3232,15 +3232,15 @@ bool CityView::handleMouseDown(Event *e)
 						Vec3<int> t = scenery->currentPosition;
 						UString debug = "";
 						debug +=
-						    format("\nCLICKED %s SCENERY %s at %s BUILDING %s",
+						    format("\nCLICKED {} SCENERY {} at {} BUILDING {}",
 						           scenery->falling || scenery->willCollapse() ? "FALLING" : "OK",
 						           scenery->type.id, t, building.id);
-						// debug += format("\n LOS BLOCK %d", battle.getLosBlockID(t.x, t.y, t.z));
+						// debug += format("\n LOS BLOCK {}", battle.getLosBlockID(t.x, t.y, t.z));
 
 						debug += format(
-						    "\nHt [%d] Con [%d] Type [%d|%d|%d] Road [%d%d%d%d] Hill [%d%d%d%d] "
+						    "\nHt [{}] Con [{}] Type [{}|{}|{}] Road [{}{}{}{}] Hill [{}{}{}{}] "
 						    "Tube "
-						    "[%d%d%d%d%d%d]",
+						    "[{}{}{}{}{}{}]",
 						    scenery->type->height, scenery->type->constitution,
 						    (int)scenery->type->tile_type, (int)scenery->type->road_type,
 						    (int)scenery->type->walk_mode, (int)scenery->type->connection[0],
@@ -3254,11 +3254,11 @@ bool CityView::handleMouseDown(Event *e)
 						auto &map = *state->current_city->map;
 						for (auto &p : scenery->supportedBy)
 						{
-							debug += format("\nCan be supported by %s", p);
+							debug += format("\nCan be supported by {}", p);
 						}
 						for (auto &p : scenery->supportedParts)
 						{
-							debug += format("\nSupports %s", p);
+							debug += format("\nSupports {}", p);
 						}
 						for (int x = t.x - 1; x <= t.x + 1; x++)
 						{
@@ -3284,7 +3284,7 @@ bool CityView::handleMouseDown(Event *e)
 												if (p == t)
 												{
 													debug += format(
-													    "\nActually supported by %s at %d %d %d",
+													    "\nActually supported by {} at {} {} {}",
 													    mp2->type.id, x - t.x, y - t.y, z - t.z);
 												}
 											}
@@ -3292,7 +3292,7 @@ bool CityView::handleMouseDown(Event *e)
 									}
 								}
 							}
-							LogWarning("%s", debug);
+							LogWarning("{}", debug);
 						}
 					}
 
@@ -3314,14 +3314,14 @@ bool CityView::handleMouseDown(Event *e)
 				{
 					vehicle =
 					    std::dynamic_pointer_cast<TileObjectVehicle>(collision.obj)->getVehicle();
-					LogWarning("CLICKED VEHICLE %s at %s", vehicle->name, vehicle->position);
+					LogWarning("CLICKED VEHICLE {} at {}", vehicle->name, vehicle->position);
 					for (auto &m : vehicle->missions)
 					{
-						LogWarning("Mission %s", m->getName());
+						LogWarning("Mission {}", m->getName());
 					}
 					for (auto &c : vehicle->cargo)
 					{
-						LogWarning("Cargo %dx%s", c.id, c.count);
+						LogWarning("Cargo {}x{}", c.id, c.count);
 					}
 					if (modifierLAlt && modifierLCtrl && modifierLShift)
 					{
@@ -3355,15 +3355,15 @@ bool CityView::handleMouseDown(Event *e)
 				{
 					vehicle = std::dynamic_pointer_cast<TileObjectVehicle>(collisionVehicle.obj)
 					              ->getVehicle();
-					LogWarning("SECONDARY CLICK ON VEHICLE %s at %s", vehicle->name,
+					LogWarning("SECONDARY CLICK ON VEHICLE {} at {}", vehicle->name,
 					           vehicle->position);
 					for (auto &m : vehicle->missions)
 					{
-						LogWarning("Mission %s", m->getName());
+						LogWarning("Mission {}", m->getName());
 					}
 					for (auto &c : vehicle->cargo)
 					{
-						LogWarning("Cargo %dx%s", c.id, c.count);
+						LogWarning("Cargo {}x{}", c.id, c.count);
 					}
 				}
 			}
@@ -3375,7 +3375,7 @@ bool CityView::handleMouseDown(Event *e)
 		{
 			projectile =
 			    std::dynamic_pointer_cast<TileObjectProjectile>(projCollision.obj)->getProjectile();
-			LogInfo("CLICKED PROJECTILE %s at %s", projectile->damage, projectile->position);
+			LogInfo("CLICKED PROJECTILE {} at {}", projectile->damage, projectile->position);
 
 			if (!vehicle && !scenery && !portal)
 			{
@@ -3503,7 +3503,7 @@ bool CityView::handleGameStateEvent(Event *e)
 			    {StageCmd::Command::PUSH,
 			     mksp<NotificationScreen>(
 			         state, *this,
-			         format("Aliens have taken over %s", gameOrgEvent->organisation->name),
+			         format("Aliens have taken over {}", gameOrgEvent->organisation->name),
 			         gameEvent->type)});
 		}
 		break;
@@ -3603,8 +3603,8 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 
 			UString title = tr("Commence investigation");
-			UString message = format(tr("All selected units and crafts have arrived at %s. "
-			                            "Proceed with investigation? (%d units)"),
+			UString message = format(tr("All selected units and crafts have arrived at {}. "
+			                            "Proceed with investigation? ({} units)"),
 			                         building->name, agents.size());
 			fw().stageQueueCommand({StageCmd::Command::PUSH,
 			                        mksp<MessageBox>(
@@ -3665,13 +3665,13 @@ bool CityView::handleGameStateEvent(Event *e)
 				}
 				if (!ufopaedia_category)
 				{
-					LogError("No UFOPaedia category found for entry %s", ufopaedia_entry->title);
+					LogError("No UFOPaedia category found for entry {}", ufopaedia_entry->title);
 				}
 			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box = mksp<MessageBox>(
 			    tr("RESEARCH COMPLETE"),
-			    format("%s\n%s\n%s", tr("Research project completed:"), ev->topic->name,
+			    format("{}\n{}\n{}", tr("Research project completed:"), ev->topic->name,
 			           tr("Do you wish to view the UFOpaedia report?")),
 			    MessageBox::ButtonOptions::YesNo,
 			    // "Yes" callback
@@ -3742,7 +3742,7 @@ bool CityView::handleGameStateEvent(Event *e)
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box = mksp<MessageBox>(
 			    tr("MANUFACTURE COMPLETED"),
-			    format("%s\n%s\n%s %d\n%d", lab_base->name, tr(item_name), tr("Quantity:"),
+			    format("{}\n{}\n{} {}\n{}", lab_base->name, tr(item_name), tr("Quantity:"),
 			           ev->goal, tr("Do you wish to reasign the Workshop?")),
 			    MessageBox::ButtonOptions::YesNo,
 			    // Yes callback
@@ -3801,7 +3801,7 @@ bool CityView::handleGameStateEvent(Event *e)
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box =
 			    mksp<MessageBox>(tr("MANUFACTURING HALTED"),
-			                     format("%s\n%s\n%s %d/%d\n%d", lab_base->name, tr(item_name),
+			                     format("{}\n{}\n{} {}/{}\n{}", lab_base->name, tr(item_name),
 			                            tr("Completion status:"), ev->done, ev->goal,
 			                            tr("Production costs exceed your available funds.")),
 			                     MessageBox::ButtonOptions::Ok);
@@ -3819,7 +3819,7 @@ bool CityView::handleGameStateEvent(Event *e)
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box =
 			    mksp<MessageBox>(tr("FACILITY COMPLETED"),
-			                     format("%s\n%s", ev->base->name, tr(ev->facility->type->name)),
+			                     format("{}\n{}", ev->base->name, tr(ev->facility->type->name)),
 			                     MessageBox::ButtonOptions::Ok);
 			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		}

--- a/game/ui/tileview/tileview.cpp
+++ b/game/ui/tileview/tileview.cpp
@@ -18,7 +18,7 @@ TileView::TileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratTileSize,
       selectedTilePosition(0, 0, 0), maxZDraw(map.size.z), centerPos(0, 0, 0),
       isoScrollSpeed(0.5, 0.5), stratScrollSpeed(2.0f, 2.0f)
 {
-	LogInfo("dpySize: %s", dpySize);
+	LogInfo("dpySize: {}", dpySize);
 }
 
 TileView::~TileView() = default;
@@ -39,7 +39,7 @@ void TileView::eventOccurred(Event *e)
 		{
 			case SDLK_F1:
 				debugHotkeyMode = !debugHotkeyMode;
-				LogWarning("DEBUG MODE %s", debugHotkeyMode);
+				LogWarning("DEBUG MODE {}", debugHotkeyMode);
 				break;
 			case SDLK_UP:
 				scrollUpKB = true;

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -43,7 +43,7 @@ UfopaediaCategoryView::UfopaediaCategoryView(sp<GameState> state, sp<UfopaediaCa
 		}
 		if (it == cat->entries.end())
 		{
-			LogError("Failed to find UFOpaedia entry %s in category %s", entry->title, cat->title);
+			LogError("Failed to find UFOpaedia entry {} in category {}", entry->title, cat->title);
 		}
 	}
 }
@@ -76,40 +76,40 @@ void UfopaediaCategoryView::begin()
 	baseY = infoLabel->Location.y;
 	for (int i = 0; i < 9; i++)
 	{
-		auto labelName = format("LABEL_%d", i + 1);
+		auto labelName = format("LABEL_{}", i + 1);
 		auto label = menuform->findControlTyped<Label>(labelName);
 		if (!label)
 		{
-			LogError("Failed to find UI control matching \"%s\"", labelName);
+			LogError("Failed to find UI control matching \"{}\"", labelName);
 		}
 		label->setText("");
 		statsLabels.push_back(label);
 
-		auto valueName = format("VALUE_%d", i + 1);
+		auto valueName = format("VALUE_{}", i + 1);
 		auto value = menuform->findControlTyped<Label>(valueName);
 		if (!value)
 		{
-			LogError("Failed to find UI control matching \"%s\"", valueName);
+			LogError("Failed to find UI control matching \"{}\"", valueName);
 		}
 		value->setText("");
 		statsValues.push_back(value);
 	}
 	for (int i = 0; i < 4; i++)
 	{
-		auto labelName = format("ORG_LABEL_%d", i + 1);
+		auto labelName = format("ORG_LABEL_{}", i + 1);
 		auto label = menuform->findControlTyped<Label>(labelName);
 		if (!label)
 		{
-			LogError("Failed to find UI control matching \"%s\"", labelName);
+			LogError("Failed to find UI control matching \"{}\"", labelName);
 		}
 		label->setText("");
 		orgLabels.push_back(label);
 
-		auto valueName = format("ORG_VALUE_%d", i + 1);
+		auto valueName = format("ORG_VALUE_{}", i + 1);
 		auto value = menuform->findControlTyped<Label>(valueName);
 		if (!value)
 		{
-			LogError("Failed to find UI control matching \"%s\"", valueName);
+			LogError("Failed to find UI control matching \"{}\"", valueName);
 		}
 		value->setText("");
 		orgValues.push_back(value);
@@ -188,7 +188,7 @@ void UfopaediaCategoryView::eventOccurred(Event *e)
 				it++;
 				if (it == this->category->entries.end())
 				{
-					LogError("Failed to find current category \"%s\"", this->category->title);
+					LogError("Failed to find current category \"{}\"", this->category->title);
 				}
 			}
 			this->position_iterator = it;
@@ -269,9 +269,9 @@ void UfopaediaCategoryView::setFormStats()
 					if (data_id != "ORG_ALIEN")
 					{
 						orgLabels[1]->setText(tr("Balance"));
-						orgValues[1]->setText(format("$%d", ref->balance));
+						orgValues[1]->setText(format("${}", ref->balance));
 						orgLabels[2]->setText(tr("Income"));
-						orgValues[2]->setText(format("$%d", ref->income));
+						orgValues[2]->setText(format("${}", ref->income));
 
 						if (ref != player)
 						{
@@ -297,7 +297,7 @@ void UfopaediaCategoryView::setFormStats()
 							relation += UString(" ") + tr(player->name);
 							orgLabels[0]->setText(relation);
 							orgLabels[3]->setText(tr("Alien Infiltration"));
-							orgValues[3]->setText(format("%d%%", ref->infiltrationValue / 2));
+							orgValues[3]->setText(format("{}%%", ref->infiltrationValue / 2));
 						}
 					}
 					break;
@@ -358,7 +358,7 @@ void UfopaediaCategoryView::setFormStats()
 					statsValues[row++]->setText(Strings::fromInteger(ref->weight));
 					statsLabels[row]->setText(tr("Size"));
 					statsValues[row++]->setText(
-					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
+					    format("{}x{}", ref->equipscreen_size.x, ref->equipscreen_size.y));
 					switch (ref->type)
 					{
 						case EquipmentSlotType::VehicleEngine:
@@ -371,9 +371,9 @@ void UfopaediaCategoryView::setFormStats()
 							statsLabels[row]->setText(tr("Damage"));
 							statsValues[row++]->setText(Strings::fromInteger(ref->damage));
 							statsLabels[row]->setText(tr("Accuracy"));
-							statsValues[row++]->setText(format("%d%%", ref->accuracy));
+							statsValues[row++]->setText(format("{}%%", ref->accuracy));
 							statsLabels[row]->setText(tr("Range"));
-							statsValues[row++]->setText(format("%dm", ref->getRangeInMetres()));
+							statsValues[row++]->setText(format("{}m", ref->getRangeInMetres()));
 							statsLabels[row]->setText(tr("Fire Rate"));
 							statsValues[row++]->setText(format(
 							    "%.2f r/s", (float)TICKS_PER_SECOND / (float)ref->fire_delay));
@@ -395,7 +395,7 @@ void UfopaediaCategoryView::setFormStats()
 							{
 								statsLabels[row]->setText(tr("Accuracy"));
 								statsValues[row++]->setText(
-								    format("+%d%%", ref->accuracy_modifier));
+								    format("+{}%%", ref->accuracy_modifier));
 							}
 							if (ref->cargo_space > 0)
 							{
@@ -415,12 +415,12 @@ void UfopaediaCategoryView::setFormStats()
 							if (ref->missile_jamming > 0)
 							{
 								statsLabels[row]->setText(tr("Jamming"));
-								statsValues[row++]->setText(format("%d%%", ref->missile_jamming));
+								statsValues[row++]->setText(format("{}%%", ref->missile_jamming));
 							}
 							if (ref->shielding > 0)
 							{
 								statsLabels[row]->setText(tr("Shielding"));
-								statsValues[row++]->setText(format("+%d", ref->shielding));
+								statsValues[row++]->setText(format("+{}", ref->shielding));
 							}
 							if (ref->cloaking)
 							{
@@ -437,7 +437,7 @@ void UfopaediaCategoryView::setFormStats()
 					statsValues[row++]->setText(Strings::fromInteger(ref->weight));
 					statsLabels[row]->setText(tr("Size"));
 					statsValues[row++]->setText(
-					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
+					    format("{}x{}", ref->equipscreen_size.x, ref->equipscreen_size.y));
 					if (ref->type == AEquipmentType::Type::Ammo ||
 					    ref->type == AEquipmentType::Type::Weapon && ref->ammo_types.empty())
 					{
@@ -446,7 +446,7 @@ void UfopaediaCategoryView::setFormStats()
 						statsLabels[row]->setText(tr("Damage Type"));
 						statsValues[row++]->setText(ref->damage_type->name);
 						statsLabels[row]->setText("Range");
-						statsValues[row++]->setText(format("%dm", ref->getRangeInMetres()));
+						statsValues[row++]->setText(format("{}m", ref->getRangeInMetres()));
 						statsLabels[row]->setText("Fire Rate");
 						statsValues[row++]->setText(format("%.2f r/s", ref->getRoundsPerSecond()));
 					}
@@ -466,7 +466,7 @@ void UfopaediaCategoryView::setFormStats()
 						statsLabels[row]->setText(tr("Damage Type"));
 						statsValues[row++]->setText(ammoType->damage_type->name);
 						statsLabels[row]->setText(tr("Range"));
-						statsValues[row++]->setText(format("%dm", ammoType->getRangeInMetres()));
+						statsValues[row++]->setText(format("{}m", ammoType->getRangeInMetres()));
 						statsLabels[row]->setText(tr("Fire Rate"));
 						statsValues[row++]->setText(
 						    format("%.2f r/s", ammoType->getRoundsPerSecond()));
@@ -493,11 +493,11 @@ void UfopaediaCategoryView::setFormStats()
 				{
 					StateRef<FacilityType> ref = {state.get(), data_id};
 					statsLabels[row]->setText(tr("Construction cost"));
-					statsValues[row++]->setText(format("$%d", ref->buildCost));
+					statsValues[row++]->setText(format("${}", ref->buildCost));
 					statsLabels[row]->setText(tr("Days to build"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->buildTime));
 					statsLabels[row]->setText(tr("Weekly cost"));
-					statsValues[row++]->setText(format("$%d", ref->weeklyCost));
+					statsValues[row++]->setText(format("${}", ref->weeklyCost));
 					if (ref->capacityAmount > 0)
 					{
 						statsLabels[row]->setText(tr("Capacity"));
@@ -578,7 +578,7 @@ void UfopaediaCategoryView::setNextSection()
 		it++;
 		if (it == state->ufopaedia.end())
 		{
-			LogError("Failed to find current category \"%s\"", this->category->title);
+			LogError("Failed to find current category \"{}\"", this->category->title);
 		}
 	}
 	// Increment it once to get the next
@@ -602,7 +602,7 @@ void UfopaediaCategoryView::setPreviousSection()
 		it++;
 		if (it == state->ufopaedia.end())
 		{
-			LogError("Failed to find current category \"%s\"", this->category->title);
+			LogError("Failed to find current category \"{}\"", this->category->title);
 		}
 	}
 	// Loop around to the beginning

--- a/game/ui/ufopaedia/ufopaediaview.cpp
+++ b/game/ui/ufopaedia/ufopaediaview.cpp
@@ -57,7 +57,7 @@ void UfopaediaView::eventOccurred(Event *e)
 				{
 					fw().stageQueueCommand(
 					    {StageCmd::Command::PUSH, mksp<UfopaediaCategoryView>(state, cat.second)});
-					LogInfo("Clicked category \"%s\"", catName);
+					LogInfo("Clicked category \"{}\"", catName);
 					return;
 				}
 			}

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -35,7 +35,7 @@ add_library(OpenApoc_Library STATIC ${LIBRARY_SOURCE_FILES}
 		${LIBRARY_HEADER_FILES})
 
 target_link_libraries(OpenApoc_Library PUBLIC ${Boost_LIBRARIES}
-		Threads::Threads)
+		Threads::Threads fmt::fmt)
 
 target_include_directories(OpenApoc_Library PUBLIC ${CMAKE_SOURCE_DIR})
 target_include_directories(OpenApoc_Library PUBLIC ${GLM_INCLUDE_DIR})

--- a/library/rect.h
+++ b/library/rect.h
@@ -118,12 +118,12 @@ template <typename T> class Rect
 
 }; // namespace OpenApoc
 
-template <typename T>
-struct fmt::formatter<OpenApoc::Rect<T>> {
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+template <typename T> struct fmt::formatter<OpenApoc::Rect<T>>
+{
+	constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
 
-  template <typename FormatContext>
-  auto format(const OpenApoc::Rect<T>& r, FormatContext& ctx) {
-return format_to(ctx.out(), "{{{},{}}}", r.p0, r.p1);
-  }
+	template <typename FormatContext> auto format(const OpenApoc::Rect<T> &r, FormatContext &ctx)
+	{
+		return format_to(ctx.out(), "{{{},{}}}", r.p0, r.p1);
+	}
 };

--- a/library/rect.h
+++ b/library/rect.h
@@ -116,10 +116,14 @@ template <typename T> class Rect
 	}
 };
 
-template <typename T> std::ostream &operator<<(std::ostream &lhs, const OpenApoc::Rect<T> &rhs)
-{
-	lhs << "{" << rhs.p0 << "," << rhs.p1 << "}";
-	return lhs;
-}
-
 }; // namespace OpenApoc
+
+template <typename T>
+struct fmt::formatter<OpenApoc::Rect<T>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const OpenApoc::Rect<T>& r, FormatContext& ctx) {
+return format_to(ctx.out(), "{{{},{}}}", r.p0, r.p1);
+  }
+};

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -157,6 +157,18 @@ UString tr(const UString &str, const UString domain)
 #endif
 	return UString(boost::locale::translate(str.str()).str(domain.str()));
 }
+UString tr(const char* str, const UString domain)
+{
+#ifdef DUMP_TRANSLATION_STRINGS
+	if (str != "")
+	{
+		trStrings[domain].insert(str);
+	}
+#endif
+	return UString(boost::locale::translate(str).str(domain.str()));
+}
+
+
 
 UString::~UString() = default;
 
@@ -459,9 +471,9 @@ bool Strings::isFloat(const UString &s)
 	return (endpos != u8str.c_str());
 }
 
-UString Strings::fromInteger(int i) { return format("%d", i); }
+UString Strings::fromInteger(int i) { return format("{}", i); }
 
-UString Strings::fromFloat(float f) { return format("%f", f); }
+UString Strings::fromFloat(float f) { return format("{}", f); }
 
 bool Strings::isWhiteSpace(UniChar c)
 {
@@ -469,6 +481,6 @@ bool Strings::isWhiteSpace(UniChar c)
 	return isspace(c) != 0;
 }
 
-UString Strings::fromU64(uint64_t i) { return format("%llu", i); }
+UString Strings::fromU64(uint64_t i) { return format("{}", i); }
 
 }; // namespace OpenApoc

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -157,7 +157,7 @@ UString tr(const UString &str, const UString domain)
 #endif
 	return UString(boost::locale::translate(str.str()).str(domain.str()));
 }
-UString tr(const char* str, const UString domain)
+UString tr(const char *str, const UString domain)
 {
 #ifdef DUMP_TRANSLATION_STRINGS
 	if (str != "")
@@ -167,8 +167,6 @@ UString tr(const char* str, const UString domain)
 #endif
 	return UString(boost::locale::translate(str).str(domain.str()));
 }
-
-
 
 UString::~UString() = default;
 

--- a/library/strings.h
+++ b/library/strings.h
@@ -8,7 +8,7 @@
 namespace OpenApoc
 {
 
-typedef char32_t UniChar;
+typedef int32_t UniChar;
 
 class UString
 {

--- a/library/strings_format.h
+++ b/library/strings_format.h
@@ -8,21 +8,38 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 
-#include "dependencies/tinyformat/tinyformat.h"
-
 #ifdef __GNUC__
 #pragma GCC diagnostic pop
 #endif
 
 #include "library/strings.h"
+#include "fmt/format.h"
+#include "fmt/printf.h"
+
+template <>
+struct fmt::formatter<OpenApoc::UString> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const OpenApoc::UString& s, FormatContext& ctx) {
+	return format_to(ctx.out(), "{}", s.str());
+  }
+};
+
 namespace OpenApoc
 {
 
+UString tr(const UString &str, const UString domain = "ufo_string");
+UString tr(const char* str, const UString domain = "ufo_string");
+
 template <typename... Args> static UString format(const UString &fmt, Args &&... args)
 {
-	return tfm::format(fmt.cStr(), std::forward<Args>(args)...);
+	return fmt::format(fmt.cStr(), std::forward<Args>(args)...);
 }
 
-UString tr(const UString &str, const UString domain = "ufo_string");
+template <typename... Args> static UString tformat(const char* fmt, Args &&... args)
+{
+	return fmt::format(tr(fmt).cStr(), std::forward<Args>(args)...);
+}
 
 } // namespace OpenApoc

--- a/library/strings_format.h
+++ b/library/strings_format.h
@@ -12,32 +12,32 @@
 #pragma GCC diagnostic pop
 #endif
 
-#include "library/strings.h"
 #include "fmt/format.h"
 #include "fmt/printf.h"
+#include "library/strings.h"
 
-template <>
-struct fmt::formatter<OpenApoc::UString> {
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+template <> struct fmt::formatter<OpenApoc::UString>
+{
+	constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
 
-  template <typename FormatContext>
-  auto format(const OpenApoc::UString& s, FormatContext& ctx) {
-	return format_to(ctx.out(), "{}", s.str());
-  }
+	template <typename FormatContext> auto format(const OpenApoc::UString &s, FormatContext &ctx)
+	{
+		return format_to(ctx.out(), "{}", s.str());
+	}
 };
 
 namespace OpenApoc
 {
 
 UString tr(const UString &str, const UString domain = "ufo_string");
-UString tr(const char* str, const UString domain = "ufo_string");
+UString tr(const char *str, const UString domain = "ufo_string");
 
 template <typename... Args> static UString format(const UString &fmt, Args &&... args)
 {
 	return fmt::format(fmt.cStr(), std::forward<Args>(args)...);
 }
 
-template <typename... Args> static UString tformat(const char* fmt, Args &&... args)
+template <typename... Args> static UString tformat(const char *fmt, Args &&... args)
 {
 	return fmt::format(tr(fmt).cStr(), std::forward<Args>(args)...);
 }

--- a/library/vec.h
+++ b/library/vec.h
@@ -4,9 +4,9 @@
 #define GLM_ENABLE_EXPERIMENTAL
 
 #define GLM_FORCE_RADIANS
+#include "library/strings_format.h"
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
-#include "library/strings_format.h"
 
 namespace OpenApoc
 {
@@ -64,24 +64,22 @@ template <typename T> bool operator<(const glm::vec<2, T, highp> &a, const glm::
 }
 } // namespace glm
 
-template <typename T>
-struct fmt::formatter<OpenApoc::Vec2<T>> {
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+template <typename T> struct fmt::formatter<OpenApoc::Vec2<T>>
+{
+	constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
 
-  template <typename FormatContext>
-  auto format(const OpenApoc::Vec2<T>& v, FormatContext& ctx) {
-return format_to(ctx.out(), "{{{},{}}}", v.x, v.y);
-  }
+	template <typename FormatContext> auto format(const OpenApoc::Vec2<T> &v, FormatContext &ctx)
+	{
+		return format_to(ctx.out(), "{{{},{}}}", v.x, v.y);
+	}
 };
 
-template <typename T>
-struct fmt::formatter<OpenApoc::Vec3<T>> {
-  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+template <typename T> struct fmt::formatter<OpenApoc::Vec3<T>>
+{
+	constexpr auto parse(format_parse_context &ctx) { return ctx.begin(); }
 
-  template <typename FormatContext>
-  auto format(const OpenApoc::Vec3<T>& v, FormatContext& ctx) {
-return format_to(ctx.out(), "{{{},{},{}}}", v.x, v.y, v.z);
-  }
+	template <typename FormatContext> auto format(const OpenApoc::Vec3<T> &v, FormatContext &ctx)
+	{
+		return format_to(ctx.out(), "{{{},{},{}}}", v.x, v.y, v.z);
+	}
 };
-
-

--- a/library/vec.h
+++ b/library/vec.h
@@ -6,7 +6,7 @@
 #define GLM_FORCE_RADIANS
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
-#include <ostream>
+#include "library/strings_format.h"
 
 namespace OpenApoc
 {
@@ -62,16 +62,26 @@ template <typename T> bool operator<(const glm::vec<2, T, highp> &a, const glm::
 	else
 		return false;
 }
-
-template <typename T> std::ostream &operator<<(std::ostream &lhs, const OpenApoc::Vec2<T> &rhs)
-{
-	lhs << "{" << rhs.x << "," << rhs.y << "}";
-	return lhs;
-}
-
-template <typename T> std::ostream &operator<<(std::ostream &lhs, const OpenApoc::Vec3<T> &rhs)
-{
-	lhs << "{" << rhs.x << "," << rhs.y << "," << rhs.z << "}";
-	return lhs;
-}
 } // namespace glm
+
+template <typename T>
+struct fmt::formatter<OpenApoc::Vec2<T>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const OpenApoc::Vec2<T>& v, FormatContext& ctx) {
+return format_to(ctx.out(), "{{{},{}}}", v.x, v.y);
+  }
+};
+
+template <typename T>
+struct fmt::formatter<OpenApoc::Vec3<T>> {
+  constexpr auto parse(format_parse_context& ctx) { return ctx.begin(); }
+
+  template <typename FormatContext>
+  auto format(const OpenApoc::Vec3<T>& v, FormatContext& ctx) {
+return format_to(ctx.out(), "{{{},{},{}}}", v.x, v.y, v.z);
+  }
+};
+
+

--- a/tests/test_colour.cpp
+++ b/tests/test_colour.cpp
@@ -40,7 +40,7 @@ int main(int argc, char **argv)
 	{
 		if (*it_expected != *it_test)
 		{
-			LogError("Colour parsing by name mismatch: expected (%d, %d, %d), got (%d, %d, %d)",
+			LogError("Colour parsing by name mismatch: expected ({}, {}, {}), got ({}, {}, {})",
 			         it_expected->r, it_expected->g, it_expected->b, it_test->r, it_test->g,
 			         it_test->b);
 			return EXIT_FAILURE;
@@ -55,7 +55,7 @@ int main(int argc, char **argv)
 	{
 		if (*it_expected != *it_test)
 		{
-			LogError("Colour parsing by name mismatch: expected (%d, %d, %d), got (%d, %d, %d)",
+			LogError("Colour parsing by name mismatch: expected ({}, {}, {}), got ({}, {}, {})",
 			         it_expected->r, it_expected->g, it_expected->b, it_test->r, it_test->g,
 			         it_test->b);
 			return EXIT_FAILURE;

--- a/tests/test_images.cpp
+++ b/tests/test_images.cpp
@@ -38,7 +38,7 @@ static bool testImage(const UString &imageName, const UString &referenceName)
 
 	if (img->size != reference->size)
 	{
-		LogWarning("Invalid size, %s doesn't match reference %s", img->size, reference->size);
+		LogWarning("Invalid size, {} doesn't match reference {}", img->size, reference->size);
 		return false;
 	}
 
@@ -54,7 +54,7 @@ static bool testImage(const UString &imageName, const UString &referenceName)
 			if (i != r)
 			{
 				LogWarning(
-				    "Image mismatch at {%d,%d} (RGBA img {%d,%d,%d,%d} != RGBA ref {%d,%d,%d,%d}",
+				    "Image mismatch at {{},{}} (RGBA img {{},{},{},{}} != RGBA ref {{},{},{},{}}",
 				    x, y, (int)i.r, (int)i.g, (int)i.b, (int)i.a, (int)r.r, (int)r.g, (int)r.b,
 				    (int)r.a);
 
@@ -112,11 +112,11 @@ int main(int argc, char **argv)
 	{
 		if (!testImage(imagePair.first, imagePair.second))
 		{
-			LogError("Image \"%s\" didn't match reference \"%s\"", imagePair.first,
+			LogError("Image \"{}\" didn't match reference \"{}\"", imagePair.first,
 			         imagePair.second);
 			return EXIT_FAILURE;
 		}
-		LogInfo("Image \"%s\" matches reference \"%s\"", imagePair.first, imagePair.second);
+		LogInfo("Image \"{}\" matches reference \"{}\"", imagePair.first, imagePair.second);
 	}
 
 	return EXIT_SUCCESS;

--- a/tests/test_images.cpp
+++ b/tests/test_images.cpp
@@ -54,7 +54,7 @@ static bool testImage(const UString &imageName, const UString &referenceName)
 			if (i != r)
 			{
 				LogWarning(
-				    "Image mismatch at {{},{}} (RGBA img {{},{},{},{}} != RGBA ref {{},{},{},{}}",
+				    "Image mismatch at {{{},{}}} (RGBA img {{{},{},{},{}}} != RGBA ref {{{},{},{},{}}}",
 				    x, y, (int)i.r, (int)i.g, (int)i.b, (int)i.a, (int)r.r, (int)r.g, (int)r.b,
 				    (int)r.a);
 

--- a/tests/test_rect.cpp
+++ b/tests/test_rect.cpp
@@ -14,7 +14,7 @@ static bool test_one_rect_compaction(std::set<Rect<T>> rect_set, unsigned expect
 {
 	if (rect_set.size() != expected_start_count)
 	{
-		LogError("Rect set has size %u at start, expected %u", (unsigned)rect_set.size(),
+		LogError("Rect set has size {} at start, expected {}", (unsigned)rect_set.size(),
 		         expected_start_count);
 		return false;
 	}
@@ -27,7 +27,7 @@ static bool test_one_rect_compaction(std::set<Rect<T>> rect_set, unsigned expect
 	}
 	if (num_collapsed && num_collapsed >= expected_start_count)
 	{
-		LogError("Somehow managed to collapse %u rects in a set containing %u rects", num_collapsed,
+		LogError("Somehow managed to collapse {} rects in a set containing {} rects", num_collapsed,
 		         expected_start_count);
 		return false;
 	}
@@ -45,7 +45,7 @@ static bool test_one_rect_compaction(std::set<Rect<T>> rect_set, unsigned expect
 
 	if (expected_end_size && rect_set.size() != expected_end_size)
 	{
-		LogError("Expected to collapse to %u rects but got %u", (unsigned)rect_set.size(),
+		LogError("Expected to collapse to {} rects but got {}", (unsigned)rect_set.size(),
 		         expected_end_size);
 		return false;
 	}
@@ -139,7 +139,7 @@ void test_point_within(Rect<int> r, Vec2<int> p, bool expected)
 {
 	if (r.within(p) != expected)
 	{
-		LogError("Point %s incorrectly %s rect %s", p, expected ? "not within" : "within", r);
+		LogError("Point {} incorrectly {} rect {}", p, expected ? "not within" : "within", r);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -147,7 +147,7 @@ void test_rect_within(Rect<int> r1, Rect<int> r2, bool expected)
 {
 	if (r1.within(r2) != expected)
 	{
-		LogError("Rect %s incorrectly %s rect %s", r2, expected ? "not within" : "within", r1);
+		LogError("Rect {} incorrectly {} rect {}", r2, expected ? "not within" : "within", r1);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -155,7 +155,7 @@ void test_rect_intersects(Rect<int> r1, Rect<int> r2, bool expected)
 {
 	if (r1.intersects(r2) != expected)
 	{
-		LogError("Rect %s incorrectly %s rect %s", r2,
+		LogError("Rect {} incorrectly {} rect {}", r2,
 		         expected ? "does not intersect" : "intersects", r1);
 		exit(EXIT_FAILURE);
 	}

--- a/tests/test_rng.cpp
+++ b/tests/test_rng.cpp
@@ -81,7 +81,7 @@ int main(int argc, char **argv)
 	LogWarning("RNG buckets:");
 	for (int i = 0; i < num_test_buckets; i++)
 	{
-		LogWarning("%d:\t%u", i, buckets[i]);
+		LogWarning("{}:\t{}", i, buckets[i]);
 	}
 
 	return EXIT_SUCCESS;

--- a/tests/test_serialize.cpp
+++ b/tests/test_serialize.cpp
@@ -55,7 +55,7 @@ bool test_gamestate_serialization(OpenApoc::sp<OpenApoc::GameState> state)
 	ss << "openapoc_test_serialize-" << std::this_thread::get_id();
 	auto tempPath = fs::temp_directory_path() / ss.str();
 	OpenApoc::UString pathString(tempPath.string());
-	LogInfo("Writing temp state to \"%s\"", pathString);
+	LogInfo("Writing temp state to \"{}\"", pathString);
 	if (!test_gamestate_serialization_roundtrip(state, pathString))
 	{
 		LogWarning("Packed save test failed");
@@ -94,7 +94,7 @@ int main(int argc, char **argv)
 
 	OpenApoc::Framework fw("OpenApoc", false);
 
-	LogInfo("Loading \"%s\"", gamestate_name);
+	LogInfo("Loading \"{}\"", gamestate_name);
 
 	auto state = OpenApoc::mksp<OpenApoc::GameState>();
 
@@ -170,9 +170,9 @@ int main(int argc, char **argv)
 			LogError("No vehicle with BattleMap found");
 			return EXIT_FAILURE;
 		}
-		LogInfo("Using vehicle map for \"%s\"", vType->name);
+		LogInfo("Using vehicle map for \"{}\"", vType->name);
 		v->type = {state.get(), vType};
-		v->name = format("%s %d", v->type->name, ++v->type->numCreated);
+		v->name = format("{} {}", v->type->name, ++v->type->numCreated);
 		state->vehicles[vID] = v;
 
 		OpenApoc::StateRef<OpenApoc::Vehicle> enemyVehicle = {state.get(), vID};

--- a/tests/test_tilemap.cpp
+++ b/tests/test_tilemap.cpp
@@ -45,7 +45,7 @@ static void test_collision(const TileMap &map, Vec3<float> line_start, Vec3<floa
 	auto collision = map.findCollision(line_start, line_end);
 	if (collision.obj != expected_collision)
 	{
-		LogError("Line between {%f,%f,%f} and {%f,%f,%f} collided with %s, expected %s",
+		LogError("Line between {{},{},{}} and {{},{},{}} collided with {}, expected {}",
 		         line_start.x, line_start.y, line_start.z, line_end.x, line_end.y, line_end.z,
 		         collision.obj ? collision.obj->getName() : "NONE",
 		         expected_collision ? expected_collision->getName() : "NONE");
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 		object.second->setPosition(initialPosition);
 		if (initialPosition != object.second->getPosition())
 		{
-			LogError("Object %s moved from {%f,%f,%f} to {%f,%f,%f}", object.second->getName(),
+			LogError("Object {} moved from {{},{},{}} to {{},{},{}}", object.second->getName(),
 			         initialPosition.x, initialPosition.y, initialPosition.z,
 			         object.second->getPosition().x, object.second->getPosition().y,
 			         object.second->getPosition().z);

--- a/tests/test_tilemap.cpp
+++ b/tests/test_tilemap.cpp
@@ -45,7 +45,7 @@ static void test_collision(const TileMap &map, Vec3<float> line_start, Vec3<floa
 	auto collision = map.findCollision(line_start, line_end);
 	if (collision.obj != expected_collision)
 	{
-		LogError("Line between {{},{},{}} and {{},{},{}} collided with {}, expected {}",
+		LogError("Line between {{{},{},{}}} and {{{},{},{}}} collided with {}, expected {}",
 		         line_start.x, line_start.y, line_start.z, line_end.x, line_end.y, line_end.z,
 		         collision.obj ? collision.obj->getName() : "NONE",
 		         expected_collision ? expected_collision->getName() : "NONE");
@@ -92,7 +92,7 @@ int main(int argc, char **argv)
 		object.second->setPosition(initialPosition);
 		if (initialPosition != object.second->getPosition())
 		{
-			LogError("Object {} moved from {{},{},{}} to {{},{},{}}", object.second->getName(),
+			LogError("Object {} moved from {{{},{},{}}} to {{{},{},{}}}", object.second->getName(),
 			         initialPosition.x, initialPosition.y, initialPosition.z,
 			         object.second->getPosition().x, object.second->getPosition().y,
 			         object.second->getPosition().z);

--- a/tests/test_unicode.cpp
+++ b/tests/test_unicode.cpp
@@ -41,9 +41,9 @@ struct example_unicode
 		{
 			if (expected_codepoints[i] != decoded_codepoints[i])
 			{
-				LogError(
-				    "String \"{}\" has unexpected codepoint at index {} - got 0x{:x} expected 0x{:x}",
-				    u8string, i, decoded_codepoints[i], expected_codepoints[i]);
+				LogError("String \"{}\" has unexpected codepoint at index {} - got 0x{:x} expected "
+				         "0x{:x}",
+				         u8string, i, decoded_codepoints[i], expected_codepoints[i]);
 				return false;
 			}
 			string2 += decoded_codepoints[i];
@@ -71,8 +71,8 @@ static bool test_remove(const UString &initial, const UString &expected, size_t 
 	removed.remove(offset, count);
 	if (removed != expected)
 	{
-		LogError("\"{}\".remove({}, {}) = \"{}\", expected \"{}\"", initial, offset, count,
-		         removed, expected);
+		LogError("\"{}\".remove({}, {}) = \"{}\", expected \"{}\"", initial, offset, count, removed,
+		         expected);
 		return false;
 	}
 	return true;

--- a/tests/test_unicode.cpp
+++ b/tests/test_unicode.cpp
@@ -14,13 +14,13 @@ struct example_unicode
 
 	bool test() const
 	{
-		LogInfo("Testing string \"%s\"", u8string);
+		LogInfo("Testing string \"{}\"", u8string);
 		const auto num_codepoints = expected_codepoints.size();
 		UString string(u8string);
 		UString string2;
 		if (string.length() != num_codepoints)
 		{
-			LogError("String \"%s\" has unexpected length %zu , expected %zu", u8string,
+			LogError("String \"{}\" has unexpected length {} , expected {}", u8string,
 			         string.length(), num_codepoints);
 			return false;
 		}
@@ -32,7 +32,7 @@ struct example_unicode
 
 		if (decoded_codepoints.size() != num_codepoints)
 		{
-			LogError("String \"%s\" has unexpected iterated length %zu , expected %zu", u8string,
+			LogError("String \"{}\" has unexpected iterated length {} , expected {}", u8string,
 			         decoded_codepoints.size(), num_codepoints);
 			return false;
 		}
@@ -42,7 +42,7 @@ struct example_unicode
 			if (expected_codepoints[i] != decoded_codepoints[i])
 			{
 				LogError(
-				    "String \"%s\" has unexpected codepoint at index %zu - got 0x%x expected 0x%x",
+				    "String \"{}\" has unexpected codepoint at index {} - got 0x{:x} expected 0x{:x}",
 				    u8string, i, decoded_codepoints[i], expected_codepoints[i]);
 				return false;
 			}
@@ -52,7 +52,7 @@ struct example_unicode
 		if (string != string2)
 		{
 			LogError(
-			    "String \"%s\" compared false after utf8->unichar->utf8 conversion - got \"%s\"",
+			    "String \"{}\" compared false after utf8->unichar->utf8 conversion - got \"{}\"",
 			    u8string, string2);
 
 			return false;
@@ -71,7 +71,7 @@ static bool test_remove(const UString &initial, const UString &expected, size_t 
 	removed.remove(offset, count);
 	if (removed != expected)
 	{
-		LogError("\"%s\".remove(%zu, %zu) = \"%s\", expected \"%s\"", initial, offset, count,
+		LogError("\"{}\".remove({}, {}) = \"{}\", expected \"{}\"", initial, offset, count,
 		         removed, expected);
 		return false;
 	}
@@ -85,7 +85,7 @@ static bool test_insert(const UString &initial, const UString &expected, size_t 
 	inserted.insert(offset, str);
 	if (inserted != expected)
 	{
-		LogError("\"%s\".inserted(%zu, \"%s\") = \"%s\", expected \"%s\"", initial, offset, str,
+		LogError("\"{}\".inserted({}, \"{}\") = \"{}\", expected \"{}\"", initial, offset, str,
 		         inserted, expected);
 		return false;
 	}
@@ -121,12 +121,12 @@ int main(int argc, char **argv)
 	auto upper = example.toUpper();
 	if (lower != lower_example)
 	{
-		LogError("toLower(\"%s\") returned \"%s\", expected \"%s\"", example, lower, lower_example);
+		LogError("toLower(\"{}\") returned \"{}\", expected \"{}\"", example, lower, lower_example);
 		return EXIT_FAILURE;
 	}
 	if (upper != upper_example)
 	{
-		LogError("toUpper(\"%s\") returned \"%s\", expected \"%s\"", example, upper, upper_example);
+		LogError("toUpper(\"{}\") returned \"{}\", expected \"{}\"", example, upper, upper_example);
 		return EXIT_FAILURE;
 	}
 

--- a/tests/test_voxel.cpp
+++ b/tests/test_voxel.cpp
@@ -14,7 +14,7 @@ static void check_voxel(Vec3<int> position, VoxelMap &v, bool expected)
 {
 	if (v.getBit(position) != expected)
 	{
-		LogError("Unexpected voxel at %s - expected %d", position, expected ? 1 : 0);
+		LogError("Unexpected voxel at {} - expected {}", position, expected ? 1 : 0);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -23,7 +23,7 @@ static void check_slice(Vec2<int> position, VoxelSlice &s, bool expected)
 {
 	if (s.getBit(position) != expected)
 	{
-		LogError("Unexpected voxel at %s - expected %d", position, expected ? 1 : 0);
+		LogError("Unexpected voxel at {} - expected {}", position, expected ? 1 : 0);
 		exit(EXIT_FAILURE);
 	}
 }
@@ -33,7 +33,7 @@ static void test_voxel(Vec3<int> voxel_size)
 	VoxelMap v{voxel_size};
 	if (v.size != voxel_size)
 	{
-		LogError("Unexpected size %s", v.size);
+		LogError("Unexpected size {}", v.size);
 		exit(EXIT_FAILURE);
 	}
 	// Ensure everything is '0' at init, and anything outside the bounds should be '0' too
@@ -52,7 +52,7 @@ static void test_voxel(Vec3<int> voxel_size)
 	v.calculateCentre();
 	if (v.getCentre() != v.size / 2)
 	{
-		LogError("Unexpected centre %s for empty map", v.getCentre());
+		LogError("Unexpected centre {} for empty map", v.getCentre());
 		exit(EXIT_FAILURE);
 	}
 
@@ -61,7 +61,7 @@ static void test_voxel(Vec3<int> voxel_size)
 
 	if (slice->size != Vec2<int>{voxel_size.x, voxel_size.y})
 	{
-		LogError("Unexpected slice size %s", slice->size);
+		LogError("Unexpected slice size {}", slice->size);
 		exit(EXIT_FAILURE);
 	}
 	// Ensure everything is '0' at init, and anything outside the bounds should be '0' too
@@ -78,12 +78,12 @@ static void test_voxel(Vec3<int> voxel_size)
 	if (bit_position.x > voxel_size.x)
 	{
 		bit_position.x = voxel_size.x - 1;
-		LogInfo("Clamping bit position x to %d", bit_position.x);
+		LogInfo("Clamping bit position x to {}", bit_position.x);
 	}
 	if (bit_position.y >= voxel_size.y)
 	{
 		bit_position.y = voxel_size.y - 1;
-		LogInfo("Clamping bit position y to %d", bit_position.y);
+		LogInfo("Clamping bit position y to {}", bit_position.y);
 	}
 
 	slice->setBit(bit_position, true);
@@ -103,7 +103,7 @@ static void test_voxel(Vec3<int> voxel_size)
 	if (bit_voxel_position.z >= voxel_size.z)
 	{
 		bit_voxel_position.z = voxel_size.z - 1;
-		LogInfo("Clamping bit position z to %d", bit_voxel_position.z);
+		LogInfo("Clamping bit position z to {}", bit_voxel_position.z);
 	}
 	v.setSlice(bit_voxel_position.z, slice);
 	for (int z = -16; z < voxel_size.z + 33; z++)
@@ -126,7 +126,7 @@ static void test_voxel(Vec3<int> voxel_size)
 	v.calculateCentre();
 	if (v.getCentre() != bit_voxel_position)
 	{
-		LogError("Unexpected centre %s for single-bit map, expected %s", v.getCentre(),
+		LogError("Unexpected centre {} for single-bit map, expected {}", v.getCentre(),
 		         bit_voxel_position);
 		exit(EXIT_FAILURE);
 	}
@@ -149,7 +149,7 @@ static void test_voxel(Vec3<int> voxel_size)
 	v.calculateCentre();
 	if (v.getCentre() != v.size / 2)
 	{
-		LogError("Unexpected centre %s for reset-to-empty map", v.getCentre());
+		LogError("Unexpected centre {} for reset-to-empty map", v.getCentre());
 		exit(EXIT_FAILURE);
 	}
 #endif
@@ -164,17 +164,17 @@ static void test_voxel(Vec3<int> voxel_size)
 	if (bit_2_voxel_position.x < 0)
 	{
 		bit_2_voxel_position.x = 0;
-		LogInfo("Clamping bit 2 position x to %d", bit_2_voxel_position.x);
+		LogInfo("Clamping bit 2 position x to {}", bit_2_voxel_position.x);
 	}
 	if (bit_2_voxel_position.y < 0)
 	{
 		bit_2_voxel_position.y = 0;
-		LogInfo("Clamping bit 2 position y to %d", bit_2_voxel_position.y);
+		LogInfo("Clamping bit 2 position y to {}", bit_2_voxel_position.y);
 	}
 	if (bit_2_voxel_position.z < 0)
 	{
 		bit_2_voxel_position.z = 0;
-		LogInfo("Clamping bit 2 position z to %d", bit_2_voxel_position.z);
+		LogInfo("Clamping bit 2 position z to {}", bit_2_voxel_position.z);
 	}
 	auto slice2 = mksp<VoxelSlice>(Vec2<int>{voxel_size.x, voxel_size.y});
 	if (bit_2_voxel_position.z == bit_voxel_position.z)
@@ -207,7 +207,7 @@ static void test_voxel(Vec3<int> voxel_size)
 	v.calculateCentre();
 	if (v.getCentre() != expected_centre)
 	{
-		LogError("Unexpected centre %s for 2 bit map, expected %s", v.getCentre(), expected_centre);
+		LogError("Unexpected centre {} for 2 bit map, expected {}", v.getCentre(), expected_centre);
 		exit(EXIT_FAILURE);
 	}
 #endif
@@ -229,7 +229,7 @@ int main(int argc, char **argv)
 	};
 	for (auto &size : voxel_sizes)
 	{
-		LogInfo("Testing voxel size %s", size);
+		LogInfo("Testing voxel size {}", size);
 		test_voxel(size);
 	}
 }

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -10,6 +10,7 @@ option(BUILD_SERIALIZATIONTOOL "Tool to work with serialized gamestate
 archives" ON)
 option(BUILD_LAUNCHER "Build the launcher" ON)
 option(BUILD_FORM_LOCALISATION "Build form locale string extractor" ON)
+option(BUILD_GAMESTATE_LOCALISATION "Build gamestate locale string extractor" ON)
 
 if(BUILD_EXTRACTOR)
 		add_subdirectory(extractors)
@@ -37,6 +38,10 @@ endif()
 
 if (BUILD_FORM_LOCALISATION)
 		add_subdirectory(form_localisation)
+endif()
+
+if (BUILD_GAMESTATE_LOCALISATION)
+		add_subdirectory(gamestate_localisation)
 endif()
 
 

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -9,6 +9,7 @@ option(BUILD_DUMPEVERYTHING "Tool that dumps all known images" OFF)
 option(BUILD_SERIALIZATIONTOOL "Tool to work with serialized gamestate
 archives" ON)
 option(BUILD_LAUNCHER "Build the launcher" ON)
+option(BUILD_FORM_LOCALISATION "Build form locale string extractor" ON)
 
 if(BUILD_EXTRACTOR)
 		add_subdirectory(extractors)
@@ -33,6 +34,11 @@ endif()
 if (BUILD_LAUNCHER)
 		add_subdirectory(launcher)
 endif()
+
+if (BUILD_FORM_LOCALISATION)
+		add_subdirectory(form_localisation)
+endif()
+
 
 # GameState serialization code generator isn't optional
 add_subdirectory(code_generators)

--- a/tools/code_generators/gamestate_serialize_gen/main.cpp
+++ b/tools/code_generators/gamestate_serialize_gen/main.cpp
@@ -103,6 +103,16 @@ void writeSource(std::ofstream &out, const StateDefinition &state)
 					newNodeFn = "getSection";
 					break;
 			}
+			if (member.second.translate)
+			{
+				out << "\tif (state->populate_translateable_strings)\n"
+				    << "\t{\n"
+				    << "\t\tUString translate_string;\n"
+				    << "\t\tserializeIn(state, node->getNode(\"" << member.first
+				    << "\"), translate_string);\n"
+				    << "\t\tstate->translateable_strings.insert(translate_string);\n"
+				    << "\t}\n";
+			}
 			out << "\t" << serializeFn << "(state, node->" << newNodeFn << "(\"" << member.first
 			    << "\"), obj." << member.first << ");\n";
 		}

--- a/tools/code_generators/luagamestate_support_gen/main.cpp
+++ b/tools/code_generators/luagamestate_support_gen/main.cpp
@@ -168,7 +168,7 @@ void writeSource(std::ofstream &out, const StateDefinition &state,
 			    << ");\n"
 			    << "\telse ";
 		}
-		out << "luaL_error(L, \"member variable %s not found in %s\", key.c_str(), \""
+		out << "luaL_error(L, \"member variable {} not found in {}\", key.c_str(), \""
 		    << object.name.c_str() << "\");\n"
 		    << "\tlua_pop(L, 3);\n"
 		    << "\treturn 0;\n"

--- a/tools/code_generators/serialization_xml.cpp
+++ b/tools/code_generators/serialization_xml.cpp
@@ -103,8 +103,14 @@ bool readXml(std::istream &in, StateDefinition &state)
 									std::cerr << "Unknown member type attribute \"" << typeName
 									          << "\"\n";
 							}
+
 							SerializeNode member(memberName);
 							member.type = type;
+							std::string translate = memberNode.attribute("translate").as_string();
+							if (translate == "true")
+							{
+								member.translate = true;
+							}
 							obj.members.push_back(std::make_pair(member.name, member));
 						}
 						else if (std::string(memberNode.name()) == "name")

--- a/tools/code_generators/serialization_xml.h
+++ b/tools/code_generators/serialization_xml.h
@@ -27,6 +27,7 @@ class SerializeNode
   public:
 	std::string name;
 	NodeType type = NodeType::Normal;
+	bool translate = false;
 	SerializeNode(std::string name) : name(name) {}
 };
 

--- a/tools/dump_everything/dump_everything.cpp
+++ b/tools/dump_everything/dump_everything.cpp
@@ -1056,13 +1056,13 @@ static void dumpLofTemps(fs::path basePath, const UString &prefix)
 	auto tabFileName = prefix + ".tab";
 	auto datFileName = prefix + ".dat";
 
-	LogWarning("Reading LOFTEMPS \"%s\"", prefix);
+	LogWarning("Reading LOFTEMPS \"{}\"", prefix);
 	size_t tabSize = 0;
 	{
 		auto tabFile = fw().data->fs.open(tabFileName);
 		if (!tabFile)
 		{
-			LogError("Failed to open LOFTEMPS tab \"%s\"", tabFileName);
+			LogError("Failed to open LOFTEMPS tab \"{}\"", tabFileName);
 			return;
 		}
 		tabSize = tabFile.size();
@@ -1074,14 +1074,14 @@ static void dumpLofTemps(fs::path basePath, const UString &prefix)
 
 	for (size_t i = 0; i < count; i++)
 	{
-		auto imgPath = format("LOFTEMPS:%s:%s:%u", datFileName, tabFileName, (unsigned)i);
+		auto imgPath = format("LOFTEMPS:{}:{}:{}", datFileName, tabFileName, (unsigned)i);
 		auto img = fw().data->loadImage(imgPath);
 		if (!img)
 		{
-			LogError("Failed to load \"%s\"", imgPath);
+			LogError("Failed to load \"{}\"", imgPath);
 			return;
 		}
-		auto outName = format("%u.png", (unsigned)i);
+		auto outName = format("{}.png", (unsigned)i);
 		auto filePath = outPath / outName.str();
 		fw().data->writeImage(filePath.native(), img);
 	}
@@ -1092,13 +1092,13 @@ static void dumpRaw(fs::path outDir, const RawImage &i)
 	auto inName = i.prefix + i.suffix;
 	auto fileName = i.prefix + ".png";
 	auto outPath = outDir / fileName.str();
-	auto imageString = format("RAW:%s:%u:%u:%s", inName, i.size.x, i.size.y, i.palette);
-	LogWarning("Reading \"%s\"", imageString);
+	auto imageString = format("RAW:{}:{}:{}:{}", inName, i.size.x, i.size.y, i.palette);
+	LogWarning("Reading \"{}\"", imageString);
 
 	auto img = fw().data->loadImage(imageString);
 	if (!img)
 	{
-		LogError("Failed to read \"%s\"", imageString);
+		LogError("Failed to read \"{}\"", imageString);
 		return;
 	}
 
@@ -1112,17 +1112,17 @@ static void dumpPck(fs::path outDir, const UString &prefix, const UString &palet
 	auto basePath = outDir / prefix.str();
 	fs::create_directories(basePath);
 	auto imageString = type + ":" + prefix + ".pck:" + prefix + ".tab";
-	LogWarning("Reading \"%s\"", imageString);
+	LogWarning("Reading \"{}\"", imageString);
 	auto imgSet = fw().data->loadImageSet(imageString);
 	if (!imgSet)
 	{
-		LogError("Failed to load image set \"%s\"", prefix);
+		LogError("Failed to load image set \"{}\"", prefix);
 		return;
 	}
 	auto palette = fw().data->loadPalette(paletteString);
 	if (!palette)
 	{
-		LogError("Failed to load palette \"%s\"", paletteString);
+		LogError("Failed to load palette \"{}\"", paletteString);
 		return;
 	}
 
@@ -1130,7 +1130,7 @@ static void dumpPck(fs::path outDir, const UString &prefix, const UString &palet
 	for (auto &img : imgSet->images)
 	{
 		auto fullPath = basePath;
-		auto imgName = format("%d.png", count);
+		auto imgName = format("{}.png", count);
 		fullPath /= imgName.str();
 		if (img)
 			fw().data->writeImage(fullPath.native(), img, palette);
@@ -1144,11 +1144,11 @@ static void dumpPcx(fs::path outDir, const UString &prefix)
 	auto pcxName = prefix + ".pcx";
 	auto path = outDir / outName.str();
 	fs::create_directories(path.parent_path());
-	LogWarning("Reading \"%s\"", pcxName);
+	LogWarning("Reading \"{}\"", pcxName);
 	auto img = fw().data->loadImage(pcxName);
 	if (!img)
 	{
-		LogError("Failed to load pcx \"%s\"", pcxName);
+		LogError("Failed to load pcx \"{}\"", pcxName);
 		return;
 	}
 	fw().data->writeImage(path.native(), img);

--- a/tools/extractors/common/datachunk.h
+++ b/tools/extractors/common/datachunk.h
@@ -16,7 +16,7 @@ template <typename T> class DataChunk
 	DataChunk(std::istream &file, off_t start_offset, off_t end_offset)
 	{
 		int count = (end_offset - start_offset) / sizeof(T);
-		LogInfo("Reading %d units of %zu bytes from offset 0x%08lx", count, sizeof(T),
+		LogInfo("Reading {} units of {} bytes from offset 0x%08lx", count, sizeof(T),
 		        start_offset);
 		file.seekg(start_offset, file.beg);
 		for (int i = 0; i < count; i++)

--- a/tools/extractors/common/datachunk.h
+++ b/tools/extractors/common/datachunk.h
@@ -16,8 +16,7 @@ template <typename T> class DataChunk
 	DataChunk(std::istream &file, off_t start_offset, off_t end_offset)
 	{
 		int count = (end_offset - start_offset) / sizeof(T);
-		LogInfo("Reading {} units of {} bytes from offset 0x%08lx", count, sizeof(T),
-		        start_offset);
+		LogInfo("Reading {} units of {} bytes from offset 0x%08lx", count, sizeof(T), start_offset);
 		file.seekg(start_offset, file.beg);
 		for (int i = 0; i < count; i++)
 		{

--- a/tools/extractors/common/strtab.cpp
+++ b/tools/extractors/common/strtab.cpp
@@ -32,7 +32,7 @@ StrTab::StrTab(std::istream &file, off_t start_offset, off_t end_offset, bool ma
 				std::stringstream ss;
 				ss << s << " " << ++unique_id[s];
 				s = ss.str();
-				LogWarning("Munged string to make unique: \"%s\"", s.c_str());
+				LogWarning("Munged string to make unique: \"{}\"", s.c_str());
 			}
 			else
 				unique_id.emplace(s, 0);
@@ -47,7 +47,7 @@ std::string StrTab::get(int offset) const
 {
 	if (offset >= (int)readStrings.size())
 	{
-		LogError("Trying to read string table entry %d - table size %zu", offset,
+		LogError("Trying to read string table entry {} - table size {}", offset,
 		         readStrings.size());
 	}
 	return readStrings[offset];

--- a/tools/extractors/common/tacp.cpp
+++ b/tools/extractors/common/tacp.cpp
@@ -22,7 +22,7 @@ TACP::TACP(std::string file_name)
 
 	if (!file)
 	{
-		LogError("Failed to open \"%s\"", file_name.c_str());
+		LogError("Failed to open \"{}\"", file_name.c_str());
 		exit(1);
 	}
 
@@ -34,7 +34,7 @@ TACP::TACP(std::string file_name)
 
 	if (crc32 != expected_tacp_crc32)
 	{
-		LogError("File \"%s\"\" has an unknown crc32 value of 0x%08x - expected 0x%08x",
+		LogError("File \"{}\"\" has an unknown crc32 value of 0x%08x - expected 0x%08x",
 		         file_name.c_str(), crc32, expected_tacp_crc32);
 	}
 

--- a/tools/extractors/common/ufo2p.cpp
+++ b/tools/extractors/common/ufo2p.cpp
@@ -22,7 +22,7 @@ UFO2P::UFO2P(std::string file_name)
 
 	if (!file)
 	{
-		LogError("Failed to open \"%s\"", file_name.c_str());
+		LogError("Failed to open \"{}\"", file_name.c_str());
 		exit(1);
 	}
 	auto data = file.readAll();
@@ -33,7 +33,7 @@ UFO2P::UFO2P(std::string file_name)
 
 	if (crc32 != expected_ufo2p_crc32)
 	{
-		LogError("File \"%s\"\" has an unknown crc32 value of 0x%08x - expected 0x%08x",
+		LogError("File \"{}\"\" has an unknown crc32 value of 0x%08x - expected 0x%08x",
 		         file_name.c_str(), crc32, expected_ufo2p_crc32);
 	}
 

--- a/tools/extractors/extract_agent_equipment.cpp
+++ b/tools/extractors/extract_agent_equipment.cpp
@@ -87,13 +87,13 @@ void InitialGameStateExtractor::extractAlienEquipmentSets(GameState &state,
 	// Equipment sets - score - alien
 	{
 		if (data_t.agent_equipment_set_score_requirement->count() != 1)
-			LogError("Incorrect amount of alien score requirement structures: encountered %u, "
+			LogError("Incorrect amount of alien score requirement structures: encountered {}, "
 			         "expected 1",
 			         (unsigned)data_t.agent_equipment_set_score_requirement->count());
 		auto sdata = data_t.agent_equipment_set_score_requirement->get(0);
 
 		if (data_t.agent_equipment_set_score_alien->count() != 1)
-			LogError("Incorrect amount of alien score equipment set structures: encountered %u, "
+			LogError("Incorrect amount of alien score equipment set structures: encountered {}, "
 			         "expected 1",
 			         (unsigned)data_t.agent_equipment_set_score_alien->count());
 		auto data = data_t.agent_equipment_set_score_alien->get(0);
@@ -101,7 +101,7 @@ void InitialGameStateExtractor::extractAlienEquipmentSets(GameState &state,
 		{
 			auto es = mksp<EquipmentSet>();
 
-			UString id = format("%sALIEN_%d", EquipmentSet::getPrefix(), (int)i + 1);
+			UString id = format("{}ALIEN_{}", EquipmentSet::getPrefix(), (int)i + 1);
 			es->id = id;
 
 			for (unsigned j = 0; j < 10; j++)
@@ -111,10 +111,10 @@ void InitialGameStateExtractor::extractAlienEquipmentSets(GameState &state,
 					if (data.weapons[j][i].clip_idx > 0)
 					{
 						es->weapons.push_back(
-						    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+						    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.weapons[j][i].weapon_idx)))},
-						     {&state, format("%s%s", AEquipmentType::getPrefix(),
+						     {&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.weapons[j][i].clip_idx)))},
 						     std::max((int)data.weapons[j][i].clip_amount, 1)});
@@ -122,7 +122,7 @@ void InitialGameStateExtractor::extractAlienEquipmentSets(GameState &state,
 					else
 					{
 						es->weapons.push_back(
-						    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+						    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.weapons[j][i].weapon_idx)))}});
 					}
@@ -130,7 +130,7 @@ void InitialGameStateExtractor::extractAlienEquipmentSets(GameState &state,
 				if (data.grenades[j][i].grenade_idx > 0 && data.grenades[j][i].grenade_amount > 0)
 				{
 					es->grenades.push_back(
-					    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+					    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 					                     canon_string(data_u.agent_equipment_names->get(
 					                         data.grenades[j][i].grenade_idx)))},
 					     data.grenades[j][i].grenade_amount});
@@ -140,24 +140,24 @@ void InitialGameStateExtractor::extractAlienEquipmentSets(GameState &state,
 					if (data.equipment[j][i][0] > 0 && data.equipment[j][i][1] > 0)
 					{
 						es->equipment.push_back(
-						    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+						    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.equipment[j][i][0])))},
-						     {&state, format("%s%s", AEquipmentType::getPrefix(),
+						     {&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.equipment[j][i][1])))}});
 					}
 					else if (data.equipment[j][i][0] > 0)
 					{
 						es->equipment.push_back(
-						    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+						    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.equipment[j][i][0])))}});
 					}
 					else
 					{
 						es->equipment.push_back(
-						    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+						    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.equipment[j][i][1])))}});
 					}
@@ -204,7 +204,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 	auto gameObjectSpriteTabFile = fw().data->fs.open(gameObjectSpriteTabFileName);
 	if (!gameObjectSpriteTabFile)
 	{
-		LogError("Failed to open dropped item sprite TAB file \"%s\"", gameObjectSpriteTabFileName);
+		LogError("Failed to open dropped item sprite TAB file \"{}\"", gameObjectSpriteTabFileName);
 		return;
 	}
 	size_t gameObjectSpriteCount = gameObjectSpriteTabFile.size() / 4;
@@ -213,7 +213,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 	auto gameObjectShadowSpriteTabFile = fw().data->fs.open(gameObjectShadowSpriteTabFileName);
 	if (!gameObjectShadowSpriteTabFile)
 	{
-		LogError("Failed to open shadow dropped item sprite TAB file \"%s\"",
+		LogError("Failed to open shadow dropped item sprite TAB file \"{}\"",
 		         gameObjectShadowSpriteTabFileName);
 		return;
 	}
@@ -223,7 +223,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 	auto heldSpriteTabFile = fw().data->fs.open(heldSpriteTabFileName);
 	if (!heldSpriteTabFile)
 	{
-		LogError("Failed to open held item sprite TAB file \"%s\"", heldSpriteTabFileName);
+		LogError("Failed to open held item sprite TAB file \"{}\"", heldSpriteTabFileName);
 		return;
 	}
 	size_t heldSpriteCount = heldSpriteTabFile.size() / 4 / 8;
@@ -233,7 +233,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 
 	// Hazards
 	{
-		UString id = format("%s%s", HazardType::getPrefix(), "STUN_GAS");
+		UString id = format("{}{}", HazardType::getPrefix(), "STUN_GAS");
 		auto h = mksp<HazardType>();
 		h->doodadType = {&state, "DOODAD_20_STUN_GAS"};
 		h->minLifetime = 1;
@@ -241,7 +241,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		state.hazard_types[id] = h;
 	}
 	{
-		UString id = format("%s%s", HazardType::getPrefix(), "ALIEN_GAS");
+		UString id = format("{}{}", HazardType::getPrefix(), "ALIEN_GAS");
 		auto h = mksp<HazardType>();
 		h->doodadType = {&state, "DOODAD_19_ALIEN_GAS"};
 		// FIXME: Confirm these values
@@ -250,7 +250,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		state.hazard_types[id] = h;
 	}
 	{
-		UString id = format("%s%s", HazardType::getPrefix(), "SMOKE");
+		UString id = format("{}{}", HazardType::getPrefix(), "SMOKE");
 		auto h = mksp<HazardType>();
 		h->doodadType = {&state, "DOODAD_18_SMOKE"};
 		h->minLifetime = 12;
@@ -258,7 +258,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		state.hazard_types[id] = h;
 	}
 	{
-		UString id = format("%s%s", HazardType::getPrefix(), "FIRE");
+		UString id = format("{}{}", HazardType::getPrefix(), "FIRE");
 		auto h = mksp<HazardType>();
 		h->doodadType = {&state, "DOODAD_17_FIRE"};
 		// Fire has a starting deviation of 0 to 2, fire's ttl works in a completely different way
@@ -278,7 +278,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		UString id = data_t.getDTypeId(i);
 		if (i != j)
 		{
-			id = format("%s_SPECIAL", id);
+			id = format("{}_SPECIAL", id);
 			d->effectType = DamageType::EffectType::Enzyme;
 		}
 
@@ -289,7 +289,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 
 		// Damage icons are located in tacdata icons, starting with id 14 and on
 		d->icon_sprite = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-		                                             "icons.tab:%d:xcom3/tacdata/tactical.pal",
+		                                             "icons.tab:{}:xcom3/tacdata/tactical.pal",
 		                                             (int)i + 14));
 		switch (i)
 		{
@@ -380,7 +380,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 			// Extra entry for special entropy damage type
 			if (j == DT_ENTROPY)
 			{
-				state.damage_types[format("%s_SPECIAL", data_t.getDTypeId(j))]
+				state.damage_types[format("{}_SPECIAL", data_t.getDTypeId(j))]
 				    ->modifiers[{&state, id}] = ddata.damage_type_data[j];
 			}
 		}
@@ -395,7 +395,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		auto edata = data_t.agent_equipment->get(i);
 
 		e->name = data_u.agent_equipment_names->get(i);
-		UString id = format("%s%s", AEquipmentType::getPrefix(), canon_string(e->name));
+		UString id = format("{}{}", AEquipmentType::getPrefix(), canon_string(e->name));
 
 		e->id = id;
 
@@ -529,7 +529,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						e->body_part = BodyPart::Helmet;
 						break;
 					default:
-						LogError("Unexpected body part type %d for ID %s", (int)adata.body_part,
+						LogError("Unexpected body part type {} for ID {}", (int)adata.body_part,
 						         id);
 				}
 				switch (adata.damage_modifier)
@@ -544,18 +544,18 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						armoredUnitPicIndex = 4;
 						break;
 					default:
-						LogError("Unexpected damage modifier %d for ID %s",
+						LogError("Unexpected damage modifier {} for ID {}",
 						         (int)adata.damage_modifier, id);
 						break;
 				}
-				e->body_image_pack = {&state, format("%s%s%d%s", BattleUnitImagePack::getPrefix(),
+				e->body_image_pack = {&state, format("{}{}{}{}", BattleUnitImagePack::getPrefix(),
 				                                     "xcom", armoredUnitPicIndex, bodyPartLetter)};
 				// Body sprites are stored in armour.pck file, in head-left-body-right-legs order
 				// Since armor damage modifier values start with 17, we can subtract that to get
 				// armor index
 				e->body_sprite = fw().data->loadImage(
 				    format("PCK:xcom3/ufodata/armour.pck:xcom3/ufodata/"
-				           "armour.tab:%d:xcom3/tacdata/equip.pal",
+				           "armour.tab:{}:xcom3/tacdata/equip.pal",
 				           (int)((adata.damage_modifier - 17) * 5 + armorBodyPicIndex)));
 			}
 			break;
@@ -690,12 +690,12 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						e->type = AEquipmentType::Type::MediKit;
 						break;
 					default:
-						LogError("Unexpected general type %d for ID %s", (int)gdata.type, id);
+						LogError("Unexpected general type {} for ID {}", (int)gdata.type, id);
 				}
 			}
 			break;
 			default:
-				LogInfo("Encountered empty item in ID %s, moving on", id);
+				LogInfo("Encountered empty item in ID {}, moving on", id);
 				continue;
 		}
 
@@ -707,13 +707,13 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		if (edata.sprite_idx < gameObjectSpriteCount)
 			e->dropped_sprite =
 			    fw().data->loadImage(format("PCK:xcom3/tacdata/gameobj.pck:xcom3/tacdata/"
-			                                "gameobj.tab:%d",
+			                                "gameobj.tab:{}",
 			                                (int)edata.sprite_idx));
 
 		if (edata.sprite_idx < gameObjectShadowSpriteCount)
 			e->dropped_shadow_sprite =
 			    fw().data->loadImage(format("PCKSHADOW:xcom3/tacdata/oshadow.pck:xcom3/tacdata/"
-			                                "oshadow.tab:%d",
+			                                "oshadow.tab:{}",
 			                                (int)edata.sprite_idx));
 
 		// Held sprites begin from 0, which corresponds to item 1, Megapol AP Grenade
@@ -722,10 +722,10 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		// There is a total 60 of them
 		int held_sprite_index = std::min((int)edata.sprite_idx, (int)heldSpriteCount - 1);
 		e->held_image_pack = {
-		    &state, format("%s%s%d", BattleUnitImagePack::getPrefix(), "item", held_sprite_index)};
+		    &state, format("{}{}{}", BattleUnitImagePack::getPrefix(), "item", held_sprite_index)};
 
 		e->equipscreen_sprite = fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/pequip.pck:xcom3/ufodata/pequip.tab:%d:xcom3/tacdata/tactical.pal",
+		    "PCK:xcom3/ufodata/pequip.pck:xcom3/ufodata/pequip.tab:{}:xcom3/tacdata/tactical.pal",
 		    (int)edata.sprite_idx));
 		e->equipscreen_size = {edata.size_x, edata.size_y};
 
@@ -740,7 +740,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		if (payload_idx != std::numeric_limits<unsigned>::max())
 		{
 			if (payload_idx >= data_t.agent_payload->count())
-				LogError("Invalid payload index %u for ID %s", payload_idx, id);
+				LogError("Invalid payload index {} for ID {}", payload_idx, id);
 
 			auto pdata = data_t.agent_payload->get(payload_idx);
 
@@ -976,7 +976,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						e->trigger_type = TriggerType::Boomeroid;
 						break;
 					default:
-						LogError("Unexpected grenade trigger type %d for ID %s",
+						LogError("Unexpected grenade trigger type {} for ID {}",
 						         (int)pdata.trigger_type, id);
 				}
 			}
@@ -1018,7 +1018,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 	// Equipment sets - score (level) - human
 	{
 		if (data_t.agent_equipment_set_score_human->count() != 1)
-			LogError("Incorrect amount of human score equipment set structures: encountered %u, "
+			LogError("Incorrect amount of human score equipment set structures: encountered {}, "
 			         "expected 1",
 			         (unsigned)data_t.agent_equipment_set_score_human->count());
 		auto data = data_t.agent_equipment_set_score_human->get(0);
@@ -1028,7 +1028,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 			{
 				auto es = mksp<EquipmentSet>();
 
-				UString id = format("%sHUMAN_%d", EquipmentSet::getPrefix(), (int)i + 1);
+				UString id = format("{}HUMAN_{}", EquipmentSet::getPrefix(), (int)i + 1);
 				es->id = id;
 
 				for (unsigned j = 0; j < 10; j++)
@@ -1038,10 +1038,10 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						if (data.weapons[j][i].clip_idx > 0)
 						{
 							es->weapons.push_back(
-							    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+							    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.weapons[j][i].weapon_idx)))},
-							     {&state, format("%s%s", AEquipmentType::getPrefix(),
+							     {&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.weapons[j][i].clip_idx)))},
 							     std::max((int)data.weapons[j][i].clip_amount, 1)});
@@ -1049,7 +1049,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						else
 						{
 							es->weapons.push_back(
-							    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+							    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.weapons[j][i].weapon_idx)))}});
 						}
@@ -1058,7 +1058,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 					    data.grenades[j][i].grenade_amount > 0)
 					{
 						es->grenades.push_back(
-						    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+						    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 						                     canon_string(data_u.agent_equipment_names->get(
 						                         data.grenades[j][i].grenade_idx)))},
 						     data.grenades[j][i].grenade_amount});
@@ -1068,24 +1068,24 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 						if (data.equipment[j][i][0] > 0 && data.equipment[j][i][1] > 0)
 						{
 							es->equipment.push_back(
-							    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+							    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.equipment[j][i][0])))},
-							     {&state, format("%s%s", AEquipmentType::getPrefix(),
+							     {&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.equipment[j][i][1])))}});
 						}
 						else if (data.equipment[j][i][0] > 0)
 						{
 							es->equipment.push_back(
-							    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+							    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.equipment[j][i][0])))}});
 						}
 						else
 						{
 							es->equipment.push_back(
-							    {{&state, format("%s%s", AEquipmentType::getPrefix(),
+							    {{&state, format("{}{}", AEquipmentType::getPrefix(),
 							                     canon_string(data_u.agent_equipment_names->get(
 							                         data.equipment[j][i][1])))}});
 						}

--- a/tools/extractors/extract_agent_types.cpp
+++ b/tools/extractors/extract_agent_types.cpp
@@ -78,15 +78,15 @@ namespace OpenApoc
 void fillAgentImagePacksByDefault(GameState &state, sp<AgentType> a, UString imagePackName)
 {
 	a->image_packs[a->image_packs.size() - 1][BodyPart::Body] = {
-	    &state, format("%s%s%s", BattleUnitImagePack::getPrefix(), imagePackName, "a")};
+	    &state, format("{}{}{}", BattleUnitImagePack::getPrefix(), imagePackName, "a")};
 	a->image_packs[a->image_packs.size() - 1][BodyPart::Legs] = {
-	    &state, format("%s%s%s", BattleUnitImagePack::getPrefix(), imagePackName, "b")};
+	    &state, format("{}{}{}", BattleUnitImagePack::getPrefix(), imagePackName, "b")};
 	a->image_packs[a->image_packs.size() - 1][BodyPart::Helmet] = {
-	    &state, format("%s%s%s", BattleUnitImagePack::getPrefix(), imagePackName, "c")};
+	    &state, format("{}{}{}", BattleUnitImagePack::getPrefix(), imagePackName, "c")};
 	a->image_packs[a->image_packs.size() - 1][BodyPart::LeftArm] = {
-	    &state, format("%s%s%s", BattleUnitImagePack::getPrefix(), imagePackName, "d")};
+	    &state, format("{}{}{}", BattleUnitImagePack::getPrefix(), imagePackName, "d")};
 	a->image_packs[a->image_packs.size() - 1][BodyPart::RightArm] = {
-	    &state, format("%s%s%s", BattleUnitImagePack::getPrefix(), imagePackName, "e")};
+	    &state, format("{}{}{}", BattleUnitImagePack::getPrefix(), imagePackName, "e")};
 }
 
 void pushEquipmentSlot(sp<AgentEquipmentLayout> a, int x, int y, int w = 1, int h = 1,
@@ -115,7 +115,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 	auto portraitSmallTabFile = fw().data->fs.open(portraitSmallTabFileName);
 	if (!portraitSmallTabFile)
 	{
-		LogError("Failed to open small portrait TAB file \"%s\"", portraitSmallTabFileName);
+		LogError("Failed to open small portrait TAB file \"{}\"", portraitSmallTabFileName);
 		return;
 	}
 	size_t portraitSmallCount = portraitSmallTabFile.size() / 4;
@@ -124,7 +124,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 	auto portraitLargeTabFile = fw().data->fs.open(portraitLargeTabFileName);
 	if (!portraitLargeTabFile)
 	{
-		LogError("Failed to open Large portrait TAB file \"%s\"", portraitLargeTabFileName);
+		LogError("Failed to open Large portrait TAB file \"{}\"", portraitLargeTabFileName);
 		return;
 	}
 	size_t portraitLargeCount = portraitLargeTabFile.size() / 4;
@@ -135,11 +135,11 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 	{
 		auto p = AgentPortrait();
 		p.icon = fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/agntico.pck:xcom3/ufodata/agntico.tab:%d:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/agntico.pck:xcom3/ufodata/agntico.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i));
 		if (i < portraitLargeCount)
 			p.photo = fw().data->loadImage(format(
-			    "PCK:xcom3/ufodata/photo.pck:xcom3/ufodata/photo.tab:%d:xcom3/ufodata/pal_01.dat",
+			    "PCK:xcom3/ufodata/photo.pck:xcom3/ufodata/photo.tab:{}:xcom3/ufodata/pal_01.dat",
 			    i));
 		portraits.push_back(p);
 	}
@@ -155,7 +155,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 		auto data = data_u.agent_types->get(i);
 
 		a->name = data_u.agent_type_names->get(i);
-		UString id = format("%s%s", AgentType::getPrefix(), canon_string(a->name));
+		UString id = format("{}{}", AgentType::getPrefix(), canon_string(a->name));
 
 		a->id = id;
 
@@ -376,14 +376,14 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 					// They all use same animation and differ in head image sets
 					a->appearance_count = 4;
 					a->animation_packs.emplace_back(
-					    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "civ"));
+					    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "civ"));
 					a->animation_packs.emplace_back(
-					    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "civ"));
+					    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "civ"));
 					a->animation_packs.emplace_back(
-					    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "civ"));
+					    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "civ"));
 				}
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "civ"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "civ"));
 				if (i == UNIT_TYPE_GREY)
 				{
 					bodyTypeName = "GREY";
@@ -398,9 +398,9 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_MULTIWORM_EGG:
 				a->appearance_count = 2;
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "mwegg1"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "mwegg1"));
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "mwegg2"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "mwegg2"));
 				bodyTypeName = "MULTIWORM_EGG";
 				infiltrationID = 0;
 				a->growthChance = 20;
@@ -412,9 +412,9 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_CHRYSALIS:
 				a->appearance_count = 2;
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "chrys1"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "chrys1"));
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "chrys2"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "chrys2"));
 				bodyTypeName = "CHRYSALIS";
 				infiltrationID = 4;
 				a->growthChance = 12;
@@ -431,7 +431,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				break;
 			case UNIT_TYPE_QUEENSPAWN:
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "queen"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "queen"));
 				bodyTypeName = "QUEENSPAWN";
 				infiltrationID = 11;
 				a->growthChance = 0;
@@ -442,7 +442,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			// Non-humanoid aliens
 			case UNIT_TYPE_BRAINSUCKER:
 				a->animation_packs.emplace_back(
-				    &state, format("%sbsk", BattleUnitAnimationPack::getPrefix()));
+				    &state, format("{}bsk", BattleUnitAnimationPack::getPrefix()));
 				bodyTypeName = "BRAINSUCKER";
 				infiltrationID = 1;
 				a->growthChance = 20;
@@ -452,7 +452,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				break;
 			case UNIT_TYPE_HYPERWORM:
 				a->animation_packs.emplace_back(
-				    &state, format("%shypr", BattleUnitAnimationPack::getPrefix()));
+				    &state, format("{}hypr", BattleUnitAnimationPack::getPrefix()));
 				bodyTypeName = "HYPERWORM";
 				infiltrationID = 3;
 				a->growthChance = 12;
@@ -463,7 +463,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				break;
 			case UNIT_TYPE_SPITTER:
 				a->animation_packs.emplace_back(
-				    &state, format("%sspitr", BattleUnitAnimationPack::getPrefix()));
+				    &state, format("{}spitr", BattleUnitAnimationPack::getPrefix()));
 				bodyTypeName = "SPITTER";
 				infiltrationID = 7;
 				a->growthChance = 2;
@@ -472,7 +472,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				break;
 			case UNIT_TYPE_POPPER:
 				a->animation_packs.emplace_back(
-				    &state, format("%spopper", BattleUnitAnimationPack::getPrefix()));
+				    &state, format("{}popper", BattleUnitAnimationPack::getPrefix()));
 				bodyTypeName = "POPPER";
 				infiltrationID = 8;
 				a->growthChance = 2;
@@ -481,7 +481,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				break;
 			case UNIT_TYPE_MICRONOID:
 				a->animation_packs.emplace_back(
-				    &state, format("%smicro", BattleUnitAnimationPack::getPrefix()));
+				    &state, format("{}micro", BattleUnitAnimationPack::getPrefix()));
 				bodyTypeName = "MICRONOID";
 				infiltrationID = 12;
 				a->growthChance = 0;
@@ -491,7 +491,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			// Special case: Multiworm, can only crawl
 			case UNIT_TYPE_MULTIWORM:
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "multi"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "multi"));
 				bodyTypeName = "MULTIWORM";
 				infiltrationID = 2;
 				a->growthChance = 12;
@@ -503,7 +503,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			// Special case: Megaspawn, can strafe
 			case UNIT_TYPE_MEGASPAWN:
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "mega"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "mega"));
 				bodyTypeName = "MEGASPAWN";
 				infiltrationID = 9;
 				a->growthChance = 2;
@@ -514,7 +514,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			// Special case: Psimorph, non-humanoid that can only fly
 			case UNIT_TYPE_PSIMORPH:
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "psi"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "psi"));
 				bodyTypeName = "PSIMORPH";
 				infiltrationID = 10;
 				a->growthChance = 2;
@@ -545,15 +545,15 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				{
 					a->appearance_count = 2;
 					a->animation_packs.emplace_back(
-					    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "unit"));
+					    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "unit"));
 				}
 				a->animation_packs.emplace_back(
-				    &state, format("%s%s", BattleUnitAnimationPack::getPrefix(), "unit"));
+				    &state, format("{}{}", BattleUnitAnimationPack::getPrefix(), "unit"));
 				break;
 		}
 
 		a->bodyType = {&state,
-		               format("%s%s", AgentBodyType::getPrefix(), canon_string(bodyTypeName))};
+		               format("{}{}", AgentBodyType::getPrefix(), canon_string(bodyTypeName))};
 
 		if (infiltrationID != -1)
 		{
@@ -567,26 +567,26 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 		{
 			// Aliens with unique shadows
 			case UNIT_TYPE_BRAINSUCKER:
-				a->shadow_pack = {&state, format("%s%s", BattleUnitImagePack::getPrefix(), "bsks")};
+				a->shadow_pack = {&state, format("{}{}", BattleUnitImagePack::getPrefix(), "bsks")};
 				break;
 			case UNIT_TYPE_HYPERWORM:
 				a->shadow_pack = {&state,
-				                  format("%s%s", BattleUnitImagePack::getPrefix(), "hyprs")};
+				                  format("{}{}", BattleUnitImagePack::getPrefix(), "hyprs")};
 				break;
 			case UNIT_TYPE_SPITTER:
 				a->shadow_pack = {&state,
-				                  format("%s%s", BattleUnitImagePack::getPrefix(), "spitrs")};
+				                  format("{}{}", BattleUnitImagePack::getPrefix(), "spitrs")};
 				break;
 			case UNIT_TYPE_POPPER:
 				a->shadow_pack = {&state,
-				                  format("%s%s", BattleUnitImagePack::getPrefix(), "poppers")};
+				                  format("{}{}", BattleUnitImagePack::getPrefix(), "poppers")};
 				break;
 			case UNIT_TYPE_MEGASPAWN:
 				a->shadow_pack = {&state,
-				                  format("%s%s", BattleUnitImagePack::getPrefix(), "megas")};
+				                  format("{}{}", BattleUnitImagePack::getPrefix(), "megas")};
 				break;
 			case UNIT_TYPE_PSIMORPH:
-				a->shadow_pack = {&state, format("%s%s", BattleUnitImagePack::getPrefix(), "psis")};
+				a->shadow_pack = {&state, format("{}{}", BattleUnitImagePack::getPrefix(), "psis")};
 				break;
 
 			// Aliens with no shadows
@@ -600,7 +600,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			// Humanoid aliens and humans
 			default:
 				a->shadow_pack = {&state,
-				                  format("%s%s", BattleUnitImagePack::getPrefix(), "shadow")};
+				                  format("{}{}", BattleUnitImagePack::getPrefix(), "shadow")};
 				break;
 		}
 
@@ -614,7 +614,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_QUANTUM_PHYSIST:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/scien.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "scntst")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "scntst")};
 				break;
 			case UNIT_TYPE_GANG_LEADER:
 				fillAgentImagePacksByDefault(state, a, "gangl");
@@ -623,7 +623,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				// Game has no picture for this unit.
 				// I think rm1 (upper class male) fits him best.
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rm1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rm1")};
 				break;
 			case UNIT_TYPE_CULT_LEADER:
 				fillAgentImagePacksByDefault(state, a, "cultl");
@@ -661,141 +661,141 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				break;
 			case UNIT_TYPE_ANDROID:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robot")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robot")};
 				a->image_packs[0][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robo1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robo1")};
 				a->image_packs.push_back(std::map<BodyPart, StateRef<BattleUnitImagePack>>());
 				a->image_packs[1][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robot")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robot")};
 				a->image_packs[1][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robo2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robo2")};
 				a->image_packs.push_back(std::map<BodyPart, StateRef<BattleUnitImagePack>>());
 				a->image_packs[2][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robot")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robot")};
 				a->image_packs[2][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robo3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robo3")};
 				a->image_packs.push_back(std::map<BodyPart, StateRef<BattleUnitImagePack>>());
 				a->image_packs[3][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robot")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robot")};
 				a->image_packs[3][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "robo4")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "robo4")};
 				break;
 			case UNIT_TYPE_GREY:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "grey")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "grey")};
 				break;
 			case UNIT_TYPE_UPPER_CLASS_FEMALE_1:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rw1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rw1")};
 				break;
 			case UNIT_TYPE_UPPER_CLASS_FEMALE_2:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rw2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rw2")};
 				break;
 			case UNIT_TYPE_UPPER_CLASS_FEMALE_3:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rw3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rw3")};
 				break;
 			case UNIT_TYPE_UPPER_CLASS_MALE_1:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rm1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rm1")};
 				break;
 			case UNIT_TYPE_UPPER_CLASS_MALE_2:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rm2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rm2")};
 				break;
 			case UNIT_TYPE_UPPER_CLASS_MALE_3:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "rm3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "rm3")};
 				break;
 			case UNIT_TYPE_CIVILIAN_FEMALE_1:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "nw1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "nw1")};
 				break;
 			case UNIT_TYPE_CIVILIAN_FEMALE_2:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "nw2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "nw2")};
 				break;
 			case UNIT_TYPE_CIVILIAN_FEMALE_3:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "nw3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "nw3")};
 				break;
 			case UNIT_TYPE_CIVILIAN_MALE_1:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "nm1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "nm1")};
 				break;
 			case UNIT_TYPE_CIVILIAN_MALE_2:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "nm2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "nm2")};
 				break;
 			case UNIT_TYPE_CIVILIAN_MALE_3:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "nm3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "nm3")};
 				break;
 			case UNIT_TYPE_LOWER_CLASS_MALE_1:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "sm1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "sm1")};
 				break;
 			case UNIT_TYPE_LOWER_CLASS_MALE_2:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "sm2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "sm2")};
 				break;
 			case UNIT_TYPE_LOWER_CLASS_MALE_3:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "sm3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "sm3")};
 				break;
 			case UNIT_TYPE_LOWER_CLASS_FEMALE_1:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "sw1")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "sw1")};
 				break;
 			case UNIT_TYPE_LOWER_CLASS_FEMALE_2:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "sw2")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "sw2")};
 				break;
 			case UNIT_TYPE_LOWER_CLASS_FEMALE_3:
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "sw3")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "sw3")};
 				break;
 			case UNIT_TYPE_MULTIWORM_EGG:
 				a->inventoryBackground =
 				    fw().data->loadImage("xcom3/tacdata/equippic/mwormegg.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "mwegga")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "mwegga")};
 				a->image_packs[0][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "mweggb")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "mweggb")};
 				a->image_packs.push_back(std::map<BodyPart, StateRef<BattleUnitImagePack>>());
 				a->image_packs[1][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "mwegga")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "mwegga")};
 				a->image_packs[1][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "mweggb")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "mweggb")};
 				break;
 			case UNIT_TYPE_BRAINSUCKER:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/sucker.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "bsk")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "bsk")};
 				break;
 			case UNIT_TYPE_MULTIWORM:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/mworm.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "multi")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "multi")};
 				break;
 			case UNIT_TYPE_HYPERWORM:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/hyperwm.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "hypr")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "hypr")};
 				break;
 			case UNIT_TYPE_CHRYSALIS:
 				a->inventoryBackground =
 				    fw().data->loadImage("xcom3/tacdata/equippic/chrysali.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "chrysa")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "chrysa")};
 				a->image_packs[0][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "chrysb")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "chrysb")};
 				a->image_packs.push_back(std::map<BodyPart, StateRef<BattleUnitImagePack>>());
 				a->image_packs[1][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "chrysa")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "chrysa")};
 				a->image_packs[1][BodyPart::Helmet] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "chrysb")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "chrysb")};
 				break;
 			case UNIT_TYPE_ANTHROPOD:
 				a->inventoryBackground =
@@ -809,12 +809,12 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_SPITTER:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/spitter.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "spitr")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "spitr")};
 				break;
 			case UNIT_TYPE_POPPER:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/popper.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "popper")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "popper")};
 				break;
 			case UNIT_TYPE_MEGASPAWN:
 				a->inventoryBackground =
@@ -826,20 +826,20 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_PSIMORPH:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/psi_m.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "psi")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "psi")};
 				break;
 			case UNIT_TYPE_QUEENSPAWN:
 				a->inventoryBackground = fw().data->loadImage("xcom3/tacdata/equippic/queen.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "queena")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "queena")};
 				a->image_packs[0][BodyPart::Legs] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "queenb")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "queenb")};
 				break;
 			case UNIT_TYPE_MICRONOID:
 				a->inventoryBackground =
 				    fw().data->loadImage("xcom3/tacdata/equippic/agregate.pcx");
 				a->image_packs[0][BodyPart::Body] = {
-				    &state, format("%s%s", BattleUnitImagePack::getPrefix(), "micro")};
+				    &state, format("{}{}", BattleUnitImagePack::getPrefix(), "micro")};
 				break;
 		}
 
@@ -967,23 +967,23 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				if (walkSfxNumbered)
 					for (int i = 1; i <= walkSfxCount; i++)
 						a->walkSfx.push_back(fw().data->loadSample(format(
-						    "RAWSOUND:xcom3/rawsound/tactical/aliens/movemnts/%s%d.raw:22050",
+						    "RAWSOUND:xcom3/rawsound/tactical/aliens/movemnts/{}{}.raw:22050",
 						    walkSfxName, i)));
 				else
 					a->walkSfx.push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/tactical/aliens/movemnts/%s.raw:22050",
+					    format("RAWSOUND:xcom3/rawsound/tactical/aliens/movemnts/{}.raw:22050",
 					           walkSfxName)));
 				if (crySfxNumbered)
 					for (int i = 1; i <= crySfxCount; i++)
 						a->crySfx.push_back(fw().data->loadSample(
-						    format("RAWSOUND:xcom3/rawsound/tactical/aliens/cries/%s%d.raw:22050",
+						    format("RAWSOUND:xcom3/rawsound/tactical/aliens/cries/{}{}.raw:22050",
 						           crySfxName, i)));
 				else
 					a->crySfx.push_back(fw().data->loadSample(format(
-					    "RAWSOUND:xcom3/rawsound/tactical/aliens/cries/%s.raw:22050", crySfxName)));
+					    "RAWSOUND:xcom3/rawsound/tactical/aliens/cries/{}.raw:22050", crySfxName)));
 				if (dieSfxName.length() > 0)
 					a->dieSfx[AgentType::Gender::Male].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/tactical/aliens/deaths/%s.raw:22050",
+					    format("RAWSOUND:xcom3/rawsound/tactical/aliens/deaths/{}.raw:22050",
 					           dieSfxName)));
 				break;
 			default:
@@ -991,20 +991,20 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				for (int i = 1; i <= 3; i++)
 				{
 					a->damageSfx[AgentType::Gender::Male].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/extra/hpainm%d.raw:22050", i)));
+					    format("RAWSOUND:xcom3/rawsound/extra/hpainm{}.raw:22050", i)));
 					a->fatalWoundSfx[AgentType::Gender::Male].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/extra/hdethm%d.raw:22050", i)));
+					    format("RAWSOUND:xcom3/rawsound/extra/hdethm{}.raw:22050", i)));
 					a->dieSfx[AgentType::Gender::Male].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/extra/hdethm%d.raw:22050", i)));
+					    format("RAWSOUND:xcom3/rawsound/extra/hdethm{}.raw:22050", i)));
 				}
 				for (int i = 1; i <= 2; i++)
 				{
 					a->damageSfx[AgentType::Gender::Female].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/extra/hpainf%d.raw:22050", i)));
+					    format("RAWSOUND:xcom3/rawsound/extra/hpainf{}.raw:22050", i)));
 					a->fatalWoundSfx[AgentType::Gender::Female].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/extra/hdethf%d.raw:22050", i)));
+					    format("RAWSOUND:xcom3/rawsound/extra/hdethf{}.raw:22050", i)));
 					a->dieSfx[AgentType::Gender::Female].push_back(fw().data->loadSample(
-					    format("RAWSOUND:xcom3/rawsound/extra/hdethf%d.raw:22050", i)));
+					    format("RAWSOUND:xcom3/rawsound/extra/hdethf{}.raw:22050", i)));
 				}
 				break;
 		}
@@ -1043,7 +1043,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 		a->armor[BodyPart::Legs] = data.armor_leg;
 		a->armor[BodyPart::RightArm] = data.armor_right;
 		a->damage_modifier = {
-		    &state, format("%s%s", DamageModifier::getPrefix(),
+		    &state, format("{}{}", DamageModifier::getPrefix(),
 		                   canon_string(data_t.damage_modifier_names->get(data.damage_modifier)))};
 		a->inventory = data.inventory == 1;
 
@@ -1078,7 +1078,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 
 				if (es_data.weapons[0].weapon_idx != 0xffffffff)
 					a->built_in_weapon_right = {
-					    &state, format("%s%s", AEquipmentType::getPrefix(),
+					    &state, format("{}{}", AEquipmentType::getPrefix(),
 					                   canon_string(data_u.agent_equipment_names->get(
 					                       es_data.weapons[0].weapon_idx)))};
 				if (id == "AGENTTYPE_MULTIWORM")
@@ -1087,7 +1087,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				}
 				else if (es_data.weapons[1].weapon_idx != 0xffffffff)
 					a->built_in_weapon_left = {
-					    &state, format("%s%s", AEquipmentType::getPrefix(),
+					    &state, format("{}{}", AEquipmentType::getPrefix(),
 					                   canon_string(data_u.agent_equipment_names->get(
 					                       es_data.weapons[1].weapon_idx)))};
 				name = "BUILTIN";
@@ -1098,7 +1098,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			name = "FULL";
 		}
 		a->equipment_layout = {
-		    &state, format("%s%s", AgentEquipmentLayout::getPrefix(), canon_string(name))};
+		    &state, format("{}{}", AgentEquipmentLayout::getPrefix(), canon_string(name))};
 
 		a->score = data.score;
 
@@ -1206,21 +1206,21 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_MICRONOID:
 			{
 				auto liveName =
-				    format("%s%s_ALIVE", AEquipmentType::getPrefix(), canon_string(a->name));
+				    format("{}{}_ALIVE", AEquipmentType::getPrefix(), canon_string(a->name));
 				auto deadName =
-				    format("%s%s_DEAD", AEquipmentType::getPrefix(), canon_string(a->name));
+				    format("{}{}_DEAD", AEquipmentType::getPrefix(), canon_string(a->name));
 
 				auto liveItem = mksp<AEquipmentType>();
 				liveItem->bioStorage = true;
 				liveItem->equipscreen_size = {6, 5};
 				liveItem->equipscreen_sprite =
 				    fw().data->loadImage(format("PCK:xcom3/ufodata/contico.pck:xcom3/ufodata/"
-				                                "contico.tab:%d:xcom3/ufodata/research.pcx",
+				                                "contico.tab:{}:xcom3/ufodata/research.pcx",
 				                                liveIdx));
 				liveItem->store_space = liveSpace;
 				liveItem->type = AEquipmentType::Type::Loot;
 				liveItem->bioRemains = {&state, deadName};
-				liveItem->name = format("Live %s", a->name);
+				liveItem->name = format("Live {}", a->name);
 				liveItem->score = a->score;
 				state.agent_equipment[liveName] = liveItem;
 				a->liveSpeciesItem = {&state, liveName};
@@ -1230,11 +1230,11 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 				deadItem->equipscreen_size = {6, 5};
 				deadItem->equipscreen_sprite =
 				    fw().data->loadImage(format("PCK:xcom3/ufodata/contico.pck:xcom3/ufodata/"
-				                                "contico.tab:%d:xcom3/ufodata/research.pcx",
+				                                "contico.tab:{}:xcom3/ufodata/research.pcx",
 				                                deadIdx));
 				deadItem->store_space = deadSpace;
 				deadItem->type = AEquipmentType::Type::Loot;
-				deadItem->name = format("Dead %s", a->name);
+				deadItem->name = format("Dead {}", a->name);
 				deadItem->score = 0;
 				state.agent_equipment[deadName] = deadItem;
 				a->deadSpeciesItem = {&state, deadName};
@@ -1251,7 +1251,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 	// None layout slot
 	{
 		UString name = "NONE";
-		UString id = format("%s%s", AgentEquipmentLayout::getPrefix(), canon_string(name));
+		UString id = format("{}{}", AgentEquipmentLayout::getPrefix(), canon_string(name));
 
 		auto a = mksp<AgentEquipmentLayout>();
 
@@ -1261,7 +1261,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 	// Builtin layout slot
 	{
 		UString name = "BUILTIN";
-		UString id = format("%s%s", AgentEquipmentLayout::getPrefix(), canon_string(name));
+		UString id = format("{}{}", AgentEquipmentLayout::getPrefix(), canon_string(name));
 
 		auto a = mksp<AgentEquipmentLayout>();
 		// Located off-screen, invisible in inventory
@@ -1276,7 +1276,7 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 	// FULL layout slot
 	{
 		UString name = "FULL";
-		UString id = format("%s%s", AgentEquipmentLayout::getPrefix(), canon_string(name));
+		UString id = format("{}{}", AgentEquipmentLayout::getPrefix(), canon_string(name));
 
 		auto a = mksp<AgentEquipmentLayout>();
 		pushEquipmentSlot(a, 1, 6, 3, 5, EquipmentSlotType::RightHand, AlignmentX::Centre,
@@ -1414,7 +1414,7 @@ void InitialGameStateExtractor::extractAgentBodyTypes(GameState &state) const
 		a->allowed_movement_states.insert(MovementState::None);
 		a->allowed_body_states.insert(BodyState::Dead);
 
-		UString id = format("%s%s", AgentBodyType::getPrefix(), canon_string(name));
+		UString id = format("{}{}", AgentBodyType::getPrefix(), canon_string(name));
 
 		// Allowed facings (nothing means everything allowed)
 		switch (i)
@@ -1706,7 +1706,7 @@ void InitialGameStateExtractor::extractAgentBodyTypes(GameState &state) const
 											                    i, fw().data->loadVoxelSlice(format(
 											                           "LOFTEMPS:xcom3/tacdata/"
 											                           "loftemps.dat:xcom3/"
-											                           "tacdata/loftemps.tab:%d",
+											                           "tacdata/loftemps.tab:{}",
 											                           pair.second)));
 										}
 									}
@@ -1717,7 +1717,7 @@ void InitialGameStateExtractor::extractAgentBodyTypes(GameState &state) const
 					break;
 					default:
 						LogError(
-						    "Large units cannot have loftemps other than 19 or 20! encountered %d.",
+						    "Large units cannot have loftemps other than 19 or 20! encountered {}.",
 						    entry.second.y);
 						break;
 				}
@@ -1755,7 +1755,7 @@ void InitialGameStateExtractor::extractAgentBodyTypes(GameState &state) const
 									a->voxelMaps[entry.first][facing][0]->setSlice(
 									    i, fw().data->loadVoxelSlice(format(
 									           "LOFTEMPS:xcom3/tacdata/loftemps.dat:xcom3/tacdata/"
-									           "loftemps.tab:%d",
+									           "loftemps.tab:{}",
 									           entry.second.y)));
 								}
 							}
@@ -1796,7 +1796,7 @@ void InitialGameStateExtractor::extractAgentBodyTypes(GameState &state) const
 									a->voxelMaps[entry.first][pair.first][j]->setSlice(
 									    i, fw().data->loadVoxelSlice(format(
 									           "LOFTEMPS:xcom3/tacdata/loftemps.dat:xcom3/tacdata/"
-									           "loftemps.tab:%d",
+									           "loftemps.tab:{}",
 									           pair.second[j])));
 								}
 							}

--- a/tools/extractors/extract_base_layouts.cpp
+++ b/tools/extractors/extract_base_layouts.cpp
@@ -36,7 +36,7 @@ void InitialGameStateExtractor::extractBaseLayouts(GameState &state) const
 					{
 						if (foundLift)
 						{
-							LogError("Unexpected repeated lift at position {{},{}} in base {}", row,
+							LogError("Unexpected repeated lift at position {{{},{}}} in base {}", row,
 							         col, id);
 						}
 						foundLift = true;
@@ -48,7 +48,7 @@ void InitialGameStateExtractor::extractBaseLayouts(GameState &state) const
 						break;
 					}
 					default:
-						LogError("Unexpected module id {} at {{},{}} in base {}",
+						LogError("Unexpected module id {} at {{{},{}}} in base {}",
 						         (int)b.module[row][col], col, row, id);
 				}
 			}

--- a/tools/extractors/extract_base_layouts.cpp
+++ b/tools/extractors/extract_base_layouts.cpp
@@ -13,7 +13,7 @@ void InitialGameStateExtractor::extractBaseLayouts(GameState &state) const
 	auto &data = this->ufo2p;
 	for (unsigned i = 0; i < data.baselayouts->count(); i++)
 	{
-		UString id = format("%s%d", BaseLayout::getPrefix(), i);
+		UString id = format("{}{}", BaseLayout::getPrefix(), i);
 		auto layout = mksp<BaseLayout>();
 		auto b = data.baselayouts->get(i);
 		bool foundLift = false;
@@ -36,7 +36,7 @@ void InitialGameStateExtractor::extractBaseLayouts(GameState &state) const
 					{
 						if (foundLift)
 						{
-							LogError("Unexpected repeated lift at position {%d,%d} in base %s", row,
+							LogError("Unexpected repeated lift at position {{},{}} in base {}", row,
 							         col, id);
 						}
 						foundLift = true;
@@ -48,14 +48,14 @@ void InitialGameStateExtractor::extractBaseLayouts(GameState &state) const
 						break;
 					}
 					default:
-						LogError("Unexpected module id %d at {%d,%d} in base %s",
+						LogError("Unexpected module id {} at {{},{}} in base {}",
 						         (int)b.module[row][col], col, row, id);
 				}
 			}
 		}
 		if (!foundLift)
 		{
-			LogError("No lift found in base %s", id);
+			LogError("No lift found in base {}", id);
 		}
 		Rect<int>::compactRectSet(layout->baseCorridors);
 		state.base_layouts[id] = layout;

--- a/tools/extractors/extract_battle_shared_resources.cpp
+++ b/tools/extractors/extract_battle_shared_resources.cpp
@@ -25,20 +25,20 @@ void InitialGameStateExtractor::extractSharedCityResources(GameState &state) con
 	{
 		state.city_common_image_list->strategyImages->push_back(
 		    fw().data->loadImage(format("PCKSTRAT:xcom3/ufodata/stratmap.pck:xcom3/ufodata/"
-		                                "stratmap.tab:%u",
+		                                "stratmap.tab:{}",
 		                                (unsigned)i)));
 	}
 	state.city_common_image_list->agentIsometric = fw().data->loadImage(format(
-	    "PCK:xcom3/ufodata/icon_m.pck:xcom3/ufodata/icon_m.tab:%d:xcom3/ufodata/pal_01.dat", 26));
+	    "PCK:xcom3/ufodata/icon_m.pck:xcom3/ufodata/icon_m.tab:{}:xcom3/ufodata/pal_01.dat", 26));
 	state.city_common_image_list->agentStrategic =
 	    fw().data->loadImage(format("PCKSTRAT:xcom3/ufodata/stratmap.pck:xcom3/ufodata/"
-	                                "stratmap.tab:%d",
+	                                "stratmap.tab:{}",
 	                                571));
 	for (int i = 586; i <= 589; i++)
 	{
 		state.city_common_image_list->portalStrategic.push_back(
 		    fw().data->loadImage(format("PCKSTRAT:xcom3/ufodata/stratmap.pck:xcom3/ufodata/"
-		                                "stratmap.tab:%d",
+		                                "stratmap.tab:{}",
 		                                i)));
 	}
 	state.city_common_image_list->projectileVoxelMap =
@@ -47,7 +47,7 @@ void InitialGameStateExtractor::extractSharedCityResources(GameState &state) con
 	{
 		state.city_common_image_list->projectileVoxelMap->setSlice(
 		    i, fw().data->loadVoxelSlice(format("LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-		                                        "ufodata/loftemps.tab:%d",
+		                                        "ufodata/loftemps.tab:{}",
 		                                        112)));
 	}
 	state.city_common_image_list->portalVoxelMap =
@@ -61,7 +61,7 @@ void InitialGameStateExtractor::extractSharedCityResources(GameState &state) con
 		}
 		state.city_common_image_list->portalVoxelMap->setSlice(
 		    i, fw().data->loadVoxelSlice(format("LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-		                                        "ufodata/loftemps.tab:%d",
+		                                        "ufodata/loftemps.tab:{}",
 		                                        index)));
 	}
 }
@@ -74,7 +74,7 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state) c
 	auto gameObjectStrategySpriteTabFile = fw().data->fs.open(gameObjectStrategySpriteTabFileName);
 	if (!gameObjectStrategySpriteTabFile)
 	{
-		LogError("Failed to open dropped item StrategySprite TAB file \"%s\"",
+		LogError("Failed to open dropped item StrategySprite TAB file \"{}\"",
 		         gameObjectStrategySpriteTabFileName);
 		return;
 	}
@@ -89,7 +89,7 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state) c
 	{
 		state.battle_common_image_list->strategyImages->push_back(
 		    fw().data->loadImage(format("PCKSTRAT:xcom3/tacdata/stratico.pck:xcom3/tacdata/"
-		                                "stratico.tab:%u",
+		                                "stratico.tab:{}",
 		                                (unsigned)i)));
 	}
 
@@ -98,19 +98,19 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state) c
 
 	state.battle_common_image_list->focusArrows.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                64)));
 	state.battle_common_image_list->focusArrows.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                65)));
 	state.battle_common_image_list->focusArrows.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                66)));
 	state.battle_common_image_list->focusArrows.push_back(
 	    fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
-	                                "icons.tab:%d:xcom3/tacdata/tactical.pal",
+	                                "icons.tab:{}:xcom3/tacdata/tactical.pal",
 	                                67)));
 
 	state.city_common_sample_list = mksp<CityCommonSampleList>();
@@ -219,12 +219,12 @@ void InitialGameStateExtractor::extractSharedBattleResources(GameState &state) c
 
 		state.battle_common_sample_list->walkSounds.push_back(mksp<std::vector<sp<Sample>>>());
 		state.battle_common_sample_list->walkSounds[i - 1]->push_back(fw().data->loadSample(
-		    format("RAWSOUND:xcom3/rawsound/extra/ft%s%d.raw:22050", sfx_name, 1)));
+		    format("RAWSOUND:xcom3/rawsound/extra/ft{}{}.raw:22050", sfx_name, 1)));
 		state.battle_common_sample_list->walkSounds[i - 1]->push_back(fw().data->loadSample(
-		    format("RAWSOUND:xcom3/rawsound/extra/ft%s%d.raw:22050", sfx_name, 2)));
+		    format("RAWSOUND:xcom3/rawsound/extra/ft{}{}.raw:22050", sfx_name, 2)));
 
 		state.battle_common_sample_list->objectDropSounds.push_back(fw().data->loadSample(
-		    format("RAWSOUND:xcom3/rawsound/extra/ob%s.raw:22050", sfx_name)));
+		    format("RAWSOUND:xcom3/rawsound/extra/ob{}.raw:22050", sfx_name)));
 	}
 
 	state.battle_common_sample_list->throwSounds.push_back(

--- a/tools/extractors/extract_battlescape_map.cpp
+++ b/tools/extractors/extract_battlescape_map.cpp
@@ -17,7 +17,7 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
                                                               const UString dirName,
                                                               const int index) const
 {
-	UString tilePrefix = format("%s_", dirName);
+	UString tilePrefix = format("{}_", dirName);
 	UString map_prefix = "xcom3/maps/";
 	UString mapunits_suffix = "/mapunits/";
 	bool baseMap = dirName == "37base";
@@ -30,14 +30,14 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 		auto inFile = fw().data->fs.open(datFileName);
 		if (!inFile)
 		{
-			LogError("Failed to open \"%s\"", fileName);
+			LogError("Failed to open \"{}\"", fileName);
 			return;
 		}
 
 		inFile.read((char *)&bdata, sizeof(bdata));
 		if (!inFile)
 		{
-			LogError("Failed to read entry in \"%s\"", fileName);
+			LogError("Failed to read entry in \"{}\"", fileName);
 			return;
 		}
 	}
@@ -49,14 +49,14 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 		auto inFile = fw().data->fs.open(fullPath);
 		if (!inFile)
 		{
-			LogError("Failed to open \"%s\"", fileName);
+			LogError("Failed to open \"{}\"", fileName);
 			return;
 		}
 
 		inFile.read((char *)&rdata, sizeof(rdata));
 		if (!inFile)
 		{
-			LogError("Failed to read entry in \"%s\"", fileName);
+			LogError("Failed to read entry in \"{}\"", fileName);
 			return;
 		}
 	}
@@ -69,7 +69,7 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 		auto inFile = fw().data->fs.open(fullPath);
 		if (!inFile)
 		{
-			LogError("Failed to open \"%s\"", fileName);
+			LogError("Failed to open \"{}\"", fileName);
 			return;
 		}
 
@@ -80,7 +80,7 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 
 	auto m = mksp<BattleMap>();
 
-	UString id = format("%s%s", BattleMap::getPrefix(), this->battleMapPaths[index]);
+	UString id = format("{}{}", BattleMap::getPrefix(), this->battleMapPaths[index]);
 
 	m->id = id;
 	m->chunk_size = {bdata.chunk_x, bdata.chunk_y, bdata.chunk_z};
@@ -125,7 +125,7 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 
 	if (bdata.destroyed_ground_idx != 0)
 		m->destroyed_ground_tile = {&state,
-		                            format("%s%s%s%u", BattleMapPartType::getPrefix(), tilePrefix,
+		                            format("{}{}{}{}", BattleMapPartType::getPrefix(), tilePrefix,
 		                                   "GD_", (unsigned)bdata.destroyed_ground_idx)};
 
 	for (int i = 0; i < 5; i++)
@@ -133,26 +133,26 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 		if (rdata.left_wall[i] != 0)
 		{
 			m->rubble_left_wall.emplace_back(
-			    &state, format("%s%s%s%u", BattleMapPartType::getPrefix(), tilePrefix, "LW_",
+			    &state, format("{}{}{}{}", BattleMapPartType::getPrefix(), tilePrefix, "LW_",
 			                   (unsigned)rdata.left_wall[i]));
 		}
 		if (rdata.right_wall[i] != 0)
 		{
 			m->rubble_right_wall.emplace_back(
-			    &state, format("%s%s%s%u", BattleMapPartType::getPrefix(), tilePrefix, "RW_",
+			    &state, format("{}{}{}{}", BattleMapPartType::getPrefix(), tilePrefix, "RW_",
 			                   (unsigned)rdata.right_wall[i]));
 		}
 		if (rdata.feature[i] != 0)
 		{
 			m->rubble_feature.emplace_back(&state,
-			                               format("%s%s%s%u", BattleMapPartType::getPrefix(),
+			                               format("{}{}{}{}", BattleMapPartType::getPrefix(),
 			                                      tilePrefix, "FT_", (unsigned)rdata.feature[i]));
 		}
 	}
 
 	for (int i = 0; i < 4; i++)
 	{
-		m->exit_grounds.emplace_back(&state, format("%s%s%s%u", BattleMapPartType::getPrefix(),
+		m->exit_grounds.emplace_back(&state, format("{}{}{}{}", BattleMapPartType::getPrefix(),
 		                                            tilePrefix, "GD_", (unsigned)firstExitIdx + i));
 	}
 
@@ -168,7 +168,7 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 	for (const auto &sdtFile : sdtFiles)
 	{
 		fileCounter++;
-		LogInfo("Reading map %s", sdtFile);
+		LogInfo("Reading map {}", sdtFile);
 		/*  Trim off '.sdt' to get the base map name */
 		LogAssert(sdtFile.length() >= 4);
 		auto secName = sdtFile.substr(0, sdtFile.length() - 4);
@@ -184,19 +184,19 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 			{
 				if (fileCounter == 0)
 				{
-					tilesName = format("%s_%02d", dirName, groundCounter);
+					tilesName = format("{}_%02d", dirName, groundCounter);
 					secID = format("SEC%02d", groundCounter);
 				}
 				else
 				{
-					tilesName = format("%s_%02d", dirName, fileCounter + 15);
+					tilesName = format("{}_%02d", dirName, fileCounter + 15);
 					secID = format("SEC%02d", fileCounter + 15);
 				}
 			}
 			else
 			{
-				tilesName = format("%s_%s", dirName, sector);
-				secID = format("SEC%s", sector);
+				tilesName = format("{}_{}", dirName, sector);
+				secID = format("SEC{}", sector);
 			}
 
 			SecSdtStructure sdata;
@@ -207,14 +207,14 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 				auto inFile = fw().data->fs.open(fullPath);
 				if (!inFile)
 				{
-					LogInfo("Sector %s not present for map %d", sector, index);
+					LogInfo("Sector {} not present for map {}", sector, index);
 					continue;
 				}
 
 				inFile.read((char *)&sdata, sizeof(sdata));
 				if (!inFile)
 				{
-					LogError("Failed to read entry in \"%s\"", fileName);
+					LogError("Failed to read entry in \"{}\"", fileName);
 					return;
 				}
 			}
@@ -249,7 +249,7 @@ void InitialGameStateExtractor::extractBattlescapeMapFromPath(GameState &state,
 
 	if (bdata.destroyed_ground_idx != 0)
 		m->destroyed_ground_tile = {&state,
-		                            format("%s%s%s%u", BattleMapPartType::getPrefix(), tilePrefix,
+		                            format("{}{}{}{}", BattleMapPartType::getPrefix(), tilePrefix,
 		                                   "GD_", (unsigned)bdata.destroyed_ground_idx)};
 
 	state.battle_maps[id] = m;
@@ -261,7 +261,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 	std::map<UString, up<BattleMapSectorTiles>> sectors;
 	UString map_prefix = "xcom3/maps/";
 	UString dirName = mapRootName;
-	UString tilePrefix = format("%s_", dirName);
+	UString tilePrefix = format("{}_", dirName);
 	bool baseMap = mapRootName == "37base";
 	BuildingDatStructure bdata;
 	{
@@ -271,14 +271,14 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 		auto inFile = fw().data->fs.open(datFileName);
 		if (!inFile)
 		{
-			LogError("Failed to open \"%s\"", fileName);
+			LogError("Failed to open \"{}\"", fileName);
 			return {};
 		}
 
 		inFile.read((char *)&bdata, sizeof(bdata));
 		if (!inFile)
 		{
-			LogError("Failed to read entry in \"%s\"", fileName);
+			LogError("Failed to read entry in \"{}\"", fileName);
 			return {};
 		}
 	}
@@ -288,7 +288,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 	for (const auto &sdtFile : sdtFiles)
 	{
 		fileCounter++;
-		LogInfo("Reading map %s", sdtFile);
+		LogInfo("Reading map {}", sdtFile);
 		/*  Trim off '.sdt' to get the base map name */
 		LogAssert(sdtFile.length() >= 4);
 		auto secName = sdtFile.substr(0, sdtFile.length() - 4);
@@ -304,16 +304,16 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 			{
 				if (fileCounter == 0)
 				{
-					tilesName = format("%s_%02d", dirName, groundCounter);
+					tilesName = format("{}_%02d", dirName, groundCounter);
 				}
 				else
 				{
-					tilesName = format("%s_%02d", dirName, fileCounter + 15);
+					tilesName = format("{}_%02d", dirName, fileCounter + 15);
 				}
 			}
 			else
 			{
-				tilesName = format("%s_%s", dirName, sector);
+				tilesName = format("{}_{}", dirName, sector);
 			}
 			up<BattleMapSectorTiles> tiles(new BattleMapSectorTiles());
 			SecSdtStructure sdata;
@@ -324,14 +324,14 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 				auto inFile = fw().data->fs.open(fullPath);
 				if (!inFile)
 				{
-					LogInfo("Sector %s not present for map %s", sector, mapRootName);
+					LogInfo("Sector {} not present for map {}", sector, mapRootName);
 					continue;
 				}
 
 				inFile.read((char *)&sdata, sizeof(sdata));
 				if (!inFile)
 				{
-					LogError("Failed to read entry in \"%s\"", fileName);
+					LogError("Failed to read entry in \"{}\"", fileName);
 					return {};
 				}
 			}
@@ -344,7 +344,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 				auto inFile = fw().data->fs.open(fullPath);
 				if (!inFile)
 				{
-					LogError("Failed to open \"%s\"", fileName);
+					LogError("Failed to open \"{}\"", fileName);
 					return {};
 				}
 
@@ -358,7 +358,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 					inFile.read((char *)&ldata, sizeof(ldata));
 					if (!inFile)
 					{
-						LogError("Failed to read entry %d in \"%s\"", i, fileName);
+						LogError("Failed to read entry {} in \"{}\"", i, fileName);
 						return {};
 					}
 
@@ -491,7 +491,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 						inFile.read((char *)&ldata, sizeof(ldata));
 						if (!inFile)
 						{
-							LogError("Failed to read entry %d in \"%s\"", i, fileName);
+							LogError("Failed to read entry {} in \"{}\"", i, fileName);
 							return {};
 						}
 
@@ -511,7 +511,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 								lp = Organisation::LootPriority::C;
 								break;
 							default:
-								LogError("Encountered invalid loot priority in %d for sector %d", i,
+								LogError("Encountered invalid loot priority in {} for sector {}", i,
 								         sector);
 								return {};
 						}
@@ -530,13 +530,13 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 				auto inFile = fw().data->fs.open(fullPath);
 				if (!inFile)
 				{
-					LogError("Failed to open \"%s\"", fileName);
+					LogError("Failed to open \"{}\"", fileName);
 				}
 				auto fileSize = inFile.size();
 
 				if (fileSize != expectedFileSize)
 				{
-					LogError("Unexpected filesize %zu - expected %u", fileSize, expectedFileSize);
+					LogError("Unexpected filesize {} - expected {}", fileSize, expectedFileSize);
 				}
 
 				for (unsigned int z = 0; z < bdata.chunk_z * sdata.chunks_z; z++)
@@ -550,14 +550,14 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 							inFile.read((char *)&tdata, sizeof(tdata));
 							if (!inFile)
 							{
-								LogError("Failed to read entry %d,%d,%d in \"%s\"", x, y, z,
+								LogError("Failed to read entry {},{},{} in \"{}\"", x, y, z,
 								         fileName);
 								return {};
 							}
 							// read ground
 							if (tdata.GD != 0)
 							{
-								auto tileName = format("%s%s%s%u", BattleMapPartType::getPrefix(),
+								auto tileName = format("{}{}{}{}", BattleMapPartType::getPrefix(),
 								                       tilePrefix, "GD_", (unsigned)tdata.GD);
 
 								tiles->initial_grounds[Vec3<int>{x, y, z}] = {&state, tileName};
@@ -565,7 +565,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 							// read left wall
 							if (tdata.LW != 0)
 							{
-								auto tileName = format("%s%s%s%u", BattleMapPartType::getPrefix(),
+								auto tileName = format("{}{}{}{}", BattleMapPartType::getPrefix(),
 								                       tilePrefix, "LW_", (unsigned)tdata.LW);
 
 								tiles->initial_left_walls[Vec3<int>{x, y, z}] = {&state, tileName};
@@ -573,7 +573,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 							// read right wall
 							if (tdata.RW != 0)
 							{
-								auto tileName = format("%s%s%s%u", BattleMapPartType::getPrefix(),
+								auto tileName = format("{}{}{}{}", BattleMapPartType::getPrefix(),
 								                       tilePrefix, "RW_", (unsigned)tdata.RW);
 
 								tiles->initial_right_walls[Vec3<int>{x, y, z}] = {&state, tileName};
@@ -599,14 +599,14 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 									}
 									else
 									{
-										LogError("Encountered gun emplacement %d in sector %s",
+										LogError("Encountered gun emplacement {} in sector {}",
 										         tdata.FT, sector);
 									}
 								}
 								else
 								{
 									auto tileName =
-									    format("%s%s%s%u", BattleMapPartType::getPrefix(),
+									    format("{}{}{}{}", BattleMapPartType::getPrefix(),
 									           tilePrefix, "FT_", (unsigned)tdata.FT);
 
 									tiles->initial_features[Vec3<int>{x, y, z}] = {&state,
@@ -622,7 +622,7 @@ InitialGameStateExtractor::extractMapSectors(GameState &state, const UString &ma
 			if (baseMap && fileCounter == 0 && groundCounter != 15)
 			{
 				auto tileName =
-				    format("%s%s%s%u", BattleMapPartType::getPrefix(), tilePrefix, "FT_", 78);
+				    format("{}{}{}{}", BattleMapPartType::getPrefix(), tilePrefix, "FT_", 78);
 
 				// key is North South West East (true = occupied, false = vacant)
 				const std::unordered_map<int, std::vector<bool>> PRESENT_ROOMS = {

--- a/tools/extractors/extract_battlescape_map_parts.cpp
+++ b/tools/extractors/extract_battlescape_map_parts.cpp
@@ -24,7 +24,7 @@ void InitialGameStateExtractor::readBattleMapParts(
 	auto inFile = fw().data->fs.open(datFileName);
 	if (!inFile)
 	{
-		LogError("Failed to open mapunits DAT file at \"%s\"", datFileName);
+		LogError("Failed to open mapunits DAT file at \"{}\"", datFileName);
 		return;
 	}
 	auto fileSize = inFile.size();
@@ -35,12 +35,12 @@ void InitialGameStateExtractor::readBattleMapParts(
 	auto strategySpriteTabFile = fw().data->fs.open(strategySpriteTabFileName);
 	if (!strategySpriteTabFile)
 	{
-		LogError("Failed to open strategy sprite TAB file \"%s\"", strategySpriteTabFileName);
+		LogError("Failed to open strategy sprite TAB file \"{}\"", strategySpriteTabFileName);
 		return;
 	}
 	size_t strategySpriteCount = strategySpriteTabFile.size() / 4;
 
-	LogInfo("Loading %zu entries from \"%s\"", objectCount, datFileName);
+	LogInfo("Loading {} entries from \"{}\"", objectCount, datFileName);
 
 	for (size_t i = 0; i < objectCount; i++)
 	{
@@ -49,16 +49,16 @@ void InitialGameStateExtractor::readBattleMapParts(
 		inFile.read((char *)&entry, sizeof(entry));
 		if (!inFile)
 		{
-			LogError("Failed to read entry %zu in \"%s\"", i, datFileName);
+			LogError("Failed to read entry {} in \"{}\"", i, datFileName);
 			return;
 		}
 
-		UString id = format("%s%u", idPrefix, i);
+		UString id = format("{}{}", idPrefix, i);
 		auto object = mksp<BattleMapPartType>();
 		if (entry.alternative_object_idx != 0)
 		{
 			object->alternative_map_part = {&state,
-			                                format("%s%u", idPrefix, entry.alternative_object_idx)};
+			                                format("{}{}", idPrefix, entry.alternative_object_idx)};
 		}
 		object->type = type;
 		object->constitution = entry.constitution;
@@ -79,7 +79,7 @@ void InitialGameStateExtractor::readBattleMapParts(
 		{
 			if ((unsigned int)entry.loftemps_lof[slice] == 0)
 				continue;
-			auto lofString = format("LOFTEMPS:%s:%s:%u", loftempsFile, loftempsTab,
+			auto lofString = format("LOFTEMPS:{}:{}:{}", loftempsFile, loftempsTab,
 			                        (unsigned int)entry.loftemps_lof[slice]);
 			object->voxelMapLOF->slices[slice] = fw().data->loadVoxelSlice(lofString);
 		}
@@ -88,13 +88,13 @@ void InitialGameStateExtractor::readBattleMapParts(
 		{
 			if ((unsigned int)entry.loftemps_los[slice] == 0)
 				continue;
-			auto lofString = format("LOFTEMPS:%s:%s:%u", loftempsFile, loftempsTab,
+			auto lofString = format("LOFTEMPS:{}:{}:{}", loftempsFile, loftempsTab,
 			                        (unsigned int)entry.loftemps_los[slice]);
 			object->voxelMapLOS->slices[slice] = fw().data->loadVoxelSlice(lofString);
 		}
 		if (entry.damaged_idx)
 		{
-			object->damaged_map_part = {&state, format("%s%u", idPrefix, entry.damaged_idx)};
+			object->damaged_map_part = {&state, format("{}{}", idPrefix, entry.damaged_idx)};
 		}
 
 		// So far haven't seen an animated object with only 1 frame, but seen objects with 1 in this
@@ -105,20 +105,20 @@ void InitialGameStateExtractor::readBattleMapParts(
 			auto animateTabFile = fw().data->fs.open(animateTabFileName);
 			if (!animateTabFile)
 			{
-				LogError("Failed to open animate sprite TAB file \"%s\"", animateTabFileName);
+				LogError("Failed to open animate sprite TAB file \"{}\"", animateTabFileName);
 				return;
 			}
 			size_t animateSpriteCount = animateTabFile.size() / 4;
 
 			if (animateSpriteCount < entry.animation_idx + entry.animation_length)
 			{
-				LogWarning("Bogus animation value, animation frames not present for ID %s", id);
+				LogWarning("Bogus animation value, animation frames not present for ID {}", id);
 			}
 			else
 			{
 				for (int j = 0; j < entry.animation_length; j++)
 				{
-					auto animateString = format("PCK:%s%s.pck:%s%s.tab:%u", dirName, "animate",
+					auto animateString = format("PCK:{}{}.pck:{}{}.tab:{}", dirName, "animate",
 					                            dirName, "animate", entry.animation_idx + j);
 					object->animation_frames.push_back(fw().data->loadImage(animateString));
 				}
@@ -126,11 +126,11 @@ void InitialGameStateExtractor::readBattleMapParts(
 		}
 
 		auto imageString =
-		    format("PCK:%s%s.pck:%s%s.tab:%u", dirName, pckName, dirName, pckName, i);
+		    format("PCK:{}{}.pck:{}{}.tab:{}", dirName, pckName, dirName, pckName, i);
 		object->sprite = fw().data->loadImage(imageString);
 		if (i < strategySpriteCount)
 		{
-			auto stratImageString = format("PCKSTRAT:%s%s.pck:%s%s.tab:%u", dirName, stratPckName,
+			auto stratImageString = format("PCKSTRAT:{}{}.pck:{}{}.tab:{}", dirName, stratPckName,
 			                               dirName, stratPckName, i);
 			object->strategySprite = fw().data->loadImage(stratImageString);
 		}
@@ -234,7 +234,7 @@ void InitialGameStateExtractor::readBattleMapParts(
 		{
 			if (gets_support_from % 10 < 1 || gets_support_from % 10 > 4)
 			{
-				LogError("Unrecognized support by id %d", (int)entry.gets_support_from);
+				LogError("Unrecognized support by id {}", (int)entry.gets_support_from);
 				return;
 			}
 			object->supportedByDirections.insert((MapDirection)(gets_support_from % 10));
@@ -260,7 +260,7 @@ void InitialGameStateExtractor::readBattleMapParts(
 					object->supportedByTypes.insert(BattleMapPartType::Type::Feature);
 					break;
 				default:
-					LogError("Unrecognized support by id %d", (int)entry.gets_support_from);
+					LogError("Unrecognized support by id {}", (int)entry.gets_support_from);
 					return;
 			}
 		}
@@ -306,7 +306,7 @@ void InitialGameStateExtractor::readBattleMapParts(
 sp<BattleMapTileset> InitialGameStateExtractor::extractTileSet(GameState &state,
                                                                const UString &name) const
 {
-	UString tilePrefix = format("%s_", name);
+	UString tilePrefix = format("{}_", name);
 	UString map_prefix = "xcom3/maps/";
 	UString mapunits_suffix = "/mapunits/";
 	UString spriteFile;

--- a/tools/extractors/extract_buildings.cpp
+++ b/tools/extractors/extract_buildings.cpp
@@ -29,8 +29,8 @@ void InitialGameStateExtractor::extractBuildingFunctions(GameState &state) const
 		{
 			f->detectionWeight = buildingFunctionDetectionWeights[i];
 		}
-		auto id = format("%s%s", BuildingFunction::getPrefix(), canon_string(f->name));
-		auto ped = format("%s%s", UfopaediaEntry::getPrefix(), canon_string(f->name));
+		auto id = format("{}{}", BuildingFunction::getPrefix(), canon_string(f->name));
+		auto ped = format("{}{}", UfopaediaEntry::getPrefix(), canon_string(f->name));
 		f->ufopaedia_entry = {&state, ped};
 		state.building_functions[id] = f;
 	}
@@ -46,12 +46,12 @@ void InitialGameStateExtractor::extractBuildings(GameState &state, UString bldFi
 	auto inFile = fw().data->fs.open(fileName);
 	if (!inFile)
 	{
-		LogError("Failed to open \"%s\"", fileName);
+		LogError("Failed to open \"{}\"", fileName);
 	}
 	auto fileSize = inFile.size();
 	auto bldCount = fileSize / sizeof(struct BldFileEntry);
 
-	LogInfo("Loading %lu buildings from %s", (unsigned long)bldCount, fileName);
+	LogInfo("Loading %lu buildings from {}", (unsigned long)bldCount, fileName);
 
 	for (unsigned i = 0; i < bldCount; i++)
 	{
@@ -63,15 +63,15 @@ void InitialGameStateExtractor::extractBuildings(GameState &state, UString bldFi
 		{
 			b->name = data.alien_building_names->get(entry.function_idx);
 			b->function = {&state,
-			               format("%s%s", BuildingFunction::getPrefix(), canon_string(b->name))};
-			LogInfo("Alien bld %d %s func %d %s", entry.name_idx, b->name, entry.function_idx,
+			               format("{}{}", BuildingFunction::getPrefix(), canon_string(b->name))};
+			LogInfo("Alien bld {} {} func {} {}", entry.name_idx, b->name, entry.function_idx,
 			        b->function.id);
 
-			b->accessTopic = {&state, format("RESEARCH_UNLOCK_ALIEN_BUILDING_%d", i)};
+			b->accessTopic = {&state, format("RESEARCH_UNLOCK_ALIEN_BUILDING_{}", i)};
 			if (i < 9)
 			{
 				b->researchUnlock.emplace_back(&state,
-				                               format("RESEARCH_UNLOCK_ALIEN_BUILDING_%d", i + 1));
+				                               format("RESEARCH_UNLOCK_ALIEN_BUILDING_{}", i + 1));
 			}
 			else
 			{
@@ -86,7 +86,7 @@ void InitialGameStateExtractor::extractBuildings(GameState &state, UString bldFi
 		{
 			b->name = data.building_names->get(entry.name_idx);
 			b->function = {&state,
-			               format("%s%s", BuildingFunction::getPrefix(),
+			               format("{}{}", BuildingFunction::getPrefix(),
 			                      canon_string(data.building_functions->get(entry.function_idx)))};
 		}
 		int battle_map_index = entry.function_idx - 1 + (alienBuilding ? 39 : 0);
@@ -131,12 +131,12 @@ void InitialGameStateExtractor::extractBuildings(GameState &state, UString bldFi
 				break;
 		}
 		b->battle_map = {
-		    &state, format("%s%s", BattleMap::getPrefix(), this->battleMapPaths[battle_map_index])};
+		    &state, format("{}{}", BattleMap::getPrefix(), this->battleMapPaths[battle_map_index])};
 		b->owner = {&state, data.getOrgId(entry.owner_idx)};
 		// Our rects are exclusive of p2
 		// Shift position by 20 tiles
 		b->bounds = {entry.x0 + 20, entry.y0 + 20, entry.x1 + 21, entry.y1 + 21};
-		auto id = format("%s%s", Building::getPrefix(), canon_string(b->name));
+		auto id = format("{}{}", Building::getPrefix(), canon_string(b->name));
 		b->city = {&state, city->id};
 		city->buildings[id] = b;
 	}

--- a/tools/extractors/extract_bulletsprites.cpp
+++ b/tools/extractors/extract_bulletsprites.cpp
@@ -16,7 +16,7 @@ std::map<UString, sp<Image>> InitialGameStateExtractor::extractBulletSpritesCity
 
 	for (unsigned i = 0; i < data.bullet_sprites->count(); i++)
 	{
-		UString path = format("%s%02u.png", path_prefix, i);
+		UString path = format("{}%02u.png", path_prefix, i);
 		auto sprite = data.bullet_sprites->get(i);
 		auto img = mksp<PaletteImage>(Vec2<unsigned int>{3, 3});
 		PaletteImageLock l(img);
@@ -43,7 +43,7 @@ std::map<UString, sp<Image>> InitialGameStateExtractor::extractBulletSpritesBatt
 
 	for (unsigned i = 0; i < data.bullet_sprites->count(); i++)
 	{
-		UString path = format("%s%02u.png", path_prefix, i);
+		UString path = format("{}%02u.png", path_prefix, i);
 		auto sprite = data.bullet_sprites->get(i);
 		auto img = mksp<PaletteImage>(Vec2<unsigned int>{3, 3});
 		PaletteImageLock l(img);

--- a/tools/extractors/extract_city_map.cpp
+++ b/tools/extractors/extract_city_map.cpp
@@ -29,7 +29,7 @@ void InitialGameStateExtractor::extractCityMap(GameState &state, UString fileNam
 	auto inFile = fw().data->fs.open(map_prefix + fileName);
 	if (!inFile)
 	{
-		LogError("Failed to open \"%s\"", fileName);
+		LogError("Failed to open \"{}\"", fileName);
 	}
 	auto fileSize = inFile.size();
 
@@ -37,7 +37,7 @@ void InitialGameStateExtractor::extractCityMap(GameState &state, UString fileNam
 
 	if (fileSize != expectedFileSize)
 	{
-		LogError("Unexpected filesize %zu - expected %u", fileSize, expectedFileSize);
+		LogError("Unexpected filesize {} - expected {}", fileSize, expectedFileSize);
 	}
 
 	city->size = {fullSize.x, fullSize.y, fullSize.z};
@@ -64,7 +64,7 @@ void InitialGameStateExtractor::extractCityMap(GameState &state, UString fileNam
 			}
 
 			auto tileName =
-			    format("%s%s%u", SceneryTileType::getPrefix(), tilePrefix, (unsigned)idx);
+			    format("{}{}{}", SceneryTileType::getPrefix(), tilePrefix, (unsigned)idx);
 
 			city->initial_tiles[Vec3<int>{x, y, 1}] = {&state, tileName};
 		}
@@ -82,7 +82,7 @@ void InitialGameStateExtractor::extractCityMap(GameState &state, UString fileNam
 				if (idx != 0)
 				{
 					auto tileName =
-					    format("%s%s%u", SceneryTileType::getPrefix(), tilePrefix, (unsigned)idx);
+					    format("{}{}{}", SceneryTileType::getPrefix(), tilePrefix, (unsigned)idx);
 
 					city->initial_tiles[Vec3<int>{x + 20, y + 20, z + 1}] = {&state, tileName};
 				}
@@ -206,7 +206,7 @@ void InitialGameStateExtractor::extractCityMap(GameState &state, UString fileNam
 
 							if (!tarTileMap[invDir])
 							{
-								LogWarning("MAP %s TILE %s at %d,%d,%d mismatch %s at dir %d",
+								LogWarning("MAP {} TILE {} at {},{},{} mismatch {} at dir {}",
 								           fileName, curTileName, x + 20, y + 20, z + 1, p.first,
 								           dir);
 							}

--- a/tools/extractors/extract_city_scenery.cpp
+++ b/tools/extractors/extract_city_scenery.cpp
@@ -74,16 +74,16 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 	auto inFile = fw().data->fs.open("xcom3/ufodata/" + datFile + ".dat");
 	if (!inFile)
 	{
-		LogError("Failed to open \"%s.dat\"", datFile);
+		LogError("Failed to open \"{}.dat\"", datFile);
 	}
 
 	auto fileSize = inFile.size();
 
 	auto tileCount = fileSize / sizeof(struct citymap_tile_entry);
-	LogInfo("Loading %zu tile entries", tileCount);
+	LogInfo("Loading {} tile entries", tileCount);
 	if (fileSize % sizeof(citymap_tile_entry))
 	{
-		LogWarning("filesize %zu doesn't divide by tile record size", fileSize);
+		LogWarning("filesize {} doesn't divide by tile record size", fileSize);
 	}
 
 	for (unsigned i = 0; i < tileCount; i++)
@@ -91,7 +91,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 		struct citymap_tile_entry entry;
 		inFile.read((char *)&entry, sizeof(entry));
 
-		UString id = format("%s%s%u", SceneryTileType::getPrefix(), tilePrefix, i);
+		UString id = format("{}{}{}", SceneryTileType::getPrefix(), tilePrefix, i);
 
 		auto tile = mksp<SceneryTileType>();
 
@@ -111,7 +111,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 				tile->walk_mode = SceneryTileType::WalkMode::Onto;
 				break;
 			default:
-				LogError("Unexpected scenery walk type %d for ID %s", (int)entry.walk_type, id);
+				LogError("Unexpected scenery walk type {} for ID {}", (int)entry.walk_type, id);
 		}
 
 		switch (entry.tile_type)
@@ -133,7 +133,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 				tile->tile_type = SceneryTileType::TileType::CityWall;
 				break;
 			default:
-				LogError("Unexpected scenery tile type %d for ID %s", (int)entry.tile_type, id);
+				LogError("Unexpected scenery tile type {} for ID {}", (int)entry.tile_type, id);
 		}
 
 		switch (entry.road_type)
@@ -148,7 +148,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 				tile->road_type = SceneryTileType::RoadType::Terminal;
 				break;
 			default:
-				LogError("Unexpected scenery road type %d for ID %s", (int)entry.road_type, id);
+				LogError("Unexpected scenery road type {} for ID {}", (int)entry.road_type, id);
 		}
 
 		tile->connection.resize(4);
@@ -243,12 +243,12 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 		}
 		if (entry.damagedtile_idx)
 		{
-			tile->damagedTile = {&state, format("%s%s%u", SceneryTileType::getPrefix(), tilePrefix,
+			tile->damagedTile = {&state, format("{}{}{}", SceneryTileType::getPrefix(), tilePrefix,
 			                                    entry.damagedtile_idx)};
 		}
 
 		auto imageString = format(
-		    "PCK:xcom3/ufodata/" + spriteFile + ".pck:xcom3/ufodata/" + spriteFile + ".tab:%u", i);
+		    "PCK:xcom3/ufodata/" + spriteFile + ".pck:xcom3/ufodata/" + spriteFile + ".tab:{}", i);
 
 		tile->sprite = fw().data->loadImage(imageString);
 
@@ -259,7 +259,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 			if (entry.voxelIdx[z] == 0)
 				continue;
 			auto lofString = format("LOFTEMPS:xcom3/ufodata/" + lofFile + ".dat:xcom3/ufodata/" +
-			                            lofFile + ".tab:%d",
+			                            lofFile + ".tab:{}",
 			                        (int)entry.voxelIdx[z]);
 			tile->voxelMap->slices[z] = fw().data->loadVoxelSlice(lofString);
 		}
@@ -267,7 +267,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 		if (entry.stratmap_idx != 0)
 		{
 			auto stratmapString = format("PCKSTRAT:xcom3/ufodata/" + stratmapFile +
-			                                 ".pck:xcom3/ufodata/" + stratmapFile + ".tab:%d",
+			                                 ".pck:xcom3/ufodata/" + stratmapFile + ".tab:{}",
 			                             (int)entry.stratmap_idx);
 			tile->strategySprite = fw().data->loadImage(stratmapString);
 		}
@@ -285,7 +285,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 		if (entry.overlaytile_idx != 0xff)
 		{
 			auto overlayString =
-			    format("PCK:xcom3/ufodata/" + ovrFile + ".pck:xcom3/ufodata/" + ovrFile + ".tab:%d",
+			    format("PCK:xcom3/ufodata/" + ovrFile + ".pck:xcom3/ufodata/" + ovrFile + ".tab:{}",
 			           (int)entry.overlaytile_idx);
 			tile->overlaySprite = fw().data->loadImage(overlayString);
 		}

--- a/tools/extractors/extract_doodads.cpp
+++ b/tools/extractors/extract_doodads.cpp
@@ -90,7 +90,7 @@ void InitialGameStateExtractor::extractDoodads(GameState &state) const
 
 				d->frames.push_back(
 				    {fw().data->loadImage(format("PCK:xcom3/ufodata/ptang.pck:xcom3/ufodata/"
-				                                 "ptang.tab:%d",
+				                                 "ptang.tab:{}",
 				                                 j)),
 				     frameTTL * (slow ? 2 : 1)});
 			}
@@ -173,7 +173,7 @@ void InitialGameStateExtractor::extractDoodads(GameState &state) const
 			{
 				d->frames.push_back(
 				    {fw().data->loadImage(format("PCK:xcom3/tacdata/ptang.pck:xcom3/tacdata/"
-				                                 "ptang.tab:%d",
+				                                 "ptang.tab:{}",
 				                                 j)),
 				     frameTTL * ttlmult});
 			}
@@ -192,12 +192,12 @@ void InitialGameStateExtractor::extractDoodads(GameState &state) const
 			d->repeatable = false;
 			d->frames.push_back(
 			    {fw().data->loadImage(format("PCK:xcom3/tacdata/ptang.pck:xcom3/tacdata/"
-			                                 "ptang.tab:%d",
+			                                 "ptang.tab:{}",
 			                                 78)),
 			     frameTTL});
 			d->frames.push_back(
 			    {fw().data->loadImage(format("PCK:xcom3/tacdata/ptang.pck:xcom3/tacdata/"
-			                                 "ptang.tab:%d",
+			                                 "ptang.tab:{}",
 			                                 77)),
 			     frameTTL});
 			state.doodad_types[id] = d;
@@ -225,7 +225,7 @@ void InitialGameStateExtractor::extractDoodads(GameState &state) const
 
 			for (int facing = 0; facing < 9; facing++)
 			{
-				UString id = format("DOODAD_BATTLE_EXPLOSION_%s", facingMap.at(facing));
+				UString id = format("DOODAD_BATTLE_EXPLOSION_{}", facingMap.at(facing));
 				auto d = mksp<DoodadType>();
 
 				// FIXME: ENSURE CORRECT
@@ -239,7 +239,7 @@ void InitialGameStateExtractor::extractDoodads(GameState &state) const
 
 					d->frames.push_back(
 					    {fw().data->loadImage(format("PCK:xcom3/tacdata/ptang.pck:xcom3/tacdata/"
-					                                 "ptang.tab:%d",
+					                                 "ptang.tab:{}",
 					                                 idx)),
 					     frameTTL * ttlmult});
 				}

--- a/tools/extractors/extract_economy.cpp
+++ b/tools/extractors/extract_economy.cpp
@@ -34,9 +34,9 @@ static std::vector<UString> vehicleAmmoNames = {
 void InitialGameStateExtractor::extractEconomy(GameState &state) const
 {
 	auto &data = this->ufo2p;
-	LogInfo("Number of economy 1 data chunks: %u", (unsigned)data.economy_data1->count());
-	LogInfo("Number of economy 2 data chunks: %u", (unsigned)data.economy_data2->count());
-	LogInfo("Number of economy 3 data chunks: %u", (unsigned)data.economy_data3->count());
+	LogInfo("Number of economy 1 data chunks: {}", (unsigned)data.economy_data1->count());
+	LogInfo("Number of economy 2 data chunks: {}", (unsigned)data.economy_data2->count());
+	LogInfo("Number of economy 3 data chunks: {}", (unsigned)data.economy_data3->count());
 
 	for (unsigned idx = 0; idx < data.economy_data1->count(); idx++)
 	{
@@ -119,7 +119,7 @@ void InitialGameStateExtractor::extractEconomy(GameState &state) const
 		if (i < 87)
 		{
 			id = data.agent_equipment_names->get(i);
-			id = format("%s%s", AEquipmentType::getPrefix(), canon_string(id));
+			id = format("{}{}", AEquipmentType::getPrefix(), canon_string(id));
 		}
 		else
 		{

--- a/tools/extractors/extract_facilities.cpp
+++ b/tools/extractors/extract_facilities.cpp
@@ -12,8 +12,8 @@ namespace OpenApoc
 void InitialGameStateExtractor::extractFacilities(GameState &state) const
 {
 	auto &data = this->ufo2p;
-	LogInfo("Number of facility strings: %u", (unsigned)data.facility_names->count());
-	LogInfo("Number of facility data chunks: %u", (unsigned)data.facility_data->count());
+	LogInfo("Number of facility strings: {}", (unsigned)data.facility_names->count());
+	LogInfo("Number of facility data chunks: {}", (unsigned)data.facility_data->count());
 
 	// Start at 2, as 'earth' and 'corridor' are handled specially, this aren't really 'facilities'
 	// in openapoc terms
@@ -23,7 +23,7 @@ void InitialGameStateExtractor::extractFacilities(GameState &state) const
 		auto f = data.facility_data->get(i);
 
 		LogInfo(
-		    "Facility %d: %s cost %d image_offset %d size %d build_time %d maint %d capacity %d", i,
+		    "Facility {}: {} cost {} image_offset {} size {} build_time {} maint {} capacity {}", i,
 		    id, (int)f.cost, (int)f.image_offset, (int)f.size, (int)f.build_time,
 		    (int)f.maintainance_cost, (int)f.capacity);
 		LogInfo("u1 0x%04x u2 0x%04x", (unsigned)f.unknown1, (unsigned)f.unknown2);
@@ -38,7 +38,7 @@ void InitialGameStateExtractor::extractFacilities(GameState &state) const
 		facilityType->size = f.size;
 		facilityType->sector = i - 2 + 16 + 15;
 		facilityType->sprite = fw().data->loadImage(
-		    format("PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:%d:xcom3/ufodata/base.pcx",
+		    format("PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:{}:xcom3/ufodata/base.pcx",
 		           (int)f.image_offset));
 
 		state.facility_types[id] = facilityType;

--- a/tools/extractors/extract_organisations.cpp
+++ b/tools/extractors/extract_organisations.cpp
@@ -18,8 +18,8 @@ namespace OpenApoc
 void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 {
 	auto &data = this->ufo2p;
-	LogInfo("Number of org strings: %zu", data.organisation_names->readStrings.size());
-	LogInfo("Number of orgs: %u", (unsigned)data.organisation_data->count());
+	LogInfo("Number of org strings: {}", data.organisation_names->readStrings.size());
+	LogInfo("Number of orgs: {}", (unsigned)data.organisation_data->count());
 
 	// Organisations
 
@@ -35,7 +35,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 		o->name = data.organisation_names->get(i);
 		o->id = id;
 
-		auto ped = format("%s%s", UfopaediaEntry::getPrefix(),
+		auto ped = format("{}{}", UfopaediaEntry::getPrefix(),
 		                  canon_string(data.organisation_names->get(i)));
 		o->ufopaedia_entry = {&state, ped};
 
@@ -71,7 +71,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 		else
 		{
 			o->icon = fw().data->loadImage(format("PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/"
-			                                      "vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
+			                                      "vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 			                                      91 + i));
 
 			auto ldata = data.organisation_raid_loot_data->get(i);
@@ -100,7 +100,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 					else
 					{
 						o->loot[priority].emplace_back(
-						    &state, format("%s%s", AEquipmentType::getPrefix(),
+						    &state, format("{}{}", AEquipmentType::getPrefix(),
 						                   canon_string(data.agent_equipment_names->get(
 						                       ldata.loot_idx[k][j]))));
 					}
@@ -177,7 +177,7 @@ void InitialGameStateExtractor::extractOrganisations(GameState &state) const
 					break;
 				// Miscellaneous (many orgs have this value)
 				default:
-					LogError("Modded game? Found unexpected vehiclePark value of %d",
+					LogError("Modded game? Found unexpected vehiclePark value of {}",
 					         (int)vdata.vehiclePark);
 				case 4:
 					o->vehiclePark[{&state, "VEHICLETYPE_PHOENIX_HOVERCAR"}] = 2;

--- a/tools/extractors/extract_research.cpp
+++ b/tools/extractors/extract_research.cpp
@@ -31,7 +31,7 @@ void InitialGameStateExtractor::extractResearch(GameState &state) const
 				r->type = ResearchTopic::Type::Physics;
 				break;
 			default:
-				LogError("Unexpected researchGroup 0x%02x for research item %s",
+				LogError("Unexpected researchGroup 0x%02x for research item {}",
 				         (unsigned)rdata.researchGroup, id);
 		}
 		switch (rdata.labSize)
@@ -43,7 +43,7 @@ void InitialGameStateExtractor::extractResearch(GameState &state) const
 				r->required_lab_size = ResearchTopic::LabSize::Large;
 				break;
 			default:
-				LogError("Unexpected labSize 0x%02x for research item %s", (unsigned)rdata.labSize,
+				LogError("Unexpected labSize 0x%02x for research item {}", (unsigned)rdata.labSize,
 				         id);
 		}
 		// FIXME: this assumed all listed techs are required, which is not true for some topics
@@ -75,7 +75,7 @@ void InitialGameStateExtractor::extractResearch(GameState &state) const
 
 		if (state.research.topics.find(id) != state.research.topics.end())
 		{
-			LogError("Multiple research topics with ID \"%s\"", id);
+			LogError("Multiple research topics with ID \"{}\"", id);
 		}
 		state.research.topics[id] = r;
 // FIXME: The ufopaedia entries here don't seem to directly map to the IDs we're currently using?
@@ -100,7 +100,7 @@ void InitialGameStateExtractor::extractResearch(GameState &state) const
 		}
 		if (paediaEntry->required_research)
 		{
-			LogError("Multiple required research for UFOPaedia topic \"%s\" - \"%s\" and \"%s\"",
+			LogError("Multiple required research for UFOPaedia topic \"{}\" - \"{}\" and \"{}\"",
 			         ufopaediaEntryID, r->name,
 			         paediaEntry->required_research->name);
 		}

--- a/tools/extractors/extract_unit_animation_packs.cpp
+++ b/tools/extractors/extract_unit_animation_packs.cpp
@@ -104,7 +104,7 @@ sp<BattleUnitAnimationPack::AnimationEntry> InitialGameStateExtractor::getAnimat
 						continue;
 					break;
 				default:
-					LogError("Impossible part index %d found in UF located at entry %d offset %d",
+					LogError("Impossible part index {} found in UF located at entry {} offset {}",
 					         part_idx, offset_uf, j);
 					break;
 			}
@@ -202,7 +202,7 @@ InitialGameStateExtractor::extractAnimationPack(GameState &state, const UString 
 
 	std::vector<AnimationDataAD> dataAD;
 	{
-		auto fileName = format("%s%s%s", dirName, path, ".ad");
+		auto fileName = format("{}{}{}", dirName, path, ".ad");
 
 		auto inFile = fw().data->fs.open(fileName);
 		if (inFile)
@@ -216,7 +216,7 @@ InitialGameStateExtractor::extractAnimationPack(GameState &state, const UString 
 				inFile.read((char *)&data, sizeof(data));
 				if (!inFile)
 				{
-					LogError("Failed to read entry in \"%s\"", fileName);
+					LogError("Failed to read entry in \"{}\"", fileName);
 					return nullptr;
 				}
 				dataAD.push_back(data);
@@ -226,7 +226,7 @@ InitialGameStateExtractor::extractAnimationPack(GameState &state, const UString 
 
 	std::vector<AnimationDataUA> dataUA;
 	{
-		auto fileName = format("%s%s%s", dirName, path, ".ua");
+		auto fileName = format("{}{}{}", dirName, path, ".ua");
 
 		auto inFile = fw().data->fs.open(fileName);
 		if (inFile)
@@ -240,7 +240,7 @@ InitialGameStateExtractor::extractAnimationPack(GameState &state, const UString 
 				inFile.read((char *)&data, sizeof(data));
 				if (!inFile)
 				{
-					LogError("Failed to read entry in \"%s\"", fileName);
+					LogError("Failed to read entry in \"{}\"", fileName);
 					return nullptr;
 				}
 				dataUA.push_back(data);
@@ -250,7 +250,7 @@ InitialGameStateExtractor::extractAnimationPack(GameState &state, const UString 
 
 	std::vector<AnimationDataUF> dataUF;
 	{
-		auto fileName = format("%s%s%s", dirName, path, ".uf");
+		auto fileName = format("{}{}{}", dirName, path, ".uf");
 
 		auto inFile = fw().data->fs.open(fileName);
 		if (inFile)
@@ -264,7 +264,7 @@ InitialGameStateExtractor::extractAnimationPack(GameState &state, const UString 
 				inFile.read((char *)&data, sizeof(data));
 				if (!inFile)
 				{
-					LogError("Failed to read entry in \"%s\"", fileName);
+					LogError("Failed to read entry in \"{}\"", fileName);
 					return nullptr;
 				}
 				dataUF.push_back(data);

--- a/tools/extractors/extract_unit_image_packs.cpp
+++ b/tools/extractors/extract_unit_image_packs.cpp
@@ -16,11 +16,11 @@ sp<BattleUnitImagePack> InitialGameStateExtractor::extractImagePack(GameState &s
 	std::ignore = state;
 	UString dirName = "xcom3/tacdata/";
 
-	auto imageTabFileName = format("%s%s.tab", dirName, path);
+	auto imageTabFileName = format("{}{}.tab", dirName, path);
 	auto imageTabFile = fw().data->fs.open(imageTabFileName);
 	if (!imageTabFile)
 	{
-		LogError("Failed to open TAB file \"%s\"", imageTabFileName);
+		LogError("Failed to open TAB file \"{}\"", imageTabFileName);
 		return nullptr;
 	}
 	size_t imageTabFileEntryCount = imageTabFile.size() / 4;
@@ -32,7 +32,7 @@ sp<BattleUnitImagePack> InitialGameStateExtractor::extractImagePack(GameState &s
 	for (size_t i = 0; i < imageTabFileEntryCount; i++)
 	{
 		p->images.push_back(
-		    fw().data->loadImage(format("%s:%s%s.pck:%s%s.tab:%u", shadow ? "PCKSHADOW" : "PCK",
+		    fw().data->loadImage(format("{}:{}{}.pck:{}{}.tab:{}", shadow ? "PCKSHADOW" : "PCK",
 		                                dirName, path, dirName, path, (unsigned)i)));
 	}
 
@@ -52,7 +52,7 @@ sp<BattleUnitImagePack> InitialGameStateExtractor::extractItemImagePack(GameStat
 	for (int j = 0; j < 8; j++)
 		p->images.push_back(
 		    fw().data->loadImage(format("PCK:xcom3/tacdata/unit/equip.pck:xcom3/tacdata/"
-		                                "unit/equip.tab:%d",
+		                                "unit/equip.tab:{}",
 		                                item * 8 + j)));
 
 	return p;
@@ -64,7 +64,7 @@ int InitialGameStateExtractor::getItemImagePacksCount() const
 	auto heldSpriteTabFile = fw().data->fs.open(heldSpriteTabFileName);
 	if (!heldSpriteTabFile)
 	{
-		LogError("Failed to open held item sprite TAB file \"%s\"", heldSpriteTabFileName);
+		LogError("Failed to open held item sprite TAB file \"{}\"", heldSpriteTabFileName);
 		return -1;
 	}
 	return heldSpriteTabFile.size() / 4 / 8;

--- a/tools/extractors/extract_vehicle_equipment.cpp
+++ b/tools/extractors/extract_vehicle_equipment.cpp
@@ -33,7 +33,7 @@ void InitialGameStateExtractor::extractVehicleEquipment(GameState &state) const
 		auto edata = data.vehicle_equipment->get(i);
 
 		e->name = data.vehicle_equipment_names->get(i);
-		UString id = format("%s%s", VEquipmentType::getPrefix(), canon_string(e->name));
+		UString id = format("{}{}", VEquipmentType::getPrefix(), canon_string(e->name));
 
 		e->id = id;
 
@@ -55,7 +55,7 @@ void InitialGameStateExtractor::extractVehicleEquipment(GameState &state) const
 				e->users.insert(VEquipmentType::User::Ammo);
 				break;
 			default:
-				LogWarning("Unexpected 'usable_by' %d for ID %s", (int)edata.usable_by, id);
+				LogWarning("Unexpected 'usable_by' {} for ID {}", (int)edata.usable_by, id);
 				continue;
 		}
 		e->weight = edata.weight;
@@ -63,11 +63,11 @@ void InitialGameStateExtractor::extractVehicleEquipment(GameState &state) const
 
 		e->max_ammo = edata.max_ammo;
 		// This is wrong!?
-		// e->ammo_type = format("%d", (int)edata.ammo_type);
+		// e->ammo_type = format("{}", (int)edata.ammo_type);
 		// Force all sprites into the correct palette by using A_RANDOM_VEHICLES_BACKGROUND pcx
 		//(I assume the parts of the palette used for this are the same on all?)
 		e->equipscreen_sprite = fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vehequip.pck:xcom3/ufodata/vehequip.tab:%d:xcom3/ufodata/vhawk.pcx",
+		    "PCK:xcom3/ufodata/vehequip.pck:xcom3/ufodata/vehequip.tab:{}:xcom3/ufodata/vhawk.pcx",
 		    (int)edata.sprite_idx));
 		e->equipscreen_size = {edata.size_x, edata.size_y};
 		e->manufacturer = {&state, data.getOrgId(edata.manufacturer)};
@@ -249,7 +249,7 @@ void InitialGameStateExtractor::extractVehicleEquipment(GameState &state) const
 				}
 
 				e->icon = fw().data->loadImage(format(
-				    "PCK:xcom3/ufodata/vs_obs.pck:xcom3/ufodata/vs_obs.tab:%d", weapon_count));
+				    "PCK:xcom3/ufodata/vs_obs.pck:xcom3/ufodata/vs_obs.tab:{}", weapon_count));
 
 				auto projectile_sprites = data.projectile_sprites->get(wData.projectile_image);
 				for (int i = 0; i < e->tail_size; i++)
@@ -300,7 +300,7 @@ void InitialGameStateExtractor::extractVehicleEquipment(GameState &state) const
 				// If we do reach here, however, should we not just log a warning and go on?
 				// Or log an error that we actually got here (which is the actual bug, and
 				// not the fact that we encountered an expected and known id for empty item)
-				LogError("Unexpected vequipment type %d for ID %s", (int)e->type, id);
+				LogError("Unexpected vequipment type {} for ID {}", (int)e->type, id);
 		}
 
 		state.vehicle_equipment[id] = e;

--- a/tools/extractors/extract_vehicles.cpp
+++ b/tools/extractors/extract_vehicles.cpp
@@ -224,7 +224,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				}
 				else
 				{
-					LogError("Unknown vehicle size {{},{}}", v.size_x, v.size_y);
+					LogError("Unknown vehicle size {{{},{}}}", v.size_x, v.size_y);
 				}
 				int animFrames = UFOAnimationFrames[id];
 

--- a/tools/extractors/extract_vehicles.cpp
+++ b/tools/extractors/extract_vehicles.cpp
@@ -58,7 +58,7 @@ static void extract_equipment_layout(GameState &state, sp<VehicleType> vehicle, 
 {
 	if (layout.slot_count > 45)
 	{
-		LogError("Invalid equipment slot count %d", (int)layout.slot_count);
+		LogError("Invalid equipment slot count {}", (int)layout.slot_count);
 	}
 	for (int i = 0; i < layout.slot_count; i++)
 	{
@@ -77,7 +77,7 @@ static void extract_equipment_layout(GameState &state, sp<VehicleType> vehicle, 
 				outSlot.type = EquipmentSlotType::VehicleGeneral;
 				break;
 			default:
-				LogError("Invalid equipment slot type %d", (int)slot.type);
+				LogError("Invalid equipment slot type {}", (int)slot.type);
 		}
 		switch (slot.alignment_x)
 		{
@@ -91,7 +91,7 @@ static void extract_equipment_layout(GameState &state, sp<VehicleType> vehicle, 
 				outSlot.align_x = AlignmentX::Right;
 				break;
 			default:
-				LogError("Invalid equipment align_x type %d", (int)slot.alignment_x);
+				LogError("Invalid equipment align_x type {}", (int)slot.alignment_x);
 		}
 		switch (slot.alignment_y)
 		{
@@ -105,7 +105,7 @@ static void extract_equipment_layout(GameState &state, sp<VehicleType> vehicle, 
 				outSlot.align_y = AlignmentY::Bottom;
 				break;
 			default:
-				LogError("Invalid equipment align_y type %d", (int)slot.alignment_x);
+				LogError("Invalid equipment align_y type {}", (int)slot.alignment_x);
 		}
 
 		outSlot.bounds = {slot.position_x, slot.position_y, slot.position_x + slot.size_x,
@@ -124,7 +124,7 @@ static void extract_equipment_layout(GameState &state, sp<VehicleType> vehicle, 
 void InitialGameStateExtractor::extractVehicles(GameState &state) const
 {
 	auto &data = this->ufo2p;
-	LogInfo("Number of vehicle strings: %zu", data.vehicle_names->readStrings.size());
+	LogInfo("Number of vehicle strings: {}", data.vehicle_names->readStrings.size());
 
 	for (unsigned i = 0; i < data.vehicle_data->count(); i++)
 	{
@@ -141,7 +141,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		vehicle->image_offset = {v.image_position_1, v.image_position_2 * 3.0f / 4.0f};
 
 		auto ped =
-		    format("%s%s", UfopaediaEntry::getPrefix(), canon_string(data.vehicle_names->get(i)));
+		    format("{}{}", UfopaediaEntry::getPrefix(), canon_string(data.vehicle_names->get(i)));
 		vehicle->ufopaedia_entry = {&state, ped};
 
 		if (i < 10)
@@ -152,7 +152,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 			                                     "RESEARCH_UNLOCK_ALIEN_CRAFT_ENERGY_SOURCE");
 			vehicle->researchUnlock.emplace_back(&state, "RESEARCH_UNLOCK_ALIEN_CRAFT_PROPULSION");
 			vehicle->researchUnlock.emplace_back(&state,
-			                                     format("RESEARCH_UNLOCK_UFO_TYPE_%d", i + 1));
+			                                     format("RESEARCH_UNLOCK_UFO_TYPE_{}", i + 1));
 		}
 
 		if (v.movement_type == 0)
@@ -166,7 +166,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 			auto bank = VehicleType::Banking::Flat;
 			for (auto &dir : directions)
 			{
-				auto str = format("PCK:xcom3/ufodata/vehicle.pck:xcom3/ufodata/vehicle.tab:%d",
+				auto str = format("PCK:xcom3/ufodata/vehicle.pck:xcom3/ufodata/vehicle.tab:{}",
 				                  (int)(v.graphic_frame + image_offset++));
 				;
 				vehicle->directional_sprites[bank][dir] = fw().data->loadImage(str);
@@ -181,7 +181,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 			{
 				for (auto &dir : directions)
 				{
-					auto str = format("PCK:xcom3/ufodata/vehicle.pck:xcom3/ufodata/vehicle.tab:%d",
+					auto str = format("PCK:xcom3/ufodata/vehicle.pck:xcom3/ufodata/vehicle.tab:{}",
 					                  (int)(v.graphic_frame + image_offset++));
 					vehicle->directional_sprites[bank][dir] = fw().data->loadImage(str);
 				}
@@ -224,23 +224,23 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				}
 				else
 				{
-					LogError("Unknown vehicle size {%d,%d}", v.size_x, v.size_y);
+					LogError("Unknown vehicle size {{},{}}", v.size_x, v.size_y);
 				}
 				int animFrames = UFOAnimationFrames[id];
 
 				for (int i = 0; i < animFrames; i++)
 				{
-					auto str = format("PCK:xcom3/ufodata/saucer.pck:xcom3/ufodata/saucer.tab:%d",
+					auto str = format("PCK:xcom3/ufodata/saucer.pck:xcom3/ufodata/saucer.tab:{}",
 					                  (int)(v.graphic_frame + i));
 					vehicle->animation_sprites.push_back(fw().data->loadImage(str));
 				}
 
-				auto str = format("PCK:xcom3/ufodata/saucer.pck:xcom3/ufodata/saucer.tab:%d",
+				auto str = format("PCK:xcom3/ufodata/saucer.pck:xcom3/ufodata/saucer.tab:{}",
 				                  (int)(v.graphic_frame + animFrames));
 
 				vehicle->crashed_sprite = fw().data->loadImage(str);
 
-				str = format("PCKSHADOW:xcom3/ufodata/shadow.pck:xcom3/ufodata/shadow.tab:%d",
+				str = format("PCKSHADOW:xcom3/ufodata/shadow.pck:xcom3/ufodata/shadow.tab:{}",
 				             (int)(v.shadow_graphic));
 				vehicle->directional_shadow_sprites[VehicleType::Direction::N] =
 				    fw().data->loadImage(str);
@@ -249,7 +249,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				// Therefore 49 + id gives map index for the ufo
 				if (i > 1)
 				{
-					vehicle->battle_map = {&state, format("%s%s", BattleMap::getPrefix(),
+					vehicle->battle_map = {&state, format("{}{}", BattleMap::getPrefix(),
 					                                      this->battleMapPaths[48 + i])};
 				}
 				// fill crews
@@ -306,7 +306,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 					for (auto &dir : directionsForThisBanking)
 					{
 						auto str =
-						    format("PCK:xcom3/ufodata/saucer.pck:xcom3/ufodata/saucer.tab:%d",
+						    format("PCK:xcom3/ufodata/saucer.pck:xcom3/ufodata/saucer.tab:{}",
 						           (int)(v.graphic_frame + image_offset++));
 						vehicle->directional_sprites[bank][dir] = fw().data->loadImage(str);
 					}
@@ -320,7 +320,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				for (auto &dir : directions)
 				{
 					auto str =
-					    format("PCKSHADOW:xcom3/ufodata/shadow.pck:xcom3/ufodata/shadow.tab:%d",
+					    format("PCKSHADOW:xcom3/ufodata/shadow.pck:xcom3/ufodata/shadow.tab:{}",
 					           (int)(v.shadow_graphic + image_offset++));
 					vehicle->directional_shadow_sprites[dir] = fw().data->loadImage(str);
 				}
@@ -328,7 +328,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		}
 		else
 		{
-			LogError("Unknown type for vehicle %s", id);
+			LogError("Unknown type for vehicle {}", id);
 		}
 
 		vehicle->acceleration = v.acceleration;
@@ -371,7 +371,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 			auto img = fw().data->loadImage(equipment_screen_image);
 			if (!img)
 			{
-				LogInfo("Skipping missing equipment screen image \"%s\"",
+				LogInfo("Skipping missing equipment screen image \"{}\"",
 				        equipment_screen_image.c_str());
 			}
 			else
@@ -383,7 +383,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		// The icons seem to be in index order starting at 4 (with 3 weird 'troop' icons and a
 		// megaspawn first?)
 		auto str = format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:{}:xcom3/ufodata/pal_01.dat",
 		    i + 4);
 		vehicle->icon = fw().data->loadImage(str);
 
@@ -391,10 +391,10 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		if (it != EquipscreenSprite.end())
 		{
 			auto str =
-			    format("PCK:xcom3/ufodata/bigveh.pck:xcom3/ufodata/bigveh.tab:%d", (int)it->second);
+			    format("PCK:xcom3/ufodata/bigveh.pck:xcom3/ufodata/bigveh.tab:{}", (int)it->second);
 			vehicle->equip_icon_big = fw().data->loadImage(str);
 
-			str = format("PCK:xcom3/ufodata/smalveh.pck:xcom3/ufodata/smalveh.tab:%d:xcom3/ufodata/"
+			str = format("PCK:xcom3/ufodata/smalveh.pck:xcom3/ufodata/smalveh.tab:{}:xcom3/ufodata/"
 			             "researc2.pcx",
 			             (int)it->second);
 			vehicle->equip_icon_small = fw().data->loadImage(str);
@@ -520,7 +520,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				losVoxelMapIndex = 111;
 				break;
 			default:
-				LogError("Unsupported vehicle loftemps index %d!", (int)v.loftemps_index);
+				LogError("Unsupported vehicle loftemps index {}!", (int)v.loftemps_index);
 		}
 
 		// read voxelmaps
@@ -535,7 +535,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		int end = v.size_z * 16 - freeSpace / 2;
 		if (end > 16)
 		{
-			LogInfo("Vehicle %s has height %d", vehicle->name, end);
+			LogInfo("Vehicle {} has height {}", vehicle->name, end);
 			end = end % 16;
 		}
 		if (freeSpace > 32)
@@ -587,14 +587,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      verticalVoxelMapIdx)));
 								vehicle
 								    ->voxelMapsLOS[FACING_NORTH]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 							}
 						}
@@ -677,14 +677,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      verticalVoxelMapIdx)));
 								vehicle
 								    ->voxelMapsLOS[FACING_NORTH]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing east
 								vehicle
@@ -692,14 +692,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      horizontalVoxelMapIndex)));
 								vehicle
 								    ->voxelMapsLOS[FACING_EAST]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing south
 								vehicle
@@ -707,14 +707,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      verticalVoxelMapIdx)));
 								vehicle
 								    ->voxelMapsLOS[FACING_SOUTH]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing west
 								vehicle
@@ -722,14 +722,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      horizontalVoxelMapIndex)));
 								vehicle
 								    ->voxelMapsLOS[FACING_WEST]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 							}
 						}
@@ -811,14 +811,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      122)));
 								vehicle
 								    ->voxelMapsLOS[FACING_NORTH]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing east
 								vehicle
@@ -826,14 +826,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      123)));
 								vehicle
 								    ->voxelMapsLOS[FACING_EAST]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing south
 								vehicle
@@ -841,14 +841,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      124)));
 								vehicle
 								    ->voxelMapsLOS[FACING_SOUTH]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing west
 								vehicle
@@ -856,14 +856,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								               [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      125)));
 								vehicle
 								    ->voxelMapsLOS[FACING_WEST]
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 							}
 						}
@@ -876,7 +876,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				if (v.size_x != 2 || v.size_y != 2)
 				{
 					LogError("Vehicle Type using loftemps 150 has invalid x and y size: expected "
-					         "2x2, got %dx%d",
+					         "2x2, got {}x{}",
 					         v.size_x, v.size_y);
 				}
 				// One facing, four maps
@@ -909,14 +909,14 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 							                              pair.first.y * v.size_x + pair.first.x]
 							    ->setSlice(i, fw().data->loadVoxelSlice(format(
 							                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-							                      "ufodata/loftemps.tab:%d",
+							                      "ufodata/loftemps.tab:{}",
 							                      pair.second)));
 							vehicle
 							    ->voxelMapsLOS[FACING_NORTH][z * v.size_y * v.size_x +
 							                                 pair.first.y * v.size_x + pair.first.x]
 							    ->setSlice(i, fw().data->loadVoxelSlice(format(
 							                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-							                      "ufodata/loftemps.tab:%d",
+							                      "ufodata/loftemps.tab:{}",
 							                      pair.second)));
 						}
 					}
@@ -1003,7 +1003,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing east
 								vehicle
@@ -1016,7 +1016,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing south
 								vehicle
@@ -1029,7 +1029,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 								// Facing west
 								vehicle
@@ -1042,7 +1042,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 								                  [z * v.size_y * v.size_x + y * v.size_x + x]
 								    ->setSlice(i, fw().data->loadVoxelSlice(format(
 								                      "LOFTEMPS:xcom3/ufodata/loftemps.dat:xcom3/"
-								                      "ufodata/loftemps.tab:%d",
+								                      "ufodata/loftemps.tab:{}",
 								                      losVoxelMapIndex)));
 							}
 						}

--- a/tools/extractors/main.cpp
+++ b/tools/extractors/main.cpp
@@ -106,12 +106,12 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 	     for (auto &imagePackStrings : e.unitImagePackPaths)
 	     {
 		     GameState s;
-		     LogInfo("Extracting image pack \"%s\"", imagePackStrings.first);
+		     LogInfo("Extracting image pack \"{}\"", imagePackStrings.first);
 
 		     auto imagePack = e.extractImagePack(s, imagePackStrings.second, false);
 		     if (!imagePack)
 		     {
-			     LogError("Failed to extract image pack \"%s\"", imagePackStrings.first);
+			     LogError("Failed to extract image pack \"{}\"", imagePackStrings.first);
 		     }
 		     else
 		     {
@@ -120,7 +120,7 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 			                                       imagePackStrings.first,
 			                                   true))
 			     {
-				     LogError("Failed to save image pack \"%s\"", imagePackStrings.first);
+				     LogError("Failed to save image pack \"{}\"", imagePackStrings.first);
 			     }
 		     }
 	     }
@@ -131,22 +131,22 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 	     for (int i = 0; i < itemImagePacksCount; i++)
 	     {
 		     GameState s;
-		     LogInfo("Extracting item image pack \"%d\"", i);
+		     LogInfo("Extracting item image pack \"{}\"", i);
 
 		     auto imagePack = e.extractItemImagePack(s, i);
 		     if (!imagePack)
 		     {
-			     LogError("Failed to extract  item image pack \"%d\"", i);
+			     LogError("Failed to extract  item image pack \"{}\"", i);
 		     }
 		     else
 		     {
 			     if (!imagePack->saveImagePack(
-			             format("%s%s%d",
+			             format("{}{}{}",
 			                    fw().getDataDir() + BattleUnitImagePack::getImagePackPath(),
 			                    "/item", i),
 			             true))
 			     {
-				     LogError("Failed to save  item image pack \"%d\"", i);
+				     LogError("Failed to save  item image pack \"{}\"", i);
 			     }
 		     }
 	     }
@@ -156,12 +156,12 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 	     for (auto &imagePackStrings : e.unitShadowPackPaths)
 	     {
 		     GameState s;
-		     LogInfo("Extracting image pack \"%s\"", imagePackStrings.first);
+		     LogInfo("Extracting image pack \"{}\"", imagePackStrings.first);
 
 		     auto imagePack = e.extractImagePack(s, imagePackStrings.second, true);
 		     if (!imagePack)
 		     {
-			     LogError("Failed to extract image pack \"%s\"", imagePackStrings.first);
+			     LogError("Failed to extract image pack \"{}\"", imagePackStrings.first);
 		     }
 		     else
 		     {
@@ -170,7 +170,7 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 			                                       imagePackStrings.first,
 			                                   true))
 			     {
-				     LogError("Failed to save image pack \"%s\"", imagePackStrings.first);
+				     LogError("Failed to save image pack \"{}\"", imagePackStrings.first);
 			     }
 		     }
 	     }
@@ -180,13 +180,13 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 	     for (auto &animationPackStrings : e.unitAnimationPackPaths)
 	     {
 		     GameState s;
-		     LogInfo("Extracting animation pack \"%s\"", animationPackStrings.first);
+		     LogInfo("Extracting animation pack \"{}\"", animationPackStrings.first);
 
 		     auto animationPack =
 		         e.extractAnimationPack(s, animationPackStrings.second, animationPackStrings.first);
 		     if (!animationPack)
 		     {
-			     LogError("Failed to extract animation pack \"%s\"", animationPackStrings.first);
+			     LogError("Failed to extract animation pack \"{}\"", animationPackStrings.first);
 		     }
 		     else
 		     {
@@ -195,7 +195,7 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 			                 animationPackStrings.first,
 			             true))
 			     {
-				     LogError("Failed to save animation pack \"%s\"", animationPackStrings.first);
+				     LogError("Failed to save animation pack \"{}\"", animationPackStrings.first);
 			     }
 		     }
 	     }
@@ -209,19 +209,19 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 		     if (tileSetName.empty())
 			     continue;
 		     GameState s;
-		     LogInfo("Extracting tileset \"%s\"", tileSetName);
+		     LogInfo("Extracting tileset \"{}\"", tileSetName);
 
 		     auto tileSet = e.extractTileSet(s, tileSetName);
 		     if (!tileSet)
 		     {
-			     LogError("Failed to extract tileset \"%s\"", tileSetName);
+			     LogError("Failed to extract tileset \"{}\"", tileSetName);
 		     }
 		     else
 		     {
 			     if (!tileSet->saveTileset(BattleMapTileset::getTilesetPath() + "/" + tileSetName,
 			                               true))
 			     {
-				     LogError("Failed to save tileset \"%s\"", tileSetName);
+				     LogError("Failed to save tileset \"{}\"", tileSetName);
 			     }
 		     }
 	     }
@@ -234,13 +234,13 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 		     if (mapName.empty())
 			     continue;
 		     GameState s;
-		     LogInfo("Extracting map sectors from \"%s\"", mapName);
+		     LogInfo("Extracting map sectors from \"{}\"", mapName);
 
 		     auto sectors = e.extractMapSectors(s, mapName);
-		     LogInfo("Extracted %u sectors from \"%s\"", (unsigned)sectors.size(), mapName);
+		     LogInfo("Extracted {} sectors from \"{}\"", (unsigned)sectors.size(), mapName);
 		     if (sectors.empty())
 		     {
-			     LogError("Failed to sectors from map \"%s\"", mapName);
+			     LogError("Failed to sectors from map \"{}\"", mapName);
 		     }
 		     for (auto &sectorPair : sectors)
 		     {
@@ -249,7 +249,7 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 			     auto path = BattleMapSectorTiles::getMapSectorPath();
 			     if (!sector->saveSector(path + "/" + sectorName, true))
 			     {
-				     LogError("Failed to save map sector \"%s\"", sectorName);
+				     LogError("Failed to save map sector \"{}\"", sectorName);
 			     }
 		     }
 	     }
@@ -288,7 +288,7 @@ int main(int argc, char *argv[])
 			auto extractor = thingsToExtract.find(extractorName);
 			if (extractor == thingsToExtract.end())
 			{
-				LogError("Unknown extractor %s", extractorName);
+				LogError("Unknown extractor {}", extractorName);
 				return EXIT_FAILURE;
 			}
 			else
@@ -302,7 +302,7 @@ int main(int argc, char *argv[])
 	InitialGameStateExtractor initialGameStateExtractor;
 	for (auto &ePair : extractorsToRun)
 	{
-		LogWarning("Running %s", ePair.first);
+		LogWarning("Running {}", ePair.first);
 		TraceObj exTrace(ePair.first);
 		ePair.second(initialGameStateExtractor);
 	}

--- a/tools/form_localisation/CMakeLists.txt
+++ b/tools/form_localisation/CMakeLists.txt
@@ -1,0 +1,21 @@
+# project name, and type
+PROJECT(OpenApoc_FormLocalisation CXX C)
+
+# check cmake version
+CMAKE_MINIMUM_REQUIRED(VERSION 3.9)
+
+set (FORMLOCALISATION_SOURCE_FILES
+	main.cpp)
+
+source_group(formlocalisation\\sources FILES ${FORMLOCALISATION_SOURCE_FILES})
+
+list(APPEND ALL_SOURCE_FILES ${FORMLOCALISATION_SOURCE_FILES})
+
+add_executable(OpenApoc_FormLocalisation ${FORMLOCALISATION_SOURCE_FILES}
+		${FORMLOCALISATION_HEADER_FILES})
+
+set( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
+
+target_link_libraries(OpenApoc_FormLocalisation OpenApoc_LibPugixml)
+
+target_include_directories(OpenApoc_FormLocalisation PUBLIC ${CMAKE_SOURCE_DIR})

--- a/tools/form_localisation/CMakeLists.txt
+++ b/tools/form_localisation/CMakeLists.txt
@@ -19,3 +19,16 @@ set( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
 target_link_libraries(OpenApoc_FormLocalisation OpenApoc_LibPugixml)
 
 target_include_directories(OpenApoc_FormLocalisation PUBLIC ${CMAKE_SOURCE_DIR})
+
+file(GLOB_RECURSE FORM_FILES ${CMAKE_SOURCE_DIR}/data/forms/*.form)
+
+set(FORM_POT_FILE ${CMAKE_SOURCE_DIR}/data/languages/forms.pot)
+
+
+add_custom_command(
+		OUTPUT ${FORM_POT_FILE}
+		COMMAND OpenApoc_FormLocalisation ${FORM_FILES} > ${FORM_POT_FILE}
+		DEPENDS ${FORM_FILES})
+
+add_custom_target(update-form-translations
+		DEPENDS ${FORM_POT_FILE})

--- a/tools/form_localisation/CMakeLists.txt
+++ b/tools/form_localisation/CMakeLists.txt
@@ -30,5 +30,5 @@ add_custom_command(
 		COMMAND OpenApoc_FormLocalisation ${FORM_FILES} > ${FORM_POT_FILE}
 		DEPENDS ${FORM_FILES})
 
-add_custom_target(update-form-translations
+add_custom_target(extract-form-translations
 		DEPENDS ${FORM_POT_FILE})

--- a/tools/form_localisation/main.cpp
+++ b/tools/form_localisation/main.cpp
@@ -1,0 +1,140 @@
+#include "dependencies/pugixml/src/pugixml.hpp"
+
+#include <iostream>
+#include <set>
+#include <string>
+#include <string_view>
+
+const auto header = R"foo(msgid ""
+msgstr ""
+"Project-Id-Version: OpenApoc\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2020-01-04 16:20+0800\n"
+"Last-Translator: JonnyH\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/x-com-apocalypse/apocalypse/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+
+)foo";
+
+static std::string escape_character(const char ch)
+{
+	if (ch == '"')
+		return "\\\"";
+	if (std::isprint(ch))
+		return std::string{ch};
+	else
+	{
+		std::cerr << "Unknown char 0x" << std::hex << (int)ch << "\n";
+		return "";
+	}
+}
+
+static std::string escape_string(const std::string_view str)
+{
+	std::string escaped;
+	for (const auto ch : str)
+	{
+		escaped += escape_character(ch);
+	}
+
+	return escaped;
+}
+
+void read_tooltip(pugi::xml_node &node, std::set<std::string> &strings)
+{
+	std::string_view text = node.attribute("text").as_string();
+	if (!text.empty())
+	{
+		strings.emplace(text);
+	}
+}
+
+void read_control(pugi::xml_node &node, std::set<std::string> &strings)
+
+{
+	const std::string_view node_name = node.name();
+
+	if (node_name == "label" || node_name == "textbutton" || node_name == "textedit")
+	{
+		std::string_view text = node.attribute("text").as_string();
+		if (!text.empty())
+		{
+			strings.emplace(text);
+		}
+	}
+
+	for (auto child : node.children())
+	{
+		const std::string_view child_name = child.name();
+		if (child_name == "control")
+		{
+			read_control(child, strings);
+		}
+		if (child_name == "tooltip")
+		{
+			read_tooltip(child, strings);
+		}
+	}
+}
+
+void read_style(pugi::xml_node &node, std::set<std::string> &strings)
+{
+	for (auto child : node.children())
+	{
+		read_control(child, strings);
+	}
+}
+
+void read_form(pugi::xml_node &node, std::set<std::string> &strings)
+{
+	for (auto child : node.children("style"))
+	{
+		read_style(child, strings);
+	}
+}
+
+int main(int argc, char **argv)
+{
+	std::set<std::string> strings;
+
+	for (int i = 1; i < argc; i++)
+	{
+		pugi::xml_document doc;
+		auto result = doc.load_file(argv[i]);
+		if (!result)
+		{
+			std::cerr << "Failed to read form \"" << argv[i] << "\" : \"" << result.description()
+			          << "\"\n";
+			return EXIT_FAILURE;
+		}
+		auto node = doc.child("openapoc");
+		if (!node)
+		{
+			std::cerr << "No \"openapoc\" root element in form file \"" << argv[i] << "\"\n";
+			return EXIT_FAILURE;
+		}
+
+		auto child = node.child("form");
+		if (!child)
+		{
+			std::cerr << "No \"openapoc.form\" element in form file \"" << argv[i] << "\"\n";
+			return EXIT_FAILURE;
+		}
+
+		read_form(child, strings);
+	}
+
+	std::cout << header;
+
+	for (const auto &string : strings)
+	{
+		const auto escaped_string = escape_string(string);
+		std::cout << "msgid \"" << escaped_string << "\"\n";
+		std::cout << "msgstr \"" << escaped_string << "\"\n\n";
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/tools/form_localisation/main.cpp
+++ b/tools/form_localisation/main.cpp
@@ -4,6 +4,7 @@
 #include <set>
 #include <string>
 #include <string_view>
+#include <cctype>
 
 const auto header = R"foo(msgid ""
 msgstr ""

--- a/tools/form_localisation/main.cpp
+++ b/tools/form_localisation/main.cpp
@@ -1,10 +1,10 @@
 #include "dependencies/pugixml/src/pugixml.hpp"
 
+#include <cctype>
 #include <iostream>
 #include <set>
 #include <string>
 #include <string_view>
-#include <cctype>
 
 const auto header = R"foo(msgid ""
 msgstr ""

--- a/tools/form_localisation/main.cpp
+++ b/tools/form_localisation/main.cpp
@@ -134,7 +134,7 @@ int main(int argc, char **argv)
 	{
 		const auto escaped_string = escape_string(string);
 		std::cout << "msgid \"" << escaped_string << "\"\n";
-		std::cout << "msgstr \"" << escaped_string << "\"\n\n";
+		std::cout << "msgstr \"\"\n\n";
 	}
 
 	return EXIT_SUCCESS;

--- a/tools/gamestate_localisation/CMakeLists.txt
+++ b/tools/gamestate_localisation/CMakeLists.txt
@@ -1,0 +1,30 @@
+# project name, and type
+PROJECT(OpenApoc_GamestateLocalisation CXX C)
+
+# check cmake version
+CMAKE_MINIMUM_REQUIRED(VERSION 3.9)
+
+set(THREADS_PREFER_PTHREAD_FLAG ON)
+find_package (Threads REQUIRED)
+
+set (GAMESTATELOCALISATION_SOURCE_FILES
+	main.cpp)
+
+source_group(gamestatelocalisation\\sources FILES ${GAMESTATELOCALISATION_SOURCE_FILES})
+
+set (GAMESTATELOCALISATION_HEADER_FILES
+	)
+
+source_group(gamestatelocalisation\\headers FILES ${GAMESTATELOCALISATION_HEADER_FILES})
+
+list(APPEND ALL_SOURCE_FILES ${GAMESTATELOCALISATION_SOURCE_FILES})
+list(APPEND ALL_HEADER_FILES ${GAMESTATELOCALISATION_HEADER_FILES})
+
+add_executable(OpenApoc_GamestateLocalisation ${GAMESTATELOCALISATION_SOURCE_FILES}
+		${GAMESTATELOCALISATION_HEADER_FILES})
+
+set( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
+
+target_link_libraries(OpenApoc_GamestateLocalisation OpenApoc_Library)
+target_link_libraries(OpenApoc_GamestateLocalisation OpenApoc_Framework)
+target_link_libraries(OpenApoc_GamestateLocalisation OpenApoc_GameState)

--- a/tools/gamestate_localisation/CMakeLists.txt
+++ b/tools/gamestate_localisation/CMakeLists.txt
@@ -28,3 +28,14 @@ set( EXECUTABLE_OUTPUT_PATH ${CMAKE_BINARY_DIR}/bin )
 target_link_libraries(OpenApoc_GamestateLocalisation OpenApoc_Library)
 target_link_libraries(OpenApoc_GamestateLocalisation OpenApoc_Framework)
 target_link_libraries(OpenApoc_GamestateLocalisation OpenApoc_GameState)
+
+set(BASE_GAMESTATE_POT_FILE ${CMAKE_SOURCE_DIR}/data/languages/base_gamestate.pot)
+set(BASE_GAMESTATE_SOURCE_FILE ${CMAKE_SOURCE_DIR}/data/mods/base/base_gamestate)
+
+add_custom_command(
+OUTPUT ${BASE_GAMESTATE_POT_FILE}
+COMMAND OpenApoc_GamestateLocalisation ${BASE_GAMESTATE_SOURCE_FILE} --Framework.CD=${CD_PATH} --Framework.Data=${CMAKE_SOURCE_DIR}/data> ${BASE_GAMESTATE_POT_FILE}
+DEPENDS ${BASE_GAMESTATE_SOURCE_FILE})
+
+add_custom_target(extract-gamestate-translations
+		DEPENDS ${BASE_GAMESTATE_POT_FILE})

--- a/tools/gamestate_localisation/main.cpp
+++ b/tools/gamestate_localisation/main.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <sstream>
 #include <string_view>
+#include <cctype>
 
 const auto header = R"foo(msgid ""
 msgstr ""

--- a/tools/gamestate_localisation/main.cpp
+++ b/tools/gamestate_localisation/main.cpp
@@ -4,10 +4,10 @@
 #include "framework/logger.h"
 #include "game/state/gamestate.h"
 #include "game/state/gamestate_serialize.h"
+#include <cctype>
 #include <iostream>
 #include <sstream>
 #include <string_view>
-#include <cctype>
 
 const auto header = R"foo(msgid ""
 msgstr ""

--- a/tools/gamestate_localisation/main.cpp
+++ b/tools/gamestate_localisation/main.cpp
@@ -1,0 +1,88 @@
+#include "framework/configfile.h"
+#include "framework/filesystem.h"
+#include "framework/framework.h"
+#include "framework/logger.h"
+#include "game/state/gamestate.h"
+#include "game/state/gamestate_serialize.h"
+#include <iostream>
+#include <sstream>
+#include <string_view>
+
+const auto header = R"foo(msgid ""
+msgstr ""
+"Project-Id-Version: OpenApoc\n"
+"POT-Creation-Date: \n"
+"PO-Revision-Date: 2020-01-04 16:20+0800\n"
+"Last-Translator: JonnyH\n"
+"Language-Team: English (United Kingdom) (http://www.transifex.com/x-com-apocalypse/apocalypse/language/en_GB/)\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Language: en_GB\n"
+
+)foo";
+
+static std::string escape_character(const char ch)
+{
+	if (ch == '"')
+		return "\\\"";
+	if (std::isprint(ch))
+		return std::string{ch};
+	else
+	{
+		std::cerr << "Unknown char 0x" << std::hex << (int)ch << "\n";
+		return "";
+	}
+}
+
+static std::string escape_string(const std::string_view str)
+{
+	std::string escaped;
+	for (const auto ch : str)
+	{
+		escaped += escape_character(ch);
+	}
+
+	return escaped;
+}
+
+int main(int argc, char **argv)
+{
+	OpenApoc::config().addPositionalArgument("input", "Input file");
+
+	if (OpenApoc::config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+
+	auto input1 = OpenApoc::config().getString("input");
+	if (input1.empty())
+	{
+		std::cerr << "Must provide at least input\n";
+		OpenApoc::config().showHelp();
+		return EXIT_FAILURE;
+	}
+
+	const auto state_path = OpenApoc::config().getString("input");
+
+	OpenApoc::Framework fw("OpenApoc", false);
+
+	auto state = OpenApoc::mksp<OpenApoc::GameState>();
+	state->populate_translateable_strings = true;
+	if (!state->loadGame(state_path))
+	{
+		std::cerr << "Failed to load input file \"" << state_path << "\"\n";
+		return EXIT_FAILURE;
+	}
+
+	std::cout << header;
+
+	for (const auto &string : state->translateable_strings)
+	{
+		const auto escaped_string = escape_string(string.cStr());
+		std::cout << "msgid \"" << escaped_string << "\"\n";
+		std::cout << "msgstr \"\"\n\n";
+	}
+
+	return EXIT_SUCCESS;
+}

--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -22,7 +22,7 @@ static std::list<std::pair<UString, ModInfo>> enumerateMods()
 	fs::path modPath = Options::modPath.get().str();
 	if (!fs::is_directory(modPath))
 	{
-		LogError("Mod path \"%s\" not a valid directory", modPath.string());
+		LogError("Mod path \"{}\" not a valid directory", modPath.string());
 		return {};
 	}
 
@@ -218,7 +218,7 @@ void LauncherWindow::play()
 	QString path = QCoreApplication::applicationDirPath() + "/OpenApoc";
 #endif
 
-	LogWarning("Running \"%s\"", path.toStdString());
+	LogWarning("Running \"{}\"", path.toStdString());
 	const auto ret = QProcess::startDetached(path);
 	if (!ret)
 	{
@@ -354,7 +354,7 @@ void LauncherWindow::showModInfo(const ModInfo &info)
 	ui->modVersion->setText(QString::fromStdString(info.getVersion().str()));
 	ui->modDescription->setText(QString::fromStdString(info.getDescription().str()));
 
-	auto linkText = format("<a href=\"%s\">%s</a>", info.getLink(), info.getLink());
+	auto linkText = format("<a href=\"{}\">{}</a>", info.getLink(), info.getLink());
 
 	ui->modLink->setText(QString::fromStdString(linkText.str()));
 }

--- a/tools/serialization_tool/main.cpp
+++ b/tools/serialization_tool/main.cpp
@@ -68,14 +68,14 @@ int main(int argc, char **argv)
 	auto state = OpenApoc::mksp<OpenApoc::GameState>();
 	if (!state->loadGame(input1))
 	{
-		LogError("Failed to load input file \"%s\"", input1);
+		LogError("Failed to load input file \"{}\"", input1);
 		return EXIT_FAILURE;
 	}
 	if (!input2.empty())
 	{
 		if (!state->loadGame(input2))
 		{
-			LogError("Failed to load second input file \"%s\"", input2);
+			LogError("Failed to load second input file \"{}\"", input2);
 			return EXIT_FAILURE;
 		}
 	}
@@ -86,14 +86,14 @@ int main(int argc, char **argv)
 	{
 		if (!referenceState->loadGame(deltaPath))
 		{
-			LogError("Failed to load delta gamestate \"%s\"", parentGamestate);
+			LogError("Failed to load delta gamestate \"{}\"", parentGamestate);
 			return EXIT_FAILURE;
 		}
 	}
 
 	if (!state->saveGameDelta(outputPath, *referenceState, pack, pretty))
 	{
-		LogError("Failed to write output gamestate to \"%s\"", outputPath);
+		LogError("Failed to write output gamestate to \"{}\"", outputPath);
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
Adds tools to dump translate-able text from .form files, as well as a tool to dump strings from a GameState archive (mod, base gamestate etc.)

These .pot files can then be merged and uploaded to transifex - long term goal would be to enable a cmake target to do much of that automatically.

TODO:
- The GameState strings extraction is a big hack, hooking into serializeIn() in nasty ways - better solutions would be to write a whole new generate GameState call tree, possibly allow some visitor-like interaction?
  * This also ends up requiring constructing a GameState and all that implies (reads all kinds of unneeded data, needs access to a data/ folder populated with extracted files)
  * Maybe could be merged into the SerializationTool?
- The form reader is manual xml - maybe doing something similar with the forms code (IE define the expected tree structure and allow visitors?) would allow better code sharing there? As currently the forms loading is a bit ad-hoc :)
- I've added fmtlib, and xgettext target to pull from a "tformat()" function - the plan being we can replace "format(tr("string %s"), whatever)" with "tformat("string {0}", whatever)" etc.
  * Note that would require a pretty significant change in many existing strings - possibly invalidating some transifex work (but inevitable, may as well rip the plaster off as early as possible)
- Think of some way of adding mods translation databases