### PR TITLE
Multiple warning fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 
 
 before_script:
-  - export CFLAGS="-Wall" CXXFLAGS="-Wall -Werror"
+  - export CFLAGS="-Wall" CXXFLAGS="-Wall -Werror -Wno-error=sign-compare"
   - $(which time) cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCLANG_TIDY=clang-tidy-8 -DCLANG_FORMAT=clang-format-8 -DENABLE_TESTS=ON -DCMAKE_C_FLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -GNinja
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ before_install:
 
 
 before_script:
-  - export CFLAGS="-Wall -Wextra" CXXFLAGS="-Wall -Wextra"
+  - export CFLAGS="-Wall" CXXFLAGS="-Wall -Werror"
   - $(which time) cmake . -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DCLANG_TIDY=clang-tidy-8 -DCLANG_FORMAT=clang-format-8 -DENABLE_TESTS=ON -DCMAKE_C_FLAGS="${CFLAGS}" -DCMAKE_CXX_FLAGS="${CXXFLAGS}" -GNinja
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
   - master
   - /release.*/
 # skip_tags: true
-os: Visual Studio 2017
+os: Visual Studio 2019
 configuration:
   - Release
 #  - Debug
@@ -35,7 +35,7 @@ before_build:
   - 7z e temp\cd.iso.xz -odata\
   - choco install nsis -pre
   - choco install ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
   - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH%
   - cmake --build .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ before_build:
   - cd c:\tools\vcpkg
   - git pull
   - git checkout 2019.12
+  - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -725,7 +725,8 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 		}
 		else if (childName == "tooltip")
 		{
-			if (ToolTipFont = ui().getFont(child.attribute("font").as_string()))
+			const auto tooltipFont = ui().getFont(child.attribute("font").as_string());
+			if (!tooltipFont)
 			{
 				ToolTipText = child.attribute("text").as_string();
 				if (!ToolTipText.empty())

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -863,6 +863,21 @@ sp<Form> Control::getForm()
 	return std::dynamic_pointer_cast<Form>(c);
 }
 
+void Control::setParent(sp<Control> Parent)
+{
+	if (Parent)
+	{
+		auto previousParent = this->owningControl.lock();
+		if (previousParent)
+		{
+			LogError("Reparenting control");
+		}
+		Parent->Controls.push_back(shared_from_this());
+		Parent->setDirty();
+	}
+	owningControl = Parent;
+}
+
 void Control::setParent(sp<Control> Parent, int position)
 {
 	if (Parent)
@@ -872,14 +887,7 @@ void Control::setParent(sp<Control> Parent, int position)
 		{
 			LogError("Reparenting control");
 		}
-		if (position == -1)
-		{
-			Parent->Controls.push_back(shared_from_this());
-		}
-		else
-		{
-			Parent->Controls.insert(Parent->Controls.begin() + position, shared_from_this());
-		}
+		Parent->Controls.insert(Parent->Controls.begin() + position, shared_from_this());
 		Parent->setDirty();
 	}
 	owningControl = Parent;

--- a/forms/control.h
+++ b/forms/control.h
@@ -137,7 +137,8 @@ class Control : public std::enable_shared_from_this<Control>
 
 	sp<Control> getParent() const;
 	sp<Form> getForm();
-	void setParent(sp<Control> Parent, int position = -1);
+	void setParent(sp<Control> Parent, int position);
+	void setParent(sp<Control> Parent);
 	sp<Control> getAncestor(sp<Control> Parent);
 
 	Vec2<int> getLocationOnScreen() const { return resolvedLocation; }

--- a/forms/multilistbox.cpp
+++ b/forms/multilistbox.cpp
@@ -236,6 +236,9 @@ void MultilistBox::eventOccured(Event *e)
 					}
 				}
 				break;
+			default:
+				// Don't handle other events
+				break;
 		}
 	}
 }

--- a/framework/apocresources/pck.cpp
+++ b/framework/apocresources/pck.cpp
@@ -112,7 +112,7 @@ static sp<PaletteImage> readPckCompression3(std::istream &input, Vec2<unsigned> 
 			return nullptr;
 		}
 		blkSize = blkFile.size();
-		blkData = std::move(blkFile.readAll());
+		blkData = blkFile.readAll();
 		LogInfo("Loaded %zu bytes of xcom.blk", blkSize);
 	}
 

--- a/framework/configfile.cpp
+++ b/framework/configfile.cpp
@@ -479,7 +479,7 @@ UString ConfigOption::getKey() const
 
 ConfigOptionString::ConfigOptionString(const UString section, const UString name,
                                        const UString description, const UString defaultValue)
-    : ConfigOption(section, name, description), defaultValue(defaultValue)
+    : ConfigOption(section, name, description)
 {
 	config().addOptionString(section, name, "", description, defaultValue);
 }
@@ -490,7 +490,7 @@ void ConfigOptionString::set(const UString &newValue) { config().set(getKey(), n
 
 ConfigOptionInt::ConfigOptionInt(const UString section, const UString name,
                                  const UString description, const int defaultValue)
-    : ConfigOption(section, name, description), defaultValue(defaultValue)
+    : ConfigOption(section, name, description)
 {
 	config().addOptionInt(section, name, "", description, defaultValue);
 }
@@ -501,7 +501,7 @@ void ConfigOptionInt::set(int newValue) { config().set(getKey(), newValue); }
 
 ConfigOptionBool::ConfigOptionBool(const UString section, const UString name,
                                    const UString description, const bool defaultValue)
-    : ConfigOption(section, name, description), defaultValue(defaultValue)
+    : ConfigOption(section, name, description)
 {
 	config().addOptionBool(section, name, "", description, defaultValue);
 }
@@ -511,7 +511,7 @@ void ConfigOptionBool::set(bool newValue) { config().set(getKey(), newValue); }
 
 ConfigOptionFloat::ConfigOptionFloat(const UString section, const UString name,
                                      const UString description, const float defaultValue)
-    : ConfigOption(section, name, description), defaultValue(defaultValue)
+    : ConfigOption(section, name, description)
 {
 	config().addOptionFloat(section, name, "", description, defaultValue);
 }

--- a/framework/configfile.h
+++ b/framework/configfile.h
@@ -78,9 +78,6 @@ class ConfigOption
 
 class ConfigOptionString : public ConfigOption
 {
-  private:
-	UString defaultValue;
-
   public:
 	ConfigOptionString(const UString section, const UString name, const UString description,
 	                   const UString defaultValue = "");
@@ -90,9 +87,6 @@ class ConfigOptionString : public ConfigOption
 
 class ConfigOptionInt : public ConfigOption
 {
-  private:
-	int defaultValue;
-
   public:
 	ConfigOptionInt(const UString section, const UString name, const UString description,
 	                const int defaultValue = 0);
@@ -102,9 +96,6 @@ class ConfigOptionInt : public ConfigOption
 
 class ConfigOptionBool : public ConfigOption
 {
-  private:
-	bool defaultValue;
-
   public:
 	ConfigOptionBool(const UString section, const UString name, const UString description,
 	                 const bool defaultValue = false);
@@ -114,9 +105,6 @@ class ConfigOptionBool : public ConfigOption
 
 class ConfigOptionFloat : public ConfigOption
 {
-  private:
-	float defaultValue;
-
   public:
 	ConfigOptionFloat(const UString section, const UString name, const UString description,
 	                  const float defaultValue = 0.0f);

--- a/framework/luaframework.cpp
+++ b/framework/luaframework.cpp
@@ -144,7 +144,6 @@ void pushToLua(lua_State *L, Xorshift128Plus<uint32_t> &v)
 	*udata = &v;
 	lua_createtable(L, 0, 0);
 	lua_pushcfunction(L, [](lua_State *L) {
-		Xorshift128Plus<uint32_t> **xorshift = (Xorshift128Plus<uint32_t> **)lua_touserdata(L, 1);
 		std::string key = lua_tostring(L, 2);
 		lua_settop(L, 0);
 		if (auto method = getLuaObjectMethods<Xorshift128Plus<uint32_t>>(key))
@@ -166,7 +165,6 @@ void pushToLua(lua_State *L, const Xorshift128Plus<uint32_t> &v)
 	*udata = &v;
 	lua_createtable(L, 0, 0);
 	lua_pushcfunction(L, [](lua_State *L) {
-		Xorshift128Plus<uint32_t> **xorshift = (Xorshift128Plus<uint32_t> **)lua_touserdata(L, 1);
 		std::string key = lua_tostring(L, 2);
 		lua_settop(L, 0);
 		if (auto method = getLuaObjectConstMethods<Xorshift128Plus<uint32_t>>(key))

--- a/framework/luaframework.h
+++ b/framework/luaframework.h
@@ -319,7 +319,7 @@ template <typename T> void pushToLua(lua_State *L, const std::set<T> &v)
 	int i = 0;
 	for (const auto &item : v)
 	{
-		pushToLua(L, v);
+		pushToLua(L, item);
 		lua_seti(L, -2, i + 1);
 		++i;
 	}

--- a/framework/luaframework.h
+++ b/framework/luaframework.h
@@ -70,7 +70,6 @@ typename std::enable_if<std::is_enum<T>::value>::type getFromLua(lua_State *L, i
 // trying to get a value from the stack into a const reference (invalid)
 template <typename T> void getFromLua(lua_State *L, int argNum, const T &v [[maybe_unused]])
 {
-	int idx = argNum;
 	if (argNum < 0)
 		argNum = lua_gettop(L) + argNum + 1;
 	luaL_error(L, "this member (#%d) cannot be set directly", argNum);

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -1189,8 +1189,6 @@ class ColouredDrawMachine
 		TRACE_FN;
 		auto &buf = this->buffers[this->current_buffer];
 
-		ColouredDescription d;
-
 		for (int i = 0; i < 4; i++)
 		{
 			buf.data.vertices[i].position = positions[i];
@@ -1215,8 +1213,6 @@ class ColouredDrawMachine
 	{
 		TRACE_FN;
 		auto &buf = this->buffers[this->current_buffer];
-
-		ColouredDescription d;
 
 		for (unsigned int i = 0; i < 2; i++)
 		{

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -142,11 +142,10 @@ class SpritesheetPage
   private:
 	up<stbrp_node[]> pack_nodes;
 	stbrp_context pack_context;
-	Vec2<int> size;
 	int page_no;
 
   public:
-	SpritesheetPage(int page_no, Vec2<int> size, int node_count) : size(size), page_no(page_no)
+	SpritesheetPage(int page_no, Vec2<int> size, int node_count) : page_no(page_no)
 	{
 		LogAssert(node_count > 0);
 		LogAssert(size.x > 0);

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3028,7 +3028,6 @@ void Battle::exitBattle(GameState &state)
 	{
 		if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
 		{
-			Vec2<int> battleLocation;
 			StateRef<City> city;
 			StateRef<Vehicle> location = {&state, state.current_battle->mission_location_id};
 			city = location->city;

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2025,6 +2025,8 @@ void Battle::checkMissionEnd(GameState &state, bool retreated, bool forceReCheck
 						case OpenApoc::MovementState::Brainsuck:
 							normalUnit = true;
 							break;
+						default:
+							break;
 					}
 					if (normalUnit)
 						break;

--- a/game/state/battle/battlemappart.cpp
+++ b/game/state/battle/battlemappart.cpp
@@ -605,6 +605,11 @@ bool BattleMapPart::findSupport(bool allowClinging)
 							partList.emplace_back(Vec3<int>{pos.x, pos.y, pos.z + p.first},
 							                      TileObject::Type::LeftWall);
 							break;
+						case MapDirection::Up:
+							[[fallthrough]];
+						case MapDirection::Down:
+							// Up and Down don't have map parts
+							break;
 					}
 				}
 
@@ -644,6 +649,11 @@ bool BattleMapPart::findSupport(bool allowClinging)
 					case MapDirection::West:
 						dx = negInc;
 						break;
+					case MapDirection::Up:
+						[[fallthrough]];
+					case MapDirection::Down:
+						// Up and Down don't have map parts
+						break;
 				}
 				partList.emplace_back(Vec3<int>{pos.x + dx, pos.y + dy, pos.z + p.first}, p.second);
 
@@ -658,6 +668,7 @@ bool BattleMapPart::findSupport(bool allowClinging)
 					switch (d)
 					{
 						case MapDirection::North:
+							[[fallthrough]];
 						case MapDirection::South:
 							switch (d)
 							{
@@ -668,11 +679,18 @@ bool BattleMapPart::findSupport(bool allowClinging)
 									dx = -1;
 									break;
 								case MapDirection::North:
+									[[fallthrough]];
 								case MapDirection::South:
 									continue;
+								case MapDirection::Up:
+									[[fallthrough]];
+								case MapDirection::Down:
+									// Up and Down don't have map parts
+									break;
 							}
 							break;
 						case MapDirection::East:
+							[[fallthrough]];
 						case MapDirection::West:
 							switch (d)
 							{
@@ -683,9 +701,20 @@ bool BattleMapPart::findSupport(bool allowClinging)
 									dy = 1;
 									break;
 								case MapDirection::East:
+									[[fallthrough]];
 								case MapDirection::West:
 									continue;
+								case MapDirection::Up:
+									[[fallthrough]];
+								case MapDirection::Down:
+									// Up and Down don't have map parts
+									break;
 							}
+							break;
+						case MapDirection::Up:
+							[[fallthrough]];
+						case MapDirection::Down:
+							// Up and Down don't have map parts
 							break;
 					}
 					partList.emplace_back(Vec3<int>{pos.x + dx, pos.y + dy, pos.z + p.first},

--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -510,7 +510,6 @@ bool AgentMission::advanceAlongPath(GameState &state, Agent &a, Vec3<float> &des
 {
 	// Add {0.5,0.5,0.5} to make it route to the center of the tile
 	static const Vec3<float> offset{0.5f, 0.5f, 0.5f};
-	static const Vec3<float> offsetLand{0.5f, 0.5f, 0.0f};
 
 	if (currentPlannedPath.empty())
 	{

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -483,7 +483,9 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 			}
 			break;
 		case FacilityType::Capacity::Chemistry:
+			[[fallthrough]];
 		case FacilityType::Capacity::Physics:
+			[[fallthrough]];
 		case FacilityType::Capacity::Workshop:
 			for (auto f = facilities.begin(); f != facilities.end(); ++f)
 			{
@@ -527,6 +529,9 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 				StateRef<AEquipmentType> ae = {&state, e.first};
 				total += ae->store_space * e.second;
 			}
+			break;
+		case FacilityType::Capacity::Nothing:
+			// Nothing needs to be handled
 			break;
 	}
 

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -974,7 +974,7 @@ bool Scenery::findSupport(bool allowClinging)
 
 		for (auto &list : incrementsList)
 		{
-			bool found;
+			bool found = false;
 			for (auto &increment : list)
 			{
 				found = false;

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -67,7 +67,6 @@ bool Scenery::attachToSomething()
 	auto pos = tileObject->getOwningTile()->position;
 	supportHardness = -10;
 	auto &map = tileObject->map;
-	auto tileType = tileObject->getType();
 	auto thisPtr = shared_from_this();
 
 	int startX = pos.x - 1;
@@ -118,7 +117,6 @@ bool Scenery::findSupport(bool allowClinging)
 		return true;
 	}
 	auto &map = tileObject->map;
-	auto tileType = tileObject->getType();
 	auto thisPtr = shared_from_this();
 
 	// Forward lookup for adding increments

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -1310,6 +1310,9 @@ void Scenery::die(GameState &state, bool forced)
 								vehiclesToDamage.push_back(v);
 								break;
 							}
+							default:
+								// Other tiles don't get damaged or block smoke
+								break;
 						}
 					}
 					for (auto &v : vehiclesToDamage)

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1703,7 +1703,6 @@ void Vehicle::provideServicePassengers(GameState &state, bool otherOrg)
 
 StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 {
-	bool fromTactical = false;
 	bool cargoArrived = false;
 	bool bioArrived = false;
 	bool recoveryArrived = false;
@@ -1716,10 +1715,6 @@ StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 	{
 		if (it->destination == currentBuilding)
 		{
-			if (!it->originalOwner)
-			{
-				fromTactical = true;
-			}
 			it->arrive(state, cargoArrived, bioArrived, recoveryArrived, transferArrived,
 			           suppliers);
 			it = cargo.erase(it);

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -3120,6 +3120,8 @@ Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 		case VehicleMission::MissionType::InfiltrateSubvert:
 		case VehicleMission::MissionType::OfferService:
 		case VehicleMission::MissionType::Teleport:
+		case VehicleMission::MissionType::DepartToSpace:
+		case VehicleMission::MissionType::ArriveFromDimensionGate:
 			if (crashed || sliding || falling || carriedVehicle)
 			{
 				delete mission;
@@ -3183,6 +3185,8 @@ bool Vehicle::setMission(GameState &state, VehicleMission *mission)
 		case VehicleMission::MissionType::InfiltrateSubvert:
 		case VehicleMission::MissionType::OfferService:
 		case VehicleMission::MissionType::Teleport:
+		case VehicleMission::MissionType::DepartToSpace:
+		case VehicleMission::MissionType::ArriveFromDimensionGate:
 			if (crashed || sliding || falling || carriedVehicle)
 			{
 				delete mission;

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -632,7 +632,6 @@ class GroundVehicleMover : public VehicleMover
 		// or to tick_scale * city_scale / speed
 		int ticksPerTile = TICK_SCALE * VELOCITY_SCALE_CITY.x / vehicle.getSpeed();
 
-		unsigned lastTicksToTurn = 0;
 		unsigned lastTicksToMove = 0;
 
 		// See that we're not in the air
@@ -1705,7 +1704,6 @@ void Vehicle::provideServicePassengers(GameState &state, bool otherOrg)
 StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 {
 	bool fromTactical = false;
-	bool agentsArrived = false;
 	bool cargoArrived = false;
 	bool bioArrived = false;
 	bool recoveryArrived = false;
@@ -2889,7 +2887,6 @@ sp<VEquipment> Vehicle::getFirstFiringWeapon(GameState &state [[maybe_unused]], 
 	sp<VEquipment> firingWeapon;
 
 	auto firePosition = getMuzzleLocation();
-	auto distanceTiles = glm::length(position - target);
 	auto distanceVoxels = this->tileObject->getDistanceTo(target);
 	bool outsideArc = false;
 

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -241,7 +241,7 @@ class FlyingVehicleMover : public VehicleMover
 
 				// Rotate space so that we see where the hit point is
 				// Calculate change-of-basis matrix
-				glm::mat3 transform;
+				glm::mat3 transform = {};
 				if (pointNorm.x == 0 && pointNorm.z == 0)
 				{
 					if (pointNorm.y < 0) // rotate 180 degrees

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -64,7 +64,7 @@ FlyingVehicleTileHelper::FlyingVehicleTileHelper(TileMap &map, Vehicle &v)
 
 FlyingVehicleTileHelper::FlyingVehicleTileHelper(TileMap &map, VehicleType &vehType, bool crashed,
                                                  int altitude)
-    : map(map), type(vehType.type), crashed(crashed), altitude(altitude)
+    : map(map), crashed(crashed), altitude(altitude)
 {
 	int xMax = 0;
 	int yMax = 0;
@@ -77,10 +77,9 @@ FlyingVehicleTileHelper::FlyingVehicleTileHelper(TileMap &map, VehicleType &vehT
 	large = size.x > 1 || size.y > 1;
 }
 
-FlyingVehicleTileHelper::FlyingVehicleTileHelper(TileMap &map, VehicleType::Type type, bool crashed,
-                                                 Vec2<int> size, int altitude)
-    : map(map), type(type), crashed(crashed), size(size), large(size.x > 1 || size.y > 1),
-      altitude(altitude)
+FlyingVehicleTileHelper::FlyingVehicleTileHelper(TileMap &map, bool crashed, Vec2<int> size,
+                                                 int altitude)
+    : map(map), crashed(crashed), size(size), large(size.x > 1 || size.y > 1), altitude(altitude)
 {
 }
 
@@ -3135,11 +3134,11 @@ UString VehicleMission::getName()
 }
 
 GroundVehicleTileHelper::GroundVehicleTileHelper(TileMap &map, Vehicle &v)
-    : GroundVehicleTileHelper(map, v.type->type, v.crashed)
+    : GroundVehicleTileHelper(map, v.type->type)
 {
 }
-GroundVehicleTileHelper::GroundVehicleTileHelper(TileMap &map, VehicleType::Type type, bool crashed)
-    : map(map), type(type), crashed(crashed)
+GroundVehicleTileHelper::GroundVehicleTileHelper(TileMap &map, VehicleType::Type type)
+    : map(map), type(type)
 {
 }
 

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -3126,6 +3126,10 @@ UString VehicleMission::getName()
 			break;
 		case MissionType::RestartNextMission:
 			break;
+		case MissionType::OfferService:
+			name += format(" counter: %u, target %s", missionCounter,
+			               targetBuilding ? targetBuilding->name : "null");
+			break;
 	}
 	return name;
 }

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -900,6 +900,9 @@ VehicleTargetHelper::adjustTargetToClosest(GameState &state, Vehicle &v, Vec3<in
 			return adjustTargetToClosestRoad(v, target);
 		case VehicleType::Type::ATV:
 			return adjustTargetToClosestGround(v, target);
+		default:
+			LogError("Vehicle [%s] has unknown type [%s]", v.name, v.type->name);
+			[[fallthrough]];
 		case VehicleType::Type::Flying:
 		case VehicleType::Type::UFO:
 			if (!adjustForFlying)
@@ -908,8 +911,6 @@ VehicleTargetHelper::adjustTargetToClosest(GameState &state, Vehicle &v, Vec3<in
 				return {Reachability::Reachable, true};
 			}
 			return adjustTargetToClosestFlying(state, v, target, vehicleAvoidance);
-		default:
-			LogError("Vehicle [%s] has unknown type [%s]", v.name, v.type->name);
 	}
 }
 
@@ -921,11 +922,12 @@ Reachability VehicleTargetHelper::isReachableTarget(const Vehicle &v, Vec3<int> 
 			return isReachableTargetRoad(v, target);
 		case VehicleType::Type::ATV:
 			return isReachableTargetGround(v, target);
+		default:
+			LogError("Vehicle [%s] has unknown type [%s]", v.name, v.type->name);
+			[[fallthrough]];
 		case VehicleType::Type::Flying:
 		case VehicleType::Type::UFO:
 			return isReachableTargetFlying(v, target);
-		default:
-			LogError("Vehicle [%s] has unknown type [%s]", v.name, v.type->name);
 	}
 }
 

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -32,7 +32,6 @@ class FlyingVehicleTileHelper : public CanEnterTileHelper
 {
   private:
 	TileMap &map;
-	VehicleType::Type type;
 	bool crashed;
 	Vec2<int> size;
 	bool large;
@@ -41,8 +40,7 @@ class FlyingVehicleTileHelper : public CanEnterTileHelper
   public:
 	FlyingVehicleTileHelper(TileMap &map, Vehicle &v);
 	FlyingVehicleTileHelper(TileMap &map, VehicleType &vehType, bool crashed, int altitude);
-	FlyingVehicleTileHelper(TileMap &map, VehicleType::Type type, bool crashed, Vec2<int> size,
-	                        int altitude);
+	FlyingVehicleTileHelper(TileMap &map, bool crashed, Vec2<int> size, int altitude);
 
 	bool canEnterTile(Tile *from, Tile *to, bool ignoreStaticUnits = false,
 	                  bool ignoreMovingUnits = true, bool ignoreAllUnits = false) const override;
@@ -74,11 +72,10 @@ class GroundVehicleTileHelper : public CanEnterTileHelper
   private:
 	TileMap &map;
 	VehicleType::Type type;
-	bool crashed;
 
   public:
 	GroundVehicleTileHelper(TileMap &map, Vehicle &v);
-	GroundVehicleTileHelper(TileMap &map, VehicleType::Type type, bool crashed);
+	GroundVehicleTileHelper(TileMap &map, VehicleType::Type type);
 
 	bool canEnterTile(Tile *from, Tile *to, bool ignoreStaticUnits = false,
 	                  bool ignoreMovingUnits = true, bool ignoreAllUnits = false) const override;

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -393,6 +393,10 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 		case GameEventType::VehicleNoFuel:
 			messageInner = format("%s %s", tr("Vehicle out of fuel:"), name);
 			break;
+		default:
+			LogWarning("GameSomethingDiedEvent %s called on non-death event %d", name,
+			           static_cast<int>(type));
+			break;
 	}
 }
 UString GameSomethingDiedEvent::message() { return messageInner; }

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -470,8 +470,6 @@ void GameState::validateAgentEquipment()
 
 void GameState::fillOrgStartingProperty()
 {
-	auto buildingIt = this->cities["CITYMAP_HUMAN"]->buildings.begin();
-
 	for (auto &o : this->organisations)
 	{
 		o.second->updateVehicleAgentPark(*this);

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -302,6 +302,10 @@ int Agent::getSkill() const
 		case AgentType::Role::Engineer:
 			skill = current_stats.engineering_skill;
 			break;
+		case AgentType::Role::Soldier:
+			// Soldiers can't be used for anything that uses a skill value
+			skill = 0;
+			break;
 	}
 
 	return skill;

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -900,7 +900,6 @@ bool Agent::getNewGoal(GameState &state)
 {
 	bool popped = false;
 	bool acquired = false;
-	Vec3<float> nextGoal;
 	// Pop finished missions if present
 	popped = popFinishedMissions(state);
 	do

--- a/game/state/shared/projectile.cpp
+++ b/game/state/shared/projectile.cpp
@@ -30,10 +30,9 @@ Projectile::Projectile(Type type, StateRef<Vehicle> firer, StateRef<Vehicle> tar
       depletionRate(depletionRate), firerVehicle(firer), firerPosition(firer->position),
       trackedVehicle(target), targetPosition(targetPosition), previousPosition(position),
       spritePositions({position}), tail_length(tail_length), projectile_sprites(projectile_sprites),
-      sprite_distance(1.0f / TILE_Y_CITY), voxelMapLos(voxelMap),
-      voxelMapLof(turnRate > 0 ? voxelMap : nullptr), manualFire(manualFire), impactSfx(impactSfx),
-      doodadType(doodadType), velocityScale(VELOCITY_SCALE_CITY), stunTicks(stunTicks),
-      splitIntoTypesCity(splitIntoTypes)
+      sprite_distance(1.0f / TILE_Y_CITY), voxelMapLof(turnRate > 0 ? voxelMap : nullptr),
+      voxelMapLos(voxelMap), manualFire(manualFire), impactSfx(impactSfx), doodadType(doodadType),
+      velocityScale(VELOCITY_SCALE_CITY), stunTicks(stunTicks), splitIntoTypesCity(splitIntoTypes)
 {
 	// enough ticks to pass 1 tile diagonally and some more since vehicles can move quite quickly
 	ownerInvulnerableTicks =
@@ -54,10 +53,10 @@ Projectile::Projectile(Type type, StateRef<BattleUnit> firer, StateRef<BattleUni
       depletionRate(depletionRate), firerUnit(firer), firerPosition(firer->position),
       trackedUnit(target), targetPosition(targetPosition), previousPosition(position),
       spritePositions({position}), tail_length(tail_length), projectile_sprites(projectile_sprites),
-      sprite_distance(1.0f / TILE_Y_BATTLE), voxelMapLos(voxelMap),
-      voxelMapLof(turnRate > 0 ? voxelMap : nullptr), manualFire(manualFire), impactSfx(impactSfx),
-      doodadType(doodadType), damageType(damageType), velocityScale(VELOCITY_SCALE_BATTLE),
-      stunTicks(stunTicks), splitIntoTypesBattle(splitIntoTypes)
+      sprite_distance(1.0f / TILE_Y_BATTLE), voxelMapLof(turnRate > 0 ? voxelMap : nullptr),
+      voxelMapLos(voxelMap), manualFire(manualFire), impactSfx(impactSfx), doodadType(doodadType),
+      damageType(damageType), velocityScale(VELOCITY_SCALE_BATTLE), stunTicks(stunTicks),
+      splitIntoTypesBattle(splitIntoTypes)
 {
 	// enough ticks to pass 1 tile diagonally
 	ownerInvulnerableTicks =

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -1645,7 +1645,7 @@ void City::groupMove(GameState &state, std::list<StateRef<Vehicle>> &selectedVeh
 		return;
 	}
 	if (selectedVehicles.size() == 1 ||
-	    selectedVehicles.size() == 2 && selectedVehicles.front()->owner != state.getPlayer())
+	    (selectedVehicles.size() == 2 && selectedVehicles.front()->owner != state.getPlayer()))
 	{
 		auto v = selectedVehicles.front();
 		if (v->owner == state.getPlayer())

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -1856,9 +1856,6 @@ void City::fillRoadSegmentMap(GameState &state [[maybe_unused]])
 											continue;
 										}
 										auto nextTile = m.getTile(nextPosition);
-										float thisCost = 0.0f;
-										bool unused = false;
-										bool jumped = false;
 										if (!helper.canEnterTile(thisTile, nextTile))
 										{
 											continue;

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -1718,7 +1718,7 @@ void City::fillRoadSegmentMap(GameState &state [[maybe_unused]])
 	tileToRoadSegmentMap.clear();
 	roadSegments.clear();
 	auto &m = *map;
-	auto helper = GroundVehicleTileHelper{m, VehicleType::Type::Road, false};
+	auto helper = GroundVehicleTileHelper{m, VehicleType::Type::Road};
 
 	// -2 means not processed, -1 means no road, otherwise segment index
 	tileToRoadSegmentMap.resize(m.size.x * m.size.y * m.size.z, -2);

--- a/game/state/tilemap/tileobject_vehicle.cpp
+++ b/game/state/tilemap/tileobject_vehicle.cpp
@@ -56,7 +56,6 @@ void TileObjectVehicle::drawStatic(Renderer &r, sp<Vehicle> vehicle, TileTransfo
 	{
 		case TileViewMode::Isometric:
 		{
-			float closestAngle = FLT_MAX;
 			sp<Image> closestImage;
 
 			if (vehicle->type->type == VehicleType::Type::UFO)

--- a/game/ui/base/aliencontainmentscreen.cpp
+++ b/game/ui/base/aliencontainmentscreen.cpp
@@ -67,7 +67,7 @@ void AlienContainmentScreen::closeScreen()
 				continue;
 			}
 			int i = 0;
-			for (auto &b : state->player_bases)
+			for ([[maybe_unused]] const auto &b : state->player_bases)
 			{
 				int bioDelta = c->getBioDelta(i);
 				if (bioDelta)

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -209,6 +209,9 @@ void BuyAndSellScreen::closeScreen()
 							case TransactionControl::Type::VehicleAmmo:
 								orgsBuyFrom.insert(c->manufacturer);
 								break;
+							default:
+								// Other types find their own transportation
+								break;
 						}
 					}
 				}
@@ -241,6 +244,9 @@ void BuyAndSellScreen::closeScreen()
 				case Organisation::PurchaseResult::OrgHasNoBuildings:
 				case Organisation::PurchaseResult::OrgHostile:
 					LogError("How did we end up buying from an org we can't buy from!?");
+					break;
+				case Organisation::PurchaseResult::OK:
+					// Everything went fine
 					break;
 			}
 		}

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -189,8 +189,6 @@ void BuyAndSellScreen::closeScreen()
 	// Step 03.01: Check transportation for purchases
 	bool purchaseTransferFound = false;
 	{
-		bool noFerry = false;
-
 		// Find all orgs that we buy from
 		std::set<StateRef<Organisation>> orgsBuyFrom;
 		for (auto &l : transactionControls)

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -220,7 +220,6 @@ void BuyAndSellScreen::closeScreen()
 		// Check orgs
 		std::list<StateRef<Organisation>> badOrgs;
 		bool transportationHostile = false;
-		bool transportationBusy = false;
 		for (auto &o : orgsBuyFrom)
 		{
 			if (o == player)
@@ -232,7 +231,6 @@ void BuyAndSellScreen::closeScreen()
 			switch (canBuy)
 			{
 				case Organisation::PurchaseResult::NoTransportAvailable:
-					transportationBusy = true;
 					badOrgs.push_back(o);
 					break;
 				case Organisation::PurchaseResult::TranportHostile:

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -509,6 +509,14 @@ void BuyAndSellScreen::executeOrders()
 								         c->itemId);
 								break;
 							}
+							case TransactionControl::Type::Soldier:
+							case TransactionControl::Type::BioChemist:
+							case TransactionControl::Type::Physicist:
+							case TransactionControl::Type::Engineer:
+							{
+								LogError("How did we manage to sell an agent type %s!", c->itemId);
+								break;
+							}
 						}
 					}
 
@@ -558,6 +566,14 @@ void BuyAndSellScreen::executeOrders()
 							{
 								StateRef<VehicleType> vehicle{state.get(), c->itemId};
 								org->purchase(*state, b.second->building, vehicle, -order);
+								break;
+							}
+							case TransactionControl::Type::Soldier:
+							case TransactionControl::Type::BioChemist:
+							case TransactionControl::Type::Physicist:
+							case TransactionControl::Type::Engineer:
+							{
+								LogError("How did we manage to sell an agent type %s!", c->itemId);
 								break;
 							}
 						}

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -128,7 +128,7 @@ void BuyAndSellScreen::closeScreen()
 				if (!c->getLinked() || c->getLinked()->front().lock() == c)
 				{
 					int i = 0;
-					for (auto &b : state->player_bases)
+					for ([[maybe_unused]] const auto &b : state->player_bases)
 					{
 						int cargoDelta = c->getCargoDelta(i);
 						if (cargoDelta)

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -560,7 +560,6 @@ void RecruitScreen::closeScreen(bool confirmed)
 	}
 
 	// Step 01 : Calculate money and lq deltas
-	int leftIndex = getLeftIndex();
 	int moneyDelta = 0;
 	std::vector<int> vecLqDelta;
 	vecLqDelta.resize(8);

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -307,7 +307,6 @@ void TransactionScreen::populateControlsAgentEquipment()
 void TransactionScreen::populateControlsVehicleEquipment()
 {
 	bool flying = type == Type::FlyingEquipment;
-	auto otherType = flying ? Type::GroundEquipment : Type::FlyingEquipment;
 	static const std::list<EquipmentSlotType> vehTypes = {EquipmentSlotType::VehicleWeapon,
 	                                                      EquipmentSlotType::VehicleGeneral,
 	                                                      EquipmentSlotType::VehicleEngine};
@@ -602,7 +601,7 @@ bool TransactionScreen::isClosable() const
 			}
 
 			int i = 0;
-			for (auto &b : state->player_bases)
+			for ([[maybe_unused]] auto &b : state->player_bases)
 			{
 				if (c->tradeState.shipmentsTotal(i++))
 				{

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -262,7 +262,7 @@ void TransferScreen::closeScreen()
 					continue;
 				}
 				int i = 0;
-				for (auto &b : state->player_bases)
+				for ([[maybe_unused]] auto &b : state->player_bases)
 				{
 					int crewDelta = c->getCrewDelta(i);
 					int cargoDelta = c->getCargoDelta(i);

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -636,6 +636,12 @@ void TransferScreen::executeOrders()
 							b.second->inventoryVehicleEquipment[c->itemId] -= order;
 							break;
 						}
+						default:
+						{
+							LogError("Unhandled TransactionControl::Type %d",
+							         static_cast<int>(c->itemType));
+							break;
+						}
 					}
 				}
 			}

--- a/game/ui/battle/battleprestart.cpp
+++ b/game/ui/battle/battleprestart.cpp
@@ -51,7 +51,7 @@ void BattlePreStart::displayAgent(sp<Agent> agent)
 	    ->setImage(lHand ? lHand->type->equipscreen_sprite : nullptr);
 }
 BattlePreStart::BattlePreStart(sp<GameState> state)
-    : Stage(), menuform(ui().getForm("battle/prestart")), TOP_LEFT({302, 80}), state(state)
+    : Stage(), TOP_LEFT({302, 80}), menuform(ui().getForm("battle/prestart")), state(state)
 {
 
 	menuform->findControlTyped<GraphicButton>("BUTTON_EQUIP")

--- a/game/ui/components/agentassignment.cpp
+++ b/game/ui/components/agentassignment.cpp
@@ -715,6 +715,9 @@ void AgentAssignment::eventOccured(Event *e)
 				}
 			}
 			break;
+		default:
+			// All other events ignored
+			break;
 	}
 }
 

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -73,9 +73,6 @@ void CheatOptions::updateMultiplierText(UString controlName, float multMin, floa
 {
 	auto bar = menuform->findControlTyped<ScrollBar>(controlName);
 	auto label = menuform->findControlTyped<Label>("TEXT_" + controlName);
-	float multValue = ((double)bar->getValue() - bar->getMinimum()) /
-	                      ((double)bar->getMaximum() - bar->getMinimum()) * (multMax - multMin) +
-	                  multMin;
 	label->setText(format("%d%%", scaleScrollbarToMultiplier(bar->getValue(), multMin, multMax,
 	                                                         bar->getMinimum(), bar->getMaximum()) *
 	                                  100));

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -139,6 +139,9 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 		case EquipmentSlotType::VehicleGeneral:
 			displayGeneral(item, type);
 			break;
+		default:
+			LogError("Unhandled equipment type %s on vehicle", type->id);
+			break;
 	}
 }
 

--- a/game/ui/skirmish/selectforces.cpp
+++ b/game/ui/skirmish/selectforces.cpp
@@ -16,7 +16,7 @@ namespace OpenApoc
 
 SelectForces::SelectForces(sp<GameState> state, Skirmish &skirmish,
                            std::map<StateRef<AgentType>, int> *aliens, int *guards, int *civilians)
-    : Stage(), skirmish(skirmish), menuform(ui().getForm("selectforces")), state(*state)
+    : Stage(), menuform(ui().getForm("selectforces")), skirmish(skirmish), state(*state)
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 	menuform->findControlTyped<Label>("LOCATION")->setText(skirmish.getLocationText());

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -971,13 +971,9 @@ BattleView::BattleView(sp<GameState> gameState)
 		}
 	};
 
-	std::function<void(FormsEvent * e)> throwRightHand = [this, throwItem](Event *) {
-		throwItem(true);
-	};
+	std::function<void(FormsEvent * e)> throwRightHand = [throwItem](Event *) { throwItem(true); };
 
-	std::function<void(FormsEvent * e)> throwLeftHand = [this, throwItem](Event *) {
-		throwItem(false);
-	};
+	std::function<void(FormsEvent * e)> throwLeftHand = [throwItem](Event *) { throwItem(false); };
 
 	std::function<void(FormsEvent * e)> finishPriming = [this, throwItem](Event *) {
 		bool right =

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2891,6 +2891,9 @@ void BattleView::eventOccurred(Event *e)
 				return;
 			}
 			break;
+		default:
+			// Other events aren't handled
+			break;
 	}
 	BattleTileView::eventOccurred(e);
 }

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -734,6 +734,7 @@ void CityTileView::render()
 					switch (m->type)
 					{
 						case VehicleMission::MissionType::AttackVehicle:
+						case VehicleMission::MissionType::RecoverVehicle:
 						{
 							if (!m->targetVehicle)
 								break;
@@ -752,8 +753,11 @@ void CityTileView::render()
 						}
 						case VehicleMission::MissionType::AttackBuilding:
 						case VehicleMission::MissionType::GotoBuilding:
+						case VehicleMission::MissionType::Land:
+						case VehicleMission::MissionType::OfferService:
+						case VehicleMission::MissionType::InvestigateBuilding:
 							buildingsSelected.insert(m->targetBuilding);
-						// Intentional fall-through
+							[[fallthrough]];
 						case VehicleMission::MissionType::Crash:
 						{
 							if (!m->currentPlannedPath.empty())
@@ -769,10 +773,21 @@ void CityTileView::render()
 						case VehicleMission::MissionType::InfiltrateSubvert:
 						case VehicleMission::MissionType::Patrol:
 						case VehicleMission::MissionType::GotoPortal:
+						case VehicleMission::MissionType::Teleport:
+						case VehicleMission::MissionType::DepartToSpace:
 						{
 							targetLocationsToDraw.emplace_back((Vec3<float>)m->targetLocation +
 							                                       Vec3<float>{0.5f, 0.5f, 0.0f},
 							                                   v.second->position, true, false);
+							break;
+						}
+						case VehicleMission::MissionType::Snooze:
+						case VehicleMission::MissionType::RestartNextMission:
+						case VehicleMission::MissionType::TakeOff:
+						case VehicleMission::MissionType::SelfDestruct:
+						case VehicleMission::MissionType::ArriveFromDimensionGate:
+						{
+							// These have no destination to draw
 							break;
 						}
 					}

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -29,10 +29,10 @@ namespace OpenApoc
 CityTileView::CityTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> stratTileSize,
                            TileViewMode initialMode, Vec3<float> screenCenterTile,
                            GameState &gameState)
-    : TileView(map, isoTileSize, stratTileSize, initialMode), state(gameState),
+    : TileView(map, isoTileSize, stratTileSize, initialMode),
       day_palette(fw().data->loadPalette("xcom3/ufodata/pal_01.dat")),
       twilight_palette(fw().data->loadPalette("xcom3/ufodata/pal_02.dat")),
-      night_palette(fw().data->loadPalette("xcom3/ufodata/pal_03.dat"))
+      night_palette(fw().data->loadPalette("xcom3/ufodata/pal_03.dat")), state(gameState)
 {
 	std::vector<sp<Palette>> newPal;
 	newPal.resize(3);

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -694,11 +694,6 @@ void CityTileView::render()
 				{
 					continue;
 				}
-				bool selected =
-				    std::find(state.current_city->cityViewSelectedAgents.begin(),
-				              state.current_city->cityViewSelectedAgents.end(),
-				              a.second) != state.current_city->cityViewSelectedAgents.end();
-
 				for (auto &m : a.second->missions)
 				{
 					if (m->type == AgentMission::MissionType::GotoBuilding)

--- a/game/ui/tileview/citytileview.h
+++ b/game/ui/tileview/citytileview.h
@@ -71,6 +71,5 @@ class CityTileView : public TileView
 	sp<Image> selectedTileImageFront;
 	Vec2<int> selectedTileImageOffset;
 	Colour alienDetectionColour;
-	float alienDetectionThickness;
 };
 } // namespace OpenApoc

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -268,6 +268,11 @@ bool CityView::handleClickedVehicle(StateRef<Vehicle> vehicle, bool rightClick,
 				setSelectionState(CitySelectionState::Normal);
 				break;
 			}
+			default:
+			{
+				// Other selection states don't affect vehicles
+				break;
+			}
 		}
 		return true;
 	}
@@ -333,6 +338,11 @@ bool CityView::handleClickedVehicle(StateRef<Vehicle> vehicle, bool rightClick,
 			orderAttack(vehicle, modifierLCtrl || modifierRCtrl);
 			setSelectionState(CitySelectionState::Normal);
 			return true;
+		}
+		default:
+		{
+			// Other selection states don't affect vehicles
+			break;
 		}
 	}
 	return false;
@@ -3439,6 +3449,11 @@ bool CityView::handleMouseDown(Event *e)
 					{
 						orderMove(position, modifierRCtrl || modifierLCtrl);
 					}
+					break;
+				}
+				default:
+				{
+					// Other selection modes don't affect these objects
 					break;
 				}
 			}

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -427,6 +427,13 @@ void UfopaediaCategoryView::setFormStats()
 								statsValues[row++]->setText(tr("Cloaks Craft"));
 							}
 							break;
+						default:
+						{
+							LogError("Trying to read non-vehicle equipment type %s on vehicle "
+							         "equipment ufopaedia page",
+							         ref->id);
+							break;
+						}
 					}
 					break;
 				}

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -446,7 +446,7 @@ void UfopaediaCategoryView::setFormStats()
 					statsValues[row++]->setText(
 					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
 					if (ref->type == AEquipmentType::Type::Ammo ||
-					    ref->type == AEquipmentType::Type::Weapon && ref->ammo_types.empty())
+					    (ref->type == AEquipmentType::Type::Weapon && ref->ammo_types.empty()))
 					{
 						statsLabels[row]->setText(tr("Power"));
 						statsValues[row++]->setText(Strings::fromInteger(ref->damage));

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -179,7 +179,7 @@ UString::UString(const char *cstr, size_t count) : u8Str(cstr, count) {}
 
 UString::UString(const UString &) = default;
 
-UString::UString(UString &&other) { this->u8Str = std::move(other.u8Str); }
+UString::UString(UString &&other) noexcept { this->u8Str = std::move(other.u8Str); }
 
 UString::UString(UniChar uc) : u8Str()
 {

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -1,6 +1,7 @@
 #include "library/strings.h"
 #include "library/strings_format.h"
 #include <cctype>
+#include <iterator>
 #include <tuple> // used for std::ignore
 
 #include <boost/algorithm/string/predicate.hpp>
@@ -251,13 +252,7 @@ UString &UString::operator+=(const UString &other)
 	return *this;
 }
 
-size_t UString::length() const
-{
-	size_t len = 0;
-	for (const auto &c : *this)
-		len++;
-	return len;
-}
+size_t UString::length() const { return std::distance(this->begin(), this->end()); }
 
 void UString::insert(size_t offset, const UString &other)
 {

--- a/library/strings.h
+++ b/library/strings.h
@@ -47,7 +47,7 @@ class UString
 	UString(UniChar uc);
 	UString(const char *cstr);
 	UString(const char *cstr, size_t count);
-	UString(UString &&other);
+	UString(UString &&other) noexcept;
 	UString(ConstIterator first, ConstIterator last);
 	UString();
 	~UString();

--- a/tools/code_generators/luagamestate_support_gen/main.cpp
+++ b/tools/code_generators/luagamestate_support_gen/main.cpp
@@ -122,7 +122,8 @@ void writeSource(std::ofstream &out, const StateDefinition &state,
 		// non-const case
 		out << "template<> int getIndexMetamethod<" << object.name << ">(lua_State* L)\n"
 		    << "{\n"
-		    << "\t" << object.name << "** obj = (" << object.name << "**)lua_touserdata(L, 1);\n"
+		    << "\t[[maybe_unused]]" << object.name << "** obj = (" << object.name
+		    << "**)lua_touserdata(L, 1);\n"
 		    << "\tstd::string key = lua_tostring(L, 2);\n"
 		    << "\tlua_settop(L, 0);\n"
 		    << "\t";
@@ -140,7 +141,7 @@ void writeSource(std::ofstream &out, const StateDefinition &state,
 		// const case
 		out << "template<> int getIndexConstMetamethod<" << object.name << ">(lua_State* L)\n"
 		    << "{\n"
-		    << "\tconst " << object.name << "** obj = (const " << object.name
+		    << "\t[[maybe_unused]] const " << object.name << "** obj = (const " << object.name
 		    << "**)lua_touserdata(L, 1);\n"
 		    << "\tstd::string key = lua_tostring(L, 2);\n"
 		    << "\tlua_settop(L, 0);\n"
@@ -159,7 +160,8 @@ void writeSource(std::ofstream &out, const StateDefinition &state,
 		// non-const only
 		out << "template<> int newIndexMetamethod<" << object.name << ">(lua_State *L)\n"
 		    << "{\n"
-		    << "\t" << object.name << "** obj = (" << object.name << "**)lua_touserdata(L, 1);\n"
+		    << "\t[[maybe_unused]]" << object.name << "** obj = (" << object.name
+		    << "**)lua_touserdata(L, 1);\n"
 		    << "\tstd::string key = lua_tostring(L, 2);\n"
 		    << "\t";
 		for (auto &m : object.members)
@@ -177,7 +179,7 @@ void writeSource(std::ofstream &out, const StateDefinition &state,
 		// const and non-const
 		out << "template<> int toStringMetamethod<" << object.name << ">(lua_State *L)\n"
 		    << "{\n"
-		    << "\tconst " << object.name << " **obj = (const " << object.name
+		    << "\t[[maybe_unused]] const " << object.name << " **obj = (const " << object.name
 		    << "**)lua_touserdata(L, -1);\n"
 		    << "\tlua_settop(L, 0);\n"
 		    << "\tlua_pushfstring(L, \"[" << object.name << " @ %p]\", (const void*)(*obj));\n"

--- a/tools/extractors/extract_city_scenery.cpp
+++ b/tools/extractors/extract_city_scenery.cpp
@@ -168,7 +168,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 			tile->tube[i] = entry.people_tube_connections[i];
 		}
 
-		if (alien && (i >= 50 && i <= 58 || i == 61))
+		if (alien && ((i >= 50 && i <= 58) || i == 61))
 		{
 			if (i == 58 || i == 61)
 			{


### PR DESCRIPTION
This now builds with clang-10 -Wmost without any warnings :)

Most seem to be switch statements not handling all cases, unused variables and constructor order.

This adds some LogError()s at switch cases that didn't seem to make sense, so may suggest a bad state, and a few other fixes (like handling more vehicle mission targets in the strategy view, more vehicle mission types handled in getName(), and what looks like a bug when trying to push a std::set<T> to lua)