### PR TITLE
Extractor: Vehicles seem to have a 'dimension travel' flag

### DIFF
--- a/data/common_patch/gamestate.xml
+++ b/data/common_patch/gamestate.xml
@@ -13,6 +13,7 @@
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="vehicle_ammo.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="research.xml"/>
   <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="agent_body_types.xml"/>
+  <xi:include xmlns:xi="http://www.w3.org/2001/XInclude" href="vehicle_types.xml"/>
   <initial_agents>
     <entry>
       <key>Soldier</key>

--- a/data/common_patch/gamestate/vehicle_types.xml
+++ b/data/common_patch/gamestate/vehicle_types.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<vehicle_types>
+  <entry>
+    <key>VEHICLETYPE_DIMENSION_PROBE</key>
+    <value>
+      <name>Dimension Probe</name>
+      <manufacturer>ORG_X-COM</manufacturer>
+    </value>
+  </entry>
+</vehicle_types>

--- a/tools/extractors/common/vehicle.h
+++ b/tools/extractors/common/vehicle.h
@@ -14,7 +14,9 @@ struct VehicleData
 	uint16_t image_position_4;
 	uint16_t graphic_frame;
 	uint16_t acceleration;
-	uint16_t unknown;
+	/* All dimension-capable craft have a non-zero value, I don't know what the values (1-8) then
+	 * mean... */
+	uint16_t dimension_travel;
 	uint16_t top_speed;
 	uint16_t shadow_graphic;
 	uint16_t shadow_position_1;

--- a/tools/extractors/extract_vehicles.cpp
+++ b/tools/extractors/extract_vehicles.cpp
@@ -199,7 +199,6 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 			if (v.animation_type == 0)
 			{
 				vehicle->type = VehicleType::Type::UFO;
-				vehicle->canEnterDimensionGate = true;
 				if (v.size_x == 1 && v.size_y == 1)
 				{
 					vehicle->mapIconType = VehicleType::MapIconType::SmallCircle;
@@ -293,7 +292,6 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 				};
 
 				vehicle->mapIconType = VehicleType::MapIconType::Arrow;
-				vehicle->canEnterDimensionGate = vehicle->manufacturer.id == "ORG_X-COM";
 
 				int image_offset = 0;
 				for (auto &bank : bankings)
@@ -336,6 +334,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		vehicle->health = v.constitution;
 		vehicle->crash_health = v.crash_constitution;
 		vehicle->weight = v.weight;
+		vehicle->canEnterDimensionGate = (v.dimension_travel != 0);
 
 		vehicle->armour[VehicleType::ArmourDirection::Rear] = v.armour_rear;
 		vehicle->armour[VehicleType::ArmourDirection::Top] = v.armour_top;


### PR DESCRIPTION
All dimension-capable vehicles have a non-zero value here, so use that
to extract if they're dimension-travel capable

Outside of 'nonzero' I'm not sure what the values mean - maybe speed, as
the larger/slower craft seem to have 1, while the fastest 8?

For reference:

VEHICLETYPE_ALIEN_PROBE: 8
VEHICLETYPE_ALIEN_SCOUT: 2
VEHICLETYPE_ALIEN_TRANSPORTER: 2
VEHICLETYPE_ALIEN_FAST_ATTACK_SHIP: 5
VEHICLETYPE_ALIEN_DESTROYER: 3
VEHICLETYPE_ALIEN_ASSAULT_SHIP: 2
VEHICLETYPE_ALIEN_BOMBER: 3
VEHICLETYPE_ALIEN_ESCORT: 4
VEHICLETYPE_ALIEN_BATTLESHIP: 1
VEHICLETYPE_ALIEN_MOTHERSHIP: 1
VEHICLETYPE_POLICE_HOVERCAR: 0
VEHICLETYPE_AIRTAXI: 0
VEHICLETYPE_RESCUE_TRANSPORT: 0
VEHICLETYPE_CONSTRUCTION_VEHICLE: 0
VEHICLETYPE_AIRTRANS: 0
VEHICLETYPE_SPACE_LINER: 0
VEHICLETYPE_PHOENIX_HOVERCAR: 0
VEHICLETYPE_HOVERBIKE: 0
VEHICLETYPE_VALKYRIE_INTERCEPTOR: 0
VEHICLETYPE_HAWK_AIR_WARRIOR: 0
VEHICLETYPE_DIMENSION_PROBE: 6
VEHICLETYPE_BIOTRANS: 3
VEHICLETYPE_EXPLORER: 4
VEHICLETYPE_RETALIATOR: 5
VEHICLETYPE_ANNIHILATOR: 7
VEHICLETYPE_AUTOTAXI: 0
VEHICLETYPE_AUTOTRANS: 0
VEHICLETYPE_POLICE_CAR: 0
VEHICLETYPE_CIVILIAN_CAR: 0
VEHICLETYPE_STORMDOG: 0
VEHICLETYPE_WOLFHOUND_APC: 0
VEHICLETYPE_BLAZER_TURBO_BIKE: 0
VEHICLETYPE_GRIFFON_AFV: 0