### PR TITLE
Import dependencies from VCPKG by default on Windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,12 @@ option(MSVC_PDB "Always generate PDB files" OFF)
 option(ENABLE_TESTS "Build some unit tests" ON)
 option(EXTRACT_DATA "Run the data extractor as part of the default target" ON)
 
+option(USE_VCPKG_GLM "Use GLM library from VCPKG toolchain" ${WIN32})
+option(USE_VCPKG_LODEPNG "Use LodePNG library from VCPKG toolchain" ${WIN32})
+option(USE_VCPKG_LUA "Use LUA library from VCPKG toolchain" ${WIN32})
+option(USE_VCPKG_MINIZ "Use MiniZ library from VCPKG toolchain" ${WIN32})
+option(USE_VCPKG_PUGIXML "Use PugiXML library from VCPKG toolchain" ${WIN32})
+
 set(CD_PATH ${CMAKE_SOURCE_DIR}/data/cd.iso CACHE STRING "Path to cd.iso (used
 by test and extractor")
 
@@ -87,9 +93,6 @@ endif()
 if ("${CMAKE_C_COMPILER_ID}" STREQUAL "Clang")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Qunused-arguments")
 endif()
-
-set(GLM_INCLUDE_DIR ${CMAKE_SOURCE_DIR}/dependencies/glm)
-MARK_AS_ADVANCED(GLM_INCLUDE_DIR)
 
 add_subdirectory(library)
 add_subdirectory(framework)

--- a/README.md
+++ b/README.md
@@ -116,13 +116,13 @@ git submodule update --init --recursive
   * For x64 builds:
 
 ```cmd
-vcpkg --triplet x64-windows install sdl2 boost-locale boost-program-options boost-uuid boost-crc qt5-base
+vcpkg --triplet x64-windows install sdl2 boost-locale boost-program-options boost-uuid boost-crc qt5-base pugixml miniz lodepng lua glm
 ```
 
   * For x86 builds:
 
 ```cmd
-vcpkg --triplet x86-windows install sdl2 boost-locale boost-program-options boost-uuid boost-crc qt5-base
+vcpkg --triplet x86-windows install sdl2 boost-locale boost-program-options boost-uuid boost-crc qt5-base pugixml miniz lodepng lua glm
 ```
 
   * For list of all supported by Vcpkg architectures: `vcpkg help triplet`

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -25,10 +25,10 @@ cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2019.12
+  - git checkout 2020.04
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
+  - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc pugixml miniz lodepng lua glm
   - vcpkg upgrade --no-dry-run
   - vcpkg remove --outdated
   - git submodule update --init --recursive

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,10 +25,10 @@ cache: c:\tools\vcpkg\installed
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2019.12
+  - git checkout 2020.04
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc
+  - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc pugixml miniz lodepng lua glm
   - vcpkg upgrade --no-dry-run
   - vcpkg remove --outdated
   - git submodule update --init --recursive

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -10,6 +10,23 @@ add_compile_options("-w")
 set(THREADS_PREFER_PTHREAD_FLAG ON)
 find_package (Threads REQUIRED)
 
+## GLM
+if(USE_VCPKG_GLM)
+	find_package(glm CONFIG REQUIRED)
+	add_library(OpenApoc_Glm INTERFACE)
+	target_link_libraries(OpenApoc_Glm INTERFACE glm)
+else()
+	file(GLOB_RECURSE GLM_HEADER_FILES glm/glm/*.h glm/glm/*.hpp glm/glm/*.inl)
+	source_group(glm\\headers FILES ${GLM_HEADER_FILES})
+
+	list(APPEND ALL_HEADER_FILES ${GLM_HEADER_FILES})
+
+	add_library(OpenApoc_Glm INTERFACE)
+	target_include_directories(OpenApoc_Glm INTERFACE
+			${CMAKE_SOURCE_DIR}/dependencies/glm)
+endif()
+
+## LibSmacker
 set (LIBSMACKER_SOURCE_FILES
 	libsmacker/smacker.c
 	libsmacker/smk_bitstream.c
@@ -28,8 +45,7 @@ list(APPEND ALL_HEADER_FILES ${LIBSMACKER_HEADER_FILES})
 add_library(OpenApoc_LibSmacker STATIC ${LIBSMACKER_SOURCE_FILES}
 		${LIBSMACKER_HEADER_FILES})
 
-target_include_directories(OpenApoc_LibSmacker PUBLIC ${CMAKE_SOURCE_DIR})
-target_include_directories(OpenApoc_LibSmacker PRIVATE
+target_include_directories(OpenApoc_LibSmacker PUBLIC
 		${CMAKE_SOURCE_DIR}/dependencies/libsmacker)
 
 if(NOT WIN32)
@@ -40,75 +56,111 @@ if (MSVC)
 	target_compile_definitions(OpenApoc_LibSmacker PRIVATE _CRT_SECURE_NO_WARNINGS)
 endif()
 
-set (MINIZ_SOURCE_FILES
-	miniz/miniz.c
-	miniz/miniz_zip.c
-	miniz/miniz_tdef.c
-	miniz/miniz_tinfl.c)
-source_group(miniz\\sources FILES ${MINIZ_SOURCE_FILES})
+## MiniZ
+if(USE_VCPKG_MINIZ)
+	find_package(miniz CONFIG REQUIRED)
+	add_library(OpenApoc_Miniz INTERFACE)
+	target_link_libraries(OpenApoc_Miniz INTERFACE miniz::miniz)
+else()
+	set (MINIZ_SOURCE_FILES
+			miniz/miniz.c
+			miniz/miniz_zip.c
+			miniz/miniz_tdef.c
+			miniz/miniz_tinfl.c)
+	source_group(miniz\\sources FILES ${MINIZ_SOURCE_FILES})
+	set (MINIZ_HEADER_FILES
+			miniz/miniz.h
+			miniz/miniz_zip.h
+			miniz/miniz_tdef.h
+			miniz/miniz_tinfl.h
+			miniz/miniz_common.h)
+	source_group(miniz\\headers FILES ${MINIZ_HEADER_FILES})
 
-list(APPEND ALL_SOURCE_FILES ${MINIZ_SOURCE_FILES})
+	list(APPEND ALL_SOURCE_FILES ${MINIZ_SOURCE_FILES})
+	list(APPEND ALL_HEADER_FILES ${MINIZ_HEADER_FILES})
 
-add_library(OpenApoc_Miniz STATIC ${MINIZ_SOURCE_FILES})
-
-target_compile_definitions(OpenApoc_Miniz PUBLIC MINIZ_NO_TIME)
-# We probably don't support any platforms without the 64-bit offset file
-# ioctls
-# But macos fails to link with this enabled... so guess we can never read >4gb
-# files there?
-if (NOT APPLE)
-	target_compile_definitions(OpenApoc_Miniz PUBLIC _LARGEFILE64_SOURCE=1)
+	add_library(OpenApoc_Miniz STATIC ${MINIZ_SOURCE_FILES}
+			${MINIZ_HEADER_FILES})
+	target_compile_definitions(OpenApoc_Miniz PUBLIC MINIZ_NO_TIME)
+	# We probably don't support any platforms without the 64-bit offset file
+	# ioctls
+	# But macos fails to link with this enabled... so guess we can never read >4gb
+	# files there?
+	if (NOT APPLE)
+		target_compile_definitions(OpenApoc_Miniz PUBLIC _LARGEFILE64_SOURCE=1)
+	endif()
+	if(NOT WIN32)
+		target_compile_definitions(OpenApoc_Miniz PUBLIC PTHREADS_AVAILABLE)
+	endif()
+	target_include_directories(OpenApoc_Miniz INTERFACE
+			${CMAKE_SOURCE_DIR}/dependencies)
+	target_include_directories(OpenApoc_Miniz PRIVATE
+			${CMAKE_SOURCE_DIR}/dependencies/miniz)
 endif()
 
-target_include_directories(OpenApoc_Miniz PUBLIC ${CMAKE_SOURCE_DIR})
-target_include_directories(OpenApoc_Miniz PRIVATE
-		${CMAKE_SOURCE_DIR}/dependencies/miniz)
+## PugiXML
+if(USE_VCPKG_PUGIXML)
+	find_package(pugixml CONFIG REQUIRED)
+	add_library(OpenApoc_LibPugixml INTERFACE)
+	target_link_libraries(OpenApoc_LibPugixml INTERFACE pugixml)
+else()
+	set(LIBPUGIXML_SOURCE_FILES
+			pugixml/src/pugixml.cpp)
+	source_group(pugixml\\sources FILES ${LIBPUGIXML_SOURCE_FILES})
+	set(LIBPUGIXML_HEADER_FILES
+			pugixml/src/pugixml.hpp
+			pugixml/src/pugiconfig.hpp)
+	source_group(pugixml\\headers FILES ${LIBPUGIXML_HEADER_FILES})
 
-if(NOT WIN32)
-	target_compile_definitions(OpenApoc_Miniz PUBLIC PTHREADS_AVAILABLE)
+	list(APPEND ALL_SOURCE_FILES ${LIBPUGIXML_SOURCE_FILES})
+	list(APPEND ALL_HEADER_FILES ${LIBPUGIXML_HEADER_FILES})
+
+	add_library(OpenApoc_LibPugixml STATIC ${LIBPUGIXML_SOURCE_FILES}
+			${LIBPUGIXML_HEADER_FILES})
+	if(NOT WIN32)
+		target_compile_definitions(OpenApoc_LibPugixml PUBLIC PTHREADS_AVAILABLE)
+	endif()
+	target_include_directories(OpenApoc_LibPugixml PUBLIC
+			${CMAKE_SOURCE_DIR}/dependencies/pugixml/src)
 endif()
 
-set (LIBPUGIXML_SOURCE_FILES
-		pugixml/src/pugixml.cpp)
+## LodePNG
+if(USE_VCPKG_LODEPNG)
+	find_package(lodepng CONFIG REQUIRED)
+	add_library(OpenApoc_LibLodepng INTERFACE)
+	target_link_libraries(OpenApoc_LibLodepng INTERFACE lodepng)
+else()
+	set(LIBLODEPNG_SOURCE_FILES
+			lodepng/lodepng.cpp)
+	source_group(lodepng\\sources FILES ${LIBLODEPNG_SOURCE_FILES})
+	set(LIBLODEPNG_HEADER_FILES
+			lodepng/lodepng.h)
+	source_group(lodepng\\headers FILES ${LIBLODEPNG_HEADER_FILES})
 
-source_group(libpugixml\\sources FILES ${LIBPUGIXML_SOURCE_FILES})
+	list(APPEND ALL_SOURCE_FILES ${LIBLODEPNG_SOURCE_FILES})
+	list(APPEND ALL_HEADER_FILES ${LIBLODEPNG_HEADER_FILES})
 
-set (LIBPUGIXML_HEADER_FILES
-		pugixml/src/pugixml.hpp
-		pugixml/src/pugiconfig.hpp)
-
-source_group(libpugixml\\headers FILES ${LIBPUGIXML_HEADER_FILES})
-
-list(APPEND ALL_SOURCE_FILES ${LIBPUGIXML_SOURCE_FILES})
-list(APPEND ALL_HEADER_FILES ${LIBPUGIXML_HEADER_FILES})
-
-add_library(OpenApoc_LibPugixml STATIC ${LIBPUGIXML_SOURCE_FILES}
-		${LIBPUGIXML_HEADER_FILES})
-
-if(NOT WIN32)
-	target_compile_definitions(OpenApoc_LibPugixml PUBLIC PTHREADS_AVAILABLE)
+	add_library(OpenApoc_LibLodepng STATIC ${LIBLODEPNG_SOURCE_FILES}
+			${LIBLODEPNG_HEADER_FILES})
+	if(NOT WIN32)
+		target_compile_definitions(OpenApoc_LibLodepng PUBLIC PTHREADS_AVAILABLE)
+	endif()
+	target_include_directories(OpenApoc_LibLodepng PUBLIC
+			${CMAKE_SOURCE_DIR}/dependencies/lodepng)
 endif()
 
-set (LIBLODEPNG_SOURCE_FILES
-		lodepng/lodepng.cpp)
+## TinyFormat
+set(TINYFORMAT_HEADER_FILES
+	tinyformat/tinyformat.h)
+source_group(tinyformat\\headers FILES ${TINYFORMAT_HEADER_FILES})
 
-source_group(libpugixml\\sources FILES ${LIBLODEPNG_SOURCE_FILES})
+list(APPEND ALL_HEADER_FILES ${TINYFORMAT_HEADER_FILES})
 
-set (LIBLODEPNG_HEADER_FILES
-		lodepng/lodepng.h)
+add_library(OpenApoc_TinyFormat INTERFACE)
+target_include_directories(OpenApoc_TinyFormat INTERFACE
+		${CMAKE_SOURCE_DIR}/dependencies/tinyformat)
 
-source_group(libpugixml\\headers FILES ${LIBLODEPNG_HEADER_FILES})
-
-list(APPEND ALL_SOURCE_FILES ${LIBLODEPNG_SOURCE_FILES})
-list(APPEND ALL_HEADER_FILES ${LIBLODEPNG_HEADER_FILES})
-
-add_library(OpenApoc_LibLodepng STATIC ${LIBLODEPNG_SOURCE_FILES}
-		${LIBLODEPNG_HEADER_FILES})
-
-if(NOT WIN32)
-	target_compile_definitions(OpenApoc_LibLodepng PUBLIC PTHREADS_AVAILABLE)
-endif()
-
+## PhysicsFS
 # Only enable the subset of physfs we actually use
 
 set(PHYSFS_ARCHIVE_7Z OFF CACHE BOOL "")
@@ -130,19 +182,28 @@ set(PHYSFS_BUILD_TEST OFF CACHE BOOL "")
 
 add_subdirectory(physfs)
 
-file (GLOB_RECURSE LUA_SOURCE_FILES lua/*.c)
-file (GLOB_RECURSE LUA_HEADER_FILES lua/*.h)
-add_library(OpenApoc_Lua STATIC ${LUA_SOURCE_FILES})
-list(APPEND ALL_SOURCE_FILES ${LUA_SOURCE_FILES})
-list(APPEND ALL_HEADER_FILES ${LUA_HEADER_FILES})
+add_library(OpenApoc_PhysFS INTERFACE)
+target_include_directories(OpenApoc_PhysFS INTERFACE
+		${CMAKE_SOURCE_DIR}/dependencies/physfs/src)
+target_link_libraries(OpenApoc_PhysFS INTERFACE physfs-static)
 
-target_include_directories(OpenApoc_Lua PUBLIC ${CMAKE_SOURCE_DIR})
-target_include_directories(OpenApoc_Lua PRIVATE
-		${CMAKE_SOURCE_DIR}/dependencies/lua)
+## LUA
+if(USE_VCPKG_LUA)
+	find_package(Lua REQUIRED)
+	add_library(OpenApoc_Lua INTERFACE)
+	target_include_directories(OpenApoc_Lua INTERFACE ${LUA_INCLUDE_DIR})
+	target_link_libraries(OpenApoc_Lua INTERFACE ${LUA_LIBRARIES})
+else()
+	file (GLOB_RECURSE LUA_SOURCE_FILES lua/*.c)
+	source_group(lua\\sources FILES ${LUA_SOURCE_FILES})
+	file (GLOB_RECURSE LUA_HEADER_FILES lua/*.h)
+	source_group(lua\\headers FILES ${LUA_HEADER_FILES})
 
-# we don't care about the coding practices of external dependencies
-target_compile_options(OpenApoc_LibSmacker PRIVATE "-w")
-target_compile_options(OpenApoc_LibPugixml PRIVATE "-w")
-target_compile_options(OpenApoc_LibLodepng PRIVATE "-w")
-target_compile_options(OpenApoc_Miniz PRIVATE "-w")
-target_compile_options(OpenApoc_Lua PRIVATE "-w")
+	list(APPEND ALL_SOURCE_FILES ${LUA_SOURCE_FILES})
+	list(APPEND ALL_HEADER_FILES ${LUA_HEADER_FILES})
+
+	add_library(OpenApoc_Lua STATIC ${LUA_SOURCE_FILES}
+			${LUA_HEADER_FILES})
+	target_include_directories(OpenApoc_Lua PUBLIC
+			${CMAKE_SOURCE_DIR}/dependencies/lua)
+endif()

--- a/forms/checkbox.cpp
+++ b/forms/checkbox.cpp
@@ -1,5 +1,4 @@
 #include "forms/checkbox.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/event.h"
 #include "framework/framework.h"
@@ -7,6 +6,7 @@
 #include "framework/renderer.h"
 #include "framework/sound.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -1,5 +1,4 @@
 #include "forms/control.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/forms.h"
 #include "forms/ui.h"
 #include "framework/configfile.h"
@@ -13,6 +12,7 @@
 #include "framework/sound.h"
 #include "framework/trace.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/form.cpp
+++ b/forms/form.cpp
@@ -1,7 +1,7 @@
 #include "form.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/framework.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/forms_pch.h
+++ b/forms/forms_pch.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/control.h"
 #include "framework/apocresources/apocfont.h"
 #include "framework/configfile.h"
@@ -22,5 +21,6 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <pugixml.hpp>
 #include <queue>
 #include <stdexcept>

--- a/forms/graphic.cpp
+++ b/forms/graphic.cpp
@@ -1,11 +1,11 @@
 #include "forms/graphic.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/image.h"
 #include "framework/renderer.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/graphicbutton.cpp
+++ b/forms/graphicbutton.cpp
@@ -1,5 +1,4 @@
 #include "forms/graphicbutton.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/scrollbar.h"
 #include "framework/data.h"
 #include "framework/event.h"
@@ -8,6 +7,7 @@
 #include "framework/renderer.h"
 #include "framework/sound.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/label.cpp
+++ b/forms/label.cpp
@@ -1,5 +1,4 @@
 #include "forms/label.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/ui.h"
 #include "framework/font.h"
 #include "framework/framework.h"
@@ -7,6 +6,7 @@
 #include "framework/renderer.h"
 #include "library/sp.h"
 #include "library/strings_format.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -1,9 +1,9 @@
 #include "forms/listbox.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/scrollbar.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/renderer.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/multilistbox.cpp
+++ b/forms/multilistbox.cpp
@@ -1,9 +1,9 @@
 #include "forms/multilistbox.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/scrollbar.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/renderer.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/scrollbar.cpp
+++ b/forms/scrollbar.cpp
@@ -1,11 +1,11 @@
 #include "forms/scrollbar.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/image.h"
 #include "framework/renderer.h"
 #include "framework/sound.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/textbutton.cpp
+++ b/forms/textbutton.cpp
@@ -1,5 +1,4 @@
 #include "forms/textbutton.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/label.h"
 #include "forms/ui.h"
 #include "framework/data.h"
@@ -10,6 +9,7 @@
 #include "framework/sound.h"
 #include "library/sp.h"
 #include "library/strings_format.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/textedit.cpp
+++ b/forms/textedit.cpp
@@ -1,5 +1,4 @@
 #include "forms/textedit.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/ui.h"
 #include "framework/event.h"
 #include "framework/font.h"
@@ -9,6 +8,7 @@
 #include "framework/renderer.h"
 #include "library/sp.h"
 #include "library/strings_format.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/ticker.cpp
+++ b/forms/ticker.cpp
@@ -1,11 +1,11 @@
 #include "forms/ticker.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/ui.h"
 #include "framework/font.h"
 #include "framework/framework.h"
 #include "framework/image.h"
 #include "framework/renderer.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/tristatebox.cpp
+++ b/forms/tristatebox.cpp
@@ -1,5 +1,4 @@
 #include "forms/tristatebox.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/event.h"
 #include "framework/framework.h"
@@ -7,6 +6,7 @@
 #include "framework/renderer.h"
 #include "framework/sound.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/forms/ui.cpp
+++ b/forms/ui.cpp
@@ -1,5 +1,4 @@
 #include "forms/ui.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "forms/forms.h"
 #include "framework/apocresources/apocfont.h"
 #include "framework/configfile.h"
@@ -7,6 +6,7 @@
 #include "framework/framework.h"
 #include "framework/trace.h"
 #include "library/sp.h"
+#include <pugixml.hpp>
 #include <stdexcept>
 
 namespace OpenApoc

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -296,11 +296,9 @@ target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_Library)
 target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_LibSmacker)
 target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_LibPugixml)
 target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_LibLodepng)
+target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_Lua)
 target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_Miniz)
+target_link_libraries(OpenApoc_Framework PUBLIC OpenApoc_PhysFS)
 target_link_libraries(OpenApoc_Framework PUBLIC ${CMAKE_DL_LIBS})
 
-target_link_libraries(OpenApoc_Framework PUBLIC physfs-static)
-
-target_include_directories(OpenApoc_Framework PRIVATE
-		${CMAKE_SOURCE_DIR}/dependencies/physfs/src)
 target_include_directories(OpenApoc_Framework PUBLIC ${CMAKE_SOURCE_DIR})

--- a/framework/apocresources/apocfont.cpp
+++ b/framework/apocresources/apocfont.cpp
@@ -1,13 +1,12 @@
 #include "framework/apocresources/apocfont.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/font.h"
 #include "framework/framework.h"
 #include "framework/logger.h"
 #include "framework/trace.h"
 #include "library/sp.h"
-
 #include <boost/locale.hpp>
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/framework/data.cpp
+++ b/framework/data.cpp
@@ -1,5 +1,4 @@
 #include "framework/data.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/apocresources/apocpalette.h"
 #include "framework/apocresources/loftemps.h"
 #include "framework/apocresources/pck.h"
@@ -21,6 +20,7 @@
 #include <fstream>
 #include <map>
 #include <mutex>
+#include <pugixml.hpp>
 #include <queue>
 
 using namespace OpenApoc;

--- a/framework/imageloader/lodepng_image.cpp
+++ b/framework/imageloader/lodepng_image.cpp
@@ -2,7 +2,6 @@
 // Created by Alexey on 20.11.2015.
 //
 
-#include "dependencies/lodepng/lodepng.h"
 #include "framework/apocresources/apocpalette.h"
 #include "framework/data.h"
 #include "framework/image.h"
@@ -11,6 +10,7 @@
 #include "framework/palette.h"
 #include "library/sp.h"
 #include "library/vec.h"
+#include <lodepng.h>
 #include <ostream>
 #include <vector>
 

--- a/framework/luaframework.h
+++ b/framework/luaframework.h
@@ -8,9 +8,9 @@
 
 extern "C"
 {
-#include "dependencies/lua/lauxlib.h"
-#include "dependencies/lua/lua.h"
-#include "dependencies/lua/lualib.h"
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
 }
 
 #include "framework/data.h"

--- a/framework/modinfo.cpp
+++ b/framework/modinfo.cpp
@@ -1,6 +1,6 @@
 #include "framework/modinfo.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/logger.h"
+#include <pugixml.hpp>
 
 namespace OpenApoc
 {

--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -6,9 +6,8 @@
 #include "framework/trace.h"
 #include "library/strings.h"
 #include "library/strings_format.h"
+#include <pugixml.hpp>
 #include <sstream>
-
-#include "dependencies/pugixml/src/pugixml.hpp"
 
 #include <boost/crc.hpp>
 #include <boost/version.hpp>

--- a/framework/serialization/providers/zipdataprovider.h
+++ b/framework/serialization/providers/zipdataprovider.h
@@ -3,8 +3,8 @@
 #include "framework/serialization/providers/serializationdataprovider.h"
 #include "library/strings.h"
 
-#include "dependencies/miniz/miniz_zip.h"
 #include <map>
+#include <miniz/miniz_zip.h>
 
 namespace OpenApoc
 {

--- a/framework/serialization/serialize.cpp
+++ b/framework/serialization/serialize.cpp
@@ -1,5 +1,4 @@
 #include "framework/serialization/serialize.h"
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/filesystem.h"
 #include "framework/logger.h"
 #include "framework/serialization/providers/filedataprovider.h"
@@ -11,6 +10,7 @@
 #include "library/strings_format.h"
 #include <deque>
 #include <map>
+#include <pugixml.hpp>
 #include <sstream>
 
 namespace OpenApoc

--- a/framework/video/smk.cpp
+++ b/framework/video/smk.cpp
@@ -12,7 +12,7 @@
 // libsmacker.h doesn't set C abi by default, so wrap
 extern "C"
 {
-#include "dependencies/libsmacker/smacker.h"
+#include <smacker.h>
 }
 
 namespace OpenApoc

--- a/game/state/luagamestate.h
+++ b/game/state/luagamestate.h
@@ -2,7 +2,7 @@
 
 extern "C"
 {
-#include "dependencies/lua/lua.h"
+#include <lua.h>
 }
 #include "library/strings.h"
 

--- a/game/state/luagamestate_support.cpp
+++ b/game/state/luagamestate_support.cpp
@@ -1,8 +1,8 @@
 extern "C"
 {
-#include "dependencies/lua/lauxlib.h"
-#include "dependencies/lua/lua.h"
-#include "dependencies/lua/lualib.h"
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
 }
 #include "game/state/luagamestate_support.h"
 #include "game/state/luagamestate_support_generated.h"

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -37,10 +37,11 @@ add_library(OpenApoc_Library STATIC ${LIBRARY_SOURCE_FILES}
 		${LIBRARY_HEADER_FILES})
 
 target_link_libraries(OpenApoc_Library PUBLIC ${Boost_LIBRARIES}
+		OpenApoc_Glm
+		OpenApoc_TinyFormat
 		Threads::Threads)
 
 target_include_directories(OpenApoc_Library PUBLIC ${CMAKE_SOURCE_DIR})
-target_include_directories(OpenApoc_Library PUBLIC ${GLM_INCLUDE_DIR})
 target_include_directories(OpenApoc_Library PUBLIC ${Boost_INCLUDE_DIRS})
 target_include_directories(OpenApoc_Library PUBLIC ${CMAKE_SOURCE_DIR}/library/compat)
 if(NOT WIN32)

--- a/library/library_pch.h
+++ b/library/library_pch.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include "dependencies/tinyformat/tinyformat.h"
 #include <algorithm>
 #include <cstdint>
 #include <fstream>
@@ -19,4 +18,5 @@
 #include <set>
 #include <stdexcept>
 #include <string>
+#include <tinyformat.h>
 #include <vector>

--- a/library/strings_format.h
+++ b/library/strings_format.h
@@ -8,7 +8,7 @@
 #pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
 #endif
 
-#include "dependencies/tinyformat/tinyformat.h"
+#include <tinyformat.h>
 
 #ifdef __GNUC__
 #pragma GCC diagnostic pop

--- a/tools/code_generators/luagamestate_support_gen/main.cpp
+++ b/tools/code_generators/luagamestate_support_gen/main.cpp
@@ -66,7 +66,7 @@ void writeHeader(std::ofstream &out, const StateDefinition &state)
 	    << "#include \"game/state/gamestate.h\"\n\n"
 	    << "#include \"game/state/luagamestate_support.h\"\n\n"
 	    << "extern \"C\"\n{\n"
-	    << "#include \"dependencies/lua/lua.h\"\n"
+	    << "#include <lua.h>\n"
 	    << "}\n\n"
 	    << "namespace OpenApoc {\n\n"
 	    << "static constexpr const char* const LUAGAMESTATE_SUPPORT_VERSION = \""

--- a/tools/code_generators/serialization_xml.h
+++ b/tools/code_generators/serialization_xml.h
@@ -1,10 +1,10 @@
 #pragma once
 // Disable automatic #pragma linking for boost - only enabled in msvc and that should provide boost
 // symbols as part of the module that uses it
-#include "dependencies/pugixml/src/pugixml.hpp"
 #include <fstream>
 #include <iostream>
 #include <list>
+#include <pugixml.hpp>
 #include <vector>
 
 #include <boost/program_options.hpp>


### PR DESCRIPTION
Here's a proposal to import uncustomised dependency libraries from VCPKG instead of building them from sources. Importing is enabled by default on Windows and could be enabled via `USE_VCPKG_*` options on other platforms, the same options could be used to disable importing on Windows.

Resolves #866.