### PR TITLE
Use fmtlib instead of tinyformat

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "dependencies/lua"]
 	path = dependencies/lua
 	url = https://github.com/lua/lua.git
+[submodule "dependencies/fmt"]
+	path = dependencies/fmt
+	url = https://github.com/fmtlib/fmt.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -17,9 +17,6 @@
 [submodule "dependencies/lodepng"]
 	path = dependencies/lodepng
 	url = https://github.com/lvandeve/lodepng.git
-[submodule "dependencies/tinyformat"]
-	path = dependencies/tinyformat
-	url = https://github.com/c42f/tinyformat.git
 [submodule "dependencies/lua"]
 	path = dependencies/lua
 	url = https://github.com/lua/lua.git

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ The following libraries are also used, but are shipped as submodules in the repo
 * [miniz](https://github.com/richgel999/miniz) - Zlib-comptible compression library.
 * [physfs](https://icculus.org/physfs/) - Library for reading data from .iso files or directory trees (Note: We use a patched version, available on [GitHub](https://github.com/JonnyH/physfs-hg-import/tree/fix-iso) - required to read the .iso files we use).
 * [pugixml](https://pugixml.org) - XML library used for reading/writing the game data files.
-* [tinyformat](https://github.com/c42f/tinyformat) - A c++ typesafe string formatting library.
+* [fmtlib](https://github.com/fmtlib/fmt) - A c++ string formatting library - proposed for c++20 standard.
 
 ### Building on Windows
 

--- a/dependencies/CMakeLists.txt
+++ b/dependencies/CMakeLists.txt
@@ -146,3 +146,5 @@ target_compile_options(OpenApoc_LibPugixml PRIVATE "-w")
 target_compile_options(OpenApoc_LibLodepng PRIVATE "-w")
 target_compile_options(OpenApoc_Miniz PRIVATE "-w")
 target_compile_options(OpenApoc_Lua PRIVATE "-w")
+
+add_subdirectory(fmt)

--- a/framework/sound/sdlraw_backend.cpp
+++ b/framework/sound/sdlraw_backend.cpp
@@ -324,7 +324,7 @@ class SDLRawBackend : public SoundBackend
 			std::lock_guard<std::recursive_mutex> l(this->audio_lock);
 			this->live_samples.emplace_back(sample, gain);
 		}
-		LogInfo("Placed sound %p on queue", sample.get());
+		LogInfo("Placed sound %s on queue", sample->path);
 	}
 
 	void playMusic(std::function<void(void *)> finishedCallback, void *callbackData) override
@@ -343,7 +343,7 @@ class SDLRawBackend : public SoundBackend
 	void setTrack(sp<MusicTrack> track) override
 	{
 		std::lock_guard<std::recursive_mutex> l(this->audio_lock);
-		LogInfo("Setting track to %p", track.get());
+		LogInfo("Setting track to %s", track->path);
 		this->track = track;
 		while (!music_queue.empty())
 			music_queue.pop();

--- a/game/state/battle/battledoor.cpp
+++ b/game/state/battle/battledoor.cpp
@@ -44,7 +44,7 @@ const UString &StateObject<BattleDoor>::getId(const GameState &state, const sp<B
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleDoor matching pointer %p", ptr.get());
+	LogError("No BattleDoor matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -77,7 +77,7 @@ const UString &StateObject<BattleUnit>::getId(const GameState &state, const sp<B
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No battleUnit matching pointer %p", ptr.get());
+	LogError("No battleUnit matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -49,7 +49,7 @@ template <> const UString &StateObject<Base>::getId(const GameState &state, cons
 		if (b.second == ptr)
 			return b.first;
 	}
-	LogError("No base matching pointer %p", ptr.get());
+	LogError("No base matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -76,7 +76,7 @@ const UString &StateObject<Building>::getId(const GameState &state, const sp<Bui
 				return b.first;
 		}
 	}
-	LogError("No building matching pointer %p", ptr.get());
+	LogError("No building matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -773,7 +773,7 @@ template <> const UString &StateObject<City>::getId(const GameState &state, cons
 			return c.first;
 		}
 	}
-	LogError("No city matching pointer %p", ptr.get());
+	LogError("No city matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/research.cpp
+++ b/game/state/city/research.cpp
@@ -182,7 +182,7 @@ const UString &StateObject<ResearchTopic>::getId(const GameState &state,
 		if (r.second == ptr)
 			return r.first;
 	}
-	LogError("No research matching pointer %p", ptr.get());
+	LogError("No research matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 
@@ -216,7 +216,7 @@ template <> const UString &StateObject<Lab>::getId(const GameState &state, const
 		if (l.second == ptr)
 			return l.first;
 	}
-	LogError("No lab matching pointer %p", ptr.get());
+	LogError("No lab matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -87,7 +87,7 @@ const UString &StateObject<Vehicle>::getId(const GameState &state, const sp<Vehi
 		if (v.second == ptr)
 			return v.first;
 	}
-	LogError("No vehicle matching pointer %p", ptr.get());
+	LogError("No vehicle matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/agenttype.cpp
+++ b/game/state/rules/agenttype.cpp
@@ -53,7 +53,7 @@ const UString &StateObject<AgentType>::getId(const GameState &state, const sp<Ag
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", ptr.get());
+	LogError("No agent_type matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 
@@ -90,7 +90,7 @@ const UString &StateObject<AgentBodyType>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", ptr.get());
+	LogError("No agent_type matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 
@@ -128,7 +128,7 @@ const UString &StateObject<AgentEquipmentLayout>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent_type matching pointer %p", ptr.get());
+	LogError("No agent_type matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -117,7 +117,7 @@ const UString &StateObject<BattleMap>::getId(const GameState &state, const sp<Ba
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No battle_map matching pointer %p", ptr.get());
+	LogError("No battle_map matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/battleunitanimationpack.cpp
+++ b/game/state/rules/battle/battleunitanimationpack.cpp
@@ -42,7 +42,7 @@ const UString &StateObject<BattleUnitAnimationPack>::getId(const GameState &stat
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleUnitAnimationPack matching pointer %p", ptr.get());
+	LogError("No BattleUnitAnimationPack matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/battle/battleunitimagepack.cpp
+++ b/game/state/rules/battle/battleunitimagepack.cpp
@@ -40,7 +40,7 @@ const UString &StateObject<BattleUnitImagePack>::getId(const GameState &state,
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No BattleUnitImagePack matching pointer %p", ptr.get());
+	LogError("No BattleUnitImagePack matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/rules/city/vehicletype.cpp
+++ b/game/state/rules/city/vehicletype.cpp
@@ -77,7 +77,7 @@ const UString &StateObject<VehicleType>::getId(const GameState &state, const sp<
 		if (v.second == ptr)
 			return v.first;
 	}
-	LogError("No vehicle type matching pointer %p", ptr.get());
+	LogError("No vehicle type matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -55,7 +55,7 @@ template <> const UString &StateObject<Agent>::getId(const GameState &state, con
 		if (a.second == ptr)
 			return a.first;
 	}
-	LogError("No agent matching pointer %p", ptr.get());
+	LogError("No agent matching pointer %p", static_cast<void *>(ptr.get()));
 	return emptyString;
 }
 

--- a/game/state/tilemap/pathfinding.cpp
+++ b/game/state/tilemap/pathfinding.cpp
@@ -384,7 +384,7 @@ std::list<Vec3<int>> TileMap::findShortestPath(Vec3<int> origin, Vec3<int> desti
 	{
 		if (maxCost > 0.0f)
 		{
-			LogInfo("Could not find path within maxPath, returning closest path ending at %s",
+			LogInfo("Could not find path within maxPath, returning closest path ending at %d",
 			        closestNodeSoFar->thisTile->position.x);
 		}
 		else

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -481,7 +481,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -495,7 +495,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -509,7 +509,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -86,7 +86,7 @@ void ControlGenerator::init(GameState &state [[maybe_unused]])
 	for (int i = 47; i <= 50; i++)
 	{
 		icons.push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%s:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 
@@ -94,7 +94,7 @@ void ControlGenerator::init(GameState &state [[maybe_unused]])
 	for (int i = 51; i <= 63; i++)
 	{
 		vehiclePassengerCountIcons.push_back(fw().data->loadImage(format(
-		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%s:xcom3/ufodata/pal_01.dat",
+		    "PCK:xcom3/ufodata/vs_icon.pck:xcom3/ufodata/vs_icon.tab:%d:xcom3/ufodata/pal_01.dat",
 		    i)));
 	}
 	labelFont = ui().getFont("smalfont");
@@ -534,7 +534,7 @@ sp<Control> ControlGenerator::createLargeAgentControl(GameState &state, const Ag
 	if (skill != UnitSkillState::Hidden)
 	{
 		auto skillLabel = baseControl->createChild<Label>(
-		    format(tr("Skill %s"), info.agent->getSkill()), singleton.labelFont);
+		    format(tr("Skill %d"), info.agent->getSkill()), singleton.labelFont);
 		skillLabel->Tint = {192, 192, 192};
 
 		skillLabel->Size = {nameLabel->Size.x, singleton.labelFont->getFontHeight()};

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -73,9 +73,10 @@ void CheatOptions::updateMultiplierText(UString controlName, float multMin, floa
 {
 	auto bar = menuform->findControlTyped<ScrollBar>(controlName);
 	auto label = menuform->findControlTyped<Label>("TEXT_" + controlName);
-	label->setText(format("%d%%", scaleScrollbarToMultiplier(bar->getValue(), multMin, multMax,
-	                                                         bar->getMinimum(), bar->getMaximum()) *
-	                                  100));
+	label->setText(
+	    format("%.0f%%", scaleScrollbarToMultiplier(bar->getValue(), multMin, multMax,
+	                                                bar->getMinimum(), bar->getMaximum()) *
+	                         100));
 }
 
 void CheatOptions::pause() {}

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(OpenApoc_Library STATIC ${LIBRARY_SOURCE_FILES}
 		${LIBRARY_HEADER_FILES})
 
 target_link_libraries(OpenApoc_Library PUBLIC ${Boost_LIBRARIES}
-		Threads::Threads)
+		Threads::Threads fmt::fmt)
 
 target_include_directories(OpenApoc_Library PUBLIC ${CMAKE_SOURCE_DIR})
 target_include_directories(OpenApoc_Library PUBLIC ${GLM_INCLUDE_DIR})

--- a/library/backtrace.cpp
+++ b/library/backtrace.cpp
@@ -172,7 +172,7 @@ UString win32_backtrace::symbolicate(const void *ip)
 	sym->SizeOfStruct = sizeof(SYMBOL_INFO);
 
 	SymFromAddr(process, (DWORD64)(ip), 0, sym);
-	str = format("  0x%p %s+0x%Ix\n", ip, sym->Name, (uintptr_t)ip - (uintptr_t)sym->Address);
+	str = format("  0x%p %s+0x%x\n", ip, sym->Name, (uintptr_t)ip - (uintptr_t)sym->Address);
 
 	free(sym);
 	return str;

--- a/library/strings.h
+++ b/library/strings.h
@@ -8,7 +8,7 @@
 namespace OpenApoc
 {
 
-typedef char32_t UniChar;
+typedef uint32_t UniChar;
 
 class UString
 {

--- a/library/strings_format.h
+++ b/library/strings_format.h
@@ -1,28 +1,24 @@
 #pragma once
 
-#define TINYFORMAT_USE_VARIADIC_TEMPLATES
-
-#ifdef __GNUC__
-// Tinyformat has a number of non-annotated switch fallthrough cases
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wimplicit-fallthrough"
-#endif
-
-#include "dependencies/tinyformat/tinyformat.h"
-
-#ifdef __GNUC__
-#pragma GCC diagnostic pop
-#endif
-
+#include "fmt/printf.h"
 #include "library/strings.h"
+
 namespace OpenApoc
 {
 
 template <typename... Args> static UString format(const UString &fmt, Args &&... args)
 {
-	return tfm::format(fmt.cStr(), std::forward<Args>(args)...);
+	return fmt::sprintf(fmt.str(), std::forward<Args>(args)...);
 }
 
 UString tr(const UString &str, const UString domain = "ufo_string");
 
 } // namespace OpenApoc
+
+template <> struct fmt::formatter<OpenApoc::UString> : formatter<std::string>
+{
+	template <typename FormatContext> auto format(const OpenApoc::UString &s, FormatContext &ctx)
+	{
+		return formatter<std::string>::format(s.str(), ctx);
+	}
+};


### PR DESCRIPTION
This is a step towards using fmt's new indexed format string API (e.g. "thing: {1} {2}" instead of "thing: %s %s"). Though it still uses the printf-compatible formats for now, at least the fmt library can support both in parallel, allowing us to phase over.

This then is more consistent with boost::locale's formatting API, which is the longterm goal to allow reorder-able translate-able strings in code.

Plus, fmt is proposed to be in c++20 (and accepted - for now :) - so likely to be more 'standard' and 'expected' in c++ going forward (and may even allow us to drop a non-standard-library dependency eventually)