### PR TITLE
ListBox: Drop AlwaysEmitSelectionEvents workaround in favor of AutoSelect setting.

### DIFF
--- a/data/forms/aequipscreen.form
+++ b/data/forms/aequipscreen.form
@@ -88,6 +88,7 @@
         <item size="0" spacing="5"/>
         <hovercolour r="255" g="255" b="255" a="0"/>
         <selcolour r="255" g="255" b="255" a="0"/>
+        <autoselect>no</autoselect>
       </listbox>
       <graphicbutton id="AGENT_SCROLL_UP" scrollprev="AGENT_SELECT_SCROLL">
         <tooltip text="Scroll Up" font="smallset"/>

--- a/data/forms/researchscreen.form
+++ b/data/forms/researchscreen.form
@@ -165,6 +165,7 @@
         <size height="160" width="320"/>
         <orientation list="vertical" scroll="horizontal"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
+        <autoselect>no</autoselect>
       </listbox>
       <scroll id="LIST_UNASSIGNED_SCROLL">
         <position x="164" y="192"/>
@@ -189,6 +190,7 @@
         <size height="256" width="128"/>
         <orientation>vertical</orientation>
         <hovercolour r="255" g="255" b="255" a="255"/>
+        <autoselect>no</autoselect>
       </listbox>
       <graphic id="MAGIC_ARROW">
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:60:xcom3/ufodata/research.pcx</image>

--- a/data/forms/researchselect.form
+++ b/data/forms/researchselect.form
@@ -50,6 +50,7 @@
         <size height="266" width="542"/>
         <orientation>vertical</orientation>
         <hovercolour r="255" g="255" b="255" a="255"/>
+        <autoselect>no</autoselect>
       </listbox>
       <label text="Project">
         <position x="23" y="63"/>

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -13,8 +13,7 @@ ListBox::ListBox() : ListBox(nullptr) {}
 ListBox::ListBox(sp<ScrollBar> ExternalScrollBar)
     : Control(), scroller_is_internal(ExternalScrollBar == nullptr), scroller(ExternalScrollBar),
       ItemSize(64), ItemSpacing(1), ListOrientation(Orientation::Vertical),
-      ScrollOrientation(ListOrientation), HoverColour(0, 0, 0, 0), SelectedColour(0, 0, 0, 0),
-      AlwaysEmitSelectionEvents(false)
+      ScrollOrientation(ListOrientation), HoverColour(0, 0, 0, 0), SelectedColour(0, 0, 0, 0)
 {
 }
 
@@ -183,11 +182,11 @@ void ListBox::eventOccured(Event *e)
 		}
 		else if (e->forms().EventFlag == FormEventType::MouseDown)
 		{
-			if (ctrl == shared_from_this() || ctrl == scroller)
+			if (ctrl == shared_from_this() || ctrl == scroller || ctrl != child)
 			{
 				child = nullptr;
 			}
-			if ((AlwaysEmitSelectionEvents || selected != child) && child != nullptr)
+			if (selected != child && child != nullptr)
 			{
 				selected = child;
 				this->pushFormEvent(FormEventType::ListBoxChangeSelected, e);
@@ -287,7 +286,7 @@ void ListBox::addItem(sp<Control> Item)
 	Item->setParent(shared_from_this());
 	Item->ToolTipFont = this->ToolTipFont;
 	resolveLocation();
-	if (selected == nullptr)
+	if (selected == nullptr && AutoSelect)
 	{
 		selected = Item;
 	}
@@ -394,6 +393,7 @@ sp<Control> ListBox::copyTo(sp<Control> CopyParent)
 	copy->ScrollOrientation = this->ScrollOrientation;
 	copy->HoverColour = this->HoverColour;
 	copy->SelectedColour = this->SelectedColour;
+	copy->AutoSelect = this->AutoSelect;
 	copyControlData(copy);
 	return copy;
 }
@@ -470,6 +470,11 @@ void ListBox::configureSelfFromXml(pugi::xml_node *node)
 		uint8_t b = selColourNode.attribute("b").as_uint(0);
 		uint8_t a = selColourNode.attribute("a").as_uint(255);
 		SelectedColour = {r, g, b, a};
+	}
+	auto autoSelectNode = node->child("autoselect");
+	if (autoSelectNode)
+	{
+		AutoSelect = autoSelectNode.text().as_bool(true);
 	}
 }
 

--- a/forms/listbox.h
+++ b/forms/listbox.h
@@ -30,11 +30,11 @@ class ListBox : public Control
 	int ItemSize, ItemSpacing;
 	Orientation ListOrientation, ScrollOrientation;
 	Colour HoverColour, SelectedColour;
+	bool AutoSelect = true;
 	// Image to use instead of frame for hover
 	sp<Image> HoverImage;
 	// Image to use instead of frame for selection
 	sp<Image> SelectedImage;
-	bool AlwaysEmitSelectionEvents;
 
 	ListBox();
 	ListBox(sp<ScrollBar> ExternalScrollBar);

--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -156,11 +156,6 @@ void ResearchScreen::begin()
 	};
 	auto assignedAgentList = form->findControlTyped<ListBox>("LIST_ASSIGNED");
 	assignedAgentList->addCallback(FormEventType::ListBoxChangeSelected, removeFn);
-
-	// Set the listboxes to always emit events, otherwise the first entry is considered 'selected'
-	// to clicking on it won't get a callback
-	assignedAgentList->AlwaysEmitSelectionEvents = true;
-	unassignedAgentList->AlwaysEmitSelectionEvents = true;
 }
 
 void ResearchScreen::pause() {}

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -65,7 +65,6 @@ void ResearchSelect::begin()
 	this->redrawResearchList();
 
 	auto research_list = form->findControlTyped<ListBox>("LIST");
-	research_list->AlwaysEmitSelectionEvents = true;
 
 	research_list->addCallback(FormEventType::ListBoxChangeSelected, [this](FormsEvent *e) {
 		LogInfo("Research selection change");
@@ -84,6 +83,8 @@ void ResearchSelect::begin()
 				                                    tr("This project is already complete."),
 				                                    MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+				// Restore previous selection
+				list->setSelected(current_topic ? control_map[current_topic] : nullptr);
 				return;
 			}
 			if (topic->required_lab_size == ResearchTopic::LabSize::Large &&
@@ -95,6 +96,8 @@ void ResearchSelect::begin()
 				                     tr("This project requires an advanced lab or workshop."),
 				                     MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+				// Restore previous selection
+				list->setSelected(current_topic ? control_map[current_topic] : nullptr);
 				return;
 			}
 			if (this->lab->type == ResearchTopic::Type::Engineering &&
@@ -105,6 +108,8 @@ void ResearchSelect::begin()
 				    tr("FUNDS EXCEEDED"), tr("Production costs exceed your available funds."),
 				    MessageBox::ButtonOptions::Ok);
 				fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+				// Restore previous selection
+				list->setSelected(current_topic ? control_map[current_topic] : nullptr);
 				return;
 			}
 		}

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -65,7 +65,6 @@ AEquipScreen::AEquipScreen(sp<GameState> state, sp<Agent> firstAgent)
 
 	// Agent list functionality
 	auto agentList = formMain->findControlTyped<ListBox>("AGENT_SELECT_BOX");
-	agentList->AlwaysEmitSelectionEvents = true;
 	agentList->addCallback(FormEventType::ListBoxChangeSelected, [this](FormsEvent *e) {
 		auto list = std::static_pointer_cast<ListBox>(e->forms().RaisedBy);
 		auto agent = list->getSelectedData<Agent>();


### PR DESCRIPTION
An alternative to #868.

Adds `<autoselect>` option to `listbox`es defaulting to **yes** (current behavior) providing ability to disable automatic selection of a newly added item in case of no previous selection. And sets the option to **no** where previously `AlwaysEmitSelectionEvents` workaround was employed.

Resolves #786.
Resolves #870.