### PR TITLE
Make forms with OK buttons closable on [Enter].

### DIFF
--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -163,12 +163,8 @@ void BaseScreen::eventOccurred(Event *e)
 	{
 		if (form->findControlTyped<TextEdit>("TEXT_BASE_NAME")->isFocused())
 			return;
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
-		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
-			return;
-		}
-		if (e->keyboard().KeyCode == SDLK_RETURN || e->keyboard().KeyCode == SDLK_KP_ENTER)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			form->findControl("BUTTON_OK")->click();
 			return;

--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -182,7 +182,7 @@ void ResearchScreen::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			form->findControl("BUTTON_OK")->click();
 			return;
 		}
 	}

--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -179,7 +179,8 @@ void ResearchScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -342,7 +342,7 @@ void ResearchSelect::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			form->findControl("BUTTON_OK")->click();
 			return;
 		}
 	}

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -339,7 +339,8 @@ void ResearchSelect::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -173,12 +173,8 @@ void VEquipScreen::eventOccurred(Event *e)
 	{
 		if (form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")->isFocused())
 			return;
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
-		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
-			return;
-		}
-		if (e->keyboard().KeyCode == SDLK_RETURN || e->keyboard().KeyCode == SDLK_KP_ENTER)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			form->findControl("BUTTON_OK")->click();
 			return;

--- a/game/ui/city/alertscreen.cpp
+++ b/game/ui/city/alertscreen.cpp
@@ -57,7 +57,8 @@ void AlertScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/city/alertscreen.cpp
+++ b/game/ui/city/alertscreen.cpp
@@ -60,7 +60,7 @@ void AlertScreen::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_QUIT")->click();
 			return;
 		}
 	}

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -61,7 +61,7 @@ void BaseBuyScreen::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			form->findControl("BUTTON_OK")->click();
 		}
 	}
 

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -58,7 +58,8 @@ void BaseBuyScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 		}

--- a/game/ui/city/basedefensescreen.cpp
+++ b/game/ui/city/basedefensescreen.cpp
@@ -70,7 +70,8 @@ void BaseDefenseScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			menuform->findControl("BUTTON_QUIT")->click();
 			return;

--- a/game/ui/city/baseselectscreen.cpp
+++ b/game/ui/city/baseselectscreen.cpp
@@ -57,7 +57,7 @@ void BaseSelectScreen::eventOccurred(Event *e)
 	    (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 	     e->keyboard().KeyCode == SDLK_KP_ENTER))
 	{
-		fw().stageQueueCommand({StageCmd::Command::POP});
+		menuform->findControl("BUTTON_OK")->click();
 	}
 	// Exclude mouse down events that are over the form
 	else if (e->type() == EVENT_MOUSE_DOWN)

--- a/game/ui/city/baseselectscreen.cpp
+++ b/game/ui/city/baseselectscreen.cpp
@@ -53,7 +53,9 @@ void BaseSelectScreen::eventOccurred(Event *e)
 		return;
 	}
 
-	if (e->type() == EVENT_KEY_DOWN && e->keyboard().KeyCode == SDLK_ESCAPE)
+	if (e->type() == EVENT_KEY_DOWN &&
+	    (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+	     e->keyboard().KeyCode == SDLK_KP_ENTER))
 	{
 		fw().stageQueueCommand({StageCmd::Command::POP});
 	}

--- a/game/ui/city/bribescreen.cpp
+++ b/game/ui/city/bribescreen.cpp
@@ -125,7 +125,7 @@ void BribeScreen::eventOccurred(Event *e)
 			case SDLK_ESCAPE:
 			case SDLK_RETURN:
 			case SDLK_KP_ENTER:
-				fw().stageQueueCommand({StageCmd::Command::POP});
+				menuform->findControl("BUTTON_QUIT")->click();
 				return;
 		}
 	}

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -82,7 +82,8 @@ void BuildingScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/city/buildingscreen.cpp
+++ b/game/ui/city/buildingscreen.cpp
@@ -85,7 +85,7 @@ void BuildingScreen::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_QUIT")->click();
 			return;
 		}
 	}

--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -107,7 +107,8 @@ void InfiltrationScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			menuform->findControl("BUTTON_QUIT")->click();
 			return;

--- a/game/ui/components/locationscreen.cpp
+++ b/game/ui/components/locationscreen.cpp
@@ -90,7 +90,8 @@ void LocationScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/components/locationscreen.cpp
+++ b/game/ui/components/locationscreen.cpp
@@ -93,7 +93,7 @@ void LocationScreen::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_QUIT")->click();
 			return;
 		}
 	}

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -104,7 +104,8 @@ void CheatOptions::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -107,7 +107,7 @@ void CheatOptions::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_OK")->click();
 			return;
 		}
 	}

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -253,7 +253,7 @@ void InGameOptions::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_OK")->click();
 			return;
 		}
 	}

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -250,7 +250,8 @@ void InGameOptions::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -114,7 +114,7 @@ void MessageLogScreen::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_OK")->click();
 			return;
 		}
 	}

--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -111,7 +111,8 @@ void MessageLogScreen::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/general/optionsmenu.cpp
+++ b/game/ui/general/optionsmenu.cpp
@@ -71,7 +71,8 @@ void OptionsMenu::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/general/optionsmenu.cpp
+++ b/game/ui/general/optionsmenu.cpp
@@ -74,7 +74,7 @@ void OptionsMenu::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_OK")->click();
 			return;
 		}
 	}

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -336,7 +336,10 @@ void SaveMenu::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (activeTextEdit && activeTextEdit->isFocused())
+			return;
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -341,7 +341,7 @@ void SaveMenu::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_QUIT")->click();
 			return;
 		}
 	}

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -134,7 +134,7 @@ void UfopaediaCategoryView::eventOccurred(Event *e)
 			case SDLK_ESCAPE:
 			case SDLK_RETURN:
 			case SDLK_KP_ENTER:
-				fw().stageQueueCommand({StageCmd::Command::POP});
+				menuform->findControl("BUTTON_QUIT")->click();
 				return;
 			case SDLK_UP:
 				setNextSection();

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -132,6 +132,8 @@ void UfopaediaCategoryView::eventOccurred(Event *e)
 		switch (e->keyboard().KeyCode)
 		{
 			case SDLK_ESCAPE:
+			case SDLK_RETURN:
+			case SDLK_KP_ENTER:
 				fw().stageQueueCommand({StageCmd::Command::POP});
 				return;
 			case SDLK_UP:

--- a/game/ui/ufopaedia/ufopaediaview.cpp
+++ b/game/ui/ufopaedia/ufopaediaview.cpp
@@ -32,7 +32,8 @@ void UfopaediaView::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_KEY_DOWN)
 	{
-		if (e->keyboard().KeyCode == SDLK_ESCAPE)
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
 			fw().stageQueueCommand({StageCmd::Command::POP});
 			return;

--- a/game/ui/ufopaedia/ufopaediaview.cpp
+++ b/game/ui/ufopaedia/ufopaediaview.cpp
@@ -35,7 +35,7 @@ void UfopaediaView::eventOccurred(Event *e)
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			menuform->findControl("BUTTON_QUIT")->click();
 			return;
 		}
 	}


### PR DESCRIPTION
Adds missing handling of [Enter] and [KP Enter] to forms with OK buttons.
Additionally unifies handling of form closing hot-keys.

Related to #294.