### PR TITLE
Update appveyor to use msvc2019

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ branches:
   - master
   - /release.*/
 # skip_tags: true
-os: Visual Studio 2017
+os: Visual Studio 2019
 configuration:
   - Release
 #  - Debug
@@ -35,7 +35,7 @@ before_build:
   - 7z e temp\cd.iso.xz -odata\
   - choco install nsis -pre
   - choco install ninja
-  - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
+  - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
   - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH%
   - cmake --build .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,6 +26,7 @@ before_build:
   - cd c:\tools\vcpkg
   - git pull
   - git checkout 2019.12
+  - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
   - vcpkg upgrade --no-dry-run


### PR DESCRIPTION
The -dev version (used on my own PR branches) already uses this, and
PR #854 causes an ICE in the 2017 version, so seeing if this helps?