### PR TITLE
Use CRTP-style inherited StateObject template

### DIFF
--- a/game/state/battle/battledoor.cpp
+++ b/game/state/battle/battledoor.cpp
@@ -14,7 +14,7 @@
 namespace OpenApoc
 {
 
-sp<BattleDoor> BattleDoor::get(const GameState &state, const UString &id)
+template <> sp<BattleDoor> StateObject<BattleDoor>::get(const GameState &state, const UString &id)
 {
 	auto it = state.current_battle->doors.find(id);
 	if (it == state.current_battle->doors.end())
@@ -25,17 +25,18 @@ sp<BattleDoor> BattleDoor::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &BattleDoor::getPrefix()
+template <> const UString &StateObject<BattleDoor>::getPrefix()
 {
 	static UString prefix = "BATTLEDOOR_";
 	return prefix;
 }
-const UString &BattleDoor::getTypeName()
+template <> const UString &StateObject<BattleDoor>::getTypeName()
 {
 	static UString name = "BattleDoor";
 	return name;
 }
-const UString &BattleDoor::getId(const GameState &state, const sp<BattleDoor> ptr)
+template <>
+const UString &StateObject<BattleDoor>::getId(const GameState &state, const sp<BattleDoor> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.current_battle->doors)

--- a/game/state/battle/battledoor.h
+++ b/game/state/battle/battledoor.h
@@ -15,9 +15,8 @@ class BattleMapPart;
 class Battle;
 class Sample;
 
-class BattleDoor : public StateObject, public std::enable_shared_from_this<BattleDoor>
+class BattleDoor : public StateObject<BattleDoor>, public std::enable_shared_from_this<BattleDoor>
 {
-	STATE_OBJECT(BattleDoor)
   public:
 	UString id;
 

--- a/game/state/battle/battlescanner.cpp
+++ b/game/state/battle/battlescanner.cpp
@@ -10,19 +10,20 @@ BattleScanner::BattleScanner()
 	movementTicks = std::vector<int>(MOTION_SCANNER_X * MOTION_SCANNER_Y, 0);
 }
 
-const UString &BattleScanner::getPrefix()
+template <> const UString &StateObject<BattleScanner>::getPrefix()
 {
 	static UString prefix = "BATTLESCANNER_";
 	return prefix;
 }
 
-const UString &BattleScanner::getTypeName()
+template <> const UString &StateObject<BattleScanner>::getTypeName()
 {
 	static UString name = "BattleScanner";
 	return name;
 }
 
-sp<BattleScanner> BattleScanner::get(const GameState &state, const UString &id)
+template <>
+sp<BattleScanner> StateObject<BattleScanner>::get(const GameState &state, const UString &id)
 {
 	auto it = state.current_battle->scanners.find(id);
 	if (it == state.current_battle->scanners.end())

--- a/game/state/battle/battlescanner.h
+++ b/game/state/battle/battlescanner.h
@@ -22,9 +22,8 @@ static const unsigned TICKS_SCANNER_REMAIN_LIT = TICKS_PER_TURN / 2;
 
 class BattleUnit;
 
-class BattleScanner : public StateObject
+class BattleScanner : public StateObject<BattleScanner>
 {
-	STATE_OBJECT(BattleScanner)
 
   public:
 	BattleScanner();

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -47,7 +47,7 @@ static const std::map<int, Vec2<int>> dir_facing_map = {{0, {0, -1}}, {1, {1, -1
                                                         {6, {-1, 0}}, {7, {-1, -1}}};
 } // namespace
 
-sp<BattleUnit> BattleUnit::get(const GameState &state, const UString &id)
+template <> sp<BattleUnit> StateObject<BattleUnit>::get(const GameState &state, const UString &id)
 {
 	auto it = state.current_battle->units.find(id);
 	if (it == state.current_battle->units.end())
@@ -58,17 +58,18 @@ sp<BattleUnit> BattleUnit::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &BattleUnit::getPrefix()
+template <> const UString &StateObject<BattleUnit>::getPrefix()
 {
 	static UString prefix = "BATTLEUNIT_";
 	return prefix;
 }
-const UString &BattleUnit::getTypeName()
+template <> const UString &StateObject<BattleUnit>::getTypeName()
 {
 	static UString name = "BattleUnit";
 	return name;
 }
-const UString &BattleUnit::getId(const GameState &state, const sp<BattleUnit> ptr)
+template <>
+const UString &StateObject<BattleUnit>::getId(const GameState &state, const sp<BattleUnit> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.current_battle->units)

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -140,9 +140,8 @@ static const std::list<BattleUnitType> BattleUnitTypeList = {
     BattleUnitType::LargeFlyer, BattleUnitType::LargeWalker, BattleUnitType::SmallFlyer,
     BattleUnitType::SmallWalker};
 
-class BattleUnit : public StateObject, public std::enable_shared_from_this<BattleUnit>
+class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_from_this<BattleUnit>
 {
-	STATE_OBJECT(BattleUnit)
   public:
 	// [Enums]
 

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -20,6 +20,39 @@ namespace OpenApoc
 
 constexpr int Base::SIZE;
 
+template <> sp<Base> StateObject<Base>::get(const GameState &state, const UString &id)
+{
+	auto it = state.player_bases.find(id);
+	if (it == state.player_bases.end())
+	{
+		LogError("No baseas matching ID \"%s\"", id);
+		return nullptr;
+	}
+	return it->second;
+}
+
+template <> const UString &StateObject<Base>::getPrefix()
+{
+	static UString prefix = "BASE_";
+	return prefix;
+}
+template <> const UString &StateObject<Base>::getTypeName()
+{
+	static UString name = "Base";
+	return name;
+}
+template <> const UString &StateObject<Base>::getId(const GameState &state, const sp<Base> ptr)
+{
+	static const UString emptyString = "";
+	for (auto &b : state.player_bases)
+	{
+		if (b.second == ptr)
+			return b.first;
+	}
+	LogError("No base matching pointer %p", ptr.get());
+	return emptyString;
+}
+
 Base::Base(GameState &state, StateRef<Building> building) : building(building)
 {
 	corridors = std::vector<std::vector<bool>>(SIZE, std::vector<bool>(SIZE, false));
@@ -546,38 +579,5 @@ int Base::getUsage(GameState &state, FacilityType::Capacity type, int delta) con
 
 	// + total / 2  due to rounding
 	return std::min(999, (100 * used + total / 2) / total);
-}
-
-sp<Base> Base::get(const GameState &state, const UString &id)
-{
-	auto it = state.player_bases.find(id);
-	if (it == state.player_bases.end())
-	{
-		LogError("No baseas matching ID \"%s\"", id);
-		return nullptr;
-	}
-	return it->second;
-}
-
-const UString &Base::getPrefix()
-{
-	static UString prefix = "BASE_";
-	return prefix;
-}
-const UString &Base::getTypeName()
-{
-	static UString name = "Base";
-	return name;
-}
-const UString &Base::getId(const GameState &state, const sp<Base> ptr)
-{
-	static const UString emptyString = "";
-	for (auto &b : state.player_bases)
-	{
-		if (b.second == ptr)
-			return b.first;
-	}
-	LogError("No base matching pointer %p", ptr.get());
-	return emptyString;
 }
 }; // namespace OpenApoc

--- a/game/state/city/base.h
+++ b/game/state/city/base.h
@@ -16,9 +16,8 @@ class Facility;
 class GameState;
 class Organisation;
 
-class Base : public StateObject, public std::enable_shared_from_this<Base>
+class Base : public StateObject<Base>, public std::enable_shared_from_this<Base>
 {
-	STATE_OBJECT(Base)
   public:
 	std::vector<std::vector<bool>> corridors;
 	std::vector<sp<Facility>> facilities;

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -17,7 +17,8 @@
 namespace OpenApoc
 {
 
-sp<BuildingFunction> BuildingFunction::get(const GameState &state, const UString &id)
+template <>
+sp<BuildingFunction> StateObject<BuildingFunction>::get(const GameState &state, const UString &id)
 {
 	auto it = state.building_functions.find(id);
 	if (it == state.building_functions.end())
@@ -28,18 +29,18 @@ sp<BuildingFunction> BuildingFunction::get(const GameState &state, const UString
 	return it->second;
 }
 
-const UString &BuildingFunction::getPrefix()
+template <> const UString &StateObject<BuildingFunction>::getPrefix()
 {
 	static UString prefix = "BUILDINGFUNCTION_";
 	return prefix;
 }
-const UString &BuildingFunction::getTypeName()
+template <> const UString &StateObject<BuildingFunction>::getTypeName()
 {
 	static UString name = "AgentType";
 	return name;
 }
 
-sp<Building> Building::get(const GameState &state, const UString &id)
+template <> sp<Building> StateObject<Building>::get(const GameState &state, const UString &id)
 {
 	for (auto &city : state.cities)
 	{
@@ -52,18 +53,19 @@ sp<Building> Building::get(const GameState &state, const UString &id)
 	return nullptr;
 }
 
-const UString &Building::getPrefix()
+template <> const UString &StateObject<Building>::getPrefix()
 {
 	static UString prefix = "BUILDING_";
 	return prefix;
 }
-const UString &Building::getTypeName()
+template <> const UString &StateObject<Building>::getTypeName()
 {
 	static UString name = "Building";
 	return name;
 }
 
-const UString &Building::getId(const GameState &state, const sp<Building> ptr)
+template <>
+const UString &StateObject<Building>::getId(const GameState &state, const sp<Building> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &c : state.cities)

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -33,9 +33,8 @@ class Cargo;
 class UfopaediaEntry;
 class ResearchTopic;
 
-class BuildingFunction : public StateObject
+class BuildingFunction : public StateObject<BuildingFunction>
 {
-	STATE_OBJECT(BuildingFunction)
   public:
 	UString name;
 	int infiltrationSpeed = 0;
@@ -43,9 +42,8 @@ class BuildingFunction : public StateObject
 	StateRef<UfopaediaEntry> ufopaedia_entry;
 };
 
-class Building : public StateObject, public std::enable_shared_from_this<Building>
+class Building : public StateObject<Building>, public std::enable_shared_from_this<Building>
 {
-	STATE_OBJECT(Building)
   public:
 	UString name;
 	StateRef<City> city;

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -737,7 +737,7 @@ sp<Vehicle> City::placeVehicle(GameState &state, StateRef<VehicleType> type,
 	return v;
 }
 
-sp<City> City::get(const GameState &state, const UString &id)
+template <> sp<City> StateObject<City>::get(const GameState &state, const UString &id)
 {
 	auto it = state.cities.find(id);
 	if (it == state.cities.end())
@@ -748,18 +748,18 @@ sp<City> City::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &City::getPrefix()
+template <> const UString &StateObject<City>::getPrefix()
 {
 	static UString prefix = "CITYMAP_";
 	return prefix;
 }
-const UString &City::getTypeName()
+template <> const UString &StateObject<City>::getTypeName()
 {
 	static UString name = "City";
 	return name;
 }
 
-const UString &City::getId(const GameState &state, const sp<City> ptr)
+template <> const UString &StateObject<City>::getId(const GameState &state, const sp<City> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &c : state.cities)

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -73,9 +73,8 @@ class RoadSegment
 	std::list<Vec3<int>> findPathThrough(int id) const;
 };
 
-class City : public StateObject, public std::enable_shared_from_this<City>
+class City : public StateObject<City>, public std::enable_shared_from_this<City>
 {
-	STATE_OBJECT(City)
   public:
 	City() = default;
 	~City() override;

--- a/game/state/city/research.cpp
+++ b/game/state/city/research.cpp
@@ -150,7 +150,8 @@ bool ProjectDependencies::satisfied(StateRef<Base> base) const
 	return true;
 }
 
-sp<ResearchTopic> ResearchTopic::get(const GameState &state, const UString &id)
+template <>
+sp<ResearchTopic> StateObject<ResearchTopic>::get(const GameState &state, const UString &id)
 {
 	auto it = state.research.topics.find(id);
 	if (it == state.research.topics.end())
@@ -160,19 +161,20 @@ sp<ResearchTopic> ResearchTopic::get(const GameState &state, const UString &id)
 	}
 	return it->second;
 }
-
-const UString &ResearchTopic::getPrefix()
+template <> const UString &StateObject<ResearchTopic>::getPrefix()
 {
 	static UString prefix = "RESEARCH_";
 	return prefix;
 }
-const UString &ResearchTopic::getTypeName()
+template <> const UString &StateObject<ResearchTopic>::getTypeName()
 {
 	static UString name = "ResearchTopic";
 	return name;
 }
 
-const UString &ResearchTopic::getId(const GameState &state, const sp<ResearchTopic> ptr)
+template <>
+const UString &StateObject<ResearchTopic>::getId(const GameState &state,
+                                                 const sp<ResearchTopic> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &r : state.research.topics)
@@ -184,7 +186,7 @@ const UString &ResearchTopic::getId(const GameState &state, const sp<ResearchTop
 	return emptyString;
 }
 
-sp<Lab> Lab::get(const GameState &state, const UString &id)
+template <> sp<Lab> StateObject<Lab>::get(const GameState &state, const UString &id)
 {
 	auto it = state.research.labs.find(id);
 	if (it == state.research.labs.end())
@@ -195,18 +197,18 @@ sp<Lab> Lab::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &Lab::getPrefix()
+template <> const UString &StateObject<Lab>::getPrefix()
 {
 	static UString prefix = "LAB_";
 	return prefix;
 }
-const UString &Lab::getTypeName()
+template <> const UString &StateObject<Lab>::getTypeName()
 {
 	static UString name = "Lab";
 	return name;
 }
 
-const UString &Lab::getId(const GameState &state, const sp<Lab> ptr)
+template <> const UString &StateObject<Lab>::getId(const GameState &state, const sp<Lab> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &l : state.research.labs)

--- a/game/state/city/research.h
+++ b/game/state/city/research.h
@@ -44,9 +44,8 @@ class ProjectDependencies
 	bool satisfied(StateRef<Base> base) const;
 };
 
-class ResearchTopic : public StateObject
+class ResearchTopic : public StateObject<ResearchTopic>
 {
-	STATE_OBJECT(ResearchTopic)
   public:
 	ResearchTopic() = default;
 	enum class Type
@@ -111,9 +110,8 @@ class ResearchDependency
 	bool satisfied() const;
 };
 
-class Lab : public StateObject
+class Lab : public StateObject<Lab>
 {
-	STATE_OBJECT(Lab)
   public:
 	Lab() = default;
 	~Lab() override;

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -66,18 +66,20 @@ float facingDistance(float f1, float f2)
 }
 } // namespace
 
-const UString &Vehicle::getPrefix()
+template <> const UString &StateObject<Vehicle>::getPrefix()
 {
 	static UString prefix = "VEHICLE_";
 	return prefix;
 }
-const UString &Vehicle::getTypeName()
+
+template <> const UString &StateObject<Vehicle>::getTypeName()
 {
 	static UString name = "Vehicle";
 	return name;
 }
 
-const UString &Vehicle::getId(const GameState &state, const sp<Vehicle> ptr)
+template <>
+const UString &StateObject<Vehicle>::getId(const GameState &state, const sp<Vehicle> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &v : state.vehicles)
@@ -3725,7 +3727,8 @@ void Vehicle::nextFrame(int ticks)
 		}
 	}
 }
-sp<Vehicle> Vehicle::get(const GameState &state, const UString &id)
+
+template <> sp<Vehicle> StateObject<Vehicle>::get(const GameState &state, const UString &id)
 {
 	auto it = state.vehicles.find(id);
 	if (it == state.vehicles.end())

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -149,11 +149,10 @@ class VehicleMover
 	virtual ~VehicleMover();
 };
 
-class Vehicle : public StateObject,
+class Vehicle : public StateObject<Vehicle>,
                 public std::enable_shared_from_this<Vehicle>,
                 public EquippableObject
 {
-	STATE_OBJECT(Vehicle)
   public:
 	~Vehicle() override;
 	Vehicle() = default;

--- a/game/state/rules/aequipmenttype.cpp
+++ b/game/state/rules/aequipmenttype.cpp
@@ -7,19 +7,20 @@
 namespace OpenApoc
 {
 
-const UString &AEquipmentType::getPrefix()
+template <> const UString &StateObject<AEquipmentType>::getPrefix()
 {
 	static UString prefix = "AEQUIPMENTTYPE_";
 	return prefix;
 }
 
-const UString &AEquipmentType::getTypeName()
+template <> const UString &StateObject<AEquipmentType>::getTypeName()
 {
 	static UString name = "AEquipmentType";
 	return name;
 }
 
-sp<AEquipmentType> AEquipmentType::get(const GameState &state, const UString &id)
+template <>
+sp<AEquipmentType> StateObject<AEquipmentType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.agent_equipment.find(id);
 	if (it == state.agent_equipment.end())
@@ -30,19 +31,20 @@ sp<AEquipmentType> AEquipmentType::get(const GameState &state, const UString &id
 	return it->second;
 }
 
-const UString &EquipmentSet::getPrefix()
+template <> const UString &StateObject<EquipmentSet>::getPrefix()
 {
 	static UString prefix = "EQUIPMENTSET_";
 	return prefix;
 }
 
-const UString &EquipmentSet::getTypeName()
+template <> const UString &StateObject<EquipmentSet>::getTypeName()
 {
 	static UString name = "EquipmentSet";
 	return name;
 }
 
-sp<EquipmentSet> EquipmentSet::get(const GameState &state, const UString &id)
+template <>
+sp<EquipmentSet> StateObject<EquipmentSet>::get(const GameState &state, const UString &id)
 {
 	auto it = state.equipment_sets_by_score.find(id);
 	if (it == state.equipment_sets_by_score.end())

--- a/game/state/rules/aequipmenttype.h
+++ b/game/state/rules/aequipmenttype.h
@@ -32,9 +32,8 @@ enum class TriggerType
 	Boomeroid
 };
 
-class AEquipmentType : public StateObject
+class AEquipmentType : public StateObject<AEquipmentType>
 {
-	STATE_OBJECT(AEquipmentType)
   public:
 	enum class Type
 	{
@@ -178,9 +177,8 @@ class AEquipmentType : public StateObject
 	bool canBeUsed(GameState &state, StateRef<Organisation> user) const;
 };
 
-class EquipmentSet : public StateObject
+class EquipmentSet : public StateObject<EquipmentSet>
 {
-	STATE_OBJECT(EquipmentSet)
   public:
 	class WeaponData
 	{

--- a/game/state/rules/agenttype.cpp
+++ b/game/state/rules/agenttype.cpp
@@ -22,7 +22,7 @@
 namespace OpenApoc
 {
 
-sp<AgentType> AgentType::get(const GameState &state, const UString &id)
+template <> sp<AgentType> StateObject<AgentType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.agent_types.find(id);
 	if (it == state.agent_types.end())
@@ -33,18 +33,19 @@ sp<AgentType> AgentType::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &AgentType::getPrefix()
+template <> const UString &StateObject<AgentType>::getPrefix()
 {
 	static UString prefix = "AGENTTYPE_";
 	return prefix;
 }
-const UString &AgentType::getTypeName()
+template <> const UString &StateObject<AgentType>::getTypeName()
 {
 	static UString name = "AgentType";
 	return name;
 }
 
-const UString &AgentType::getId(const GameState &state, const sp<AgentType> ptr)
+template <>
+const UString &StateObject<AgentType>::getId(const GameState &state, const sp<AgentType> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.agent_types)
@@ -56,7 +57,8 @@ const UString &AgentType::getId(const GameState &state, const sp<AgentType> ptr)
 	return emptyString;
 }
 
-sp<AgentBodyType> AgentBodyType::get(const GameState &state, const UString &id)
+template <>
+sp<AgentBodyType> StateObject<AgentBodyType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.agent_body_types.find(id);
 	if (it == state.agent_body_types.end())
@@ -67,18 +69,20 @@ sp<AgentBodyType> AgentBodyType::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &AgentBodyType::getPrefix()
+template <> const UString &StateObject<AgentBodyType>::getPrefix()
 {
 	static UString prefix = "AGENTBODYTYPE_";
 	return prefix;
 }
-const UString &AgentBodyType::getTypeName()
+template <> const UString &StateObject<AgentBodyType>::getTypeName()
 {
 	static UString name = "AgentBodyType";
 	return name;
 }
 
-const UString &AgentBodyType::getId(const GameState &state, const sp<AgentBodyType> ptr)
+template <>
+const UString &StateObject<AgentBodyType>::getId(const GameState &state,
+                                                 const sp<AgentBodyType> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.agent_body_types)
@@ -90,7 +94,9 @@ const UString &AgentBodyType::getId(const GameState &state, const sp<AgentBodyTy
 	return emptyString;
 }
 
-sp<AgentEquipmentLayout> AgentEquipmentLayout::get(const GameState &state, const UString &id)
+template <>
+sp<AgentEquipmentLayout> StateObject<AgentEquipmentLayout>::get(const GameState &state,
+                                                                const UString &id)
 {
 	auto it = state.agent_equipment_layouts.find(id);
 	if (it == state.agent_equipment_layouts.end())
@@ -101,19 +107,20 @@ sp<AgentEquipmentLayout> AgentEquipmentLayout::get(const GameState &state, const
 	return it->second;
 }
 
-const UString &AgentEquipmentLayout::getPrefix()
+template <> const UString &StateObject<AgentEquipmentLayout>::getPrefix()
 {
 	static UString prefix = "AGENTEQUIPMENTLAYOUT_";
 	return prefix;
 }
-const UString &AgentEquipmentLayout::getTypeName()
+template <> const UString &StateObject<AgentEquipmentLayout>::getTypeName()
 {
 	static UString name = "AgentEquipmentLayout";
 	return name;
 }
 
-const UString &AgentEquipmentLayout::getId(const GameState &state,
-                                           const sp<AgentEquipmentLayout> ptr)
+template <>
+const UString &StateObject<AgentEquipmentLayout>::getId(const GameState &state,
+                                                        const sp<AgentEquipmentLayout> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.agent_equipment_layouts)

--- a/game/state/rules/agenttype.h
+++ b/game/state/rules/agenttype.h
@@ -118,16 +118,14 @@ class AgentPortrait
 	sp<Image> icon;
 };
 
-class AgentEquipmentLayout : public StateObject
+class AgentEquipmentLayout : public StateObject<AgentEquipmentLayout>
 {
-	STATE_OBJECT(AgentEquipmentLayout)
   public:
 	std::list<EquipmentLayoutSlot> slots;
 };
 
-class AgentType : public StateObject
+class AgentType : public StateObject<AgentType>
 {
-	STATE_OBJECT(AgentType)
   public:
 	enum class Role
 	{
@@ -240,9 +238,8 @@ class AgentType : public StateObject
 	sp<Sample> gravLiftSfx;
 };
 
-class AgentBodyType : public StateObject
+class AgentBodyType : public StateObject<AgentBodyType>
 {
-	STATE_OBJECT(AgentBodyType)
   public:
 	// This, among others, determines whether unit has built-in hover capability, can can be
 	// overridden by use of certain armor

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -88,7 +88,7 @@ int getCorridorSectorID(const Base &base, Vec2<int> pos)
 }
 } // namespace
 
-sp<BattleMap> BattleMap::get(const GameState &state, const UString &id)
+template <> sp<BattleMap> StateObject<BattleMap>::get(const GameState &state, const UString &id)
 {
 	auto it = state.battle_maps.find(id);
 	if (it == state.battle_maps.end())
@@ -98,18 +98,18 @@ sp<BattleMap> BattleMap::get(const GameState &state, const UString &id)
 	}
 	return it->second;
 }
-
-const UString &BattleMap::getPrefix()
+template <> const UString &StateObject<BattleMap>::getPrefix()
 {
 	static UString prefix = "BATTLEMAP_";
 	return prefix;
 }
-const UString &BattleMap::getTypeName()
+template <> const UString &StateObject<BattleMap>::getTypeName()
 {
 	static UString name = "BattleMap";
 	return name;
 }
-const UString &BattleMap::getId(const GameState &state, const sp<BattleMap> ptr)
+template <>
+const UString &StateObject<BattleMap>::getId(const GameState &state, const sp<BattleMap> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.battle_maps)

--- a/game/state/rules/battle/battlemap.h
+++ b/game/state/rules/battle/battlemap.h
@@ -19,9 +19,8 @@ class Vehicle;
 class BattleMapPartType;
 class BattleMapSector;
 
-class BattleMap : public StateObject
+class BattleMap : public StateObject<BattleMap>
 {
-	STATE_OBJECT(BattleMap)
 
   public:
 	// Different ways to alter map size for generation

--- a/game/state/rules/battle/battlemapparttype.cpp
+++ b/game/state/rules/battle/battlemapparttype.cpp
@@ -7,7 +7,8 @@
 namespace OpenApoc
 {
 
-sp<BattleMapPartType> BattleMapPartType::get(const GameState &state, const UString &id)
+template <>
+sp<BattleMapPartType> StateObject<BattleMapPartType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.battleMapTiles.find(id);
 	if (it != state.battleMapTiles.end())
@@ -17,12 +18,12 @@ sp<BattleMapPartType> BattleMapPartType::get(const GameState &state, const UStri
 	return nullptr;
 }
 
-const UString &BattleMapPartType::getPrefix()
+template <> const UString &StateObject<BattleMapPartType>::getPrefix()
 {
 	static UString prefix = "BATTLEMAPPART_";
 	return prefix;
 }
-const UString &BattleMapPartType::getTypeName()
+template <> const UString &StateObject<BattleMapPartType>::getTypeName()
 {
 	static UString name = "BattleMapPart";
 	return name;

--- a/game/state/rules/battle/battlemapparttype.h
+++ b/game/state/rules/battle/battlemapparttype.h
@@ -15,9 +15,8 @@ class DamageModifier;
 class Image;
 class VoxelMap;
 
-class BattleMapPartType : public StateObject
+class BattleMapPartType : public StateObject<BattleMapPartType>
 {
-	STATE_OBJECT(BattleMapPartType)
   public:
 	enum class Type
 	{

--- a/game/state/rules/battle/battlemapsector.h
+++ b/game/state/rules/battle/battlemapsector.h
@@ -21,9 +21,8 @@ enum class SpawnType
 	Civilian
 };
 
-class BattleMapSector : public StateObject
+class BattleMapSector : public StateObject<BattleMapSector>
 {
-	STATE_OBJECT(BattleMapSector)
   public:
 	BattleMapSector() = default;
 	~BattleMapSector() override = default;

--- a/game/state/rules/battle/battleunitanimationpack.cpp
+++ b/game/state/rules/battle/battleunitanimationpack.cpp
@@ -9,7 +9,9 @@ namespace OpenApoc
 
 UString BattleUnitAnimationPack::getAnimationPackPath() { return "/animationpacks"; }
 
-sp<BattleUnitAnimationPack> BattleUnitAnimationPack::get(const GameState &state, const UString &id)
+template <>
+sp<BattleUnitAnimationPack> StateObject<BattleUnitAnimationPack>::get(const GameState &state,
+                                                                      const UString &id)
 {
 	auto it = state.battle_unit_animation_packs.find(id);
 	if (it == state.battle_unit_animation_packs.end())
@@ -20,18 +22,19 @@ sp<BattleUnitAnimationPack> BattleUnitAnimationPack::get(const GameState &state,
 	return it->second;
 }
 
-const UString &BattleUnitAnimationPack::getPrefix()
+template <> const UString &StateObject<BattleUnitAnimationPack>::getPrefix()
 {
 	static UString prefix = "BATTLEUNITIANIMATIONPACK_";
 	return prefix;
 }
-const UString &BattleUnitAnimationPack::getTypeName()
+template <> const UString &StateObject<BattleUnitAnimationPack>::getTypeName()
 {
 	static UString name = "BattleUnitAnimationPack";
 	return name;
 }
-const UString &BattleUnitAnimationPack::getId(const GameState &state,
-                                              const sp<BattleUnitAnimationPack> ptr)
+template <>
+const UString &StateObject<BattleUnitAnimationPack>::getId(const GameState &state,
+                                                           const sp<BattleUnitAnimationPack> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.battle_unit_animation_packs)

--- a/game/state/rules/battle/battleunitanimationpack.h
+++ b/game/state/rules/battle/battleunitanimationpack.h
@@ -24,9 +24,8 @@ enum class ItemWieldMode
 	TwoHanded
 };
 
-class BattleUnitAnimationPack : public StateObject
+class BattleUnitAnimationPack : public StateObject<BattleUnitAnimationPack>
 {
-	STATE_OBJECT(BattleUnitAnimationPack)
   public:
 	class AnimationEntry
 	{

--- a/game/state/rules/battle/battleunitimagepack.cpp
+++ b/game/state/rules/battle/battleunitimagepack.cpp
@@ -7,7 +7,9 @@ namespace OpenApoc
 
 UString BattleUnitImagePack::getImagePackPath() { return "/imagepacks"; }
 
-sp<BattleUnitImagePack> BattleUnitImagePack::get(const GameState &state, const UString &id)
+template <>
+sp<BattleUnitImagePack> StateObject<BattleUnitImagePack>::get(const GameState &state,
+                                                              const UString &id)
 {
 	auto it = state.battle_unit_image_packs.find(id);
 	if (it == state.battle_unit_image_packs.end())
@@ -18,17 +20,19 @@ sp<BattleUnitImagePack> BattleUnitImagePack::get(const GameState &state, const U
 	return it->second;
 }
 
-const UString &BattleUnitImagePack::getPrefix()
+template <> const UString &StateObject<BattleUnitImagePack>::getPrefix()
 {
 	static UString prefix = "BATTLEUNITIMAGEPACK_";
 	return prefix;
 }
-const UString &BattleUnitImagePack::getTypeName()
+template <> const UString &StateObject<BattleUnitImagePack>::getTypeName()
 {
 	static UString name = "BattleUnitImagePack";
 	return name;
 }
-const UString &BattleUnitImagePack::getId(const GameState &state, const sp<BattleUnitImagePack> ptr)
+template <>
+const UString &StateObject<BattleUnitImagePack>::getId(const GameState &state,
+                                                       const sp<BattleUnitImagePack> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.battle_unit_image_packs)

--- a/game/state/rules/battle/battleunitimagepack.h
+++ b/game/state/rules/battle/battleunitimagepack.h
@@ -9,9 +9,8 @@
 namespace OpenApoc
 {
 class Image;
-class BattleUnitImagePack : public StateObject
+class BattleUnitImagePack : public StateObject<BattleUnitImagePack>
 {
-	STATE_OBJECT(BattleUnitImagePack)
   public:
 	Vec2<float> image_offset;
 

--- a/game/state/rules/battle/damage.cpp
+++ b/game/state/rules/battle/damage.cpp
@@ -5,19 +5,19 @@
 namespace OpenApoc
 {
 
-const UString &HazardType::getPrefix()
+template <> const UString &StateObject<HazardType>::getPrefix()
 {
 	static UString prefix = "HAZARD_";
 	return prefix;
 }
 
-const UString &HazardType::getTypeName()
+template <> const UString &StateObject<HazardType>::getTypeName()
 {
 	static UString name = "HazardType";
 	return name;
 }
 
-sp<HazardType> HazardType::get(const GameState &state, const UString &id)
+template <> sp<HazardType> StateObject<HazardType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.hazard_types.find(id);
 	if (it == state.hazard_types.end())
@@ -28,19 +28,20 @@ sp<HazardType> HazardType::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &DamageModifier::getPrefix()
+template <> const UString &StateObject<DamageModifier>::getPrefix()
 {
 	static UString prefix = "DAMAGEMODIFIER_";
 	return prefix;
 }
 
-const UString &DamageModifier::getTypeName()
+template <> const UString &StateObject<DamageModifier>::getTypeName()
 {
 	static UString name = "DamageModifier";
 	return name;
 }
 
-sp<DamageModifier> DamageModifier::get(const GameState &state, const UString &id)
+template <>
+sp<DamageModifier> StateObject<DamageModifier>::get(const GameState &state, const UString &id)
 {
 	auto it = state.damage_modifiers.find(id);
 	if (it == state.damage_modifiers.end())
@@ -51,19 +52,19 @@ sp<DamageModifier> DamageModifier::get(const GameState &state, const UString &id
 	return it->second;
 }
 
-const UString &DamageType::getPrefix()
+template <> const UString &StateObject<DamageType>::getPrefix()
 {
 	static UString prefix = "DAMAGETYPE_";
 	return prefix;
 }
 
-const UString &DamageType::getTypeName()
+template <> const UString &StateObject<DamageType>::getTypeName()
 {
 	static UString name = "DamageType";
 	return name;
 }
 
-sp<DamageType> DamageType::get(const GameState &state, const UString &id)
+template <> sp<DamageType> StateObject<DamageType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.damage_types.find(id);
 	if (it == state.damage_types.end())

--- a/game/state/rules/battle/damage.h
+++ b/game/state/rules/battle/damage.h
@@ -11,9 +11,8 @@ class Sample;
 class DoodadType;
 class GameState;
 
-class HazardType : public StateObject
+class HazardType : public StateObject<HazardType>
 {
-	STATE_OBJECT(HazardType)
   public:
 	StateRef<DoodadType> doodadType;
 	sp<Sample> sound;
@@ -35,9 +34,8 @@ class HazardType : public StateObject
 	int getLifetime(GameState &state);
 };
 
-class DamageModifier : public StateObject
+class DamageModifier : public StateObject<DamageModifier>
 {
-	STATE_OBJECT(DamageModifier)
   public:
 	// nothing?
 };
@@ -49,9 +47,8 @@ enum class DamageSource
 	Debuff
 };
 
-class DamageType : public StateObject
+class DamageType : public StateObject<DamageType>
 {
-	STATE_OBJECT(DamageType)
   public:
 	enum class BlockType
 	{

--- a/game/state/rules/city/baselayout.cpp
+++ b/game/state/rules/city/baselayout.cpp
@@ -4,7 +4,7 @@
 namespace OpenApoc
 {
 
-sp<BaseLayout> BaseLayout::get(const GameState &state, const UString &id)
+template <> sp<BaseLayout> StateObject<BaseLayout>::get(const GameState &state, const UString &id)
 {
 	auto it = state.base_layouts.find(id);
 	if (it == state.base_layouts.end())
@@ -15,12 +15,12 @@ sp<BaseLayout> BaseLayout::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &BaseLayout::getPrefix()
+template <> const UString &StateObject<BaseLayout>::getPrefix()
 {
 	static UString prefix = "BASELAYOUT_";
 	return prefix;
 }
-const UString &BaseLayout::getTypeName()
+template <> const UString &StateObject<BaseLayout>::getTypeName()
 {
 	static UString name = "BaseLayout";
 	return name;

--- a/game/state/rules/city/baselayout.h
+++ b/game/state/rules/city/baselayout.h
@@ -8,9 +8,8 @@
 namespace OpenApoc
 {
 
-class BaseLayout : public StateObject
+class BaseLayout : public StateObject<BaseLayout>
 {
-	STATE_OBJECT(BaseLayout)
   public:
 	std::set<Rect<int>> baseCorridors;
 	Vec2<int> baseLift = {0, 0};

--- a/game/state/rules/city/facilitytype.cpp
+++ b/game/state/rules/city/facilitytype.cpp
@@ -12,7 +12,8 @@ FacilityType::FacilityType()
 
 bool FacilityType::isVisible() const { return !this->fixed && this->dependency.satisfied(); }
 
-sp<FacilityType> FacilityType::get(const GameState &state, const UString &id)
+template <>
+sp<FacilityType> StateObject<FacilityType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.facility_types.find(id);
 	if (it == state.facility_types.end())
@@ -23,13 +24,13 @@ sp<FacilityType> FacilityType::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &FacilityType::getPrefix()
+template <> const UString &StateObject<FacilityType>::getPrefix()
 {
 	static UString prefix = "FACILITYTYPE_";
 	return prefix;
 }
 
-const UString &FacilityType::getTypeName()
+template <> const UString &StateObject<FacilityType>::getTypeName()
 {
 	static UString name = "FacilityType";
 	return name;

--- a/game/state/rules/city/facilitytype.h
+++ b/game/state/rules/city/facilitytype.h
@@ -11,9 +11,8 @@ namespace OpenApoc
 class Image;
 class UfopaediaEntry;
 class BattleMapSector;
-class FacilityType : public StateObject
+class FacilityType : public StateObject<FacilityType>
 {
-	STATE_OBJECT(FacilityType)
   public:
 	enum class Capacity
 	{

--- a/game/state/rules/city/scenerytiletype.cpp
+++ b/game/state/rules/city/scenerytiletype.cpp
@@ -5,7 +5,8 @@
 namespace OpenApoc
 {
 
-sp<SceneryTileType> SceneryTileType::get(const GameState &state, const UString &id)
+template <>
+sp<SceneryTileType> StateObject<SceneryTileType>::get(const GameState &state, const UString &id)
 {
 	for (auto &pair : state.cities)
 	{
@@ -17,12 +18,12 @@ sp<SceneryTileType> SceneryTileType::get(const GameState &state, const UString &
 	return nullptr;
 }
 
-const UString &SceneryTileType::getPrefix()
+template <> const UString &StateObject<SceneryTileType>::getPrefix()
 {
 	static UString prefix = "CITYTILE_";
 	return prefix;
 }
-const UString &SceneryTileType::getTypeName()
+template <> const UString &StateObject<SceneryTileType>::getTypeName()
 {
 	static UString name = "SceneryTileType";
 	return name;

--- a/game/state/rules/city/scenerytiletype.h
+++ b/game/state/rules/city/scenerytiletype.h
@@ -9,9 +9,8 @@ namespace OpenApoc
 {
 class Image;
 class VoxelMap;
-class SceneryTileType : public StateObject
+class SceneryTileType : public StateObject<SceneryTileType>
 {
-	STATE_OBJECT(SceneryTileType)
   public:
 	SceneryTileType() = default;
 

--- a/game/state/rules/city/ufogrowth.cpp
+++ b/game/state/rules/city/ufogrowth.cpp
@@ -4,7 +4,7 @@
 namespace OpenApoc
 {
 
-sp<UFOGrowth> UFOGrowth::get(const GameState &state, const UString &id)
+template <> sp<UFOGrowth> StateObject<UFOGrowth>::get(const GameState &state, const UString &id)
 {
 	auto it = state.ufo_growth_lists.find(id);
 	if (it == state.ufo_growth_lists.end())
@@ -15,12 +15,12 @@ sp<UFOGrowth> UFOGrowth::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &UFOGrowth::getPrefix()
+template <> const UString &StateObject<UFOGrowth>::getPrefix()
 {
 	static UString prefix = "UFO_GROWTH_";
 	return prefix;
 }
-const UString &UFOGrowth::getTypeName()
+template <> const UString &StateObject<UFOGrowth>::getTypeName()
 {
 	static UString name = "UFOGrowth";
 	return name;

--- a/game/state/rules/city/ufogrowth.h
+++ b/game/state/rules/city/ufogrowth.h
@@ -7,9 +7,8 @@
 namespace OpenApoc
 {
 
-class UFOGrowth : public StateObject
+class UFOGrowth : public StateObject<UFOGrowth>
 {
-	STATE_OBJECT(UFOGrowth)
   public:
 	int week = 0;
 	std::vector<std::pair<UString, int>> vehicleTypeList;

--- a/game/state/rules/city/ufoincursion.cpp
+++ b/game/state/rules/city/ufoincursion.cpp
@@ -4,7 +4,8 @@
 namespace OpenApoc
 {
 
-sp<UFOIncursion> UFOIncursion::get(const GameState &state, const UString &id)
+template <>
+sp<UFOIncursion> StateObject<UFOIncursion>::get(const GameState &state, const UString &id)
 {
 	auto it = state.ufo_incursions.find(id);
 	if (it == state.ufo_incursions.end())
@@ -15,12 +16,12 @@ sp<UFOIncursion> UFOIncursion::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &UFOIncursion::getPrefix()
+template <> const UString &StateObject<UFOIncursion>::getPrefix()
 {
 	static UString prefix = "UFO_INCURSION_";
 	return prefix;
 }
-const UString &UFOIncursion::getTypeName()
+template <> const UString &StateObject<UFOIncursion>::getTypeName()
 {
 	static UString name = "UFOIncursion";
 	return name;

--- a/game/state/rules/city/ufoincursion.h
+++ b/game/state/rules/city/ufoincursion.h
@@ -9,9 +9,8 @@
 namespace OpenApoc
 {
 
-class UFOIncursion : public StateObject
+class UFOIncursion : public StateObject<UFOIncursion>
 {
-	STATE_OBJECT(UFOIncursion)
   public:
 	enum class PrimaryMission
 	{

--- a/game/state/rules/city/ufomissionpreference.cpp
+++ b/game/state/rules/city/ufomissionpreference.cpp
@@ -4,7 +4,9 @@
 namespace OpenApoc
 {
 
-sp<UFOMissionPreference> UFOMissionPreference::get(const GameState &state, const UString &id)
+template <>
+sp<UFOMissionPreference> StateObject<UFOMissionPreference>::get(const GameState &state,
+                                                                const UString &id)
 {
 	auto it = state.ufo_mission_preference.find(id);
 	if (it == state.ufo_mission_preference.end())
@@ -15,12 +17,12 @@ sp<UFOMissionPreference> UFOMissionPreference::get(const GameState &state, const
 	return it->second;
 }
 
-const UString &UFOMissionPreference::getPrefix()
+template <> const UString &StateObject<UFOMissionPreference>::getPrefix()
 {
 	static UString prefix = "UFO_MISSION_PREFERENCE_";
 	return prefix;
 }
-const UString &UFOMissionPreference::getTypeName()
+template <> const UString &StateObject<UFOMissionPreference>::getTypeName()
 {
 	static UString name = "UFOMissionPreference";
 	return name;

--- a/game/state/rules/city/ufomissionpreference.h
+++ b/game/state/rules/city/ufomissionpreference.h
@@ -8,9 +8,8 @@
 namespace OpenApoc
 {
 
-class UFOMissionPreference : public StateObject
+class UFOMissionPreference : public StateObject<UFOMissionPreference>
 {
-	STATE_OBJECT(UFOMissionPreference)
   public:
 	int week = 0;
 	std::list<UFOIncursion::PrimaryMission> missionList;

--- a/game/state/rules/city/ufopaedia.cpp
+++ b/game/state/rules/city/ufopaedia.cpp
@@ -9,7 +9,8 @@ UfopaediaEntry::UfopaediaEntry() : data_type(Data::Nothing) {}
 
 bool UfopaediaEntry::isVisible() const { return this->dependency.satisfied(); }
 
-sp<UfopaediaEntry> UfopaediaEntry::get(const GameState &state, const UString &id)
+template <>
+sp<UfopaediaEntry> StateObject<UfopaediaEntry>::get(const GameState &state, const UString &id)
 {
 	for (auto &cat : state.ufopaedia)
 	{
@@ -21,12 +22,12 @@ sp<UfopaediaEntry> UfopaediaEntry::get(const GameState &state, const UString &id
 	return nullptr;
 }
 
-const UString &UfopaediaEntry::getPrefix()
+template <> const UString &StateObject<UfopaediaEntry>::getPrefix()
 {
 	static UString prefix = "PAEDIAENTRY_";
 	return prefix;
 }
-const UString &UfopaediaEntry::getTypeName()
+template <> const UString &StateObject<UfopaediaEntry>::getTypeName()
 {
 	static UString name = "UfopaediaEntry";
 	return name;

--- a/game/state/rules/city/ufopaedia.h
+++ b/game/state/rules/city/ufopaedia.h
@@ -12,9 +12,8 @@ namespace OpenApoc
 class ResearchTopic;
 class LazyImage;
 
-class UfopaediaEntry : public StateObject
+class UfopaediaEntry : public StateObject<UfopaediaEntry>
 {
-	STATE_OBJECT(UfopaediaEntry)
   public:
 	enum class Data
 	{
@@ -38,9 +37,8 @@ class UfopaediaEntry : public StateObject
 	bool isVisible() const;
 };
 
-class UfopaediaCategory : public StateObject
+class UfopaediaCategory : public StateObject<UfopaediaCategory>
 {
-	STATE_OBJECT(UfopaediaCategory)
   public:
 	UString title;
 	UString description;

--- a/game/state/rules/city/vammotype.cpp
+++ b/game/state/rules/city/vammotype.cpp
@@ -4,19 +4,19 @@
 namespace OpenApoc
 {
 
-const UString &VAmmoType::getPrefix()
+template <> const UString &StateObject<VAmmoType>::getPrefix()
 {
 	static UString prefix = "VEQUIPMENTAMMOTYPE_";
 	return prefix;
 }
 
-const UString &VAmmoType::getTypeName()
+template <> const UString &StateObject<VAmmoType>::getTypeName()
 {
 	static UString name = "VAmmoType";
 	return name;
 }
 
-sp<VAmmoType> VAmmoType::get(const GameState &state, const UString &id)
+template <> sp<VAmmoType> StateObject<VAmmoType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.vehicle_ammo.find(id);
 	if (it == state.vehicle_ammo.end())

--- a/game/state/rules/city/vammotype.h
+++ b/game/state/rules/city/vammotype.h
@@ -11,9 +11,8 @@ class Image;
 class Sample;
 class Organisation;
 
-class VAmmoType : public StateObject
+class VAmmoType : public StateObject<VAmmoType>
 {
-	STATE_OBJECT(VAmmoType)
   public:
 	VAmmoType() = default;
 

--- a/game/state/rules/city/vehicletype.cpp
+++ b/game/state/rules/city/vehicletype.cpp
@@ -47,7 +47,7 @@ const Vec3<float> &VehicleType::directionToVector(Direction d)
 
 bool VehicleType::isGround() const { return type == Type::Road || type == Type::ATV; }
 
-sp<VehicleType> VehicleType::get(const GameState &state, const UString &id)
+template <> sp<VehicleType> StateObject<VehicleType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.vehicle_types.find(id);
 	if (it == state.vehicle_types.end())
@@ -58,17 +58,18 @@ sp<VehicleType> VehicleType::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &VehicleType::getPrefix()
+template <> const UString &StateObject<VehicleType>::getPrefix()
 {
 	static UString prefix = "VEHICLETYPE_";
 	return prefix;
 }
-const UString &VehicleType::getTypeName()
+template <> const UString &StateObject<VehicleType>::getTypeName()
 {
 	static UString name = "VehicleType";
 	return name;
 }
-const UString &VehicleType::getId(const GameState &state, const sp<VehicleType> ptr)
+template <>
+const UString &StateObject<VehicleType>::getId(const GameState &state, const sp<VehicleType> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &v : state.vehicle_types)

--- a/game/state/rules/city/vehicletype.h
+++ b/game/state/rules/city/vehicletype.h
@@ -23,9 +23,8 @@ class ResearchTopic;
 class AgentType;
 class UfopaediaEntry;
 
-class VehicleType : public StateObject
+class VehicleType : public StateObject<VehicleType>
 {
-	STATE_OBJECT(VehicleType)
   public:
 	enum class Type
 	{

--- a/game/state/rules/city/vequipmenttype.cpp
+++ b/game/state/rules/city/vequipmenttype.cpp
@@ -5,19 +5,20 @@
 namespace OpenApoc
 {
 
-const UString &VEquipmentType::getPrefix()
+template <> const UString &StateObject<VEquipmentType>::getPrefix()
 {
 	static UString prefix = "VEQUIPMENTTYPE_";
 	return prefix;
 }
 
-const UString &VEquipmentType::getTypeName()
+template <> const UString &StateObject<VEquipmentType>::getTypeName()
 {
 	static UString name = "VEquipmentType";
 	return name;
 }
 
-sp<VEquipmentType> VEquipmentType::get(const GameState &state, const UString &id)
+template <>
+sp<VEquipmentType> StateObject<VEquipmentType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.vehicle_equipment.find(id);
 	if (it == state.vehicle_equipment.end())

--- a/game/state/rules/city/vequipmenttype.h
+++ b/game/state/rules/city/vequipmenttype.h
@@ -19,9 +19,8 @@ class DoodadType;
 class Organisation;
 class VAmmoType;
 
-class VEquipmentType : public StateObject
+class VEquipmentType : public StateObject<VEquipmentType>
 {
-	STATE_OBJECT(VEquipmentType)
   public:
 	VEquipmentType() = default;
 

--- a/game/state/rules/doodadtype.cpp
+++ b/game/state/rules/doodadtype.cpp
@@ -4,8 +4,9 @@
 
 namespace OpenApoc
 {
+template <>
 
-sp<DoodadType> DoodadType::get(const GameState &state, const UString &id)
+sp<DoodadType> StateObject<DoodadType>::get(const GameState &state, const UString &id)
 {
 	auto it = state.doodad_types.find(id);
 	if (it == state.doodad_types.end())
@@ -16,12 +17,12 @@ sp<DoodadType> DoodadType::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &DoodadType::getPrefix()
+template <> const UString &StateObject<DoodadType>::getPrefix()
 {
 	static UString prefix = "DOODAD_";
 	return prefix;
 }
-const UString &DoodadType::getTypeName()
+template <> const UString &StateObject<DoodadType>::getTypeName()
 {
 	static UString name = "DoodadType";
 	return name;

--- a/game/state/rules/doodadtype.h
+++ b/game/state/rules/doodadtype.h
@@ -19,9 +19,8 @@ class DoodadFrame
 	DoodadFrame(sp<Image> image, int time) : image(image), time(time){};
 };
 
-class DoodadType : public StateObject
+class DoodadType : public StateObject<DoodadType>
 {
-	STATE_OBJECT(DoodadType)
   public:
 	DoodadType() = default;
 	int lifetime = 0;

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -26,7 +26,7 @@ namespace OpenApoc
 static const unsigned TICKS_PER_PHYSICAL_TRAINING = 4 * TICKS_PER_HOUR;
 static const unsigned TICKS_PER_PSI_TRAINING = 4 * TICKS_PER_HOUR;
 
-sp<Agent> Agent::get(const GameState &state, const UString &id)
+template <> sp<Agent> StateObject<Agent>::get(const GameState &state, const UString &id)
 {
 	auto it = state.agents.find(id);
 	if (it == state.agents.end())
@@ -37,17 +37,17 @@ sp<Agent> Agent::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &Agent::getPrefix()
+template <> const UString &StateObject<Agent>::getPrefix()
 {
 	static UString prefix = "AGENT_";
 	return prefix;
 }
-const UString &Agent::getTypeName()
+template <> const UString &StateObject<Agent>::getTypeName()
 {
 	static UString name = "Agent";
 	return name;
 }
-const UString &Agent::getId(const GameState &state, const sp<Agent> ptr)
+template <> const UString &StateObject<Agent>::getId(const GameState &state, const sp<Agent> ptr)
 {
 	static const UString emptyString = "";
 	for (auto &a : state.agents)

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -55,11 +55,10 @@ enum class TrainingAssignment
 	Psi
 };
 
-class Agent : public StateObject,
+class Agent : public StateObject<Agent>,
               public std::enable_shared_from_this<Agent>,
               public EquippableObject
 {
-	STATE_OBJECT(Agent)
   public:
 	Agent() = default;
 

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -764,7 +764,8 @@ bool Organisation::bribedBy(GameState &state, StateRef<Organisation> other, int 
 	return true;
 }
 
-sp<Organisation> Organisation::get(const GameState &state, const UString &id)
+template <>
+sp<Organisation> StateObject<Organisation>::get(const GameState &state, const UString &id)
 {
 	auto it = state.organisations.find(id);
 	if (it == state.organisations.end())
@@ -775,12 +776,12 @@ sp<Organisation> Organisation::get(const GameState &state, const UString &id)
 	return it->second;
 }
 
-const UString &Organisation::getPrefix()
+template <> const UString &StateObject<Organisation>::getPrefix()
 {
 	static UString prefix = "ORG_";
 	return prefix;
 }
-const UString &Organisation::getTypeName()
+template <> const UString &StateObject<Organisation>::getTypeName()
 {
 	static UString name = "Organisation";
 	return name;

--- a/game/state/shared/organisation.h
+++ b/game/state/shared/organisation.h
@@ -33,9 +33,8 @@ class VehicleType;
 class UfopaediaEntry;
 class Image;
 
-class Organisation : public StateObject
+class Organisation : public StateObject<Organisation>
 {
-	STATE_OBJECT(Organisation)
   public:
 	enum class PurchaseResult
 	{

--- a/game/state/stateobject.h
+++ b/game/state/stateobject.h
@@ -25,29 +25,14 @@ template <typename T> class StateRefMap : public std::map<UString, sp<T>>
 	}
 };
 
-#define STATE_OBJECT(Type)                                                                         \
-  public:                                                                                          \
-	static sp<Type> get(const GameState &state, const UString &id);                                \
-	static const UString &getId(const GameState &state, const sp<Type> ptr);                       \
-	static const UString &getPrefix();                                                             \
-	static const UString &getTypeName();                                                           \
-	static UString generateObjectID(GameState &state)                                              \
-	{                                                                                              \
-		auto id = getNextObjectID(state, getPrefix());                                             \
-		return getPrefix() + Strings::fromU64(id);                                                 \
-	}
-
-class StateObject
+template <typename T> class StateObject
 {
   public:
 	StateObject() = default;
 	virtual ~StateObject() = default;
 
-#if 0
-
 	static sp<T> get(const GameState &state, const UString &id);
 	static const UString &getId(const GameState &state, const sp<T> ptr);
-
 	static const UString &getPrefix();
 	static const UString &getTypeName();
 	static UString generateObjectID(GameState &state)
@@ -55,7 +40,6 @@ class StateObject
 		auto id = getNextObjectID(state, getPrefix());
 		return getPrefix() + Strings::fromU64(id);
 	}
-#endif
 
 	virtual void destroy(){};
 	// StateObjects are not copy-able


### PR DESCRIPTION
Instead of a STATE_OBJECT macro to inject the member functions for
StateObject reference mangagement, use a CRTP-style template.

This is a lot more "idiomatic c++", but otherwise shouldn't change any
behaviour.