### PR TITLE
Make ammo autoreload prefer the same type as previously loaded

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -123,6 +123,7 @@ void dumpOptionsToLog()
 	dumpOption(optionSkipTurbo);
 	dumpOption(optionRunAndKneel);
 	dumpOption(optionSeedRng);
+	dumpOption(optionAutoReload);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -385,6 +386,8 @@ ConfigOptionBool optionSkipTurbo("OpenApoc.NewFeature", "SkipTurboMovement",
 ConfigOptionBool optionRunAndKneel("OpenApoc.NewFeature", "RunAndKneel",
                                    "All units run and kneel by default", false);
 ConfigOptionBool optionSeedRng("OpenApoc.NewFeature", "SeedRng", "Seed RNG on game start", true);
+ConfigOptionBool optionAutoReload("OpenApoc.NewFeature", "AutoReload",
+                                  "Automatically reload weapons when empty", true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -101,6 +101,7 @@ extern ConfigOptionBool optionFuelCrashingVehicles;
 extern ConfigOptionBool optionSkipTurbo;
 extern ConfigOptionBool optionRunAndKneel;
 extern ConfigOptionBool optionSeedRng;
+extern ConfigOptionBool optionAutoReload;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -169,6 +169,7 @@
 		<name>AEquipment</name>
 		<member>type</member>
 		<member>payloadType</member>
+		<member>lastLoadedAmmoType</member>
 		<member>equippedPosition</member>
 		<member>equippedSlotType</member>
 		<member>ownerAgent</member>

--- a/game/state/shared/aequipment.cpp
+++ b/game/state/shared/aequipment.cpp
@@ -288,6 +288,35 @@ void AEquipment::startFiring(WeaponAimingMode fireMode, bool instant)
 	aimingMode = fireMode;
 }
 
+static sp<AEquipment> getAutoreloadAmmoType(const AEquipment &weapon)
+{
+	LogAssert(weapon.type->type == AEquipmentType::Type::Weapon);
+	LogAssert(weapon.getPayloadType() != weapon.type);
+
+	// Prefer loading the same type of ammo again
+	if (weapon.lastLoadedAmmoType)
+	{
+		auto equippedAmmo = weapon.ownerAgent->getFirstItemByType(weapon.lastLoadedAmmoType);
+		if (equippedAmmo)
+		{
+			LogAssert(equippedAmmo->type->type == AEquipmentType::Type::Ammo);
+			return equippedAmmo;
+		}
+	}
+	// Otherwise find any possible ammo on the agent
+	for (const auto &ammoType : weapon.type->ammo_types)
+	{
+		auto equippedAmmo = weapon.ownerAgent->getFirstItemByType(ammoType);
+		if (equippedAmmo)
+		{
+			LogAssert(equippedAmmo->type->type == AEquipmentType::Type::Ammo);
+			return equippedAmmo;
+		}
+	}
+	// No ammo found
+	return nullptr;
+}
+
 void AEquipment::loadAmmo(GameState &state, sp<AEquipment> ammoItem)
 {
 	// Cannot load if this is using itself for payload or is not a weapon
@@ -303,16 +332,7 @@ void AEquipment::loadAmmo(GameState &state, sp<AEquipment> ammoItem)
 			LogError("Trying to auto-reload a weapon not in agent inventory!?");
 			return;
 		}
-		auto it = type->ammo_types.rbegin();
-		while (it != type->ammo_types.rend())
-		{
-			ammoItem = ownerAgent->getFirstItemByType(*it);
-			if (ammoItem)
-			{
-				break;
-			}
-			it++;
-		}
+		ammoItem = getAutoreloadAmmoType(*this);
 	}
 	// Cannot load non-ammo or if no ammo was found in the inventory
 	if (!ammoItem || ammoItem->type->type != AEquipmentType::Type::Ammo)
@@ -325,6 +345,8 @@ void AEquipment::loadAmmo(GameState &state, sp<AEquipment> ammoItem)
 	{
 		return;
 	}
+	// Store the loaded ammo type for autoreload
+	lastLoadedAmmoType = ammoItem->type;
 
 	// If this has ammo then swap
 	if (payloadType)

--- a/game/state/shared/aequipment.cpp
+++ b/game/state/shared/aequipment.cpp
@@ -1,7 +1,7 @@
 #include "game/state/shared/aequipment.h"
-#include "framework/configfile.h"
 #include "framework/framework.h"
 #include "framework/logger.h"
+#include "framework/options.h"
 #include "framework/sound.h"
 #include "game/state/battle/battle.h"
 #include "game/state/battle/battleitem.h"
@@ -292,6 +292,12 @@ static sp<AEquipment> getAutoreloadAmmoType(const AEquipment &weapon)
 {
 	LogAssert(weapon.type->type == AEquipmentType::Type::Weapon);
 	LogAssert(weapon.getPayloadType() != weapon.type);
+
+	// Check if the auto-reload option is disabled
+	if (!Options::optionAutoReload.get())
+	{
+		return nullptr;
+	}
 
 	// Prefer loading the same type of ammo again
 	if (weapon.lastLoadedAmmoType)

--- a/game/state/shared/aequipment.h
+++ b/game/state/shared/aequipment.h
@@ -33,6 +33,7 @@ class AEquipment : public std::enable_shared_from_this<AEquipment>, public Equip
 	StateRef<AEquipmentType> type;
 	// Type of loaded ammunition
 	StateRef<AEquipmentType> payloadType;
+	StateRef<AEquipmentType> lastLoadedAmmoType;
 	// Function to simplify getting payload for weapons and grenades
 	StateRef<AEquipmentType> getPayloadType() const;
 

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -104,6 +104,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
     {"OpenApoc.NewFeature", "RunAndKneel"},
     {"OpenApoc.NewFeature", "SeedRng"},
+    {"OpenApoc.NewFeature", "AutoReload"},
 
     {"OpenApoc.Mod", "StunHostileAction"},
     {"OpenApoc.Mod", "RaidHostileAction"},


### PR DESCRIPTION
This stops annoying stuff like autocannons switching to HE ammo and
shooting your feet, despite still having a spare AP reload available