### PR TITLE
Include <iostream> in logger

### DIFF
--- a/framework/logger.cpp
+++ b/framework/logger.cpp
@@ -3,7 +3,9 @@
 #include "framework/framework.h"
 #include "library/backtrace.h"
 #include "library/sp.h"
+#include <iostream>
 #include <mutex>
+
 namespace OpenApoc
 {
 


### PR DESCRIPTION
This uses std::cerr, so should include iostream. It seems on many stdlib
implementations, this was included by proxy, but not guaranteed (and
seems to break on new libc++ versions)