### PR TITLE
Wip/fmt translate redux

### DIFF
--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -13,6 +13,7 @@
 #include "framework/sound.h"
 #include "framework/trace.h"
 #include "library/sp.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -730,7 +731,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 			{
 				ToolTipText = child.attribute("text").as_string();
 				if (!ToolTipText.empty())
-					ToolTipText = tr(ToolTipText);
+					ToolTipText = translate(ToolTipText);
 			}
 			else
 			{

--- a/forms/label.cpp
+++ b/forms/label.cpp
@@ -6,7 +6,7 @@
 #include "framework/image.h"
 #include "framework/renderer.h"
 #include "library/sp.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -96,7 +96,7 @@ sp<Control> Label::copyTo(sp<Control> CopyParent)
 void Label::configureSelfFromXml(pugi::xml_node *node)
 {
 	Control::configureSelfFromXml(node);
-	text = tr(node->attribute("text").as_string());
+	text = translate(node->attribute("text").as_string());
 
 	UString tintAttribute = node->attribute("tint").as_string();
 	if (!tintAttribute.empty())

--- a/forms/textbutton.cpp
+++ b/forms/textbutton.cpp
@@ -9,7 +9,7 @@
 #include "framework/renderer.h"
 #include "framework/sound.h"
 #include "library/sp.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -152,7 +152,7 @@ void TextButton::configureSelfFromXml(pugi::xml_node *node)
 
 	if (node->attribute("text"))
 	{
-		label->setText(tr(node->attribute("text").as_string()));
+		label->setText(translate(node->attribute("text").as_string()));
 	}
 	auto fontNode = node->child("font");
 	if (fontNode)

--- a/forms/textedit.cpp
+++ b/forms/textedit.cpp
@@ -8,7 +8,7 @@
 #include "framework/keycodes.h"
 #include "framework/renderer.h"
 #include "library/sp.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -278,7 +278,7 @@ void TextEdit::configureSelfFromXml(pugi::xml_node *node)
 
 	if (node->attribute("text"))
 	{
-		text = tr(node->attribute("text").as_string());
+		text = translate(node->attribute("text").as_string());
 	}
 	auto fontNode = node->child("font");
 	if (fontNode)

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -41,7 +41,7 @@
 #include "game/state/tilemap/tileobject_doodad.h"
 #include "game/state/tilemap/tileobject_projectile.h"
 #include "game/state/tilemap/tileobject_shadow.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 #include "library/xorshift.h"
 #include <algorithm>
 #include <glm/glm.hpp>
@@ -3735,23 +3735,23 @@ UString BattleScore::getText()
 	auto total = getTotal();
 	if (total > 500)
 	{
-		return tr("Very Good");
+		return translate("Very Good");
 	}
 	else if (total > 200)
 	{
-		return tr("Good");
+		return translate("Good");
 	}
 	else if (total > 0)
 	{
-		return tr("OK");
+		return translate("OK");
 	}
 	else if (total > -200)
 	{
-		return tr("Poor");
+		return translate("Poor");
 	}
 	else
 	{
-		return tr("Very Poor");
+		return translate("Very Poor");
 	}
 }
 

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -7,7 +7,7 @@
 #include "game/state/rules/city/vehicletype.h"
 #include "game/state/shared/agent.h"
 #include "game/state/shared/organisation.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -68,11 +68,11 @@ UString GameEvent::message()
 	switch (type)
 	{
 		case GameEventType::MissionCompletedBuildingAlien:
-			return tr("Mission completed in Alien building.");
+			return translate("Mission completed in Alien building.");
 		case GameEventType::MissionCompletedVehicle:
-			return tr("X-COM returning from UFO mission.");
+			return translate("X-COM returning from UFO mission.");
 		case GameEventType::BuildingDisabled:
-			return tr("Building has been disabled");
+			return translate("Building has been disabled");
 		default:
 			break;
 	}
@@ -84,50 +84,50 @@ UString GameVehicleEvent::message()
 	switch (type)
 	{
 		case GameEventType::UfoSpotted:
-			return tr("UFO spotted.");
+			return translate("UFO spotted.");
 		case GameEventType::UfoCrashed:
-			return format("%s %s", tr("UFO crash landed:"), vehicle->name);
+			return tformat("UFO crash landed: {1}") % vehicle->name;
 		case GameEventType::UfoRecoveryUnmanned:
-			return format("%s %s", tr("Unmanned UFO recovered:"), vehicle->name);
+			return tformat("Unmanned UFO recovered: {1}") % vehicle->name;
 		case GameEventType::VehicleRecovered:
-			return format("%s %s", tr("Vehicle successfully recovered:"), vehicle->name);
+			return tformat("Vehicle successfully recovered: {1}") % vehicle->name;
 		case GameEventType::VehicleNoFuel:
-			return format("%s %s", tr("Vehicle out of fuel:"), vehicle->name);
+			return tformat("Vehicle out of fuel: {1}") % vehicle->name;
 		case GameEventType::UfoRecoveryBegin:
 			return "";
 		case GameEventType::VehicleLightDamage:
-			return format("%s %s", tr("Vehicle lightly damaged:"), vehicle->name);
+			return tformat("Vehicle lightly damaged: {1}") % vehicle->name;
 		case GameEventType::VehicleModerateDamage:
-			return format("%s %s", tr("Vehicle moderately damaged:"), vehicle->name);
+			return tformat("Vehicle moderately damaged: {1}") % vehicle->name;
 		case GameEventType::VehicleHeavyDamage:
-			return format("%s %s", tr("Vehicle heavily damaged:"), vehicle->name);
+			return tformat("Vehicle heavily damaged: {1}") % vehicle->name;
 		case GameEventType::VehicleEscaping:
-			return format("%s %s", tr("Vehicle returning to base as damaged:"), vehicle->name);
+			return tformat("Vehicle returning to base as damaged: {1}") % vehicle->name;
 		case GameEventType::VehicleNoAmmo:
-			return format("%s %s", vehicle->name, tr(": Weapon out of ammo:"));
+			return tformat("{1}: Weapon out of ammo") % vehicle->name;
 		case GameEventType::VehicleLowFuel:
-			return format("%s %s", tr("Vehicle low on fuel:"), vehicle->name);
+			return tformat("Vehicle low on fuel: {1}") % vehicle->name;
 		case GameEventType::VehicleRepaired:
-			return format("%s %s", tr("Vehicle Repaired:"), vehicle->name);
+			return tformat("Vehicle Repaired: {1}") % vehicle->name;
 		case GameEventType::VehicleRearmed:
-			return format("%s %s", tr("Vehicle Rearmed:"), vehicle->name);
+			return tformat("Vehicle Rearmed: {1}") % vehicle->name;
 		case GameEventType::VehicleRefuelled:
-			return format("%s %s", tr("Vehicle Refuelled:"), vehicle->name);
+			return tformat("Vehicle Refuelled: {1}") % vehicle->name;
 		case GameEventType::VehicleNoEngine:
-			return format("%s %s", tr("Vehicle has no engine:"), vehicle->name);
+			return tformat("Vehicle has no engine: {1}") % vehicle->name;
 		case GameEventType::UnauthorizedVehicle:
 			if (vehicle->type->isGround())
 			{
-				return tr("An illegal road vehicle has been detected.");
+				return translate("An illegal road vehicle has been detected.");
 			}
 			else
 			{
-				return tr("An illegal flyer has been detected.");
+				return translate("An illegal flyer has been detected.");
 			}
 		case GameEventType::NotEnoughAmmo:
-			return format("%s %s", tr("Not enough ammo to rearm vehicle:"), vehicle->name);
+			return tformat("Not enough ammo to rearm vehicle: {1}") % vehicle->name;
 		case GameEventType::NotEnoughFuel:
-			return format("%s %s", tr("Not enough fuel to refuel vehicle"), vehicle->name);
+			return tformat("Not enough fuel to refuel vehicle {1}") % vehicle->name;
 		default:
 			LogError("Invalid vehicle event type");
 			break;
@@ -142,55 +142,54 @@ UString GameAgentEvent::message()
 		case GameEventType::AgentArrived:
 			if (flag)
 			{
-				return format("%s %s", tr("New transfer arrived:"), agent->name);
+				return tformat("New transfer arrived: {1}") % agent->name;
 			}
 			else
 			{
-				return format("%s %s", tr("New recruit arrived:"), agent->name);
+				return tformat("New recruit arrived: {1}") % agent->name;
 			}
 		case GameEventType::AgentUnableToReach:
-			return format(
-			    "%s%s", agent->name,
-			    tr(": Unable to reach destination due to damaged people tube network and / or "
-			       "poor diplomatic relations with Transtellar."));
+			tformat("{1}: Unable to reach destination due to damaged people tube network and / or "
+			        "poor diplomatic relations with Transtellar.") %
+			    agent->name;
 		case GameEventType::HostileSpotted:
-			return format("%s", tr("Hostile unit spotted"));
+			return translate("Hostile unit spotted");
 		case GameEventType::AgentBrainsucked:
-			return format("%s %s", tr("Unit Brainsucked:"), agent->name);
+			return tformat("Unit Brainsucked: {1}") % agent->name;
 		case GameEventType::AgentDiedBattle:
-			return format("%s %s", tr("Unit has died:"), agent->name);
+			return tformat("Unit has died: {1}") % agent->name;
 		case GameEventType::HostileDied:
-			return format("%s %s", tr("Hostile unit has died"), agent->name);
+			return tformat("Hostile unit has died: {1}") % agent->name;
 		case GameEventType::UnknownDied:
-			return format("%s", tr("Unknown Unit has died"));
+			return translate("Unknown Unit has died");
 		case GameEventType::AgentCriticallyWounded:
-			return format("%s: %s", tr("Unit critically wounded"), agent->name);
+			return tformat("Unit critically wounded: {1}") % agent->name;
 		case GameEventType::AgentBadlyInjured:
-			return format("%s %s", tr("Unit badly injured:"), agent->name);
+			return tformat("Unit badly injured: {1}") % agent->name;
 		case GameEventType::AgentInjured:
-			return format("%s %s", tr("Unit injured:"), agent->name);
+			return tformat("Unit injured: {1}") % agent->name;
 		case GameEventType::AgentUnderFire:
-			return format("%s %s", tr("Unit under fire:"), agent->name);
+			return tformat("Unit under fire: {1}") % agent->name;
 		case GameEventType::AgentUnconscious:
-			return format("%s %s", tr("Unit has lost consciousness:"), agent->name);
+			return tformat("Unit has lost consciousness: {1}") % agent->name;
 		case GameEventType::AgentLeftCombat:
-			return format("%s %s", tr("Unit has left combat zone:"), agent->name);
+			return tformat("Unit has left combat zone: {1}") % agent->name;
 		case GameEventType::AgentFrozen:
-			return format("%s %s", tr("Unit has frozen:"), agent->name);
+			return tformat("Unit has frozen: {1}") % agent->name;
 		case GameEventType::AgentBerserk:
-			return format("%s %s", tr("Unit has gone berserk:"), agent->name);
+			return tformat("Unit has gone berserk: {1}") % agent->name;
 		case GameEventType::AgentPanicked:
-			return format("%s %s", tr("Unit has panicked:"), agent->name);
+			return tformat("Unit has panicked: {1}") % agent->name;
 		case GameEventType::AgentPanicOver:
-			return format("%s %s", tr("Unit has stopped panicking:"), agent->name);
+			return tformat("Unit has stopped panicking: {1}") % agent->name;
 		case GameEventType::AgentPsiAttacked:
-			return format("%s %s", tr("Psionic attack on unit:"), agent->name);
+			return tformat("Psionic attack on unit: {1}") % agent->name;
 		case GameEventType::AgentPsiControlled:
-			return format("%s %s", tr("Unit under Psionic control:"), agent->name);
+			return tformat("Unit under Psionic control: {1}") % agent->name;
 		case GameEventType::AgentPsiOver:
-			return format("%s %s", tr("Unit freed from Psionic control:"), agent->name);
+			return tformat("Unit freed from Psionic control: {1}") % agent->name;
 		case GameEventType::NoLOF:
-			return format("%s", tr("No line of fire"));
+			return translate("No line of fire");
 		case GameEventType::AgentPsiProbed:
 			return "";
 		default:
@@ -205,16 +204,16 @@ UString GameBuildingEvent::message()
 	switch (type)
 	{
 		case GameEventType::MissionCompletedBuildingNormal:
-			return format("%s %s", tr("X-COM returning from mission at:"), building->name);
+			return tformat("X-COM returning from mission at: {1}") % building->name;
 		case GameEventType::MissionCompletedBuildingRaid:
-			return format("%s %s", tr("X-COM returning from raid at:"), building->name);
+			return tformat("X-COM returning from raid at: {1}") % building->name;
 		case GameEventType::BuildingAttacked:
-			return format("%s %s %s %s", tr("Building under attack :"), building->name,
-			              tr("Attacked by:"), actor->name);
+			return tformat("Building under attack : {1} Attacked by: {2}") % building->name %
+			       actor->name;
 		case GameEventType::AlienSpotted:
-			return tr("Live Alien spotted.");
+			return translate("Live Alien spotted.");
 		case GameEventType::CargoExpiresSoon:
-			return format("%s %s", tr("Cargo expires soon:"), building->name);
+			return tformat("Cargo expires soon: {1}") % building->name;
 		case GameEventType::CommenceInvestigation:
 			return "";
 		default:
@@ -229,52 +228,50 @@ UString GameBaseEvent::message()
 	switch (type)
 	{
 		case GameEventType::AgentRearmed:
-			return tr("Agent(s) rearmed:") + " " + base->name;
+			return tformat("Agent(s) rearmed: {1}") % base->name;
 		case GameEventType::CargoExpired:
 			if (actor)
 			{
 				if (actor == base->building->owner)
 				{
-					return tr("Cargo expired:") + " " + base->name + " " + tr("Returned to base");
+					return tformat("Cargo expired: {1}. Returned to base") % base->name;
 				}
 				else
 				{
-					return tr("Cargo expired:") + " " + base->name + " " +
-					       tr("Refunded by supplier: ") + actor->name;
+					return tformat("Cargo expired: {1}. Refunded by supplier: {2}") % base->name %
+					       actor->name;
 				}
 			}
 			else
 			{
-				return tr("Cargo expired:") + " " + base->name;
+				return tformat("Cargo expired: {1}") % base->name;
 			}
 		case GameEventType::CargoSeized:
 		{
-			return tr("Cargo seized:") + " " + base->name + " " + tr("By hostile organisation: ") +
-			       actor->name;
+			return tformat("Cargo seized: {1} by {2}") % base->name % actor->name;
 		}
 		case GameEventType::CargoArrived:
 			if (actor)
 			{
-				return tr("Cargo arrived:") + " " + base->name + " " + tr("Supplier: ") +
-				       actor->name;
+				return tformat("Cargo arrived: {1}. Supplier: {2}") % base->name % actor->name;
 			}
 			else
 			{
-				return tr("Cargo arrived:") + " " + base->name;
+				return tformat("Cargo arrived: {1}") % base->name;
 			}
 		case GameEventType::TransferArrived:
 			if (flag)
 			{
-				return tr("Transferred Alien specimens have arrived:") + " " + base->name;
+				return tformat("Transferred Alien specimens have arrived: {1}") % base->name;
 			}
 			else
 			{
-				return tr("Transferred goods have arrived:") + " " + base->name;
+				return tformat("Transferred goods have arrived: {1}") % base->name;
 			}
 		case GameEventType::RecoveryArrived:
-			return tr("Items from tactical combat zone have arrived:") + " " + base->name;
+			return tformat("Items from tactical combat zone have arrived: {1}") % base->name;
 		case GameEventType::MissionCompletedBase:
-			return tr("Base mission completed at:") + " " + base->name;
+			return tformat("Base mission completed at: {1}") % base->name;
 
 		default:
 			LogError("Invalid event type");
@@ -288,8 +285,8 @@ UString GameBattleEvent::message()
 	switch (type)
 	{
 		case GameEventType::NewTurn:
-			return tr("Turn:") + " " + format("%d", battle->currentTurn) + "   " + tr("Side:") +
-			       "  " + tr(battle->currentActiveOrganisation->name);
+			return tformat("Turn: {1} Side: {2}") % battle->currentTurn %
+			       translate(battle->currentActiveOrganisation->name);
 		default:
 			LogError("Invalid battle event type");
 			break;
@@ -363,35 +360,34 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 	switch (type)
 	{
 		case GameEventType::AgentDiedCity:
-			messageInner = format("%s %s", tr("Agent has died:"), name);
+			messageInner = tformat("Agent has died: {1}") % name;
 			break;
 		case GameEventType::BaseDestroyed:
 			if (actor.length() > 0)
 			{
-				messageInner = tr("X-COM base destroyed by hostile forces.");
+				messageInner = translate("X-COM base destroyed by hostile forces.");
 			}
 			else
 			{
-				messageInner = tr("X-COM Base destroyed due to collapsing building.");
+				messageInner = translate("X-COM Base destroyed due to collapsing building.");
 			}
 			break;
 		case GameEventType::VehicleDestroyed:
 			if (actor.length() > 0)
 			{
-				messageInner = format("%s %s %s: %s", tr("Vehicle destroyed:"), name,
-				                      tr("destroyed by"), actor);
+				messageInner = tformat("Vehicle destroyed: {1} destroyed by: {2}") % name % actor;
 			}
 			else
 			{
-				messageInner = format("%s %s", tr("Vehicle destroyed:"), name);
+				messageInner = tformat("Vehicle destroyed: {1}") % name;
 			}
 			break;
 		case GameEventType::VehicleRecovered:
 			messageInner =
-			    format("%s %s", tr("Scrapped vehicle recovered in irreparable condition:"), name);
+			    tformat("Scrapped vehicle recovered in irreparable condition: {1}") % name;
 			break;
 		case GameEventType::VehicleNoFuel:
-			messageInner = format("%s %s", tr("Vehicle out of fuel:"), name);
+			messageInner = tformat("Vehicle out of fuel: {1}") % name;
 			break;
 		default:
 			LogWarning("GameSomethingDiedEvent %s called on non-death event %d", name,

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -1,6 +1,6 @@
 #include "game/state/gametime.h"
 #include "game/state/gametime_facet.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 #include <locale>
 #include <sstream>
 
@@ -71,26 +71,30 @@ UString GameTime::getLongDateString() const
 		DATE_LONG_FORMAT = new std::locale(std::locale::classic(), dateFacet);
 
 		std::vector<std::string> months = {
-		    tr("January").str(), tr("February").str(), tr("March").str(),
-		    tr("April").str(),   tr("May").str(),      tr("June").str(),
-		    tr("July").str(),    tr("August").str(),   tr("September").str(),
-		    tr("October").str(), tr("November").str(), tr("December").str()};
+		    translate("January").str(), translate("February").str(), translate("March").str(),
+		    translate("April").str(),   translate("May").str(),      translate("June").str(),
+		    translate("July").str(),    translate("August").str(),   translate("September").str(),
+		    translate("October").str(), translate("November").str(), translate("December").str()};
 		dateFacet->long_month_names(months);
 
 		std::vector<std::string> weekdays = {
-		    tr("Sunday").str(),   tr("Monday").str(), tr("Tuesday").str(), tr("Wednesday").str(),
-		    tr("Thursday").str(), tr("Friday").str(), tr("Saturday").str()};
+		    translate("Sunday").str(),    translate("Monday").str(),   translate("Tuesday").str(),
+		    translate("Wednesday").str(), translate("Thursday").str(), translate("Friday").str(),
+		    translate("Saturday").str()};
 		dateFacet->long_weekday_names(weekdays);
 
 		std::vector<std::string> days = {
-		    tr("1st").str(),  tr("2nd").str(),  tr("3rd").str(),  tr("4th").str(),
-		    tr("5th").str(),  tr("6th").str(),  tr("7th").str(),  tr("8th").str(),
-		    tr("9th").str(),  tr("10th").str(), tr("11th").str(), tr("12th").str(),
-		    tr("13th").str(), tr("14th").str(), tr("15th").str(), tr("16th").str(),
-		    tr("17th").str(), tr("18th").str(), tr("19th").str(), tr("20th").str(),
-		    tr("21st").str(), tr("22nd").str(), tr("23rd").str(), tr("24th").str(),
-		    tr("25th").str(), tr("26th").str(), tr("27th").str(), tr("28th").str(),
-		    tr("29th").str(), tr("30th").str(), tr("31st").str()};
+		    translate("1st").str(),  translate("2nd").str(),  translate("3rd").str(),
+		    translate("4th").str(),  translate("5th").str(),  translate("6th").str(),
+		    translate("7th").str(),  translate("8th").str(),  translate("9th").str(),
+		    translate("10th").str(), translate("11th").str(), translate("12th").str(),
+		    translate("13th").str(), translate("14th").str(), translate("15th").str(),
+		    translate("16th").str(), translate("17th").str(), translate("18th").str(),
+		    translate("19th").str(), translate("20th").str(), translate("21st").str(),
+		    translate("22nd").str(), translate("23rd").str(), translate("24th").str(),
+		    translate("25th").str(), translate("26th").str(), translate("27th").str(),
+		    translate("28th").str(), translate("29th").str(), translate("30th").str(),
+		    translate("31st").str()};
 		dateFacet->longDayNames(days);
 	}
 	ss.imbue(*DATE_LONG_FORMAT);
@@ -107,21 +111,24 @@ UString GameTime::getShortDateString() const
 		DATE_SHORT_FORMAT = new std::locale(std::locale::classic(), dateFacet);
 
 		std::vector<std::string> months = {
-		    tr("January").str(), tr("February").str(), tr("March").str(),
-		    tr("April").str(),   tr("May").str(),      tr("June").str(),
-		    tr("July").str(),    tr("August").str(),   tr("September").str(),
-		    tr("October").str(), tr("November").str(), tr("December").str()};
+		    translate("January").str(), translate("February").str(), translate("March").str(),
+		    translate("April").str(),   translate("May").str(),      translate("June").str(),
+		    translate("July").str(),    translate("August").str(),   translate("September").str(),
+		    translate("October").str(), translate("November").str(), translate("December").str()};
 		dateFacet->long_month_names(months);
 
 		std::vector<std::string> days = {
-		    tr("1st").str(),  tr("2nd").str(),  tr("3rd").str(),  tr("4th").str(),
-		    tr("5th").str(),  tr("6th").str(),  tr("7th").str(),  tr("8th").str(),
-		    tr("9th").str(),  tr("10th").str(), tr("11th").str(), tr("12th").str(),
-		    tr("13th").str(), tr("14th").str(), tr("15th").str(), tr("16th").str(),
-		    tr("17th").str(), tr("18th").str(), tr("19th").str(), tr("20th").str(),
-		    tr("21st").str(), tr("22nd").str(), tr("23rd").str(), tr("24th").str(),
-		    tr("25th").str(), tr("26th").str(), tr("27th").str(), tr("28th").str(),
-		    tr("29th").str(), tr("30th").str(), tr("31st").str()};
+		    translate("1st").str(),  translate("2nd").str(),  translate("3rd").str(),
+		    translate("4th").str(),  translate("5th").str(),  translate("6th").str(),
+		    translate("7th").str(),  translate("8th").str(),  translate("9th").str(),
+		    translate("10th").str(), translate("11th").str(), translate("12th").str(),
+		    translate("13th").str(), translate("14th").str(), translate("15th").str(),
+		    translate("16th").str(), translate("17th").str(), translate("18th").str(),
+		    translate("19th").str(), translate("20th").str(), translate("21st").str(),
+		    translate("22nd").str(), translate("23rd").str(), translate("24th").str(),
+		    translate("25th").str(), translate("26th").str(), translate("27th").str(),
+		    translate("28th").str(), translate("29th").str(), translate("30th").str(),
+		    translate("31st").str()};
 		dateFacet->longDayNames(days);
 	}
 	ss.imbue(*DATE_SHORT_FORMAT);
@@ -129,7 +136,7 @@ UString GameTime::getShortDateString() const
 	return ss.str();
 }
 
-UString GameTime::getWeekString() const { return format("%s %d", tr("Week"), getWeek()); }
+UString GameTime::getWeekString() const { return tformat("Week {1}") % getWeek(); }
 
 unsigned int GameTime::getWeek() const
 {

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -17,7 +17,7 @@
 #include "game/state/shared/aequipment.h"
 #include "game/state/shared/organisation.h"
 #include "game/state/tilemap/tileobject_scenery.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 #include <glm/glm.hpp>
 
 namespace OpenApoc
@@ -267,19 +267,19 @@ UString Agent::getRankName() const
 	switch (rank)
 	{
 		case Rank::Rookie:
-			return tr("Rookie");
+			return translate("Rookie");
 		case Rank::Squaddie:
-			return tr("Squaddie");
+			return translate("Squaddie");
 		case Rank::SquadLeader:
-			return tr("Squad leader");
+			return translate("Squad leader");
 		case Rank::Sergeant:
-			return tr("Sergeant");
+			return translate("Sergeant");
 		case Rank::Captain:
-			return tr("Captain");
+			return translate("Captain");
 		case Rank::Colonel:
-			return tr("Colonel");
+			return translate("Colonel");
 		case Rank::Commander:
-			return tr("Commander");
+			return translate("Commander");
 	}
 	LogError("Unknown rank %d", (int)rank);
 	return "";

--- a/game/ui/base/aliencontainmentscreen.cpp
+++ b/game/ui/base/aliencontainmentscreen.cpp
@@ -17,6 +17,7 @@
 #include "game/ui/base/basestage.h"
 #include "game/ui/general/messagebox.h"
 #include "game/ui/general/transactioncontrol.h"
+#include "library/strings_translate.h"
 #include <array>
 
 namespace OpenApoc
@@ -25,7 +26,7 @@ namespace OpenApoc
 AlienContainmentScreen::AlienContainmentScreen(sp<GameState> state, bool forceLimits)
     : TransactionScreen(state, forceLimits)
 {
-	form->findControlTyped<Label>("TITLE")->setText(tr("ALIEN CONTAINMENT"));
+	form->findControlTyped<Label>("TITLE")->setText(translate("ALIEN CONTAINMENT"));
 	form->findControlTyped<Graphic>("BG")->setImage(
 	    fw().data->loadImage("xcom3/ufodata/aliencon.pcx"));
 	form->findControlTyped<Graphic>("DOLLAR_ICON")->setVisible(false);
@@ -43,7 +44,7 @@ AlienContainmentScreen::AlienContainmentScreen(sp<GameState> state, bool forceLi
 	form->findControlTyped<RadioButton>("BUTTON_FLYING")->setVisible(false);
 	form->findControlTyped<RadioButton>("BUTTON_GROUND")->setVisible(false);
 
-	confirmClosureText = tr("Confirm Alien Containment Orders");
+	confirmClosureText = translate("Confirm Alien Containment Orders");
 
 	type = Type::Aliens;
 	form->findControlTyped<RadioButton>("BUTTON_ALIENS")->setChecked(true);
@@ -103,8 +104,8 @@ void AlienContainmentScreen::closeScreen()
 		// Found bad base
 		if (bad_base)
 		{
-			UString title(tr("Alien Containment space exceeded"));
-			UString message(tr("Alien Containment space exceeded. Destroy more Aliens!"));
+			UString title(translate("Alien Containment space exceeded"));
+			UString message(translate("Alien Containment space exceeded. Destroy more Aliens!"));
 
 			fw().stageQueueCommand(
 			    {StageCmd::Command::PUSH,

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -27,7 +27,7 @@
 #include "game/ui/general/aequipscreen.h"
 #include "game/ui/general/messagebox.h"
 #include "game/ui/ufopaedia/ufopaediacategoryview.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -108,8 +108,9 @@ void BaseScreen::begin()
 			    fw().stageQueueCommand(
 			        {StageCmd::Command::PUSH,
 			         mksp<MessageBox>(
-			             tr("Transfer"),
-			             tr("At least two bases are required before transfers become possible."),
+			             translate("Transfer"),
+			             translate(
+			                 "At least two bases are required before transfers become possible."),
 			             MessageBox::ButtonOptions::Ok)});
 		    }
 		    else
@@ -314,30 +315,33 @@ void BaseScreen::eventOccurred(Event *e)
 						case Base::BuildError::Occupied:
 							fw().stageQueueCommand(
 							    {StageCmd::Command::PUSH,
-							     mksp<MessageBox>(tr("Area Occupied By Existing Facility"),
-							                      tr("Existing facilities in this area of the base "
-							                         "must be destroyed "
-							                         "before construction work can begin."),
-							                      MessageBox::ButtonOptions::Ok)});
+							     mksp<MessageBox>(
+							         translate("Area Occupied By Existing Facility"),
+							         translate("Existing facilities in this area of the base "
+							                   "must be destroyed "
+							                   "before construction work can begin."),
+							         MessageBox::ButtonOptions::Ok)});
 							break;
 						case Base::BuildError::OutOfBounds:
 							fw().stageQueueCommand(
 							    {StageCmd::Command::PUSH,
 							     mksp<MessageBox>(
-							         tr("Planning Permission Denied"),
-							         tr("Planning permission is denied for this proposed extension "
-							            "to "
-							            "the base, on the grounds that the additional excavations "
-							            "required would seriously weaken the foundations of the "
-							            "building."),
+							         translate("Planning Permission Denied"),
+							         translate(
+							             "Planning permission is denied for this proposed "
+							             "extension "
+							             "to "
+							             "the base, on the grounds that the additional excavations "
+							             "required would seriously weaken the foundations of the "
+							             "building."),
 							         MessageBox::ButtonOptions::Ok)});
 							break;
 						case Base::BuildError::NoMoney:
 							fw().stageQueueCommand(
 							    {StageCmd::Command::PUSH,
-							     mksp<MessageBox>(tr("Funds exceeded"),
-							                      tr("The proposed construction work is not "
-							                         "possible with your available funds."),
+							     mksp<MessageBox>(translate("Funds exceeded"),
+							                      translate("The proposed construction work is not "
+							                                "possible with your available funds."),
 							                      MessageBox::ButtonOptions::Ok)});
 							break;
 						case Base::BuildError::Indestructible:
@@ -361,7 +365,8 @@ void BaseScreen::eventOccurred(Event *e)
 						case Base::BuildError::NoError:
 							fw().stageQueueCommand(
 							    {StageCmd::Command::PUSH,
-							     mksp<MessageBox>(tr("Destroy facility"), tr("Are you sure?"),
+							     mksp<MessageBox>(translate("Destroy facility"),
+							                      translate("Are you sure?"),
 							                      MessageBox::ButtonOptions::YesNo, [this] {
 								                      this->state->current_base->destroyFacility(
 								                          *this->state, this->selection);
@@ -371,7 +376,7 @@ void BaseScreen::eventOccurred(Event *e)
 						case Base::BuildError::Occupied:
 							fw().stageQueueCommand(
 							    {StageCmd::Command::PUSH,
-							     mksp<MessageBox>(tr("Facility in use"), tr(""),
+							     mksp<MessageBox>(translate("Facility in use"), "",
 							                      MessageBox::ButtonOptions::Ok)});
 						default:
 							break;
@@ -394,24 +399,24 @@ void BaseScreen::eventOccurred(Event *e)
 	}
 	if (dragFacility)
 	{
-		selText->setText(tr(dragFacility->name));
+		selText->setText(translate(dragFacility->name));
 		selGraphic->setImage(dragFacility->sprite);
-		statsLabels[0]->setText(tr("Cost to build"));
+		statsLabels[0]->setText(translate("Cost to build"));
 		statsValues[0]->setText(format("$%d", dragFacility->buildCost));
-		statsLabels[1]->setText(tr("Days to build"));
+		statsLabels[1]->setText(translate("Days to build"));
 		statsValues[1]->setText(format("%d", dragFacility->buildTime));
-		statsLabels[2]->setText(tr("Maintenance cost"));
+		statsLabels[2]->setText(translate("Maintenance cost"));
 		statsValues[2]->setText(format("$%d", dragFacility->weeklyCost));
 	}
 	else if (selFacility != nullptr)
 	{
-		selText->setText(tr(selFacility->type->name));
+		selText->setText(translate(selFacility->type->name));
 		selGraphic->setImage(selFacility->type->sprite);
 		if (selFacility->type->capacityAmount > 0)
 		{
-			statsLabels[0]->setText(tr("Capacity"));
+			statsLabels[0]->setText(translate("Capacity"));
 			statsValues[0]->setText(format("%d", selFacility->type->capacityAmount));
-			statsLabels[1]->setText(tr("Usage"));
+			statsLabels[1]->setText(translate("Usage"));
 			statsValues[1]->setText(
 			    format("%d%%", state->current_base->getUsage(*state, selFacility)));
 		}
@@ -423,11 +428,11 @@ void BaseScreen::eventOccurred(Event *e)
 		    "PCK:xcom3/ufodata/base.pck:xcom3/ufodata/base.tab:%d:xcom3/ufodata/base.pcx", sprite);
 		if (sprite != 0)
 		{
-			selText->setText(tr("Corridor"));
+			selText->setText(translate("Corridor"));
 		}
 		else
 		{
-			selText->setText(tr("Earth"));
+			selText->setText(translate("Earth"));
 		}
 		selGraphic->setImage(fw().data->loadImage(image));
 	}

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -20,6 +20,7 @@
 #include "game/state/shared/organisation.h"
 #include "game/ui/general/messagebox.h"
 #include "game/ui/general/transactioncontrol.h"
+#include "library/strings_translate.h"
 #include <array>
 
 namespace OpenApoc
@@ -28,7 +29,7 @@ namespace OpenApoc
 BuyAndSellScreen::BuyAndSellScreen(sp<GameState> state, bool forceLimits)
     : TransactionScreen(state, forceLimits)
 {
-	form->findControlTyped<Label>("TITLE")->setText(tr("BUY AND SELL"));
+	form->findControlTyped<Label>("TITLE")->setText(translate("BUY AND SELL"));
 	form->findControlTyped<Graphic>("BG")->setImage(
 	    fw().data->loadImage("xcom3/ufodata/buy&sell.pcx"));
 	form->findControlTyped<Graphic>("DOLLAR_ICON")->setVisible(true);
@@ -66,7 +67,7 @@ BuyAndSellScreen::BuyAndSellScreen(sp<GameState> state, bool forceLimits)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *) { this->setDisplayType(Type::GroundEquipment); });
 
-	confirmClosureText = tr("Confirm Sales/Purchases");
+	confirmClosureText = translate("Confirm Sales/Purchases");
 
 	type = Type::Vehicle;
 	form->findControlTyped<RadioButton>("BUTTON_VEHICLES")->setChecked(true);
@@ -105,10 +106,11 @@ void BuyAndSellScreen::closeScreen()
 	{
 		if (player->balance + moneyDelta < 0)
 		{
-			fw().stageQueueCommand({StageCmd::Command::PUSH,
-			                        mksp<MessageBox>(tr("Funds exceeded"),
-			                                         tr("Order limited by your available funds."),
-			                                         MessageBox::ButtonOptions::Ok)});
+			fw().stageQueueCommand(
+			    {StageCmd::Command::PUSH,
+			     mksp<MessageBox>(translate("Funds exceeded"),
+			                      translate("Order limited by your available funds."),
+			                      MessageBox::ButtonOptions::Ok)});
 			return;
 		}
 	}
@@ -159,10 +161,11 @@ void BuyAndSellScreen::closeScreen()
 		// Found bad base
 		if (bad_base)
 		{
-			UString title(tr("Storage space exceeded"));
-			UString message(forceLimits
-			                    ? tr("Storage space exceeded. Sell off more items!")
-			                    : tr("Order limited by the available storage space at this base."));
+			UString title(translate("Storage space exceeded"));
+			UString message(
+			    forceLimits
+			        ? translate("Storage space exceeded. Sell off more items!")
+			        : translate("Order limited by the available storage space at this base."));
 
 			fw().stageQueueCommand(
 			    {StageCmd::Command::PUSH,
@@ -255,15 +258,12 @@ void BuyAndSellScreen::closeScreen()
 			// If player can ferry themselves then give option
 			if (config().getBool("OpenApoc.NewFeature.AllowManualCargoFerry"))
 			{
-				UString message = transportationHostile
-				                      ? format("%s %s",
-				                               tr("Hostile organization refuses to carry out the "
-				                                  "requested transportation for this company."),
-				                               tr("Proceed?"))
-				                      : format("%s %s",
-				                               tr("No free transport to carry out the requested "
-				                                  "transportation detected in the city."),
-				                               tr("Proceed?"));
+				UString message =
+				    transportationHostile
+				        ? translate("Hostile organization refuses to carry out the "
+				                    "requested transportation for this company. Proceed?")
+				        : translate("No free transport to carry out the requested "
+				                    "transportation detected in the city. Proceed?");
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::YesNo,
@@ -274,10 +274,8 @@ void BuyAndSellScreen::closeScreen()
 			else if (!transportationHostile)
 			{
 				// FIXME: Different message maybe? Same for now
-				UString message = format("%s %s",
-				                         tr("No free transport to carry out the requested "
-				                            "transportation detected in the city."),
-				                         tr("Proceed?"));
+				UString message = translate("No free transport to carry out the requested "
+				                            "transportation detected in the city. Proceed?");
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::YesNo,
@@ -290,8 +288,8 @@ void BuyAndSellScreen::closeScreen()
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title,
-				                      tr("Hostile organization refuses to carry out the "
-				                         "requested transportation for this company."),
+				                      translate("Hostile organization refuses to carry out the "
+				                                "requested transportation for this company."),
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}
@@ -365,14 +363,10 @@ void BuyAndSellScreen::closeScreen()
 			{
 				UString message =
 				    transportationHostile
-				        ? format("%s %s",
-				                 tr("This hostile organization refuses to carry out the "
-				                    "requested transfer."),
-				                 tr("Proceed?"))
-				        : format("%s %s",
-				                 tr("No free transport to carry out the requested "
-				                    "transportation detected in the city."),
-				                 tr("Proceed?"));
+				        ? translate("This hostile organization refuses to carry out the "
+				                    "requested transfer. Proceed?")
+				        : translate("No free transport to carry out the requested "
+				                    "transportation detected in the city. Proceed?");
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::YesNo,
@@ -383,10 +377,8 @@ void BuyAndSellScreen::closeScreen()
 			else if (!transportationHostile)
 			{
 				// FIXME: Different message maybe? Same for now
-				UString message = format("%s %s",
-				                         tr("No free transport to carry out the requested "
-				                            "transportation detected in the city."),
-				                         tr("Proceed?"));
+				UString message = translate("No free transport to carry out the requested "
+				                            "transportation detected in the city. Proceed?");
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::YesNo,
@@ -399,8 +391,8 @@ void BuyAndSellScreen::closeScreen()
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title,
-				                      tr("This hostile organization refuses to carry out "
-				                         "the requested transfer."),
+				                      translate("This hostile organization refuses to carry out "
+				                                "the requested transfer."),
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -26,7 +26,7 @@
 #include "game/ui/components/controlgenerator.h"
 #include "game/ui/general/agentsheet.h"
 #include "game/ui/general/messagebox.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -119,8 +119,8 @@ RecruitScreen::RecruitScreen(sp<GameState> state)
 				{
 					fw().stageQueueCommand(
 					    {StageCmd::Command::PUSH,
-					     mksp<MessageBox>(tr("Accomodation exceeded"),
-					                      tr("Transfer limited by available accommodation."),
+					     mksp<MessageBox>(translate("Accomodation exceeded"),
+					                      translate("Transfer limited by available accommodation."),
 					                      MessageBox::ButtonOptions::Ok)});
 				}
 				else
@@ -235,16 +235,16 @@ void RecruitScreen::setDisplayType(const AgentType::Role role)
 	switch (type)
 	{
 		case AgentType::Role::Soldier:
-			label->setText(tr("X-COM Agents"));
+			label->setText(translate("X-COM Agents"));
 			break;
 		case AgentType::Role::BioChemist:
-			label->setText(tr("Biochemists"));
+			label->setText(translate("Biochemists"));
 			break;
 		case AgentType::Role::Physicist:
-			label->setText(tr("Quantum Physicists"));
+			label->setText(translate("Quantum Physicists"));
 			break;
 		case AgentType::Role::Engineer:
-			label->setText(tr("Engineers"));
+			label->setText(translate("Engineers"));
 			break;
 	}
 
@@ -476,16 +476,17 @@ void RecruitScreen::attemptCloseScreen()
 
 	if (hired != 0 || fired != 0 || transferred != 0)
 	{
-		UString message =
-		    format("%d %s\n%d %s", hired, tr("unit(s) hired"), fired, tr("unit(s) fired."));
+		// TODO: Translate pleurals
+		UString message;
 		if (transferred > 0)
-		{
-			message = format("%s\n(%d %s)", message, transferred, tr("units(s) transferred"));
-		}
+			message = tformat("{1} unit(s) hired\n {2} unit(s) fired\n {3} unit(s) transferred") %
+			          hired % fired % transferred;
+		else
+			message = tformat("{1} unit(s) hired\n {2} unit(s) fired\n") % hired % fired;
 		fw().stageQueueCommand(
 		    {StageCmd::Command::PUSH,
 		     mksp<MessageBox>(
-		         tr("Confirm Orders"), message, MessageBox::ButtonOptions::YesNoCancel,
+		         translate("Confirm Orders"), message, MessageBox::ButtonOptions::YesNoCancel,
 		         [this] { this->closeScreen(true); }, [this] { this->closeScreen(); })});
 	}
 	else
@@ -609,7 +610,8 @@ void RecruitScreen::closeScreen(bool confirmed)
 	{
 		fw().stageQueueCommand(
 		    {StageCmd::Command::PUSH,
-		     mksp<MessageBox>(tr("Funds exceeded"), tr("Order limited by your available funds."),
+		     mksp<MessageBox>(translate("Funds exceeded"),
+		                      translate("Order limited by your available funds."),
 		                      MessageBox::ButtonOptions::Ok)});
 		return;
 	}
@@ -630,10 +632,11 @@ void RecruitScreen::closeScreen(bool confirmed)
 	// Found bad base
 	if (bad_base)
 	{
-		fw().stageQueueCommand({StageCmd::Command::PUSH,
-		                        mksp<MessageBox>(tr("Accomodation exceeded"),
-		                                         tr("Transfer limited by available accommodation."),
-		                                         MessageBox::ButtonOptions::Ok)});
+		fw().stageQueueCommand(
+		    {StageCmd::Command::PUSH,
+		     mksp<MessageBox>(translate("Accomodation exceeded"),
+		                      translate("Transfer limited by available accommodation."),
+		                      MessageBox::ButtonOptions::Ok)});
 		if (bad_base != state->current_base)
 		{
 			for (auto &view : miniViews)

--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -17,7 +17,7 @@
 #include "game/state/gamestate.h"
 #include "game/ui/base/researchselect.h"
 #include "game/ui/components/controlgenerator.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -327,7 +327,7 @@ void ResearchScreen::setCurrentLabInfo()
 		assignedAgentList->clear();
 		form->findControlTyped<Label>("TEXT_LAB_TYPE")->setText("");
 		auto totalSkillLabel = form->findControlTyped<Label>("TEXT_TOTAL_SKILL");
-		totalSkillLabel->setText(format(tr("Total Skill: %d"), 0));
+		totalSkillLabel->setText(tformat("Total Skill: {1}") % 0);
 		updateProgressInfo();
 		return;
 	}
@@ -339,17 +339,17 @@ void ResearchScreen::setCurrentLabInfo()
 
 	if (labType == FacilityType::Capacity::Chemistry)
 	{
-		labTypeName = tr("Biochemistry");
+		labTypeName = translate("Biochemistry");
 		listedAgentType = AgentType::Role::BioChemist;
 	}
 	else if (labType == FacilityType::Capacity::Physics)
 	{
-		labTypeName = tr("Quantum Physics");
+		labTypeName = translate("Quantum Physics");
 		listedAgentType = AgentType::Role::Physicist;
 	}
 	else if (labType == FacilityType::Capacity::Workshop)
 	{
-		labTypeName = tr("Engineering");
+		labTypeName = translate("Engineering");
 		listedAgentType = AgentType::Role::Engineer;
 	}
 	else
@@ -410,8 +410,8 @@ void ResearchScreen::setCurrentLabInfo()
 	unassignedAgentList->ItemSize = agentEntryHeight;
 
 	auto totalSkillLabel = form->findControlTyped<Label>("TEXT_TOTAL_SKILL");
-	totalSkillLabel->setText(
-	    format(tr("Total Skill: %d"), this->viewFacility->lab->getTotalSkill()));
+	totalSkillLabel->setText(tformat("Total Skill: {1}") %
+	                         this->viewFacility->lab->getTotalSkill());
 
 	// update scientists quantity for selected lab
 	auto uiListLabs = form->findControlTyped<ListBox>("LIST_SMALL_LABS");
@@ -475,9 +475,9 @@ void ResearchScreen::updateProgressInfo()
 		}
 		progressBar->setImage(progressImage);
 		auto topicTitle = form->findControlTyped<Label>("TEXT_CURRENT_PROJECT");
-		topicTitle->setText(tr(topic->name));
+		topicTitle->setText(translate(topic->name));
 		auto completionPercent = form->findControlTyped<Label>("TEXT_PROJECT_COMPLETION");
-		auto completionText = format(tr("%d%%"), static_cast<int>(projectProgress * 100.0f));
+		auto completionText = format("%d%%", static_cast<int>(projectProgress * 100.0f));
 		completionPercent->setText(completionText);
 	}
 	else
@@ -485,7 +485,7 @@ void ResearchScreen::updateProgressInfo()
 		auto progressBar = form->findControlTyped<Graphic>("GRAPHIC_PROGRESS_BAR");
 		progressBar->setImage(nullptr);
 		auto topicTitle = form->findControlTyped<Label>("TEXT_CURRENT_PROJECT");
-		topicTitle->setText(tr("No Project"));
+		topicTitle->setText(translate("No Project"));
 		auto completionPercent = form->findControlTyped<Label>("TEXT_PROJECT_COMPLETION");
 		completionPercent->setText("");
 	}

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -18,7 +18,7 @@
 #include "game/state/rules/city/vequipmenttype.h"
 #include "game/state/shared/organisation.h"
 #include "game/ui/general/messagebox.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -43,22 +43,22 @@ void ResearchSelect::begin()
 	switch (this->lab->type)
 	{
 		case ResearchTopic::Type::BioChem:
-			title->setText(tr("Select Biochemistry Project"));
-			progress->setText(tr("Progress"));
-			skill->setText(tr("Skill"));
+			title->setText(translate("Select Biochemistry Project"));
+			progress->setText(translate("Progress"));
+			skill->setText(translate("Skill"));
 			break;
 		case ResearchTopic::Type::Physics:
-			title->setText(tr("Select Physics Project"));
-			progress->setText(tr("Progress"));
-			skill->setText(tr("Skill"));
+			title->setText(translate("Select Physics Project"));
+			progress->setText(translate("Progress"));
+			skill->setText(translate("Skill"));
 			break;
 		case ResearchTopic::Type::Engineering:
-			title->setText(tr("Select Manufacturing Project"));
-			progress->setText(tr("Unit Cost"));
-			skill->setText(tr("Skill Hours"));
+			title->setText(translate("Select Manufacturing Project"));
+			progress->setText(translate("Unit Cost"));
+			skill->setText(translate("Skill Hours"));
 			break;
 		default:
-			title->setText(tr("Select Unknown Project"));
+			title->setText(translate("Select Unknown Project"));
 			break;
 	}
 	this->populateResearchList();
@@ -80,8 +80,8 @@ void ResearchSelect::begin()
 			if (topic->isComplete())
 			{
 				LogInfo("Topic already complete");
-				auto message_box = mksp<MessageBox>(tr("PROJECT COMPLETE"),
-				                                    tr("This project is already complete."),
+				auto message_box = mksp<MessageBox>(translate("PROJECT COMPLETE"),
+				                                    translate("This project is already complete."),
 				                                    MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 				return;
@@ -90,10 +90,10 @@ void ResearchSelect::begin()
 			    this->lab->size == ResearchTopic::LabSize::Small)
 			{
 				LogInfo("Topic is large and lab is small");
-				auto message_box =
-				    mksp<MessageBox>(tr("PROJECT TOO LARGE"),
-				                     tr("This project requires an advanced lab or workshop."),
-				                     MessageBox::ButtonOptions::Ok);
+				auto message_box = mksp<MessageBox>(
+				    translate("PROJECT TOO LARGE"),
+				    translate("This project requires an advanced lab or workshop."),
+				    MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 				return;
 			}
@@ -101,9 +101,10 @@ void ResearchSelect::begin()
 			    topic->cost > state->player->balance)
 			{
 				LogInfo("Cannot afford to manufacture");
-				auto message_box = mksp<MessageBox>(
-				    tr("FUNDS EXCEEDED"), tr("Production costs exceed your available funds."),
-				    MessageBox::ButtonOptions::Ok);
+				auto message_box =
+				    mksp<MessageBox>(translate("FUNDS EXCEEDED"),
+				                     translate("Production costs exceed your available funds."),
+				                     MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 				return;
 			}
@@ -125,8 +126,8 @@ void ResearchSelect::begin()
 		auto pic = this->form->findControlTyped<Graphic>("GRAPHIC_SELECTED");
 		if (topic)
 		{
-			title->setText(tr(topic->name));
-			description->setText(tr(topic->description));
+			title->setText(translate(topic->name));
+			description->setText(translate(topic->description));
 			if (topic->picture)
 			{
 				pic->setImage(topic->picture);
@@ -242,7 +243,7 @@ void ResearchSelect::populateResearchList()
 			if (this->lab->type == ResearchTopic::Type::Engineering)
 				progress_text = format("$%d", t->cost);
 			else
-				progress_text = tr("Complete");
+				progress_text = translate("Complete");
 			auto progress_label =
 			    control->createChild<Label>(progress_text, ui().getFont("smalfont"));
 			progress_label->Size = {100, 18};
@@ -301,13 +302,13 @@ void ResearchSelect::populateResearchList()
 		switch (t->required_lab_size)
 		{
 			case ResearchTopic::LabSize::Small:
-				labSize = tr("Small");
+				labSize = translate("Small");
 				break;
 			case ResearchTopic::LabSize::Large:
-				labSize = tr("Large");
+				labSize = translate("Large");
 				break;
 			default:
-				labSize = tr("UNKNOWN");
+				labSize = translate("UNKNOWN");
 				break;
 		}
 

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -24,6 +24,7 @@
 #include "game/ui/general/agentsheet.h"
 #include "game/ui/general/messagebox.h"
 #include "game/ui/general/transactioncontrol.h"
+#include "library/strings_translate.h"
 #include <array>
 
 namespace OpenApoc
@@ -32,7 +33,7 @@ namespace OpenApoc
 TransferScreen::TransferScreen(sp<GameState> state, bool forceLimits)
     : TransactionScreen(state, forceLimits), bigUnitRanks(RecruitScreen::getBigUnitRanks())
 {
-	form->findControlTyped<Label>("TITLE")->setText(tr("TRANSFER"));
+	form->findControlTyped<Label>("TITLE")->setText(translate("TRANSFER"));
 	form->findControlTyped<Graphic>("BG")->setImage(
 	    fw().data->loadImage("xcom3/ufodata/transfer.pcx"));
 	form->findControlTyped<Graphic>("DOLLAR_ICON")->setVisible(false);
@@ -100,7 +101,7 @@ TransferScreen::TransferScreen(sp<GameState> state, bool forceLimits)
 		}
 	}
 
-	confirmClosureText = tr("Confirm Transfers");
+	confirmClosureText = translate("Confirm Transfers");
 
 	type = Type::Soldier;
 	form->findControlTyped<RadioButton>("BUTTON_SOLDIERS")->setChecked(true);
@@ -321,20 +322,20 @@ void TransferScreen::closeScreen()
 			UString message;
 			if (crewOverLimit)
 			{
-				title = tr("Accomodation exceeded");
-				message = tr("Transfer limited by available accommodation.");
+				title = translate("Accomodation exceeded");
+				message = translate("Transfer limited by available accommodation.");
 				type = Type::Soldier;
 			}
 			else if (cargoOverLimit)
 			{
-				title = tr("Storage space exceeded");
-				message = tr("Transfer limited by available storage space.");
+				title = translate("Storage space exceeded");
+				message = translate("Transfer limited by available storage space.");
 				type = Type::AgentEquipment;
 			}
 			else if (alienOverLimit)
 			{
-				title = tr("Alien Containment space exceeded");
-				message = tr("Transfer limited by available Alien Containment space.");
+				title = translate("Alien Containment space exceeded");
+				message = translate("Transfer limited by available Alien Containment space.");
 				type = Type::Aliens;
 			}
 			fw().stageQueueCommand(
@@ -423,14 +424,10 @@ void TransferScreen::closeScreen()
 			{
 				UString message =
 				    transportationHostile
-				        ? format("%s %s",
-				                 tr("This hostile organization refuses to carry out the "
-				                    "requested transfer."),
-				                 tr("Proceed?"))
-				        : format("%s %s",
-				                 tr("No free transport to carry out the requested "
-				                    "transportation detected in the city."),
-				                 tr("Proceed?"));
+				        ? translate("This hostile organization refuses to carry out the "
+				                    "requested transfer. Proceed?")
+				        : translate("No free transport to carry out the requested "
+				                    "transportation detected in the city. Proceed?");
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::YesNo,
@@ -441,10 +438,8 @@ void TransferScreen::closeScreen()
 			else if (!transportationHostile)
 			{
 				// FIXME: Different message maybe? Same for now
-				UString message = format("%s %s",
-				                         tr("No free transport to carry out the requested "
-				                            "transportation detected in the city."),
-				                         tr("Proceed?"));
+				UString message = translate("No free transport to carry out the requested "
+				                            "transportation detected in the city. Proceed?");
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::YesNo,
@@ -457,8 +452,8 @@ void TransferScreen::closeScreen()
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
 				     mksp<MessageBox>(title,
-				                      tr("This hostile organization refuses to carry out "
-				                         "the requested transfer."),
+				                      translate("This hostile organization refuses to carry out "
+				                                "the requested transfer."),
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}

--- a/game/ui/battle/battledebriefing.cpp
+++ b/game/ui/battle/battledebriefing.cpp
@@ -11,6 +11,7 @@
 #include "game/state/gamestate.h"
 #include "game/state/rules/battle/battlecommonimagelist.h"
 #include "game/ui/tileview/cityview.h"
+#include "library/strings_translate.h"
 #include <cmath>
 
 namespace OpenApoc
@@ -45,8 +46,7 @@ BattleDebriefing::BattleDebriefing(sp<GameState> state)
 	for (auto &u : state->current_battle->unitsPromoted)
 	{
 		menuform->findControlTyped<Label>(format("PROMOTION_%d", idx++))
-		    ->setText(
-		        format("%s %s %s", u->agent->name, tr("promoted to"), u->agent->getRankName()));
+		    ->setText(tformat("{1} promoted to {2}") % u->agent->name % u->agent->getRankName());
 	}
 }
 

--- a/game/ui/city/alertscreen.cpp
+++ b/game/ui/city/alertscreen.cpp
@@ -16,7 +16,7 @@
 #include "game/ui/components/agentassignment.h"
 #include "game/ui/general/aequipscreen.h"
 #include "game/ui/general/messagebox.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -25,9 +25,9 @@ AlertScreen::AlertScreen(sp<GameState> state, sp<Building> building)
     : Stage(), menuform(ui().getForm("city/alert")), state(state), building(building)
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
-	menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(tr(building->owner->name));
+	menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(translate(building->owner->name));
 	menuform->findControlTyped<Label>("TEXT_BUILDING_FUNCTION")
-	    ->setText(tr(building->function->name));
+	    ->setText(translate(building->function->name));
 }
 
 AlertScreen::~AlertScreen() = default;
@@ -72,9 +72,9 @@ void AlertScreen::eventOccurred(Event *e)
 			{
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
-				     mksp<MessageBox>(tr("No Agents Selected"),
-				                      tr("You need to select the agents you want to "
-				                         "become active within the building."),
+				     mksp<MessageBox>(translate("No Agents Selected"),
+				                      translate("You need to select the agents you want to "
+				                                "become active within the building."),
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -18,7 +18,7 @@
 #include "game/ui/components/basegraphics.h"
 #include "game/ui/general/messagebox.h"
 #include "game/ui/tileview/cityview.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -40,7 +40,7 @@ void BaseBuyScreen::begin()
 	form->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 
 	auto text = form->findControlTyped<Label>("TEXT_PRICE");
-	text->setText(format(tr("This Building will cost $%d"), price));
+	text->setText(tformat("This Building will cost ${1}") % price);
 
 	form->findControlTyped<Graphic>("GRAPHIC_MINIMAP")
 	    ->setImage(BaseGraphics::drawMinimap(state, *base->building));
@@ -152,9 +152,9 @@ void BaseBuyScreen::eventOccurred(Event *e)
 			}
 			else
 			{
-				auto messagebox =
-				    mksp<MessageBox>(tr("No Sale"), tr("Not enough money to buy this building."),
-				                     MessageBox::ButtonOptions::Ok);
+				auto messagebox = mksp<MessageBox>(
+				    translate("No Sale"), translate("Not enough money to buy this building."),
+				    MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, messagebox});
 			}
 		}

--- a/game/ui/city/bribescreen.h
+++ b/game/ui/city/bribescreen.h
@@ -28,8 +28,6 @@ class BribeScreen : public Stage
 
 	// Update info about deal.
 	void updateInfo();
-	// Get the offer of a bribe.
-	UString getOfferString(int itWillCost, const UString &newAttitude) const;
 
   public:
 	BribeScreen(sp<GameState> state);

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -17,7 +17,7 @@
 #include "game/ui/components/agentassignment.h"
 #include "game/ui/general/aequipscreen.h"
 #include "game/ui/general/messagebox.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -49,10 +49,10 @@ BuildingScreen::BuildingScreen(sp<GameState> state, sp<Building> building)
     : Stage(), menuform(ui().getForm("city/building")), state(state), building(building)
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
-	menuform->findControlTyped<Label>("TEXT_BUILDING_NAME")->setText(tr(building->name));
-	menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(tr(building->owner->name));
+	menuform->findControlTyped<Label>("TEXT_BUILDING_NAME")->setText(translate(building->name));
+	menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(translate(building->owner->name));
 	menuform->findControlTyped<Label>("TEXT_BUILDING_FUNCTION")
-	    ->setText(tr(building->function->name));
+	    ->setText(translate(building->function->name));
 }
 
 BuildingScreen::~BuildingScreen() = default;
@@ -103,7 +103,8 @@ void BuildingScreen::eventOccurred(Event *e)
 			{
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
-				     mksp<MessageBox>(tr("No Entrance"), tr("Cannot raid as building destroyed"),
+				     mksp<MessageBox>(translate("No Entrance"),
+				                      translate("Cannot raid as building destroyed"),
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}
@@ -112,10 +113,10 @@ void BuildingScreen::eventOccurred(Event *e)
 			{
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
-				     mksp<MessageBox>(tr("No Entrance"),
-				                      tr("Our Agents are unable to find an entrance to this "
-				                         "building. Our Scientists "
-				                         "back at HQ must complete their research."),
+				     mksp<MessageBox>(translate("No Entrance"),
+				                      translate("Our Agents are unable to find an entrance to this "
+				                                "building. Our Scientists "
+				                                "back at HQ must complete their research."),
 				                      MessageBox::ButtonOptions::Ok)});
 				return;
 			}
@@ -131,10 +132,11 @@ void BuildingScreen::eventOccurred(Event *e)
 			{
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,
-				     mksp<MessageBox>(tr("No Agents Selected"),
-				                      tr("You need to select the agents you want to become active "
-				                         "within the building."),
-				                      MessageBox::ButtonOptions::Ok)});
+				     mksp<MessageBox>(
+				         translate("No Agents Selected"),
+				         translate("You need to select the agents you want to become active "
+				                   "within the building."),
+				         MessageBox::ButtonOptions::Ok)});
 			}
 			else
 			{
@@ -152,7 +154,8 @@ void BuildingScreen::eventOccurred(Event *e)
 					}
 					if (!foundAlien)
 					{
-						UString message = "You have not found any Aliens in this building.";
+						UString message =
+						    translate("You have not found any Aliens in this building.");
 						if (building->owner != state->getPlayer())
 						{
 							auto priorRelationship =
@@ -163,33 +166,36 @@ void BuildingScreen::eventOccurred(Event *e)
 							if (newRelationship != priorRelationship &&
 							    newRelationship == Organisation::Relation::Unfriendly)
 							{
-								message = "You have not found any Aliens in this building. As "
-								          "a consequence of your "
-								          "unwelcome intrusion the owner of the building has "
-								          "now become unfriendly "
-								          "towards X-Com.";
+								message =
+								    translate("You have not found any Aliens in this building. As "
+								              "a consequence of your "
+								              "unwelcome intrusion the owner of the building has "
+								              "now become unfriendly "
+								              "towards X-Com.");
 							}
 							else if (newRelationship != priorRelationship &&
 							         newRelationship == Organisation::Relation::Hostile)
 							{
-								message = "You have not found any Aliens in this building. As "
-								          "a consequence of your "
-								          "unwelcome intrusion the owner of the building has "
-								          "now become hostile towards"
-								          " X-Com.";
+								message =
+								    translate("You have not found any Aliens in this building. As "
+								              "a consequence of your "
+								              "unwelcome intrusion the owner of the building has "
+								              "now become hostile towards"
+								              " X-Com.");
 							}
 							else
 							{
-								message = "You have not found any Aliens in this building. "
-								          "As a consequence of your "
-								          "unwelcome intrusion the owner of the building is "
-								          "less favorably disposed "
-								          "towards X-Com.";
+								message =
+								    translate("You have not found any Aliens in this building. "
+								              "As a consequence of your "
+								              "unwelcome intrusion the owner of the building is "
+								              "less favorably disposed "
+								              "towards X-Com.");
 							}
 						}
 						fw().stageQueueCommand(
 						    {StageCmd::Command::PUSH,
-						     mksp<MessageBox>(tr("No Hostile Forces Discovered"), tr(message),
+						     mksp<MessageBox>(translate("No Hostile Forces Discovered"), message,
 						                      MessageBox::ButtonOptions::Ok)});
 					}
 					else
@@ -214,8 +220,9 @@ void BuildingScreen::eventOccurred(Event *e)
 						fw().stageQueueCommand(
 						    {StageCmd::Command::PUSH,
 						     mksp<MessageBox>(
-						         tr("No Hostile Forces Discovered"),
-						         tr("You have not found any hostile forces in this building."),
+						         translate("No Hostile Forces Discovered"),
+						         translate(
+						             "You have not found any hostile forces in this building."),
 						         MessageBox::ButtonOptions::Ok)});
 						return;
 					}

--- a/game/ui/city/scorescreen.cpp
+++ b/game/ui/city/scorescreen.cpp
@@ -13,6 +13,7 @@
 #include "game/state/shared/agent.h"
 #include "game/state/shared/organisation.h"
 #include "game/ui/base/recruitscreen.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -86,7 +87,7 @@ void ScoreScreen::setScoreMode()
 		    format("%d", state->totalScore.getTotal()));
 	}
 
-	title->setText(tr("SCORE"));
+	title->setText(translate("SCORE"));
 	formScore->setVisible(true);
 	formFinance->setVisible(false);
 }
@@ -157,13 +158,13 @@ void ScoreScreen::setFinanceMode()
 
 		int balance = state->getPlayer()->balance;
 		formFinance->findControlTyped<Label>("INITIAL")->setText(
-		    format("%s $%d", tr("Initial funds>"), balance));
+		    format("%s $%d", translate("Initial funds>"), balance));
 		formFinance->findControlTyped<Label>("REMAINING")
-		    ->setText(
-		        format("%s $%d", tr("Remaining finds>"), balance - agentsSalary - basesCosts));
+		    ->setText(format("%s $%d", translate("Remaining funds>"),
+		                     balance - agentsSalary - basesCosts));
 	}
 
-	title->setText(tr("FINANCE"));
+	title->setText(translate("FINANCE"));
 	formScore->setVisible(false);
 	formFinance->setVisible(true);
 }

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -25,6 +25,7 @@
 #include "game/state/rules/city/vehicletype.h"
 #include "game/state/rules/city/vequipmenttype.h"
 #include "game/state/shared/agent.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -534,7 +535,7 @@ sp<Control> ControlGenerator::createLargeAgentControl(GameState &state, const Ag
 	if (skill != UnitSkillState::Hidden)
 	{
 		auto skillLabel = baseControl->createChild<Label>(
-		    format(tr("Skill %s"), info.agent->getSkill()), singleton.labelFont);
+		    tformat("Skill {1}") % info.agent->getSkill(), singleton.labelFont);
 		skillLabel->Tint = {192, 192, 192};
 
 		skillLabel->Size = {nameLabel->Size.x, singleton.labelFont->getFontHeight()};
@@ -637,7 +638,7 @@ sp<Control> ControlGenerator::createOrganisationControl(GameState &state,
 	// FIXME: There's an extra 1 pixel here that's annoying
 	baseControl->Size.x -= 1;
 	baseControl->Name = "ORG_FRAME_" + info.organisation->name;
-	baseControl->ToolTipText = tr(info.organisation->name);
+	baseControl->ToolTipText = translate(info.organisation->name);
 	baseControl->setData(info.organisation);
 
 	auto vehicleIcon = baseControl->createChild<Graphic>(info.organisation->icon);

--- a/game/ui/components/locationscreen.cpp
+++ b/game/ui/components/locationscreen.cpp
@@ -15,7 +15,7 @@
 #include "game/ui/base/vequipscreen.h"
 #include "game/ui/components/agentassignment.h"
 #include "game/ui/general/aequipscreen.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -27,7 +27,7 @@ LocationScreen::LocationScreen(sp<GameState> state, sp<Agent> agent)
 	{
 		building = agent->currentBuilding;
 	}
-	menuform->findControlTyped<Label>("CAPTION")->setText(tr("AGENT LOCATION"));
+	menuform->findControlTyped<Label>("CAPTION")->setText(translate("AGENT LOCATION"));
 	menuform->findControlTyped<Graphic>("BG")->setImage(
 	    fw().data->loadImage("xcom3/ufodata/location.pcx"));
 }
@@ -39,7 +39,7 @@ LocationScreen::LocationScreen(sp<GameState> state, sp<Vehicle> vehicle)
 	{
 		building = vehicle->currentBuilding;
 	}
-	menuform->findControlTyped<Label>("CAPTION")->setText(tr("VEHICLE LOCATION"));
+	menuform->findControlTyped<Label>("CAPTION")->setText(translate("VEHICLE LOCATION"));
 	menuform->findControlTyped<Graphic>("BG")->setImage(
 	    fw().data->loadImage("xcom3/ufodata/locatn2.pcx"));
 }
@@ -54,17 +54,20 @@ void LocationScreen::begin()
 	                      agentAssignmentPlaceholder->Location, agentAssignmentPlaceholder->Size);
 	if (building)
 	{
-		menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(tr(building->owner->name));
+		menuform->findControlTyped<Label>("TEXT_OWNER_NAME")
+		    ->setText(translate(building->owner->name));
 		agentAssignment->setLocation(building);
 	}
 	else if (agent)
 	{
-		menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(tr(agent->owner->name));
+		menuform->findControlTyped<Label>("TEXT_OWNER_NAME")
+		    ->setText(translate(agent->owner->name));
 		agentAssignment->setLocation(agent);
 	}
 	else if (vehicle)
 	{
-		menuform->findControlTyped<Label>("TEXT_OWNER_NAME")->setText(tr(vehicle->owner->name));
+		menuform->findControlTyped<Label>("TEXT_OWNER_NAME")
+		    ->setText(translate(vehicle->owner->name));
 		agentAssignment->setLocation(vehicle);
 	}
 	else

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -3,6 +3,7 @@
 #include "forms/label.h"
 #include "game/state/gamestate.h"
 #include "game/state/rules/battle/damage.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -55,7 +56,7 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 	    ->setImage(item ? item->getEquipmentImage() : itemType.equipscreen_sprite);
 
 	// when possible, the actual item's weight takes precedence
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
+	form->findControlTyped<Label>("LABEL_1_L")->setText(translate("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")
 	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
 
@@ -101,35 +102,35 @@ void AEquipmentSheet::displayGrenade(sp<AEquipment> item [[maybe_unused]],
 {
 	form->findControlTyped<Label>("LABEL_2_C")->setText(itemType.damage_type->name);
 
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Power"));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(translate("Power"));
 	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", itemType.damage));
 }
 
 void AEquipmentSheet::displayAmmo(sp<AEquipment> item, const AEquipmentType &itemType)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_2_L")->setText(translate("Accuracy"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", itemType.accuracy));
 
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Fire rate"));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(translate("Fire rate"));
 	form->findControlTyped<Label>("LABEL_3_R")
 	    ->setText(format("%.2f", itemType.getRoundsPerSecond()));
 
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(translate("Range"));
 	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", itemType.getRangeInTiles()));
 
-	form->findControlTyped<Label>("LABEL_6_C")->setText(tr("Ammo Type:"));
+	form->findControlTyped<Label>("LABEL_6_C")->setText(translate("Ammo Type:"));
 	form->findControlTyped<Label>("LABEL_7_C")->setText(itemType.damage_type->name);
 
-	form->findControlTyped<Label>("LABEL_8_L")->setText(tr("Power"));
+	form->findControlTyped<Label>("LABEL_8_L")->setText(translate("Power"));
 	form->findControlTyped<Label>("LABEL_8_R")->setText(format("%d", itemType.damage));
 
-	form->findControlTyped<Label>("LABEL_9_L")->setText(tr("Rounds"));
+	form->findControlTyped<Label>("LABEL_9_L")->setText(translate("Rounds"));
 	form->findControlTyped<Label>("LABEL_9_R")
 	    ->setText(item ? format("%d / %d", item->ammo, itemType.max_ammo)
 	                   : format("%d", itemType.max_ammo));
 	if (itemType.recharge > 0)
 	{
-		form->findControlTyped<Label>("LABEL_10_C")->setText(tr("(Recharges)"));
+		form->findControlTyped<Label>("LABEL_10_C")->setText(translate("(Recharges)"));
 	}
 }
 
@@ -143,17 +144,17 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 	}
 
 	auto &ammoType = *itemType.ammo_types.begin();
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_2_L")->setText(translate("Accuracy"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", ammoType->accuracy));
 
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Fire rate"));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(translate("Fire rate"));
 	form->findControlTyped<Label>("LABEL_3_R")
 	    ->setText(format("%.2f", ammoType->getRoundsPerSecond()));
 
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(translate("Range"));
 	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", ammoType->getRangeInTiles()));
 
-	form->findControlTyped<Label>("LABEL_5_C")->setText(tr("Ammo types:"));
+	form->findControlTyped<Label>("LABEL_5_C")->setText(translate("Ammo types:"));
 	int ammoNum = 1;
 	for (auto &ammo : itemType.ammo_types)
 	{
@@ -167,7 +168,7 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 
 void AEquipmentSheet::displayArmor(sp<AEquipment> item, const AEquipmentType &itemType)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Protection"));
+	form->findControlTyped<Label>("LABEL_2_L")->setText(translate("Protection"));
 	form->findControlTyped<Label>("LABEL_2_R")
 	    ->setText(item ? format("%d / %d", item->armor, itemType.armor)
 	                   : format("%d", itemType.armor));
@@ -181,10 +182,10 @@ void AEquipmentSheet::displayOther(sp<AEquipment> item [[maybe_unused]],
 void AEquipmentSheet::displayAlien(sp<AEquipment> item, const AEquipmentType &itemType)
 {
 	form->findControlTyped<Label>("ITEM_NAME")
-	    ->setText(itemType.bioStorage ? tr("Alien Organism") : tr("Alien Artifact"));
+	    ->setText(itemType.bioStorage ? translate("Alien Organism") : translate("Alien Artifact"));
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(itemType.equipscreen_sprite);
 
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
+	form->findControlTyped<Label>("LABEL_1_L")->setText(translate("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")
 	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
 }

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -32,6 +32,7 @@
 #include "game/ui/general/aequipmentsheet.h"
 #include "game/ui/general/agentsheet.h"
 #include "game/ui/general/messagebox.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -161,11 +162,11 @@ void AEquipScreen::begin()
 	auto mode = getMode();
 	if (mode == Mode::Enemy)
 	{
-		formMain->findControlTyped<Label>("EQUIP_AGENT")->setText(tr("MIND PROBE"));
+		formMain->findControlTyped<Label>("EQUIP_AGENT")->setText(translate("MIND PROBE"));
 	}
 	else
 	{
-		formMain->findControlTyped<Label>("EQUIP_AGENT")->setText(tr("EQUIP AGENT"));
+		formMain->findControlTyped<Label>("EQUIP_AGENT")->setText(translate("EQUIP AGENT"));
 	}
 
 	formMain->findControlTyped<RadioButton>("BUTTON_SHOW_WEAPONS")->setChecked(true);
@@ -514,9 +515,10 @@ void AEquipScreen::handleItemPickup(Vec2<int> mousePos)
 	}
 	else if (alienArtifact)
 	{
-		auto message_box = mksp<MessageBox>(
-		    tr("Alien Artifact"), tr("You must research Alien technology before you can use it."),
-		    MessageBox::ButtonOptions::Ok);
+		auto message_box =
+		    mksp<MessageBox>(translate("Alien Artifact"),
+		                     translate("You must research Alien technology before you can use it."),
+		                     MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 	}
 	else // no doll equipment under cursor
@@ -537,10 +539,10 @@ void AEquipScreen::handleItemPickup(Vec2<int> mousePos)
 		}
 		else if (alienArtifact)
 		{
-			auto message_box =
-			    mksp<MessageBox>(tr("Alien Artifact"),
-			                     tr("You must research Alien technology before you can use it."),
-			                     MessageBox::ButtonOptions::Ok);
+			auto message_box = mksp<MessageBox>(
+			    translate("Alien Artifact"),
+			    translate("You must research Alien technology before you can use it."),
+			    MessageBox::ButtonOptions::Ok);
 			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		}
 	}
@@ -578,17 +580,18 @@ void AEquipScreen::handleItemPlacement(Vec2<int> mousePos)
 	}
 	if (insufficientTU)
 	{
-		auto message_box = mksp<MessageBox>(
-		    tr("NOT ENOUGH TU'S"),
-		    format("%s %d", tr("TU cost per item picked up:"), currentAgent->unit->getPickupCost()),
-		    MessageBox::ButtonOptions::Ok);
+		auto message_box = mksp<MessageBox>(translate("NOT ENOUGH TU'S"),
+		                                    tformat("TU cost per item picked up: {1}") %
+		                                        currentAgent->unit->getPickupCost(),
+		                                    MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 	}
 	else if (alienArtifact)
 	{
-		auto message_box = mksp<MessageBox>(
-		    tr("Alien Artifact"), tr("You must research Alien technology before you can use it."),
-		    MessageBox::ButtonOptions::Ok);
+		auto message_box =
+		    mksp<MessageBox>(translate("Alien Artifact"),
+		                     translate("You must research Alien technology before you can use it."),
+		                     MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 	}
 	// Other agents
@@ -648,10 +651,10 @@ void AEquipScreen::handleItemPlacement(bool toAgent)
 	}
 	if (insufficientTU)
 	{
-		auto message_box = mksp<MessageBox>(
-		    tr("NOT ENOUGH TU'S"),
-		    format("%s %d", tr("TU cost per item picked up:"), currentAgent->unit->getPickupCost()),
-		    MessageBox::ButtonOptions::Ok);
+		auto message_box = mksp<MessageBox>(translate("NOT ENOUGH TU'S"),
+		                                    tformat("TU cost per item picked up: {1}") %
+		                                        currentAgent->unit->getPickupCost(),
+		                                    MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 	}
 	// Other agents
@@ -1877,9 +1880,9 @@ void AEquipScreen::attemptCloseScreen()
 	{
 		fw().stageQueueCommand(
 		    {StageCmd::Command::PUSH,
-		     mksp<MessageBox>(tr("WARNING"),
-		                      tr("You will lose any equipment left on the floor. "
-		                         "Are you sure you wish to leave this agent?"),
+		     mksp<MessageBox>(translate("WARNING"),
+		                      translate("You will lose any equipment left on the floor. "
+		                                "Are you sure you wish to leave this agent?"),
 		                      MessageBox::ButtonOptions::YesNo, [this] { this->closeScreen(); })});
 	}
 	else

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -9,6 +9,7 @@
 #include "framework/renderer.h"
 #include "game/state/gamestate.h"
 #include "game/state/rules/battle/damage.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -38,7 +39,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	form->findControlTyped<Graphic>("SELECTED_RANK")
 	    ->setImage(item.type->displayRank ? ranks[(int)item.rank] : nullptr);
 
-	form->findControlTyped<Label>("LABEL_1")->setText(tr("Health"));
+	form->findControlTyped<Label>("LABEL_1")->setText(translate("Health"));
 	form->findControlTyped<Graphic>("VALUE_1")->setImage(
 	    createStatsBar(item.initial_stats.health, item.current_stats.health,
 	                   item.modified_stats.health, 100, healthColour, {88, 7}));
@@ -46,7 +47,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_1")->getText() +
 	    format(": %d/%d", item.modified_stats.health, item.current_stats.health);
 
-	form->findControlTyped<Label>("LABEL_2")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_2")->setText(translate("Accuracy"));
 	form->findControlTyped<Graphic>("VALUE_2")->setImage(
 	    createStatsBar(item.initial_stats.accuracy, item.current_stats.accuracy,
 	                   item.modified_stats.accuracy, 100, accuracyColour, {88, 7}));
@@ -54,7 +55,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_2")->getText() +
 	    format(": %d/%d", item.modified_stats.accuracy, item.current_stats.accuracy);
 
-	form->findControlTyped<Label>("LABEL_3")->setText(tr("Reactions"));
+	form->findControlTyped<Label>("LABEL_3")->setText(translate("Reactions"));
 	form->findControlTyped<Graphic>("VALUE_3")->setImage(
 	    createStatsBar(item.initial_stats.reactions, item.current_stats.reactions,
 	                   item.modified_stats.reactions, 100, reactionsColour, {88, 7}));
@@ -62,7 +63,8 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_3")->getText() +
 	    format(": %d/%d", item.modified_stats.reactions, item.current_stats.reactions);
 
-	form->findControlTyped<Label>("LABEL_4")->setText(turnBased ? tr("Time Units") : tr("Speed"));
+	form->findControlTyped<Label>("LABEL_4")->setText(turnBased ? translate("Time Units")
+	                                                            : translate("Speed"));
 	form->findControlTyped<Graphic>("VALUE_4")->ToolTipText =
 	    form->findControlTyped<Label>("LABEL_4")->getText();
 	if (turnBased)
@@ -83,7 +85,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 		           item.current_stats.getDisplaySpeedValue());
 	}
 
-	form->findControlTyped<Label>("LABEL_5")->setText(tr("Stamina"));
+	form->findControlTyped<Label>("LABEL_5")->setText(translate("Stamina"));
 	form->findControlTyped<Graphic>("VALUE_5")->setImage(createStatsBar(
 	    item.initial_stats.getDisplayStaminaValue(), item.current_stats.getDisplayStaminaValue(),
 	    item.modified_stats.getDisplayStaminaValue(), 100, staminaColour, {88, 7}));
@@ -92,7 +94,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    format(": %d/%d", item.modified_stats.getDisplayStaminaValue(),
 	           item.current_stats.getDisplayStaminaValue());
 
-	form->findControlTyped<Label>("LABEL_6")->setText(tr("Bravery"));
+	form->findControlTyped<Label>("LABEL_6")->setText(translate("Bravery"));
 	form->findControlTyped<Graphic>("VALUE_6")->setImage(
 	    createStatsBar(item.initial_stats.bravery, item.current_stats.bravery,
 	                   item.modified_stats.bravery, 100, braveryColour, {88, 7}));
@@ -100,7 +102,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_6")->getText() +
 	    format(": %d/%d", item.modified_stats.bravery, item.current_stats.bravery);
 
-	form->findControlTyped<Label>("LABEL_7")->setText(tr("Strength"));
+	form->findControlTyped<Label>("LABEL_7")->setText(translate("Strength"));
 	form->findControlTyped<Graphic>("VALUE_7")->setImage(
 	    createStatsBar(item.initial_stats.strength, item.current_stats.strength,
 	                   item.modified_stats.strength, 100, strengthColour, {88, 7}));
@@ -108,7 +110,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_7")->getText() +
 	    format(": %d/%d", item.modified_stats.strength, item.current_stats.strength);
 
-	form->findControlTyped<Label>("LABEL_8")->setText(tr("Psi-energy"));
+	form->findControlTyped<Label>("LABEL_8")->setText(translate("Psi-energy"));
 	form->findControlTyped<Graphic>("VALUE_8")->setImage(
 	    createStatsBar(item.initial_stats.psi_energy, item.current_stats.psi_energy,
 	                   item.modified_stats.psi_energy, 100, psiEnergyColour, {88, 7}));
@@ -116,7 +118,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_8")->getText() +
 	    format(": %d/%d", item.modified_stats.psi_energy, item.current_stats.psi_energy);
 
-	form->findControlTyped<Label>("LABEL_9")->setText(tr("Psi-attack"));
+	form->findControlTyped<Label>("LABEL_9")->setText(translate("Psi-attack"));
 	form->findControlTyped<Graphic>("VALUE_9")->setImage(
 	    createStatsBar(item.initial_stats.psi_attack, item.current_stats.psi_attack,
 	                   item.modified_stats.psi_attack, 100, psiAttackColour, {88, 7}));
@@ -124,7 +126,7 @@ void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool 
 	    form->findControlTyped<Label>("LABEL_9")->getText() +
 	    format(": %d/%d", item.modified_stats.psi_attack, item.current_stats.psi_attack);
 
-	form->findControlTyped<Label>("LABEL_10")->setText(tr("Psi-defence"));
+	form->findControlTyped<Label>("LABEL_10")->setText(translate("Psi-defence"));
 	form->findControlTyped<Graphic>("VALUE_10")
 	    ->setImage(createStatsBar(item.initial_stats.psi_defence, item.current_stats.psi_defence,
 	                              item.modified_stats.psi_defence, 100, psiDefenceColour, {88, 7}));

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -21,6 +21,7 @@
 #include "game/ui/general/savemenu.h"
 #include "game/ui/skirmish/skirmish.h"
 #include "game/ui/tileview/cityview.h"
+#include "library/strings_translate.h"
 #include <list>
 
 namespace OpenApoc
@@ -115,7 +116,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.Mod", "BSKLauncherSound"},
 };
 
-std::vector<UString> listNames = {tr("Message Toggles"), tr("OpenApoc Features")};
+std::vector<UString> listNames = {translate("Message Toggles"), translate("OpenApoc Features")};
 } // namespace
 
 InGameOptions::InGameOptions(sp<GameState> state)
@@ -162,7 +163,8 @@ void InGameOptions::loadList(int id)
 		UString full_name = p.first + "." + p.second;
 		checkBox->setData(mksp<UString>(full_name));
 		checkBox->setChecked(config().getBool(full_name));
-		auto label = checkBox->createChild<Label>(tr(config().describe(p.first, p.second)), font);
+		auto label =
+		    checkBox->createChild<Label>(translate(config().describe(p.first, p.second)), font);
 		label->Size = {216, listControl->ItemSize};
 		label->Location = {24, 0};
 		listControl->addItem(checkBox);
@@ -308,8 +310,8 @@ void InGameOptions::eventOccurred(Event *e)
 			    *state, state->current_battle->currentPlayer, true);
 			fw().stageQueueCommand(
 			    {StageCmd::Command::PUSH,
-			     mksp<MessageBox>(tr("Abort Mission"),
-			                      format("%s %d", tr("Units Lost :"), unitsLost),
+			     mksp<MessageBox>(translate("Abort Mission"),
+			                      tformat("Units Lost : {1}") % unitsLost,
 			                      MessageBox::ButtonOptions::YesNo, [this] {
 				                      state->current_battle->abortMission(*state);
 				                      Battle::finishBattle(*state);

--- a/game/ui/general/messagebox.cpp
+++ b/game/ui/general/messagebox.cpp
@@ -8,7 +8,7 @@
 #include "framework/framework.h"
 #include "framework/keycodes.h"
 #include "framework/renderer.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -43,7 +43,7 @@ MessageBox::MessageBox(const UString &title, const UString &text, ButtonOptions 
 	{
 		case ButtonOptions::Ok:
 		{
-			auto bOk = form->createChild<TextButton>(tr("OK"), ui().getFont("smallset"));
+			auto bOk = form->createChild<TextButton>(translate("OK"), ui().getFont("smallset"));
 			bOk->Name = "BUTTON_OK";
 			bOk->Size = BUTTON_SIZE;
 			bOk->RenderStyle = TextButton::ButtonRenderStyle::Bevel;
@@ -55,14 +55,14 @@ MessageBox::MessageBox(const UString &title, const UString &text, ButtonOptions 
 		}
 		case ButtonOptions::YesNo:
 		{
-			auto bYes = form->createChild<TextButton>(tr("Yes"), ui().getFont("smallset"));
+			auto bYes = form->createChild<TextButton>(translate("Yes"), ui().getFont("smallset"));
 			bYes->Name = "BUTTON_YES";
 			bYes->Size = BUTTON_SIZE;
 			bYes->RenderStyle = TextButton::ButtonRenderStyle::Bevel;
 			bYes->Location.x = MARGIN;
 			bYes->Location.y = lText->Location.y + lText->Size.y + MARGIN;
 
-			auto bNo = form->createChild<TextButton>(tr("No"), ui().getFont("smallset"));
+			auto bNo = form->createChild<TextButton>(translate("No"), ui().getFont("smallset"));
 			bNo->Name = "BUTTON_NO";
 			bNo->Size = BUTTON_SIZE;
 			bNo->RenderStyle = TextButton::ButtonRenderStyle::Bevel;
@@ -74,21 +74,22 @@ MessageBox::MessageBox(const UString &title, const UString &text, ButtonOptions 
 		}
 		case ButtonOptions::YesNoCancel:
 		{
-			auto bYes = form->createChild<TextButton>(tr("Yes"), ui().getFont("smallset"));
+			auto bYes = form->createChild<TextButton>(translate("Yes"), ui().getFont("smallset"));
 			bYes->Name = "BUTTON_YES";
 			bYes->Size = BUTTON_SIZE_2;
 			bYes->RenderStyle = TextButton::ButtonRenderStyle::Bevel;
 			bYes->Location.x = MARGIN;
 			bYes->Location.y = lText->Location.y + lText->Size.y + MARGIN;
 
-			auto bNo = form->createChild<TextButton>(tr("No"), ui().getFont("smallset"));
+			auto bNo = form->createChild<TextButton>(translate("No"), ui().getFont("smallset"));
 			bNo->Name = "BUTTON_NO2";
 			bNo->Size = BUTTON_SIZE_2;
 			bNo->RenderStyle = TextButton::ButtonRenderStyle::Bevel;
 			bNo->Location.x = form->Size.x / 2 - bNo->Size.x / 2;
 			bNo->Location.y = lText->Location.y + lText->Size.y + MARGIN;
 
-			auto bCan = form->createChild<TextButton>(tr("Cancel"), ui().getFont("smallset"));
+			auto bCan =
+			    form->createChild<TextButton>(translate("Cancel"), ui().getFont("smallset"));
 			bCan->Name = "BUTTON_CANCEL";
 			bCan->Size = BUTTON_SIZE_2;
 			bCan->RenderStyle = TextButton::ButtonRenderStyle::Bevel;

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -18,6 +18,7 @@
 #include "game/state/rules/city/vammotype.h"
 #include "game/state/shared/organisation.h"
 #include "game/ui/general/messagebox.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -107,9 +108,10 @@ void TransactionControl::updateValues()
 
 				auto message_box = mksp<MessageBox>(
 				    manufacturerName,
-				    manufacturerHostile ? tr("Order canceled by the hostile manufacturer.")
-				                        : tr("Manufacturer has no intact buildings in this city to "
-				                             "deliver goods from."),
+				    manufacturerHostile
+				        ? translate("Order canceled by the hostile manufacturer.")
+				        : translate("Manufacturer has no intact buildings in this city to "
+				                    "deliver goods from."),
 				    MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 				return;
@@ -612,7 +614,7 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 	// Add controls
 
 	// Name
-	const UString &labelName = researched ? tr(name) : tr("Alien Artifact");
+	const UString &labelName = researched ? translate(name) : translate("Alien Artifact");
 	if (labelName.length() > 0)
 	{
 		auto label = control->createChild<Label>(labelName, labelFont);
@@ -624,7 +626,7 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 	// Manufacturer
 	if (control->manufacturerName.length() > 0)
 	{
-		auto label = control->createChild<Label>(tr(control->manufacturerName), labelFont);
+		auto label = control->createChild<Label>(translate(control->manufacturerName), labelFont);
 		if (manufacturerHostile || manufacturerUnavailable)
 		{
 			label->Tint = {255, 50, 25};

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -5,6 +5,7 @@
 #include "game/state/gamestate.h"
 #include "game/state/rules/battle/damage.h"
 #include "game/state/tilemap/tilemap.h"
+#include "library/strings_translate.h"
 #include <list>
 
 namespace OpenApoc
@@ -70,15 +71,15 @@ void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> ve
 	    ->setText(vehicle ? vehicle->name : vehicleType->name);
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(vehicleType->equip_icon_small);
 
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Constitution"));
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Armor"));
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Top Speed"));
-	form->findControlTyped<Label>("LABEL_5_L")->setText(tr("Acceleration"));
-	form->findControlTyped<Label>("LABEL_6_L")->setText(tr("Weight"));
-	form->findControlTyped<Label>("LABEL_7_L")->setText(tr("Fuel"));
-	form->findControlTyped<Label>("LABEL_8_L")->setText(tr("Passengers"));
-	form->findControlTyped<Label>("LABEL_9_L")->setText(tr("Cargo"));
+	form->findControlTyped<Label>("LABEL_1_L")->setText(translate("Constitution"));
+	form->findControlTyped<Label>("LABEL_2_L")->setText(translate("Armor"));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(translate("Accuracy"));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(translate("Top Speed"));
+	form->findControlTyped<Label>("LABEL_5_L")->setText(translate("Acceleration"));
+	form->findControlTyped<Label>("LABEL_6_L")->setText(translate("Weight"));
+	form->findControlTyped<Label>("LABEL_7_L")->setText(translate("Fuel"));
+	form->findControlTyped<Label>("LABEL_8_L")->setText(translate("Passengers"));
+	form->findControlTyped<Label>("LABEL_9_L")->setText(translate("Cargo"));
 
 	std::list<sp<VEquipmentType>> defaultEquipment;
 	for (auto &e : vehicleType->initial_equipment_list)
@@ -124,7 +125,7 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 	form->findControlTyped<Label>("ITEM_NAME")->setText(item ? item->type->name : type->name);
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
 
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
+	form->findControlTyped<Label>("LABEL_1_L")->setText(translate("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
 
 	// Draw equipment stats
@@ -147,25 +148,25 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 
 void VehicleSheet::displayEngine(sp<VEquipment> item [[maybe_unused]], sp<VEquipmentType> type)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Top Speed"));
+	form->findControlTyped<Label>("LABEL_2_L")->setText(translate("Top Speed"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->top_speed));
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Power"));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(translate("Power"));
 	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->power));
 }
 
 void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Damage"));
+	form->findControlTyped<Label>("LABEL_2_L")->setText(translate("Damage"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->damage));
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Range"));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(translate("Range"));
 	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->getRangeInTiles()));
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(translate("Accuracy"));
 	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d%%", type->accuracy));
 
 	// Only show rounds if non-zero (IE not infinite ammo)
 	if (type->max_ammo != 0)
 	{
-		form->findControlTyped<Label>("LABEL_5_L")->setText(tr("Rounds"));
+		form->findControlTyped<Label>("LABEL_5_L")->setText(translate("Rounds"));
 		form->findControlTyped<Label>("LABEL_5_R")
 		    ->setText(item ? format("%d / %d", item->ammo, type->max_ammo)
 		                   : format("%d", type->max_ammo));
@@ -177,42 +178,48 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 	int statsCount = 2;
 	if (type->accuracy_modifier)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Accuracy"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Accuracy"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d%%", 100 - type->accuracy_modifier));
 		statsCount++;
 	}
 	if (type->cargo_space)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Cargo"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Cargo"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->cargo_space));
 		statsCount++;
 	}
 	if (type->passengers)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Passengers"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Passengers"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->passengers));
 		statsCount++;
 	}
 	if (type->alien_space)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Aliens Held"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Aliens Held"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->alien_space));
 		statsCount++;
 	}
 	if (type->missile_jamming)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Jamming"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Jamming"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->missile_jamming));
 		statsCount++;
 	}
 	if (type->shielding)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Shielding"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Shielding"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->shielding));
 		statsCount++;
@@ -220,21 +227,22 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 	if (type->cloaking)
 	{
 		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
-		    ->setText(tr("Cloaks Craft"));
+		    ->setText(translate("Cloaks Craft"));
 		statsCount++;
 	}
 	if (type->teleporting)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Teleports"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(translate("Teleports"));
 		statsCount++;
 	}
 }
 
 void VehicleSheet::displayAlien(sp<VEquipmentType> type)
 {
-	form->findControlTyped<Label>("ITEM_NAME")->setText(tr("Alien Artifact"));
+	form->findControlTyped<Label>("ITEM_NAME")->setText(translate("Alien Artifact"));
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
+	form->findControlTyped<Label>("LABEL_1_L")->setText(translate("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
 }
 

--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -26,7 +26,7 @@
 #include "game/state/tilemap/tileobject_battlemappart.h"
 #include "game/state/tilemap/tileobject_battleunit.h"
 #include "game/state/tilemap/tileobject_shadow.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 #include <glm/glm.hpp>
 
 namespace OpenApoc
@@ -318,10 +318,10 @@ BattleTileView::BattleTileView(TileMap &map, Vec3<int> isoTileSize, Vec2<int> st
 		tuIndicators.push_back(font->getString(format("%d", i)));
 	}
 	tuSeparator = font->getString("/");
-	pathPreviewTooFar = font->getString(tr("Too Far"));
-	pathPreviewUnreachable = font->getString(tr("Blocked"));
-	attackCostOutOfRange = font->getString(tr("Out of range"));
-	attackCostNoArc = font->getString(tr("No arc of throw"));
+	pathPreviewTooFar = font->getString(translate("Too Far"));
+	pathPreviewUnreachable = font->getString(translate("Blocked"));
+	attackCostOutOfRange = font->getString(translate("Out of range"));
+	attackCostNoArc = font->getString(translate("No arc of throw"));
 
 	for (int i = 0; i < 16; i++)
 	{

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -48,7 +48,7 @@
 #include "game/ui/general/messagelogscreen.h"
 #include "game/ui/general/savemenu.h"
 #include "library/sp.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 #include <cmath>
 #include <glm/glm.hpp>
 
@@ -172,7 +172,7 @@ BattleView::BattleView(sp<GameState> gameState)
 	}
 	{
 		executePlanPopup = mksp<BattleTurnBasedConfirmBox>(
-		    tr("Execute remaining movement orders for this unit?"),
+		    translate("Execute remaining movement orders for this unit?"),
 		    [this] {
 			    unitPendingConfirmation->missions.pop_front();
 			    unitPendingConfirmation = nullptr;
@@ -1672,30 +1672,30 @@ void BattleView::update()
 			if ((battle.loserHasRetreated && battle.playerWon) ||
 			    (battle.winnerHasRetreated && !battle.playerWon))
 			{
-				message = tr("All hostile units have fled the combat zone. You win.");
+				message = translate("All hostile units have fled the combat zone. You win.");
 			}
 			else if ((battle.loserHasRetreated && !battle.playerWon) ||
 			         (battle.winnerHasRetreated && battle.playerWon) ||
 			         (!battle.playerWon && !battle.loserHasRetreated && !battle.winnerHasRetreated))
 			{
-				message = tr("All your units have fled the combat zone. You win.");
+				message = translate("All your units have fled the combat zone. You win.");
 			}
 			else
 			{
-				message = tr("All hostile units are dead or unconscious. You win.");
+				message = translate("All hostile units are dead or unconscious. You win.");
 			}
 		}
 		else if (battle.loserHasRetreated)
 		{
-			message = tr("All your units have fled the combat zone. You lose.");
+			message = translate("All your units have fled the combat zone. You lose.");
 		}
 		else if (battle.winnerHasRetreated)
 		{
-			message = tr("All hostile units have fled the combat zone. You lose.");
+			message = translate("All hostile units have fled the combat zone. You lose.");
 		}
 		else
 		{
-			message = tr("All your units are unconscious or dead. You lose.");
+			message = translate("All your units are unconscious or dead. You lose.");
 		}
 		fw().stageQueueCommand(
 		    {StageCmd::Command::PUSH, mksp<MessageBox>("", message, MessageBox::ButtonOptions::Ok,
@@ -2116,7 +2116,7 @@ void BattleView::refreshDelayText()
 	UString text;
 	if (delay == 0)
 	{
-		text = format(tr("Activates now."));
+		text = format(translate("Activates now."));
 	}
 	else
 	{
@@ -2124,16 +2124,16 @@ void BattleView::refreshDelayText()
 		{
 			if (delay == 1)
 			{
-				text = format(tr("Activates at end of turn."));
+				text = format(translate("Activates at end of turn."));
 			}
 			else
 			{
-				text = format("%s %d", tr("Turns before activation:"), delay - 1);
+				text = tformat("Turns before activation: {1}") % (delay - 1);
 			}
 		}
 		else
 		{
-			text = format(tr("Delay = %i"), (int)((float)delay / 4.0f));
+			text = tformat("Delay = {1}") % (int)((float)delay / 4.0f);
 		}
 	}
 	primingTab->findControlTyped<Label>("DELAY_TEXT")->setText(text);
@@ -2143,7 +2143,8 @@ void BattleView::refreshRangeText()
 {
 	int range = primingTab->findControlTyped<ScrollBar>("RANGE_SLIDER")->getValue();
 
-	UString text = format(tr("Range = %2.1fm."), ((float)(range + 1) * 1.5f));
+	UString text =
+	    tformat("Range = {1,num=fixed,width=2,precision=1}") % ((float)(range + 1) * 1.5f);
 	primingTab->findControlTyped<Label>("RANGE_TEXT")->setText(text);
 }
 
@@ -2462,9 +2463,10 @@ void BattleView::orderUse(bool right, bool automatic)
 	}
 	if (!item->canBeUsed(*state))
 	{
-		auto message_box = mksp<MessageBox>(
-		    tr("Alien Artifact"), tr("You must research Alien technology before you can use it."),
-		    MessageBox::ButtonOptions::Ok);
+		auto message_box =
+		    mksp<MessageBox>(translate("Alien Artifact"),
+		                     translate("You must research Alien technology before you can use it."),
+		                     MessageBox::ButtonOptions::Ok);
 		fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		return;
 	}
@@ -4010,29 +4012,30 @@ void BattleView::updateItemInfo(bool right)
 		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_HAND")
 		    ->setImage(info.itemType->equipscreen_sprite);
 		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_HAND")->ToolTipText =
-		    tr(info.itemType->name);
+		    translate(info.itemType->name);
 		if (info.damageType)
 		{
 			activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_DAMAGETYPE")
 			    ->setImage(info.damageType->icon_sprite);
 			activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_DAMAGETYPE")->ToolTipText =
-			    tr(info.damageType->name);
+			    translate(info.damageType->name);
 		}
 		else
 		{
 			activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_DAMAGETYPE")
 			    ->setImage(nullptr);
 			activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_DAMAGETYPE")->ToolTipText =
-			    tr("None");
+			    translate("None");
 		}
 	}
 	else
 	{
 		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_HAND")->setImage(nullptr);
-		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_HAND")->ToolTipText = tr("Empty");
+		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_HAND")->ToolTipText =
+		    translate("Empty");
 		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_DAMAGETYPE")->setImage(nullptr);
 		activeTab->findControlTyped<Graphic>("IMAGE_" + name + "_DAMAGETYPE")->ToolTipText =
-		    tr("None");
+		    translate("None");
 	}
 
 	// Selection bracket

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -72,7 +72,7 @@
 #include "game/ui/ufopaedia/ufopaediacategoryview.h"
 #include "game/ui/ufopaedia/ufopaediaview.h"
 #include "library/sp.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 #include <glm/glm.hpp>
 
 // Uncomment to start with paused
@@ -1525,7 +1525,7 @@ void CityView::begin()
 	{
 		state->newGame = false;
 		baseForm->findControlTyped<Ticker>("NEWS_TICKER")
-		    ->addMessage(tr("Welcome to X-COM Apocalypse"));
+		    ->addMessage(translate("Welcome to X-COM Apocalypse"));
 	}
 }
 
@@ -1972,7 +1972,7 @@ void CityView::update()
 					    ->setImage(weaponType[i]->icon);
 					uiTabs[1]
 					    ->findControlTyped<Graphic>(format("VEHICLE_WEAPON_%d", i + 1))
-					    ->ToolTipText = tr(weaponType[i]->name);
+					    ->ToolTipText = translate(weaponType[i]->name);
 					uiTabs[1]
 					    ->findControlTyped<CheckBox>(format("VEHICLE_WEAPON_%d_DISABLED", i + 1))
 					    ->setVisible(true);
@@ -2050,7 +2050,7 @@ void CityView::update()
 			StateRef<Base> base;
 			if (agent->type->role == AgentType::Role::Soldier)
 			{
-				auto agentRName = tr(agent->getRankName()) + UString(" ") + agent->name;
+				auto agentRName = translate(agent->getRankName()) + UString(" ") + agent->name;
 				agentName->setText(agentRName);
 				if (agent->currentBuilding == agent->homeBuilding)
 				{
@@ -2066,21 +2066,21 @@ void CityView::update()
 					if (!agent->recentlyHired)
 					{
 						if (agent->currentBuilding)
-							agentAssignment->setText(tr("At") + UString(" ") +
-							                         tr(agent->currentBuilding->name));
+							agentAssignment->setText(tformat("At {1}") %
+							                         translate(agent->currentBuilding->name));
 						else if (agent->currentVehicle && agent->currentVehicle->currentBuilding)
 							agentAssignment->setText(
-							    tr("At") + UString(" ") +
-							    tr(agent->currentVehicle->currentBuilding->name));
+							    tformat("At {1}") %
+							    translate(agent->currentVehicle->currentBuilding->name));
 						else if (!agent->missions.empty() &&
 						         agent->missions.front()->targetBuilding)
 						{
 							if (agent->missions.front()->targetBuilding == agent->homeBuilding)
-								agentAssignment->setText(tr("Returning to base"));
+								agentAssignment->setText(translate("Returning to base"));
 							else
 								agentAssignment->setText(
-								    tr("Traveling to:") + UString(" ") +
-								    tr(agent->missions.front()->targetBuilding->name));
+								    tformat("Traveling to: {1}") %
+								    translate(agent->missions.front()->targetBuilding->name));
 						}
 						else if (agent->currentVehicle &&
 						         !agent->currentVehicle->missions.empty() &&
@@ -2088,18 +2088,18 @@ void CityView::update()
 						{
 							if (agent->currentVehicle->missions.front()->targetBuilding ==
 							    agent->homeBuilding)
-								agentAssignment->setText(tr("Returning to base"));
+								agentAssignment->setText(translate("Returning to base"));
 							else
-								agentAssignment->setText(tr("Traveling to:") + UString(" ") +
-								                         tr(agent->currentVehicle->missions.front()
-								                                ->targetBuilding->name));
+								agentAssignment->setText(
+								    tformat("Traveling to: {1}") %
+								    translate(agent->currentVehicle->missions.front()
+								                  ->targetBuilding->name));
 						}
 						else
-							agentAssignment->setText(tr("Traveling to:") + UString(" ") +
-							                         tr("map point"));
+							agentAssignment->setText(translate("Traveling to: map point"));
 					}
 					else
-						agentAssignment->setText(tr("Reporting to base"));
+						agentAssignment->setText(translate("Reporting to base"));
 				}
 			}
 			else
@@ -2112,31 +2112,32 @@ void CityView::update()
 			{
 				if (agent->missions.empty() &&
 				    agent->modified_stats.health < agent->current_stats.health)
-					agentAssignment->setText(tr("Wounded"));
+					agentAssignment->setText(translate("Wounded"));
 				else
 					switch (agent->trainingAssignment)
 					{
 						case TrainingAssignment::None:
 							if (agent->type->canTrain)
-								agentAssignment->setText(tr("Not assigned to training"));
+								agentAssignment->setText(translate("Not assigned to training"));
 							else
-								agentAssignment->setText(tr("(Android training not possible)"));
+								agentAssignment->setText(
+								    translate("(Android training not possible)"));
 							break;
 						case TrainingAssignment::Physical:
 						{
-							UString efficiency = tr("Combat training (efficiency=");
 							int usage = base->getUsage(*state, FacilityType::Capacity::Training);
 							usage = (100.0f / std::max(100, usage)) * 100;
-							efficiency += format("%d%%", usage) + UString(")");
+							UString efficiency =
+							    tformat("Combat training (efficiency={1}%)") % usage;
 							agentAssignment->setText(efficiency);
 							break;
 						}
 						case TrainingAssignment::Psi:
 						{
-							UString efficiency = tr("Psionic training (efficiency=");
 							int usage = base->getUsage(*state, FacilityType::Capacity::Psi);
 							usage = (100.0f / std::max(100, usage)) * 100;
-							efficiency += format("%d%%", usage) + UString(")");
+							UString efficiency =
+							    tformat("Psionic training (efficiency={1}%)") % usage;
 							agentAssignment->setText(efficiency);
 							break;
 						}
@@ -2249,15 +2250,16 @@ void CityView::update()
 						{
 							if (fac->lab->current_project)
 							{
-								UString pr = tr(fac->lab->current_project->name);
 								int progress = (static_cast<float>(
 								                    fac->lab->current_project->man_hours_progress) /
 								                fac->lab->current_project->man_hours) *
 								               100;
-								agentAssignment->setText(pr + format(" (%d%%)", progress));
+								UString pr = tformat("{1} ({2}%)") %
+								             translate(fac->lab->current_project->name) % progress;
+								agentAssignment->setText(pr);
 							}
 							else
-								agentAssignment->setText(tr("No project assigned"));
+								agentAssignment->setText(translate("No project assigned"));
 							break;
 						}
 					}
@@ -2265,9 +2267,9 @@ void CityView::update()
 				else
 				{
 					if (!agent->recentlyHired)
-						agentAssignment->setText(tr("Not assigned to lab"));
+						agentAssignment->setText(translate("Not assigned to lab"));
 					else
-						agentAssignment->setText(tr("Reporting to base"));
+						agentAssignment->setText(translate("Reporting to base"));
 				}
 			}
 			else
@@ -2372,7 +2374,6 @@ void CityView::update()
 						{
 							if (fac->lab->current_project)
 							{
-								UString pr = tr(fac->lab->current_project->name);
 								int progress =
 								    (static_cast<float>(fac->lab->manufacture_man_hours_invested +
 								                        fac->lab->current_project->man_hours *
@@ -2380,10 +2381,12 @@ void CityView::update()
 								     (fac->lab->current_project->man_hours *
 								      fac->lab->manufacture_goal)) *
 								    100;
-								agentAssignment->setText(pr + format(" (%d%%)", progress));
+								UString pr = tformat("{1} ({2}%)") %
+								             translate(fac->lab->current_project->name) % progress;
+								agentAssignment->setText(pr);
 							}
 							else
-								agentAssignment->setText(tr("No project assigned"));
+								agentAssignment->setText(translate("No project assigned"));
 							break;
 						}
 					}
@@ -2391,9 +2394,9 @@ void CityView::update()
 				else
 				{
 					if (!agent->recentlyHired)
-						agentAssignment->setText(tr("Not assigned to workshop"));
+						agentAssignment->setText(translate("Not assigned to workshop"));
 					else
-						agentAssignment->setText(tr("Reporting to base"));
+						agentAssignment->setText(translate("Reporting to base"));
 				}
 			}
 			else
@@ -2498,15 +2501,16 @@ void CityView::update()
 						{
 							if (fac->lab->current_project)
 							{
-								UString pr = tr(fac->lab->current_project->name);
 								int progress = (static_cast<float>(
 								                    fac->lab->current_project->man_hours_progress) /
 								                fac->lab->current_project->man_hours) *
 								               100;
-								agentAssignment->setText(pr + format(" (%d%%)", progress));
+								UString pr = tformat("{1} ({2}%)") %
+								             fac->lab->current_project->name % progress;
+								agentAssignment->setText(pr);
 							}
 							else
-								agentAssignment->setText(tr("No project assigned"));
+								agentAssignment->setText(translate("No project assigned"));
 							break;
 						}
 					}
@@ -2514,9 +2518,9 @@ void CityView::update()
 				else
 				{
 					if (!agent->recentlyHired)
-						agentAssignment->setText(tr("Not assigned to lab"));
+						agentAssignment->setText(translate("Not assigned to lab"));
 					else
-						agentAssignment->setText(tr("Reporting to base"));
+						agentAssignment->setText(translate("Reporting to base"));
 				}
 			}
 			else
@@ -2711,27 +2715,32 @@ void CityView::update()
 		                    static_cast<int>(selectedOrg->isRelatedTo(state->getPlayer())) ==
 		                        state->current_city->cityViewOrgButtonIndex - 1))
 		{
-			uiTabs[7]->findControlTyped<Label>("TEXT_ORG_NAME")->setText(tr(selectedOrg->name));
-			UString relation = "";
+			uiTabs[7]
+			    ->findControlTyped<Label>("TEXT_ORG_NAME")
+			    ->setText(translate(selectedOrg->name));
+			UString relation;
 			switch (selectedOrg->isRelatedTo(state->getPlayer()))
 			{
 				case Organisation::Relation::Allied:
-					relation += tr(": allied with:");
+					relation = tformat(": allied with: {0}") % translate(state->getPlayer()->name);
 					break;
 				case Organisation::Relation::Friendly:
-					relation += tr(": friendly with:");
+					relation =
+					    tformat(": friendly with: {0}") % translate(state->getPlayer()->name);
 					break;
 				case Organisation::Relation::Neutral:
-					relation += tr(": neutral towards:");
+					relation =
+					    tformat(": neutral towards: {0}") % translate(state->getPlayer()->name);
 					break;
 				case Organisation::Relation::Unfriendly:
-					relation += tr(": unfriendly towards:");
+					relation =
+					    tformat(": unfriendly towards: {0}") % translate(state->getPlayer()->name);
 					break;
 				case Organisation::Relation::Hostile:
-					relation += tr(": hostile towards:");
+					relation =
+					    tformat(": hostile towards: {0}") % translate(state->getPlayer()->name);
 					break;
 			}
-			relation += UString(" ") + tr(state->getPlayer()->name);
 			uiTabs[7]->findControlTyped<Label>("TEXT_ORG_RELATION")->setText(relation);
 		}
 		else
@@ -3634,9 +3643,9 @@ bool CityView::handleGameStateEvent(Event *e)
 				break;
 			}
 
-			UString title = tr("Commence investigation");
-			UString message = format(tr("All selected units and crafts have arrived at %s. "
-			                            "Proceed with investigation? (%d units)"),
+			UString title = translate("Commence investigation");
+			UString message = format(translate("All selected units and crafts have arrived at %s. "
+			                                   "Proceed with investigation? (%d units)"),
 			                         building->name, agents.size());
 			fw().stageQueueCommand({StageCmd::Command::PUSH,
 			                        mksp<MessageBox>(
@@ -3702,9 +3711,10 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box = mksp<MessageBox>(
-			    tr("RESEARCH COMPLETE"),
-			    format("%s\n%s\n%s", tr("Research project completed:"), ev->topic->name,
-			           tr("Do you wish to view the UFOpaedia report?")),
+			    translate("RESEARCH COMPLETE"),
+			    tformat(
+			        "Research project completed:\n{1}\nDo you wish to view the UFOPaedia report?") %
+			        ev->topic->name,
 			    MessageBox::ButtonOptions::YesNo,
 			    // "Yes" callback
 			    [game_state, lab_facility, ufopaedia_category, ufopaedia_entry]() {
@@ -3773,9 +3783,9 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box = mksp<MessageBox>(
-			    tr("MANUFACTURE COMPLETED"),
-			    format("%s\n%s\n%s %d\n%d", lab_base->name, tr(item_name), tr("Quantity:"),
-			           ev->goal, tr("Do you wish to reasign the Workshop?")),
+			    translate("MANUFACTURE COMPLETED"),
+			    tformat("{1}\n{2}\nQuantity: {3}\nDo you wish to reassign the Workshop?") %
+			        lab_base->name % translate(item_name) % ev->goal,
 			    MessageBox::ButtonOptions::YesNo,
 			    // Yes callback
 			    [game_state, lab_facility]() {
@@ -3832,10 +3842,10 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			auto message_box =
-			    mksp<MessageBox>(tr("MANUFACTURING HALTED"),
-			                     format("%s\n%s\n%s %d/%d\n%d", lab_base->name, tr(item_name),
-			                            tr("Completion status:"), ev->done, ev->goal,
-			                            tr("Production costs exceed your available funds.")),
+			    mksp<MessageBox>(translate("MANUFACTURING HALTED"),
+			                     tformat("{1}\n{2}\nCompletion status: {3}/{4}\nProduction costs "
+			                             "exceed your available funds") %
+			                         lab_base->name % translate(item_name) % ev->done % ev->goal,
 			                     MessageBox::ButtonOptions::Ok);
 			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		}
@@ -3849,10 +3859,10 @@ bool CityView::handleGameStateEvent(Event *e)
 				return true;
 			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);
-			auto message_box =
-			    mksp<MessageBox>(tr("FACILITY COMPLETED"),
-			                     format("%s\n%s", ev->base->name, tr(ev->facility->type->name)),
-			                     MessageBox::ButtonOptions::Ok);
+			auto message_box = mksp<MessageBox>(translate("FACILITY COMPLETED"),
+			                                    tformat("{1}\n{2}") % ev->base->name %
+			                                        translate(ev->facility->type->name),
+			                                    MessageBox::ButtonOptions::Ok);
 			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		}
 		break;
@@ -3976,14 +3986,14 @@ void CityView::setSelectionState(CitySelectionState selectionState)
 		case CitySelectionState::AttackBuilding:
 		{
 			overlayTab->findControlTyped<Label>("TEXT")->setText(
-			    tr("Click on building for selected vehicle to attack"));
+			    translate("Click on building for selected vehicle to attack"));
 			overlayTab->setVisible(true);
 			break;
 		}
 		case CitySelectionState::AttackVehicle:
 		{
 			overlayTab->findControlTyped<Label>("TEXT")->setText(
-			    tr("Click on target vehicle for selected vehicle"));
+			    translate("Click on target vehicle for selected vehicle"));
 			overlayTab->setVisible(true);
 			break;
 		}
@@ -3994,22 +4004,22 @@ void CityView::setSelectionState(CitySelectionState selectionState)
 			{
 				if (state->current_city->cityViewSelectedVehicles.size() > 1)
 				{
-					message = tr("Click on destination building for selected vehicles");
+					message = translate("Click on destination building for selected vehicles");
 				}
 				else
 				{
-					message = tr("Click on destination building for selected vehicle");
+					message = translate("Click on destination building for selected vehicle");
 				}
 			}
 			else
 			{
 				if (state->current_city->cityViewSelectedAgents.size() > 1)
 				{
-					message = tr("Click on destination building for selected people");
+					message = translate("Click on destination building for selected people");
 				}
 				else
 				{
-					message = tr("Click on destination building for selected person");
+					message = translate("Click on destination building for selected person");
 				}
 			}
 			overlayTab->findControlTyped<Label>("TEXT")->setText(message);
@@ -4019,13 +4029,13 @@ void CityView::setSelectionState(CitySelectionState selectionState)
 		case CitySelectionState::GotoLocation:
 		{
 			overlayTab->findControlTyped<Label>("TEXT")->setText(
-			    tr("Click on destination map point for selected vehicle"));
+			    translate("Click on destination map point for selected vehicle"));
 			overlayTab->setVisible(true);
 			break;
 		}
 		case CitySelectionState::ManualControl:
 		{
-			overlayTab->findControlTyped<Label>("TEXT")->setText(tr("Manual control"));
+			overlayTab->findControlTyped<Label>("TEXT")->setText(translate("Manual control"));
 			overlayTab->setVisible(true);
 			break;
 		}

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -275,23 +275,28 @@ void UfopaediaCategoryView::setFormStats()
 
 						if (ref != player)
 						{
-							UString relation ;
+							UString relation;
 							switch (ref->isRelatedTo(player))
 							{
 								case Organisation::Relation::Allied:
-									relation = tformat("{1}: allied towards: {2}")%translate(ref->name) % translate(player->name);
+									relation = tformat("{1}: allied towards: {2}") %
+									           translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Friendly:
-									relation = tformat("{1}: friendly towards: {2}")%translate(ref->name) % translate(player->name);
+									relation = tformat("{1}: friendly towards: {2}") %
+									           translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Neutral:
-									relation = tformat("{1}: neutral towards: {2}")%translate(ref->name) % translate(player->name);
+									relation = tformat("{1}: neutral towards: {2}") %
+									           translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Unfriendly:
-									relation = tformat("{1}: unfriendly towards: {2}")%translate(ref->name) % translate(player->name);
+									relation = tformat("{1}: unfriendly towards: {2}") %
+									           translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Hostile:
-									relation = tformat("{1}: hostile towards: {2}")%translate(ref->name) % translate(player->name);
+									relation = tformat("{1}: hostile towards: {2}") %
+									           translate(ref->name) % translate(player->name);
 									break;
 							}
 							orgLabels[0]->setText(relation);

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -18,7 +18,7 @@
 #include "game/state/rules/city/vequipmenttype.h"
 #include "game/state/shared/organisation.h"
 #include "library/sp.h"
-#include "library/strings_format.h"
+#include "library/strings_translate.h"
 
 namespace OpenApoc
 {
@@ -65,7 +65,7 @@ void UfopaediaCategoryView::begin()
 			continue;
 		}
 
-		auto entryControl = mksp<TextButton>(tr(entry->title), infoLabel->getFont());
+		auto entryControl = mksp<TextButton>(translate(entry->title), infoLabel->getFont());
 		entryControl->Name = "ENTRY_SHORTCUT";
 		entryControl->RenderStyle = TextButton::ButtonRenderStyle::Flat;
 		entryControl->TextHAlign = HorizontalAlignment::Left;
@@ -229,8 +229,8 @@ void UfopaediaCategoryView::setFormData()
 		background = this->position_iterator->second->background->getRealImage();
 	}
 	menuform->findControlTyped<Graphic>("BACKGROUND_PICTURE")->setImage(background);
-	auto tr_description = tr(description);
-	auto tr_title = tr(title);
+	auto tr_description = translate(description);
+	auto tr_title = translate(title);
 	menuform->findControlTyped<Label>("TEXT_INFO")->setText(tr_description);
 	menuform->findControlTyped<Label>("TEXT_TITLE_DATA")->setText(tr_title);
 
@@ -268,35 +268,34 @@ void UfopaediaCategoryView::setFormStats()
 					// FIXME: Should this be hardcoded?
 					if (data_id != "ORG_ALIEN")
 					{
-						orgLabels[1]->setText(tr("Balance"));
+						orgLabels[1]->setText(translate("Balance"));
 						orgValues[1]->setText(format("$%d", ref->balance));
-						orgLabels[2]->setText(tr("Income"));
+						orgLabels[2]->setText(translate("Income"));
 						orgValues[2]->setText(format("$%d", ref->income));
 
 						if (ref != player)
 						{
-							UString relation = tr(ref->name);
+							UString relation ;
 							switch (ref->isRelatedTo(player))
 							{
 								case Organisation::Relation::Allied:
-									relation += tr(": allied towards:");
+									relation = tformat("{1}: allied towards: {2}")%translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Friendly:
-									relation += tr(": friendly towards:");
+									relation = tformat("{1}: friendly towards: {2}")%translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Neutral:
-									relation += tr(": neutral towards:");
+									relation = tformat("{1}: neutral towards: {2}")%translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Unfriendly:
-									relation += tr(": unfriendly towards:");
+									relation = tformat("{1}: unfriendly towards: {2}")%translate(ref->name) % translate(player->name);
 									break;
 								case Organisation::Relation::Hostile:
-									relation += tr(": hostile towards:");
+									relation = tformat("{1}: hostile towards: {2}")%translate(ref->name) % translate(player->name);
 									break;
 							}
-							relation += UString(" ") + tr(player->name);
 							orgLabels[0]->setText(relation);
-							orgLabels[3]->setText(tr("Alien Infiltration"));
+							orgLabels[3]->setText(translate("Alien Infiltration"));
 							orgValues[3]->setText(format("%d%%", ref->infiltrationValue / 2));
 						}
 					}
@@ -305,18 +304,18 @@ void UfopaediaCategoryView::setFormStats()
 				case UfopaediaEntry::Data::Vehicle:
 				{
 					StateRef<VehicleType> ref = {state.get(), data_id};
-					statsLabels[row]->setText(tr("Constitution"));
+					statsLabels[row]->setText(translate("Constitution"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->health));
 					int armour = 0;
 					for (auto &slot : ref->armour)
 					{
 						armour += slot.second;
 					}
-					statsLabels[row]->setText(tr("Armor"));
+					statsLabels[row]->setText(translate("Armor"));
 					statsValues[row++]->setText(Strings::fromInteger(armour));
-					statsLabels[row]->setText(tr("Weight"));
+					statsLabels[row]->setText(translate("Weight"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->weight));
-					statsLabels[row]->setText(tr("Passengers"));
+					statsLabels[row]->setText(translate("Passengers"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->passengers));
 					int weaponSpace = 0;
 					int weaponAmount = 0;
@@ -341,90 +340,90 @@ void UfopaediaCategoryView::setFormStats()
 								break;
 						}
 					}
-					statsLabels[row]->setText(tr("Weapons space"));
+					statsLabels[row]->setText(translate("Weapons space"));
 					statsValues[row++]->setText(Strings::fromInteger(weaponSpace));
-					statsLabels[row]->setText(tr("Weapons slots"));
+					statsLabels[row]->setText(translate("Weapons slots"));
 					statsValues[row++]->setText(Strings::fromInteger(weaponAmount));
-					statsLabels[row]->setText(tr("Engine size"));
+					statsLabels[row]->setText(translate("Engine size"));
 					statsValues[row++]->setText(Strings::fromInteger(engineSpace));
-					statsLabels[row]->setText(tr("Equipment space"));
+					statsLabels[row]->setText(translate("Equipment space"));
 					statsValues[row++]->setText(Strings::fromInteger(generalSpace));
 					break;
 				}
 				case UfopaediaEntry::Data::VehicleEquipment:
 				{
 					StateRef<VEquipmentType> ref = {state.get(), data_id};
-					statsLabels[row]->setText(tr("Weight"));
+					statsLabels[row]->setText(translate("Weight"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->weight));
-					statsLabels[row]->setText(tr("Size"));
+					statsLabels[row]->setText(translate("Size"));
 					statsValues[row++]->setText(
 					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
 					switch (ref->type)
 					{
 						case EquipmentSlotType::VehicleEngine:
-							statsLabels[row]->setText(tr("Power"));
+							statsLabels[row]->setText(translate("Power"));
 							statsValues[row++]->setText(Strings::fromInteger(ref->power));
-							statsLabels[row]->setText(tr("Top Speed"));
+							statsLabels[row]->setText(translate("Top Speed"));
 							statsValues[row++]->setText(Strings::fromInteger(ref->top_speed));
 							break;
 						case EquipmentSlotType::VehicleWeapon:
-							statsLabels[row]->setText(tr("Damage"));
+							statsLabels[row]->setText(translate("Damage"));
 							statsValues[row++]->setText(Strings::fromInteger(ref->damage));
-							statsLabels[row]->setText(tr("Accuracy"));
+							statsLabels[row]->setText(translate("Accuracy"));
 							statsValues[row++]->setText(format("%d%%", ref->accuracy));
-							statsLabels[row]->setText(tr("Range"));
+							statsLabels[row]->setText(translate("Range"));
 							statsValues[row++]->setText(format("%dm", ref->getRangeInMetres()));
-							statsLabels[row]->setText(tr("Fire Rate"));
+							statsLabels[row]->setText(translate("Fire Rate"));
 							statsValues[row++]->setText(format(
 							    "%.2f r/s", (float)TICKS_PER_SECOND / (float)ref->fire_delay));
 							if (ref->max_ammo > 0 && ref->ammo_type)
 							{
-								statsLabels[row]->setText(tr("Ammo type"));
-								statsValues[row++]->setText(tr(ref->ammo_type->name));
-								statsLabels[row]->setText(tr("Ammo capacity"));
+								statsLabels[row]->setText(translate("Ammo type"));
+								statsValues[row++]->setText(translate(ref->ammo_type->name));
+								statsLabels[row]->setText(translate("Ammo capacity"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->max_ammo));
 							}
 							if (ref->turn_rate > 0)
 							{
-								statsLabels[row]->setText(tr("Turn Rate"));
+								statsLabels[row]->setText(translate("Turn Rate"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->turn_rate));
 							}
 							break;
 						case EquipmentSlotType::VehicleGeneral:
 							if (ref->accuracy_modifier > 0)
 							{
-								statsLabels[row]->setText(tr("Accuracy"));
+								statsLabels[row]->setText(translate("Accuracy"));
 								statsValues[row++]->setText(
 								    format("+%d%%", ref->accuracy_modifier));
 							}
 							if (ref->cargo_space > 0)
 							{
-								statsLabels[row]->setText(tr("Cargo"));
+								statsLabels[row]->setText(translate("Cargo"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->cargo_space));
 							}
 							if (ref->passengers > 0)
 							{
-								statsLabels[row]->setText(tr("Passengers"));
+								statsLabels[row]->setText(translate("Passengers"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->passengers));
 							}
 							if (ref->alien_space > 0)
 							{
-								statsLabels[row]->setText(tr("Aliens Held"));
+								statsLabels[row]->setText(translate("Aliens Held"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->alien_space));
 							}
 							if (ref->missile_jamming > 0)
 							{
-								statsLabels[row]->setText(tr("Jamming"));
+								statsLabels[row]->setText(translate("Jamming"));
 								statsValues[row++]->setText(format("%d%%", ref->missile_jamming));
 							}
 							if (ref->shielding > 0)
 							{
-								statsLabels[row]->setText(tr("Shielding"));
+								statsLabels[row]->setText(translate("Shielding"));
 								statsValues[row++]->setText(format("+%d", ref->shielding));
 							}
 							if (ref->cloaking)
 							{
-								statsValues[row++]->setText(tr("Cloaks Craft"));
+								statsValues[row++]->setText(translate("Cloaks Craft"));
 							}
 							break;
 						default:
@@ -440,55 +439,55 @@ void UfopaediaCategoryView::setFormStats()
 				case UfopaediaEntry::Data::Equipment:
 				{
 					StateRef<AEquipmentType> ref = {state.get(), data_id};
-					statsLabels[row]->setText(tr("Weight"));
+					statsLabels[row]->setText(translate("Weight"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->weight));
-					statsLabels[row]->setText(tr("Size"));
+					statsLabels[row]->setText(translate("Size"));
 					statsValues[row++]->setText(
 					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
 					if (ref->type == AEquipmentType::Type::Ammo ||
 					    (ref->type == AEquipmentType::Type::Weapon && ref->ammo_types.empty()))
 					{
-						statsLabels[row]->setText(tr("Power"));
+						statsLabels[row]->setText(translate("Power"));
 						statsValues[row++]->setText(Strings::fromInteger(ref->damage));
-						statsLabels[row]->setText(tr("Damage Type"));
+						statsLabels[row]->setText(translate("Damage Type"));
 						statsValues[row++]->setText(ref->damage_type->name);
-						statsLabels[row]->setText("Range");
+						statsLabels[row]->setText(translate("Range"));
 						statsValues[row++]->setText(format("%dm", ref->getRangeInMetres()));
-						statsLabels[row]->setText("Fire Rate");
+						statsLabels[row]->setText(translate("Fire Rate"));
 						statsValues[row++]->setText(format("%.2f r/s", ref->getRoundsPerSecond()));
 					}
 					else if (ref->type == AEquipmentType::Type::Grenade)
 					{
-						statsLabels[row]->setText(tr("Power"));
+						statsLabels[row]->setText(translate("Power"));
 						statsValues[row++]->setText(Strings::fromInteger(ref->damage));
-						statsLabels[row]->setText(tr("Damage Type"));
+						statsLabels[row]->setText(translate("Damage Type"));
 						statsValues[row++]->setText(ref->damage_type->name);
 					}
 					else if (ref->type == AEquipmentType::Type::Weapon &&
 					         ref->ammo_types.size() == 1)
 					{
 						const auto &ammoType = *ref->ammo_types.begin();
-						statsLabels[row]->setText(tr("Power"));
+						statsLabels[row]->setText(translate("Power"));
 						statsValues[row++]->setText(Strings::fromInteger(ammoType->damage));
-						statsLabels[row]->setText(tr("Damage Type"));
+						statsLabels[row]->setText(translate("Damage Type"));
 						statsValues[row++]->setText(ammoType->damage_type->name);
-						statsLabels[row]->setText(tr("Range"));
+						statsLabels[row]->setText(translate("Range"));
 						statsValues[row++]->setText(format("%dm", ammoType->getRangeInMetres()));
-						statsLabels[row]->setText(tr("Fire Rate"));
+						statsLabels[row]->setText(translate("Fire Rate"));
 						statsValues[row++]->setText(
 						    format("%.2f r/s", ammoType->getRoundsPerSecond()));
 					}
 					else if (ref->type == AEquipmentType::Type::Weapon &&
 					         ref->ammo_types.size() > 1)
 					{
-						statsLabels[row]->setText(tr("Power"));
-						statsValues[row++]->setText(tr("Depends on clip"));
-						statsLabels[row]->setText(tr("Damage Type"));
-						statsValues[row++]->setText(tr("Depends on clip"));
-						statsLabels[row]->setText(tr("Range"));
-						statsValues[row++]->setText(tr("Depends on clip"));
-						statsLabels[row]->setText(tr("Fire Rate"));
-						statsValues[row++]->setText(tr("Depends on clip"));
+						statsLabels[row]->setText(translate("Power"));
+						statsValues[row++]->setText(translate("Depends on clip"));
+						statsLabels[row]->setText(translate("Damage Type"));
+						statsValues[row++]->setText(translate("Depends on clip"));
+						statsLabels[row]->setText(translate("Range"));
+						statsValues[row++]->setText(translate("Depends on clip"));
+						statsLabels[row]->setText(translate("Fire Rate"));
+						statsValues[row++]->setText(translate("Depends on clip"));
 					}
 					else if (ref->type == AEquipmentType::Type::Armor)
 					{
@@ -499,15 +498,15 @@ void UfopaediaCategoryView::setFormStats()
 				case UfopaediaEntry::Data::Facility:
 				{
 					StateRef<FacilityType> ref = {state.get(), data_id};
-					statsLabels[row]->setText(tr("Construction cost"));
+					statsLabels[row]->setText(translate("Construction cost"));
 					statsValues[row++]->setText(format("$%d", ref->buildCost));
-					statsLabels[row]->setText(tr("Days to build"));
+					statsLabels[row]->setText(translate("Days to build"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->buildTime));
-					statsLabels[row]->setText(tr("Weekly cost"));
+					statsLabels[row]->setText(translate("Weekly cost"));
 					statsValues[row++]->setText(format("$%d", ref->weeklyCost));
 					if (ref->capacityAmount > 0)
 					{
-						statsLabels[row]->setText(tr("Capacity"));
+						statsLabels[row]->setText(translate("Capacity"));
 						statsValues[row++]->setText(Strings::fromInteger(ref->capacityAmount));
 					}
 					break;

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -22,6 +22,7 @@ set (LIBRARY_HEADER_FILES
 	sp.h
 	strings.h
 	strings_format.h
+	strings_translate.h
 	vec.h
 	resource.h
 	voxel.h

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -119,46 +119,6 @@ static size_t unichar_to_utf8(const UniChar uc, char str[4])
 	return unichar_to_utf8(REPLACEMENT_CHARACTER, str);
 }
 
-#ifdef DUMP_TRANSLATION_STRINGS
-
-static std::map<UString, std::set<UString>> trStrings;
-
-void dumpStrings()
-{
-	for (auto &p : trStrings)
-	{
-		UString outFileName = p.first + ".po";
-		std::ofstream outFile(outFileName.str());
-		outFile << "msgid \"\"\n"
-		        << "msgstr \"\"\n"
-		        << "\"Project-Id-Version: Apocalypse\\n\"\n"
-		        << "\"MIME-Version: 1.0\\n\"\n"
-		        << "\"Content-Type: text/plain; charset=UTF-8\\n\"\n"
-		        << "\"Content-Transfer-Encoding: 8bit\\n\"\n"
-		        << "\"Language: en\\n\""
-		        << "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"\n\n";
-		for (auto &str : p.second)
-		{
-			auto escapedStr = str;
-			outFile << "msgid \"" << str << "\"\n";
-			outFile << "msgstr \"" << str << "\"\n\n";
-		}
-	}
-}
-
-#endif
-
-UString tr(const UString &str, const UString domain)
-{
-#ifdef DUMP_TRANSLATION_STRINGS
-	if (str != "")
-	{
-		trStrings[domain].insert(str);
-	}
-#endif
-	return UString(boost::locale::translate(str.str()).str(domain.str()));
-}
-
 UString::~UString() = default;
 
 UString::UString() : u8Str() {}

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -194,6 +194,22 @@ UString::UString(UString::ConstIterator first, UString::ConstIterator last)
 {
 }
 
+UString::UString(const boost::locale::basic_format<char> &format_string)
+{
+	// TODO: Are stringstreams imbued with the correct locale?
+	std::ostringstream ss;
+	ss << format_string;
+	this->u8Str = ss.str();
+}
+
+UString::UString(const boost::locale::basic_message<char> &message_string)
+{
+	// TODO: Are stringstreams imbued with the correct locale?
+	std::ostringstream ss;
+	ss << message_string;
+	this->u8Str = ss.str();
+}
+
 const std::string &UString::str() const { return this->u8Str; }
 
 const char *UString::cStr() const { return this->u8Str.c_str(); }

--- a/library/strings.h
+++ b/library/strings.h
@@ -5,6 +5,12 @@
 #include <string>
 #include <vector>
 
+namespace boost::locale
+{
+template <typename T> class basic_format;
+template <typename T> class basic_message;
+} // namespace boost::locale
+
 namespace OpenApoc
 {
 
@@ -46,6 +52,8 @@ class UString
 	UString(std::string &&str);
 	UString(UniChar uc);
 	UString(const char *cstr);
+	UString(const boost::locale::basic_format<char> &format_string);
+	UString(const boost::locale::basic_message<char> &message_string);
 	UString(const char *cstr, size_t count);
 	UString(UString &&other) noexcept;
 	UString(ConstIterator first, ConstIterator last);

--- a/library/strings.h
+++ b/library/strings.h
@@ -129,8 +129,4 @@ class Strings
 	static bool isWhiteSpace(UniChar c);
 };
 
-#ifdef DUMP_TRANSLATION_STRINGS
-void dumpStrings();
-#endif
-
 }; // namespace OpenApoc

--- a/library/strings_format.h
+++ b/library/strings_format.h
@@ -23,6 +23,4 @@ template <typename... Args> static UString format(const UString &fmt, Args &&...
 	return tfm::format(fmt.cStr(), std::forward<Args>(args)...);
 }
 
-UString tr(const UString &str, const UString domain = "ufo_string");
-
 } // namespace OpenApoc

--- a/library/strings_translate.h
+++ b/library/strings_translate.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <boost/locale/format.hpp>
+#include <boost/locale/message.hpp>
+
+namespace OpenApoc
+{
+
+class UString;
+
+inline auto translate(const UString &str) { return boost::locale::translate(str.str()); }
+
+inline auto tformat(const char *str) { return boost::locale::format(boost::locale::translate(str)); }
+
+// TODO: Pleural message formatting
+
+}; // namespace OpenApoc

--- a/library/strings_translate.h
+++ b/library/strings_translate.h
@@ -10,7 +10,10 @@ class UString;
 
 inline auto translate(const UString &str) { return boost::locale::translate(str.str()); }
 
-inline auto tformat(const char *str) { return boost::locale::format(boost::locale::translate(str)); }
+inline auto tformat(const char *str)
+{
+	return boost::locale::format(boost::locale::translate(str));
+}
 
 // TODO: Pleural message formatting
 


### PR DESCRIPTION
A work-in-progress at moving from a single tr(string) call to boost::locale's message formatting

RE the boost-locale discussion in issue #773 

This means that strings can be translated at as a while rather than piecemeal depending on how they're constructed in code.

Going forward it's always best to construct strings for display in sensible units, to allow translators some sanity.

e.g. if you want the string:
"Moving item {1} from {2} to {3} will take {4} hours"
doing that all in one tformat() call like this:
tformat("Moving item {1} from {2} to {3} will take {4} hours") % %item_name % source % destination % time;
will allow the string to be translated as a whole, possible reordered etc.

But in quite a few places, stings were constructed piecemeal, e.g:
string = "Moving Item "
string += item_name
string += "from"
etc. etc.

That means that even if each string section is wrapped in a translate-aware replacement call (e.g. tr(), now replaced by translate()) the translators only see the strings "Moving Item" and "from", can't reorder them, and any instance of "from" will be replaced by the translated version - even if it doesn't make sense in context.