### PR TITLE
Destroy falling UFOs on touchdown in Alien Dimension.

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -1405,8 +1405,15 @@ void VehicleMission::update(GameState &state, Vehicle &v, unsigned int ticks, bo
 		{
 			if (finished)
 			{
-				fw().pushEvent(new GameVehicleEvent(GameEventType::UfoCrashed,
-				                                    {&state, v.shared_from_this()}));
+				if (v.city.id == "CITYMAP_HUMAN")
+				{
+					fw().pushEvent(new GameVehicleEvent(GameEventType::UfoCrashed,
+					                                    {&state, v.shared_from_this()}));
+				}
+				else
+				{
+					v.die(state, false);
+				}
 				return;
 			}
 			auto vTile = v.tileObject;


### PR DESCRIPTION
Falling UFOs no longer survive the crash in Alien Dimension.

Resolves #682.