### PR TITLE
[interface] Fix selecting already-in-progress list item after change selection

### DIFF
--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -74,36 +74,39 @@ void ResearchSelect::begin()
 		if (topic->current_lab)
 		{
 			LogInfo("Topic already in progress");
-			return;
 		}
-		if (topic->isComplete())
+		else
 		{
-			LogInfo("Topic already complete");
-			auto message_box =
-			    mksp<MessageBox>(tr("PROJECT COMPLETE"), tr("This project is already complete."),
-			                     MessageBox::ButtonOptions::Ok);
-			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
-			return;
-		}
-		if (topic->required_lab_size == ResearchTopic::LabSize::Large &&
-		    this->lab->size == ResearchTopic::LabSize::Small)
-		{
-			LogInfo("Topic is large and lab is small");
-			auto message_box = mksp<MessageBox>(
-			    tr("PROJECT TOO LARGE"), tr("This project requires an advanced lab or workshop."),
-			    MessageBox::ButtonOptions::Ok);
-			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
-			return;
-		}
-		if (this->lab->type == ResearchTopic::Type::Engineering &&
-		    topic->cost > state->player->balance)
-		{
-			LogInfo("Cannot afford to manufacture");
-			auto message_box = mksp<MessageBox>(tr("FUNDS EXCEEDED"),
-			                                    tr("Production costs exceed your available funds."),
-			                                    MessageBox::ButtonOptions::Ok);
-			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
-			return;
+			if (topic->isComplete())
+			{
+				LogInfo("Topic already complete");
+				auto message_box = mksp<MessageBox>(tr("PROJECT COMPLETE"),
+				                                    tr("This project is already complete."),
+				                                    MessageBox::ButtonOptions::Ok);
+				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+				return;
+			}
+			if (topic->required_lab_size == ResearchTopic::LabSize::Large &&
+			    this->lab->size == ResearchTopic::LabSize::Small)
+			{
+				LogInfo("Topic is large and lab is small");
+				auto message_box =
+				    mksp<MessageBox>(tr("PROJECT TOO LARGE"),
+				                     tr("This project requires an advanced lab or workshop."),
+				                     MessageBox::ButtonOptions::Ok);
+				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+				return;
+			}
+			if (this->lab->type == ResearchTopic::Type::Engineering &&
+			    topic->cost > state->player->balance)
+			{
+				LogInfo("Cannot afford to manufacture");
+				auto message_box = mksp<MessageBox>(
+				    tr("FUNDS EXCEEDED"), tr("Production costs exceed your available funds."),
+				    MessageBox::ButtonOptions::Ok);
+				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+				return;
+			}
 		}
 		current_topic = topic;
 		this->redrawResearchList();


### PR DESCRIPTION
Fixes `researchselection` when already-in-progress list item unable to select after changing selection.

Found this bug and fix it while trying to fix #786