### PR TITLE
Remove dead vehicles from selection.

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -942,6 +942,23 @@ void OpenApoc::GameState::cleanUpDeathNote()
 		for (auto &name : this->vehiclesDeathNote)
 		{
 			vehicles.erase(name);
+
+			// Remove vehicle from selection
+			for (const auto &[cityId, city] : cities)
+			{
+				for (auto it = city->cityViewSelectedVehicles.begin();
+				     it != city->cityViewSelectedVehicles.end();)
+				{
+					if (it->id == name)
+					{
+						it = city->cityViewSelectedVehicles.erase(it);
+					}
+					else
+					{
+						++it;
+					}
+				}
+			}
 		}
 		vehiclesDeathNote.clear();
 	}


### PR DESCRIPTION
Resolves a CTD on `CityView::render` when the list of selected vehicles contains a non-present entry.

Although the issue was uncovered as a result of #878, it manifests under different circumstances as well; here's a repro:
1. Fly to Alien Dimension.
2. Order XCOM units to return to Human Dimension.
3. Select any UFO and leave it selected till cityscape changes to Human Dimension.
4. Wait for the selected UFO to invade Human Dimension.
5. Destroy it.
6. Save the game.
7. Reload the game.
8. Fly to Alien Dimension.

Related to https://github.com/OpenApoc/OpenApoc/issues/788#issuecomment-634602993.