### PR TITLE
Align filled and unfilled parts of progress bars on Recruit and Transaction screens.

### DIFF
--- a/data/forms/recruitscreen.form
+++ b/data/forms/recruitscreen.form
@@ -103,7 +103,7 @@
       </label>
 
       <graphic id="FACILITY_FIRST_FILL">
-        <position x="219" y="60"/>
+        <position x="218" y="60"/>
         <size width="2" height="50"/>
       </graphic>
       <label id="FACILITY_FIRST_TEXT">

--- a/data/forms/transactionscreen.form
+++ b/data/forms/transactionscreen.form
@@ -168,7 +168,7 @@
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:62:xcom3/ufodata/research.pcx</image>
       </graphic>
       <graphic id="FACILITY_FIRST_FILL">
-        <position x="219" y="60"/>
+        <position x="218" y="60"/>
         <size width="2" height="50"/>
       </graphic>
       <label id="FACILITY_FIRST_TEXT">


### PR DESCRIPTION
Transaction screen before PR:
![image](https://user-images.githubusercontent.com/13639229/81483411-939b0e80-9246-11ea-96aa-5392828a5b0e.png)

Transaction screen in vanila:
![image](https://user-images.githubusercontent.com/13639229/81483417-a44b8480-9246-11ea-81b5-b6693154c117.png)

Recruit screen before PR:
![image](https://user-images.githubusercontent.com/13639229/81483421-ac0b2900-9246-11ea-9609-b251c07e8a7a.png)

Recruit screen in vanila:
![image](https://user-images.githubusercontent.com/13639229/81483427-b5949100-9246-11ea-87b4-bf1feaca7232.png)
