### PR TITLE
WIP: add op="delete" attribute to serialization xml

### DIFF
--- a/framework/serialization/serialize.cpp
+++ b/framework/serialization/serialize.cpp
@@ -78,6 +78,8 @@ class XMLSerializationNode final : public SerializationNode
 
 	UString getName() override;
 	void setName(const UString &str) override;
+	UString getAttribute(const UString &attribute) override;
+	void setAttribute(const UString &attribute, const UString &value) override;
 	UString getValue() override;
 	void setValue(const UString &str) override;
 
@@ -314,6 +316,16 @@ void XMLSerializationNode::setName(const UString &str) { node.set_name(str.cStr(
 UString XMLSerializationNode::getValue() { return node.text().get(); }
 
 void XMLSerializationNode::setValue(const UString &str) { node.text().set(str.cStr()); }
+
+UString XMLSerializationNode::getAttribute(const UString &attribute)
+{
+	return node.attribute(attribute.cStr()).value();
+}
+
+void XMLSerializationNode::setAttribute(const UString &attribute, const UString &value)
+{
+	node.attribute(attribute.cStr()).set_value(value.cStr());
+}
 
 unsigned int XMLSerializationNode::getValueUInt() { return node.text().as_uint(); }
 

--- a/framework/serialization/serialize.h
+++ b/framework/serialization/serialize.h
@@ -28,6 +28,8 @@ class SerializationNode
 
 	virtual UString getName() = 0;
 	virtual void setName(const UString &str) = 0;
+	virtual UString getAttribute(const UString &attribute) = 0;
+	virtual void setAttribute(const UString &attribute, const UString &value) = 0;
 	virtual UString getValue() = 0;
 	virtual void setValue(const UString &str) = 0;
 

--- a/game/state/gamestate_serialize.h
+++ b/game/state/gamestate_serialize.h
@@ -340,6 +340,11 @@ void serializeIn(const GameState *state, SerializationNode *node, std::list<T> &
 {
 	if (!node)
 		return;
+	const auto delete_list = (node->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+	if (delete_list)
+	{
+		list.clear();
+	}
 	auto entry = node->getNodeOpt("entry");
 	while (entry)
 	{
@@ -354,6 +359,11 @@ void serializeIn(const GameState *state, SerializationNode *node, std::vector<T>
 {
 	if (!node)
 		return;
+	const auto delete_vector = (node->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+	if (delete_vector)
+	{
+		vector.clear();
+	}
 	auto entry = node->getNodeOpt("entry");
 	uint64_t sizeHint = 0;
 	serializeIn(state, node->getNodeOpt("sizeHint"), sizeHint);
@@ -376,12 +386,25 @@ void serializeIn(const GameState *state, SerializationNode *node, std::set<T> &s
 {
 	if (!node)
 		return;
+	const auto delete_set = (node->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+	if (delete_set)
+	{
+		set.clear();
+	}
 	auto entry = node->getNodeOpt("entry");
 	while (entry)
 	{
 		T type = {};
 		serializeIn(state, entry, type);
-		set.insert(type);
+		const auto delete_entry = (entry->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+		if (delete_entry)
+		{
+			set.erase(type);
+		}
+		else
+		{
+			set.insert(type);
+		}
 		entry = entry->getNextSiblingOpt("entry");
 	}
 }

--- a/game/state/gamestate_serialize.h
+++ b/game/state/gamestate_serialize.h
@@ -71,6 +71,10 @@
 namespace OpenApoc
 {
 
+static const UString OVERRIDE_OP_ATTRIBUTE = "override";
+static const UString DELETE_OP_ATTRIBUTE = "delete";
+static const UString APPEND_OP_ATTRIBUTE = "append";
+
 template <typename T> bool operator==(const StateRefMap<T> &a, const StateRefMap<T> &b)
 {
 	if (a.size() != b.size())
@@ -219,13 +223,32 @@ void serializeIn(const GameState *state, SerializationNode *node, std::map<Key, 
 {
 	if (!node)
 		return;
+
+	const auto delete_map = (node->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+	if (delete_map)
+	{
+		map.clear();
+	}
 	auto entry = node->getNodeOpt("entry");
 	while (entry)
 	{
 		Key key;
-		serializeIn(state, entry->getNodeReq("key"), key);
-		auto &value = map[key];
-		serializeIn(state, entry->getNodeReq("value"), value);
+		const auto keyNode = entry->getNodeReq("key");
+		serializeIn(state, keyNode, key);
+
+		const auto delete_node = (entry->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+
+		if (delete_node)
+		{
+			map.erase(key);
+		}
+
+		const auto valueNode = entry->getNodeOpt("value");
+		if (valueNode)
+		{
+			auto &value = map[key];
+			serializeIn(state, valueNode, value);
+		}
 
 		entry = entry->getNextSiblingOpt("entry");
 	}
@@ -237,13 +260,31 @@ void serializeInSectionMap(const GameState *state, SerializationNode *node,
 {
 	if (!node)
 		return;
+	const auto delete_map = (node->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+	if (delete_map)
+	{
+		map.clear();
+	}
 	auto entry = node->getNodeOpt("entry");
 	while (entry)
 	{
 		UString key;
-		serializeIn(state, entry->getNodeReq("key"), key);
-		auto &value = map[key];
-		serializeIn(state, entry->getSectionReq(key.cStr()), value);
+		const auto keyNode = entry->getNodeReq("key");
+		serializeIn(state, keyNode, key);
+
+		const auto delete_node = (entry->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+		if (delete_node)
+		{
+			map.erase(key);
+		}
+
+		const auto sectionNode = entry->getSectionOpt(key.cStr());
+		if (sectionNode)
+		{
+
+			auto &value = map[key];
+			serializeIn(state, sectionNode, value);
+		}
 
 		entry = entry->getNextSiblingOpt("entry");
 	}
@@ -255,13 +296,31 @@ void serializeIn(const GameState *state, SerializationNode *node, std::map<Key, 
 {
 	if (!node)
 		return;
+	const auto delete_map = (node->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+	if (delete_map)
+	{
+		map.clear();
+	}
 	auto entry = node->getNodeOpt("entry");
 	while (entry)
 	{
 		Key key = {};
-		serializeIn(state, entry->getNodeReq("key"), key, keyMap);
-		auto &value = map[key];
-		serializeIn(state, entry->getNodeReq("value"), value);
+		const auto keyNode = entry->getNodeReq("key");
+		serializeIn(state, keyNode, key);
+
+		const auto delete_node = (entry->getAttribute("op") == DELETE_OP_ATTRIBUTE);
+		if (delete_node)
+		{
+			map.erase(key);
+		}
+
+		const auto valueNode = entry->getNodeReq("value");
+		if (valueNode)
+		{
+
+			auto &value = map[key];
+			serializeIn(state, valueNode, value);
+		}
 
 		entry = entry->getNextSiblingOpt("entry");
 	}


### PR DESCRIPTION
This adds a way of removing items from lists/maps/vectors/sets in the GameState.

Copied from #784 (which this should help solve):

Adding 'commands' to lists (e.g. 'append'/'delete') in the xml format has been on the todo list for a while - and is necessary for issues like this.

I'm generally leaning towards an attribute instead of a subnode, but I think the bikeshed should be painted mauve.

e.g. a 'op' attribute, only valid on lists/vectors/maps and map keys (though the last can be overridden, it's not currently possible to /remove/ them)

- For lists and vectors (as they're treated the same) the 'op' attribute can gave one of two values, 'append' and 'delete' - 'append' being the default. To replace a list, use 'delete' and then follow it with the new entries as normal.

e.g.
```
<my_list op="delete">
</my_list>
```

would remove all entries from my_list and:

```
<my_list op="delete">
<entry>1</entry>
</my_list>
```

would result in a list with a single entry - "1" - no matter how many entries were previously in the list.

No 'op' attribute would be treated as 'append' - which is the current behavior (any following entries are appended as new objects to the existing list)

- Maps would be 'override' and 'delete' - 'override' being the default, which would be the current behavior (e.g. add new or override if already matching key). 'delete' would replace the entire map with an empty map (removing all entries) before processing any following entries as normal.

e.g.
```
<my_map op="delete">
</my_map>
```

would result in an empty my_map

```
<my_map op="delete">
<entry>
<key>KEY1</key>
<value>VALUE1</value>
</entry>
</my_map>
```

would result in a map with a single entry with the key "KEY1" and "VALUE1"


- Map entries 'op' attribute can have one of the same values - 'override' and 'delete' - override being the default. Entries with a <key> with the op="delete" attribute but no value would be removed from the map, otherwise a new default <value> object would be created and populated as normal.

e.g.

```
<my_map>
<entry op="delete">
<key>KEY1</key>
</entry>
</my_map>
```

would remove a matching key of "KEY1" from the map - TODO: What happens if the key isn't found?

```
<my_map>
<entry op="delete">
<key>KEY1</key>
<value></value>
</entry>
</my_map>
```

would replace (or add) a matching key of "KEY1" from the map with a default constructed object - IE ALL it's members would return to default

```
<my_map>
<entry op="delete">
<key>KEY1</key>
<value>
  <child_value>3</child_value>
</value>
</entry>
</my_map>
```

would replace (or add) a matching key of "KEY1" from the map with a default constructed object then set "child_value" in it - IE ALL OTHER members would return to default


I think that fits all use cases?