### PR TITLE
Fix debug unit stunning in presence of retreated units.

### DIFF
--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -3013,7 +3013,7 @@ bool BattleView::handleKeyDown(Event *e)
 				bool local = !(modifierLCtrl || modifierRCtrl);
 				for (auto &u : battle.units)
 				{
-					if (u.second->isDead())
+					if (u.second->isDead() || u.second->retreated)
 					{
 						continue;
 					}


### PR DESCRIPTION
Fixes a battlescape debug CTD when stunning a unit with [S] is preceded by removing some other unit(s) with [K].