### PR TITLE
Fix to #799

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -88,11 +88,14 @@ void Base::die(GameState &state, bool collapse)
 	}
 	for (auto a : building->currentAgents)
 	{
-		a->die(state, true);
+		auto agent = a;
+		agent->die(state, true);
 	}
-	for (auto v : building->currentVehicles)
+	auto vehicles = building->currentVehicles;
+	for (auto v : vehicles)
 	{
-		v->die(state, true);
+		auto vehicle = v;
+		vehicle->die(state, true);
 	}
 	building->base.clear();
 	building->owner = state.getGovernment();

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -105,6 +105,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 
 	std::list<EventMessage> messages;
 
+	int baseIndex = 1;
 	int difficulty = 0;
 	bool firstDetection = false;
 	uint64_t nextInvasion = 0;

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -62,6 +62,7 @@
 		<member type="Section">equipment_sets_by_level</member>
 		<member type="Section">building_functions</member>
 		<member>messages</member>
+    <member>baseIndex</member>
 		<member>difficulty</member>
 		<member>firstDetection</member>
 		<member>nextInvasion</member>
@@ -2039,3 +2040,4 @@
 		<member>cityDamage</member>
 	</object>
 </openapoc_gamestate>
+

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -141,9 +141,11 @@ void BaseBuyScreen::eventOccurred(Event *e)
 						a.second->setMission(*state, AgentMission::gotoBuilding(*state, *a.second));
 					}
 				}
-				base->name = "Base " + Strings::fromInteger(state->player_bases.size() + 1);
-				state->player_bases[Base::getPrefix() +
-				                    Strings::fromInteger(state->player_bases.size() + 1)] = base;
+
+				state->baseIndex += 1;
+				base->name = "Base " + Strings::fromInteger(state->baseIndex);
+				state->player_bases[Base::getPrefix() + Strings::fromInteger(state->baseIndex)] =
+				    base;
 				base->building->base = {state.get(), base};
 
 				fw().stageQueueCommand({StageCmd::Command::REPLACE, mksp<CityView>(state)});

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1532,7 +1532,29 @@ void CityView::resume()
 	modifierRShift = false;
 
 	this->uiTabs[0]->findControlTyped<Label>("TEXT_BASE_NAME")->setText(state->current_base->name);
-	miniViews.clear();
+
+	refreshBaseView();
+}
+
+void CityView::refreshBaseView()
+{
+	if (miniViews.size() != state->player_bases.size())
+	{
+		this->uiTabs[0]
+		    ->findControlTyped<Label>("TEXT_BASE_NAME")
+		    ->setText(state->current_base->name);
+		for (auto view : miniViews)
+		{
+			view->setData(nullptr);
+			view->setImage(nullptr);
+			view->setDepressedImage(nullptr);
+			view->ToolTipText = "";
+			view->setVisible(false);
+		}
+
+		miniViews.clear();
+	}
+
 	int b = 0;
 	for (auto &pair : state->player_bases)
 	{
@@ -1543,6 +1565,7 @@ void CityView::resume()
 		{
 			LogError("Failed to find UI control matching \"%s\"", viewName);
 		}
+		view->setVisible(true);
 		view->setData(viewBase);
 		auto viewImage = BaseGraphics::drawMiniBase(*viewBase);
 		view->setImage(viewImage);
@@ -1806,6 +1829,12 @@ void CityView::update()
 	// Update time display
 	auto clockControl = baseForm->findControlTyped<Label>("CLOCK");
 	clockControl->setText(state->gameTime.getLongTimeString());
+
+	// Update base icons
+	if (activeTab == uiTabs[0])
+	{
+		refreshBaseView();
+	}
 
 	// Update owned vehicle controls
 	if (activeTab == uiTabs[1])

--- a/game/ui/tileview/cityview.h
+++ b/game/ui/tileview/cityview.h
@@ -128,6 +128,7 @@ class CityView : public CityTileView
 
 	void begin() override;
 	void resume() override;
+	void refreshBaseView();
 	void update() override;
 	void render() override;
 	void eventOccurred(Event *e) override;


### PR DESCRIPTION
Refreshes base icons after losing a base.
Keeps track of the base number uses it to continually name new bases.