### PR TITLE
Don't attempt to rescue unreachable craft.

### DIFF
--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -143,12 +143,23 @@ class VehicleTargetHelper
 	                                                const VehicleAvoidance vehicleAvoidance,
 	                                                bool adjustForFlying);
 
+	// Checks reachability of the target location for the given vehicle.
+	// Args:
+	//   vehicle: Vehicle, only used for looking up the type.
+	//   target: Location to be checked for reachability.
+	// Returns: Reachability, see above for details.
+	static Reachability isReachableTarget(const Vehicle &v, Vec3<int> target);
+
   private:
 	static AdjustTargetResult adjustTargetToClosestFlying(GameState &state, Vehicle &v,
 	                                                      Vec3<int> &target,
 	                                                      const VehicleAvoidance vehicleAvoidance);
 	static AdjustTargetResult adjustTargetToClosestRoad(Vehicle &v, Vec3<int> &target);
 	static AdjustTargetResult adjustTargetToClosestGround(Vehicle &v, Vec3<int> &target);
+
+	static Reachability isReachableTargetFlying(const Vehicle &v, Vec3<int> target);
+	static Reachability isReachableTargetRoad(const Vehicle &v, Vec3<int> target);
+	static Reachability isReachableTargetGround(const Vehicle &v, Vec3<int> target);
 };
 
 class VehicleMission
@@ -185,7 +196,7 @@ class VehicleMission
 	bool acquireTargetBuilding(GameState &state, Vehicle &v);
 	void updateTimer(unsigned ticks);
 	void takePositionNearPortal(GameState &state, Vehicle &v);
-	static bool canRecoverVehicle(GameState &state, Vehicle &v, Vehicle &target);
+	static bool canRecoverVehicle(const GameState &state, const Vehicle &v, const Vehicle &target);
 
 	// Methods to create new missions
 

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -185,6 +185,7 @@ class VehicleMission
 	bool acquireTargetBuilding(GameState &state, Vehicle &v);
 	void updateTimer(unsigned ticks);
 	void takePositionNearPortal(GameState &state, Vehicle &v);
+	static bool canRecoverVehicle(GameState &state, Vehicle &v, Vehicle &target);
 
 	// Methods to create new missions
 

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -327,8 +327,8 @@ void Organisation::updateMissions(GameState &state)
 		// Rescue owned
 		for (auto &v : state.vehicles)
 		{
-			if (v.second->city == rescueTransport->city && v.second->crashed &&
-			    !v.second->carriedByVehicle && v.second->owner.id == id)
+			if (v.second->city == rescueTransport->city && v.second->owner.id == id &&
+			    VehicleMission::canRecoverVehicle(state, *rescueTransport, *v.second))
 			{
 				bool foundRescuer = false;
 				for (auto &r : state.vehicles)
@@ -360,9 +360,9 @@ void Organisation::updateMissions(GameState &state)
 		// Rescue allies but not aliens
 		for (auto &v : state.vehicles)
 		{
-			if (v.second->city == rescueTransport->city && v.second->crashed &&
-			    v.second->owner != state.getAliens() && !v.second->carriedByVehicle &&
-			    v.second->owner.id != id && isRelatedTo(v.second->owner) == Relation::Allied)
+			if (v.second->city == rescueTransport->city && v.second->owner != state.getAliens() &&
+			    v.second->owner.id != id && isRelatedTo(v.second->owner) == Relation::Allied &&
+			    VehicleMission::canRecoverVehicle(state, *rescueTransport, *v.second))
 			{
 				bool foundRescuer = false;
 				for (auto &r : state.vehicles)


### PR DESCRIPTION
Adjusts decision making for rescue-capable crafts to not consider unreachable crashes as viable targets.

This prevents Rescue Transports from becoming stuck in the "GotoLocation - RestartLastMission" loop trying to recover a crashed craft obstructed by a scenery, while ignoring other crashes.