### PR TITLE
Remove all dead vehicles immediately after a battle.

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3455,6 +3455,9 @@ void Battle::exitBattle(GameState &state)
 	}
 
 	state.current_battle = nullptr;
+
+	// Remove all dead vehicles from the state
+	state.cleanUpDeathNote();
 }
 
 void Battle::loadResources(GameState &state)


### PR DESCRIPTION
Resolves an issue with "resurrecting" vehicles when loading a save game made right after a battle (e.g. UFO recovery).

The issue manifests if player saves the game right after a UFO recovery battle concludes and before unpausing the cityscape, and loads this save file -- the recovered UFO gets "resurrected".

Here's a repro save game -- unpause and wait for the battle to end, save the game in cityscape and load the saev:
[save_issue-recovered-ufo.zip](https://github.com/OpenApoc/OpenApoc/files/4656524/save_issue-recovered-ufo.zip)