### PR TITLE
Add a debug_trap that should break to an attached debugger

### DIFF
--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -1,6 +1,7 @@
 #include "framework/logger.h"
 #include "framework/configfile.h"
 #include "framework/framework.h"
+#include "library/backtrace.h"
 #include "library/sp.h"
 #include <mutex>
 namespace OpenApoc
@@ -46,6 +47,7 @@ void Log(LogLevel level, UString prefix, const UString &text)
 void _logAssert(UString prefix, UString string, int line, UString file)
 {
 	Log(LogLevel::Error, prefix, format("%s:%d Assertion failed %s", file, line, string));
+	debug_trap();
 	exit(1);
 }
 

--- a/library/backtrace.cpp
+++ b/library/backtrace.cpp
@@ -1,6 +1,13 @@
 #ifdef _WIN32
 #define BACKTRACE_WINDOWS
 #define _CRT_SECURE_NO_WARNINGS
+#define WIN32_LEAN_AND_MEAN
+#define NOMINMAX
+#define USE_DEBUGBREAK_TRAP
+#else
+// We assume we're on a posix platform if not windows
+#define USE_SIGNAL_TRAP
+#include <signal.h>
 #endif
 
 #include "library/backtrace.h"
@@ -24,6 +31,15 @@
 
 namespace OpenApoc
 {
+
+#ifdef USE_DEBUGBREAK_TRAP
+void debug_trap() { DebugBreak(); }
+#endif
+
+#ifdef USE_SIGNAL_TRAP
+void debug_trap() { raise(SIGTRAP); }
+#endif
+
 #if defined(BACKTRACE_LIBUNWIND)
 
 class libunwind_backtrace : public backtrace

--- a/library/backtrace.h
+++ b/library/backtrace.h
@@ -16,4 +16,7 @@ class backtrace
 std::ostream &operator<<(std::ostream &lhs, const backtrace &bt);
 
 up<backtrace> new_backtrace();
+
+void debug_trap();
+
 } // namespace OpenApoc


### PR DESCRIPTION
Add it to failed asserts, as otherwise it'll abort() even in a debugger,
which is less than ideal