### PR TITLE
Androids do not trigger brainsucker pods

### DIFF
--- a/data/common_patch/gamestate/agent_types.xml
+++ b/data/common_patch/gamestate/agent_types.xml
@@ -535,6 +535,7 @@
       <improvementPercentagePhysical>100</improvementPercentagePhysical>
 	  <improvementPercentagePsi>100</improvementPercentagePsi>
 	  <canTrain>true</canTrain>
+      <immuneToBrainsuckers>false</immuneToBrainsuckers>
       <playable>true</playable>
       <allowsDirectControl>true</allowsDirectControl>
       <aiType>Group</aiType>
@@ -778,6 +779,7 @@
       <improvementPercentagePhysical>100</improvementPercentagePhysical>
 	  <improvementPercentagePsi>100</improvementPercentagePsi>
 	  <canTrain>true</canTrain>
+      <immuneToBrainsuckers>false</immuneToBrainsuckers>
       <playable>true</playable>
       <allowsDirectControl>true</allowsDirectControl>
       <aiType>Group</aiType>
@@ -973,6 +975,7 @@
       <improvementPercentagePhysical>10</improvementPercentagePhysical>
 	  <improvementPercentagePsi>0</improvementPercentagePsi>
 	  <canTrain>false</canTrain>
+      <immuneToBrainsuckers>true</immuneToBrainsuckers>
       <playable>true</playable>
       <allowsDirectControl>true</allowsDirectControl>
       <aiType>Group</aiType>

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -3707,7 +3707,7 @@ void BattleUnit::triggerProximity(GameState &state)
 void BattleUnit::triggerBrainsuckers(GameState &state)
 {
 	// Androids do not trigger brainsuckers
-	if(this->agent->type->canTrain == false)
+	if(this->agent->type->immuneToBrainsuckers == false)
 	{
 		return;
 	}

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -3706,6 +3706,12 @@ void BattleUnit::triggerProximity(GameState &state)
 
 void BattleUnit::triggerBrainsuckers(GameState &state)
 {
+	// Androids do not trigger brainsuckers
+	if(this->agent->type->canTrain == false)
+	{
+		return;
+	}
+	
 	StateRef<DamageType> brainsucker = {&state, "DAMAGETYPE_BRAINSUCKER"};
 	if (brainsucker->dealDamage(100, agent->type->damage_modifier) == 0)
 		return;

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -3707,11 +3707,11 @@ void BattleUnit::triggerProximity(GameState &state)
 void BattleUnit::triggerBrainsuckers(GameState &state)
 {
 	// Androids do not trigger brainsuckers
-	if(this->agent->type->immuneToBrainsuckers)
+	if (this->agent->type->immuneToBrainsuckers)
 	{
 		return;
 	}
-	
+
 	StateRef<DamageType> brainsucker = {&state, "DAMAGETYPE_BRAINSUCKER"};
 	if (brainsucker->dealDamage(100, agent->type->damage_modifier) == 0)
 		return;

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -3707,7 +3707,7 @@ void BattleUnit::triggerProximity(GameState &state)
 void BattleUnit::triggerBrainsuckers(GameState &state)
 {
 	// Androids do not trigger brainsuckers
-	if(this->agent->type->immuneToBrainsuckers == false)
+	if(this->agent->type->immuneToBrainsuckers)
 	{
 		return;
 	}

--- a/game/state/rules/agenttype.h
+++ b/game/state/rules/agenttype.h
@@ -187,6 +187,8 @@ class AgentType : public StateObject<AgentType>
 	int improvementPercentagePsi = 0;
 	// Can be assigned to training
 	bool canTrain = false;
+	// Is agent immune to brainsuckers
+	bool immuneToBrainsuckers = false;
 	// Can this be generated for the player
 	bool playable = false;
 	// Can this be controlled by a player (if false, even when control is gained, AI will act)


### PR DESCRIPTION
The brainsucker pods are triggering correctly but Androids should not trigger them.
#762

I think this is how it worked in the original. In the original the aliens do not even target the androids if they are carrying the brainsucker launcher.