### PR TITLE
Fix a CTD on opening the tile view while a vehicle returns from UFO recovery.

### DIFF
--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -756,7 +756,10 @@ void CityTileView::render()
 						case VehicleMission::MissionType::Land:
 						case VehicleMission::MissionType::OfferService:
 						case VehicleMission::MissionType::InvestigateBuilding:
-							buildingsSelected.insert(m->targetBuilding);
+							if (m->targetBuilding)
+							{
+								buildingsSelected.insert(m->targetBuilding);
+							}
 							[[fallthrough]];
 						case VehicleMission::MissionType::Crash:
 						{


### PR DESCRIPTION
After a UFO battle ends XCOM vehicle gets assigned an `Offer Service` mission without a target building, resulting in a CTD if player switches to the city tile view.

https://github.com/OpenApoc/OpenApoc/blob/e65b5fe4a1d997ed1d8bcbd3c2e313ae4307ab74/game/state/battle/battle.cpp#L3362