### PR TITLE
c++20 preparation workarounds

### DIFF
--- a/framework/font.cpp
+++ b/framework/font.cpp
@@ -67,7 +67,7 @@ sp<PaletteImage> BitmapFont::getGlyph(UniChar codepoint)
 		// FIXME: Hack - assume all missing glyphs are spaces
 		// TODO: Fallback fonts?
 		LogWarning("Font %s missing glyph for character \"%s\" (codepoint %u)", this->getName(),
-		           UString(codepoint), codepoint);
+		           UString(codepoint), static_cast<uint32_t>(codepoint));
 		auto missingGlyph = this->getGlyph(UString::u8Char(' '));
 		fontbitmaps.emplace(codepoint, missingGlyph);
 	}

--- a/framework/modinfo.cpp
+++ b/framework/modinfo.cpp
@@ -53,7 +53,7 @@ std::optional<ModInfo> ModInfo::getInfo(const UString &path)
 	{
 		for (const auto node : requiresNode.children("entry"))
 		{
-			info.requires().push_back(node.value());
+			info.requirements().push_back(node.value());
 		}
 	}
 
@@ -84,9 +84,9 @@ bool ModInfo::writeInfo(const UString &path)
 	infoNode.append_child("modloadscript").text() = modLoadScript.cStr();
 
 	auto requiresNode = infoNode.append_child("requires");
-	for (const auto &require : _requires)
+	for (const auto &requirement : _requirements)
 	{
-		requiresNode.append_child("entry").text() = require.cStr();
+		requiresNode.append_child("entry").text() = requirement.cStr();
 	}
 	auto conflictsNode = infoNode.append_child("conflicts");
 	for (const auto &conflict : _conflicts)

--- a/framework/modinfo.h
+++ b/framework/modinfo.h
@@ -14,7 +14,7 @@ class ModInfo
 	UString description;
 	UString link;
 	UString ID;
-	std::list<UString> _requires;
+	std::list<UString> _requirements;
 	std::list<UString> _conflicts;
 	UString dataPath;
 	UString statePath;
@@ -46,8 +46,8 @@ class ModInfo
 	const UString &getID() const { return ID; }
 	void setID(const UString &newID) { ID = newID; }
 	// A list of IDs this mod depends on
-	const std::list<UString> &requires() const { return _requires; }
-	std::list<UString> requires() { return _requires; }
+	const std::list<UString> &requirements() const { return _requirements; }
+	std::list<UString> requirements() { return _requirements; }
 	// A list of IDs this mod is known to not work with
 	const std::list<UString> &conflicts() const { return _conflicts; }
 	std::list<UString> conflicts() { return _conflicts; }

--- a/library/line.h
+++ b/library/line.h
@@ -123,12 +123,12 @@ template <typename T, bool conservative> class LineSegmentIterator
 		return *this;
 	}
 
-	bool operator==(const LineSegmentIterator &other)
+	bool operator==(const LineSegmentIterator &other) const
 	{
 		return (this->point * step == other.point * step);
 	}
 
-	bool operator!=(const LineSegmentIterator &other) { return !(*this == other); }
+	bool operator!=(const LineSegmentIterator &other) const { return !(*this == other); }
 
 	Vec3<T> &operator*() { return point; }
 };

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -466,4 +466,8 @@ bool Strings::isWhiteSpace(UniChar c)
 
 UString Strings::fromU64(uint64_t i) { return format("%llu", i); }
 
+#ifdef __cpp_char8_t
+UString::UString(const char8_t *cstr) : u8Str(reinterpret_cast<const char *>(cstr)) {}
+#endif
+
 }; // namespace OpenApoc

--- a/library/strings.h
+++ b/library/strings.h
@@ -52,6 +52,10 @@ class UString
 	UString();
 	~UString();
 
+#ifdef __cpp_char8_t
+	UString(const char8_t *cstr);
+#endif
+
 	UString(const UString &other);
 	UString &operator=(const UString &other);
 

--- a/tests/test_unicode.cpp
+++ b/tests/test_unicode.cpp
@@ -43,7 +43,8 @@ struct example_unicode
 			{
 				LogError(
 				    "String \"%s\" has unexpected codepoint at index %zu - got 0x%x expected 0x%x",
-				    u8string, i, decoded_codepoints[i], expected_codepoints[i]);
+				    u8string, i, static_cast<uint32_t>(decoded_codepoints[i]),
+				    static_cast<uint32_t>(expected_codepoints[i]));
 				return false;
 			}
 			string2 += decoded_codepoints[i];

--- a/tests/test_unicode.cpp
+++ b/tests/test_unicode.cpp
@@ -11,6 +11,10 @@ struct example_unicode
 
 	example_unicode(const char *str, std::vector<UniChar> codepoints)
 	    : u8string(str), expected_codepoints(codepoints){};
+#ifdef __cpp_char8_t
+	example_unicode(const char8_t *str, std::vector<UniChar> codepoints)
+	    : u8string(reinterpret_cast<const char *>(str)), expected_codepoints(codepoints){};
+#endif
 
 	bool test() const
 	{


### PR DESCRIPTION
This allows us to build with c++20 enabled - the biggest changes are the introduction of char8_t for utf8 character streams, and char32_t and similar no longer being implicitly cast-able to other integer types (As they're meant to be utf32 codepoints, not "numbers")

Note this is a /workaround/ - a long-term solution would be to replace the entire UString type with u8string (as they effectively mean the same thing - "utf8-encoded bytes" - and move the helpers we use to free functions (if they can't be replaced by standard library functions).

Unfortunately, pre-c++20 didn't define all the types (e.g. char8_t being distinct from 'char'), so until we move completely to only even newer c++ versions we probably need some level of hackery.