### PR TITLE
Remove UString and just use std::string and std::u32string

### DIFF
--- a/forms/control.cpp
+++ b/forms/control.cpp
@@ -651,7 +651,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 
 			UString widthAttr = child.attribute("width").as_string();
 			// if size ends with % this means that it is special (percentage) size
-			if (Strings::isInteger(widthAttr) && !widthAttr.endsWith("%"))
+			if (Strings::isInteger(widthAttr) && !ends_with(widthAttr, "%"))
 			{
 				Size.x = child.attribute("width").as_int();
 			}
@@ -661,7 +661,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 			}
 			UString heightAttr = child.attribute("height").as_string();
 			// if size ends with % this means that it is special (percentage) size
-			if (Strings::isInteger(heightAttr) && !heightAttr.endsWith("%"))
+			if (Strings::isInteger(heightAttr) && !ends_with(heightAttr, "%"))
 			{
 				Size.y = child.attribute("height").as_int();
 			}
@@ -672,7 +672,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 
 			if (specialsizex != "")
 			{
-				if (specialsizex.str().back() == '%')
+				if (specialsizex.back() == '%')
 				{
 					// Skip % sign at the end
 					auto sizeRatio = Strings::toFloat(specialsizex) / 100.0f;
@@ -687,7 +687,7 @@ void Control::configureSelfFromXml(pugi::xml_node *node)
 
 			if (specialsizey != "")
 			{
-				if (specialsizey.str().back() == '%')
+				if (specialsizey.back() == '%')
 				{
 					auto sizeRatio = Strings::toFloat(specialsizey) / 100.0f;
 					setRelativeHeight(sizeRatio);

--- a/forms/textedit.h
+++ b/forms/textedit.h
@@ -18,11 +18,11 @@ class TextEdit : public Control
   private:
 	bool caretDraw;
 	int caretTimer;
-	UString text;
+	U32String text;
 	UString cursor;
 	sp<BitmapFont> font;
 	bool editing;
-	UString allowedCharacters;
+	U32String allowedCharacters;
 	size_t textMaxLength = std::string::npos;
 	void raiseEvent(FormEventType Type);
 

--- a/forms/ui.cpp
+++ b/forms/ui.cpp
@@ -78,7 +78,7 @@ std::vector<UString> UI::getFormIDs()
 			LogWarning("Unexpected form file prefix for \"%s\"", name);
 			continue;
 		}
-		if (!name.endsWith(".form"))
+		if (!ends_with(name, ".form"))
 		{
 			LogWarning("Unexpected extension on form file \"%s\"", name);
 			continue;

--- a/framework/apocresources/apocfont.cpp
+++ b/framework/apocresources/apocfont.cpp
@@ -58,7 +58,7 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 	int kerning = 0;
 	UString fontName;
 
-	std::map<UniChar, UString> charMap;
+	std::map<char32_t, UString> charMap;
 
 	fontName = fontNode.attribute("name").value();
 	if (fontName.empty())
@@ -104,7 +104,7 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 			continue;
 		}
 
-		auto pointString = boost::locale::conv::utf_to_utf<UniChar>(glyphString.cStr());
+		auto pointString = boost::locale::conv::utf_to_utf<char32_t>(glyphString.c_str());
 
 		if (pointString.length() != 1)
 		{
@@ -113,7 +113,7 @@ sp<BitmapFont> ApocalypseFont::loadFont(const UString &fontDescPath)
 			         fontName, glyphString, pointString.length());
 			continue;
 		}
-		UniChar c = pointString[0];
+		char32_t c = pointString[0];
 
 		if (charMap.find(c) != charMap.end())
 		{

--- a/framework/apocresources/apocfont.h
+++ b/framework/apocresources/apocfont.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "library/sp.h"
+#include "library/strings.h"
 
 namespace pugi
 {
@@ -10,7 +11,6 @@ class xml_node;
 namespace OpenApoc
 {
 
-class UString;
 class BitmapFont;
 
 class ApocalypseFont

--- a/framework/apocresources/apocpalette.cpp
+++ b/framework/apocresources/apocpalette.cpp
@@ -67,7 +67,7 @@ static_assert(sizeof(struct PcxHeader) == 128, "PcxHeader unexpected size");
 sp<Palette> loadPCXPalette(Data &data, const UString fileName)
 {
 	auto length = fileName.length();
-	if (length < 4 || fileName.substr(length - 4, 4).toUpper() != ".PCX")
+	if (length < 4 || to_upper(fileName.substr(length - 4, 4)) != ".PCX")
 	{
 		LogInfo("Skipping file \"%s\" as it doesn't look like a .pcx", fileName);
 		return nullptr;

--- a/framework/apocresources/pck.h
+++ b/framework/apocresources/pck.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "library/sp.h"
+#include "library/strings.h"
 
 namespace OpenApoc
 {
 
 class Data;
 class ImageSet;
-class UString;
 
 class PCKLoader
 {

--- a/framework/apocresources/rawimage.h
+++ b/framework/apocresources/rawimage.h
@@ -1,13 +1,13 @@
 #pragma once
 
 #include "library/sp.h"
+#include "library/strings.h"
 #include "library/vec.h"
 
 namespace OpenApoc
 {
 
 class Data;
-class UString;
 class PaletteImage;
 class ImageSet;
 

--- a/framework/data.cpp
+++ b/framework/data.cpp
@@ -196,7 +196,7 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 	sp<VoxelSlice> slice;
 	if (path.substr(0, 9) == "LOFTEMPS:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		// "LOFTEMPS:DATFILE:TABFILE:INDEX"
 		//  or
 		// "LOFTEMPS:DATFILE:TABFILE:INDEX:X:Y"
@@ -207,7 +207,7 @@ sp<VoxelSlice> DataImpl::loadVoxelSlice(const UString &path)
 		}
 		// Cut off the index to get the LOFTemps file
 		UString cacheKey = splitString[0] + splitString[1] + splitString[2];
-		cacheKey = cacheKey.toUpper();
+		cacheKey = to_upper(cacheKey);
 		sp<LOFTemps> lofTemps = this->LOFVoxelCache[cacheKey].lock();
 		if (!lofTemps)
 		{
@@ -278,7 +278,7 @@ sp<ImageSet> DataImpl::loadImageSet(const UString &path)
 		return this->loadImageSet(alias->second);
 	}
 
-	UString cacheKey = path.toUpper();
+	UString cacheKey = to_upper(path);
 	sp<ImageSet> imgSet = this->imageSetCache[cacheKey].lock();
 	if (imgSet)
 	{
@@ -288,7 +288,7 @@ sp<ImageSet> DataImpl::loadImageSet(const UString &path)
 	//"RAW:PATH:WIDTH:HEIGHT[:optional/ignored]"
 	if (path.substr(0, 4) == "RAW:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		imgSet = RawImage::loadSet(
 		    *this, splitString[1],
 		    Vec2<int>{Strings::toInteger(splitString[2]), Strings::toInteger(splitString[3])});
@@ -297,17 +297,17 @@ sp<ImageSet> DataImpl::loadImageSet(const UString &path)
 	//"PCK:PCKFILE:TABFILE[:optional/ignored]"
 	else if (path.substr(0, 4) == "PCK:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		imgSet = PCKLoader::load(*this, splitString[1], splitString[2]);
 	}
 	else if (path.substr(0, 9) == "PCKSTRAT:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		imgSet = PCKLoader::loadStrat(*this, splitString[1], splitString[2]);
 	}
 	else if (path.substr(0, 10) == "PCKSHADOW:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		imgSet = PCKLoader::loadShadow(*this, splitString[1], splitString[2]);
 	}
 	else
@@ -335,7 +335,7 @@ sp<Sample> DataImpl::loadSample(UString path)
 		return this->loadSample(alias->second);
 	}
 
-	UString cacheKey = path.toUpper();
+	UString cacheKey = to_upper(path);
 	sp<Sample> sample = this->sampleCache[cacheKey].lock();
 	if (sample)
 		return sample;
@@ -396,7 +396,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 	}
 
 	// Use an uppercase version of the path for the cache key
-	UString cacheKey = path.toUpper();
+	UString cacheKey = to_upper(path);
 	sp<Image> img;
 	// Don't cache lazy loading image wrappers, the image data when really loaded will go through
 	// the cache as normal, but we don't want to think we've loaded an image when it's just a lazy
@@ -418,7 +418,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 	}
 	else if (path.substr(0, 4) == "RAW:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		// Raw resources come in the format:
 		//"RAW:PATH:WIDTH:HEIGHT[:PALETTE]"
 		// or
@@ -472,7 +472,8 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 	}
 	else if (path.substr(0, 4) == "PCK:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
+
 		if (splitString.size() != 3 && splitString.size() != 4 && splitString.size() != 5)
 		{
 			LogError("Invalid PCK resource string: \"%s\"", path);
@@ -517,7 +518,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 	}
 	else if (path.substr(0, 9) == "PCKSTRAT:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		if (splitString.size() != 3 && splitString.size() != 4 && splitString.size() != 5)
 		{
 			LogError("Invalid PCKSTRAT resource string: \"%s\"", path);
@@ -557,7 +558,7 @@ sp<Image> DataImpl::loadImage(const UString &path, bool lazy)
 	}
 	else if (path.substr(0, 10) == "PCKSHADOW:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		if (splitString.size() != 3 && splitString.size() != 4 && splitString.size() != 5)
 		{
 			LogError("Invalid PCKSHADOW resource string: \"%s\"", path);
@@ -673,7 +674,7 @@ sp<Palette> DataImpl::loadPalette(const UString &path)
 	}
 
 	// Use an uppercase version of the path for the cache key
-	UString cacheKey = path.toUpper();
+	UString cacheKey = to_upper(path);
 
 	auto pal = this->paletteCache[cacheKey].lock();
 	if (pal)
@@ -740,7 +741,7 @@ sp<Video> DataImpl::loadVideo(const UString &path)
 
 	if (path.substr(0, 4) == "SMK:")
 	{
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		if (splitString.size() != 2)
 		{
 			LogError("Invalid SMK string: \"%s\"", path);
@@ -760,7 +761,7 @@ sp<Video> DataImpl::loadVideo(const UString &path)
 
 bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palette)
 {
-	auto outPath = fs::path(systemPath.str());
+	auto outPath = fs::path(systemPath);
 	auto outDir = outPath.parent_path();
 	if (!outDir.empty())
 	{
@@ -782,7 +783,7 @@ bool DataImpl::writeImage(UString systemPath, sp<Image> image, sp<Palette> palet
 			return false;
 		}
 	}
-	std::ofstream outFile(systemPath.str(), std::ios::binary);
+	std::ofstream outFile(systemPath, std::ios::binary);
 	if (!outFile)
 	{
 		LogWarning("Failed to open \"%s\" for writing", systemPath);

--- a/framework/data.h
+++ b/framework/data.h
@@ -2,6 +2,7 @@
 
 #include "framework/fs.h"
 #include "library/sp.h"
+#include "library/strings.h"
 #include <vector>
 
 namespace OpenApoc
@@ -16,7 +17,6 @@ class Palette;
 class VoxelSlice;
 class Video;
 class PaletteImage;
-class UString;
 
 class Data
 {

--- a/framework/font.cpp
+++ b/framework/font.cpp
@@ -21,7 +21,9 @@ sp<PaletteImage> BitmapFont::getString(const UString &Text)
 
 	img = mksp<PaletteImage>(Vec2<int>{width, height});
 
-	for (const auto &c : Text)
+	auto u32Text = to_u32string(Text);
+
+	for (const auto &c : u32Text)
 	{
 		auto glyph = this->getGlyph(c);
 		PaletteImage::blit(glyph, img, {0, 0}, {pos, 0});
@@ -37,7 +39,9 @@ int BitmapFont::getFontWidth(const UString &Text)
 {
 	int textlen = 0;
 
-	for (const auto &c : Text)
+	auto u32Text = to_u32string(Text);
+
+	for (const auto &c : u32Text)
 	{
 		auto glyph = this->getGlyph(c);
 		textlen += glyph->size.x;
@@ -60,15 +64,15 @@ int BitmapFont::getEstimateCharacters(int FitInWidth) const
 	return FitInWidth / averagecharacterwidth;
 }
 
-sp<PaletteImage> BitmapFont::getGlyph(UniChar codepoint)
+sp<PaletteImage> BitmapFont::getGlyph(char32_t codepoint)
 {
 	if (fontbitmaps.find(codepoint) == fontbitmaps.end())
 	{
 		// FIXME: Hack - assume all missing glyphs are spaces
 		// TODO: Fallback fonts?
 		LogWarning("Font %s missing glyph for character \"%s\" (codepoint %u)", this->getName(),
-		           UString(codepoint), static_cast<uint32_t>(codepoint));
-		auto missingGlyph = this->getGlyph(UString::u8Char(' '));
+		           to_ustring(std::u32string(1, codepoint)), static_cast<uint32_t>(codepoint));
+		auto missingGlyph = this->getGlyph(to_char32(' '));
 		fontbitmaps.emplace(codepoint, missingGlyph);
 	}
 	return fontbitmaps[codepoint];
@@ -76,7 +80,7 @@ sp<PaletteImage> BitmapFont::getGlyph(UniChar codepoint)
 
 sp<Palette> BitmapFont::getPalette() const { return this->palette; }
 
-sp<BitmapFont> BitmapFont::loadFont(const std::map<UniChar, UString> &glyphMap, int spaceWidth,
+sp<BitmapFont> BitmapFont::loadFont(const std::map<char32_t, UString> &glyphMap, int spaceWidth,
                                     int fontHeight, int kerning, UString fontName,
                                     sp<Palette> defaultPalette)
 {
@@ -136,7 +140,7 @@ sp<BitmapFont> BitmapFont::loadFont(const std::map<UniChar, UString> &glyphMap, 
 	// Always add a 'space' image:
 
 	auto spaceImage = mksp<PaletteImage>(Vec2<int>{spaceWidth, fontHeight});
-	font->fontbitmaps[UString::u8Char(' ')] = spaceImage;
+	font->fontbitmaps[to_char32(' ')] = spaceImage;
 
 	return font;
 }
@@ -144,16 +148,18 @@ sp<BitmapFont> BitmapFont::loadFont(const std::map<UniChar, UString> &glyphMap, 
 std::list<UString> BitmapFont::wordWrapText(const UString &Text, int MaxWidth)
 {
 	int txtwidth;
-	std::list<UString> lines = Text.splitlist("\n");
+	auto lines = split(Text, "\n");
 	std::list<UString> wrappedLines;
 
-	for (UString str : lines)
+	for (const UString &str : lines)
 	{
 		txtwidth = getFontWidth(str);
 
 		if (txtwidth > MaxWidth)
 		{
-			auto remainingChunks = str.splitlist(" ");
+			auto remainingChunksVector = split(str, " ");
+			auto remainingChunks =
+			    std::list<UString>(remainingChunksVector.begin(), remainingChunksVector.end());
 			UString currentLine;
 
 			while (!remainingChunks.empty())

--- a/framework/font.h
+++ b/framework/font.h
@@ -17,13 +17,13 @@ class BitmapFont
 	int fontheight;
 	int averagecharacterwidth;
 	int kerning;
-	std::map<UniChar, sp<PaletteImage>> fontbitmaps;
+	std::map<char32_t, sp<PaletteImage>> fontbitmaps;
 	UString name;
 	sp<Palette> palette;
 
   public:
 	virtual ~BitmapFont();
-	virtual sp<PaletteImage> getGlyph(UniChar codepoint);
+	virtual sp<PaletteImage> getGlyph(char32_t codepoint);
 	virtual sp<PaletteImage> getString(const UString &Text);
 	virtual int getFontWidth(const UString &Text);
 	virtual int getFontHeight() const;
@@ -34,7 +34,7 @@ class BitmapFont
 	std::list<UString> wordWrapText(const UString &Text, int MaxWidth);
 
 	/* Reads in set of "Character":"glyph description string" pairs */
-	static sp<BitmapFont> loadFont(const std::map<UniChar, UString> &charMap, int spaceWidth,
+	static sp<BitmapFont> loadFont(const std::map<char32_t, UString> &charMap, int spaceWidth,
 	                               int fontHeight, int kerning, UString fontName,
 	                               sp<Palette> defaultPalette);
 };

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -253,7 +253,7 @@ Framework::Framework(const UString programName, bool createWindow)
 
 	if (!PHYSFS_isInit())
 	{
-		if (PHYSFS_init(programName.cStr()) == 0)
+		if (PHYSFS_init(programName.c_str()) == 0)
 		{
 			PHYSFS_ErrorCode error = PHYSFS_getLastErrorCode();
 			LogError("Failed to init code %i PHYSFS: %s", (int)error, PHYSFS_getErrorByCode(error));
@@ -293,7 +293,7 @@ Framework::Framework(const UString programName, bool createWindow)
 
 	logPath += "/log.txt";
 
-	enableFileLogger(logPath.cStr());
+	enableFileLogger(logPath.c_str());
 
 	Options::dumpOptionsToLog();
 
@@ -317,17 +317,17 @@ Framework::Framework(const UString programName, bool createWindow)
 	{
 		auto langPath = path + "/languages";
 		LogInfo("Adding \"%s\" to language path", langPath);
-		gen.add_messages_path(langPath.str());
+		gen.add_messages_path(langPath);
 	}
 
 	std::vector<UString> translationDomains = {"paedia_string", "ufo_string"};
 	for (auto &domain : translationDomains)
 	{
 		LogInfo("Adding \"%s\" to translation domains", domain);
-		gen.add_messages_domain(domain.str());
+		gen.add_messages_domain(domain);
 	}
 
-	std::locale loc = gen(desiredLanguageName.str());
+	std::locale loc = gen(desiredLanguageName);
 	std::locale::global(loc);
 
 	auto localeName = std::use_facet<boost::locale::info>(loc).name();
@@ -559,7 +559,7 @@ void Framework::processEvents()
 				{
 					screenshotName = format("screenshot%03d.png", screenshotId);
 					screenshotId++;
-				} while (fs::exists(fs::path(screenshotName.str())));
+				} while (fs::exists(fs::path(screenshotName)));
 				LogWarning("Writing screenshot to \"%s\"", screenshotName);
 				if (!p->defaultSurface->rendererPrivateData)
 				{
@@ -930,7 +930,7 @@ void Framework::displayInitialise()
 	p->registeredRenderers["GL_2_0"].reset(getGL20RendererFactory());
 #endif
 
-	for (auto &rendererName : Options::renderersOption.get().split(':'))
+	for (auto &rendererName : split(Options::renderersOption.get(), ":"))
 	{
 		auto rendererFactory = p->registeredRenderers.find(rendererName);
 		if (rendererFactory == p->registeredRenderers.end())
@@ -1022,7 +1022,7 @@ void Framework::displaySetTitle(UString NewTitle)
 {
 	if (p->window)
 	{
-		SDL_SetWindowTitle(p->window, NewTitle.cStr());
+		SDL_SetWindowTitle(p->window, NewTitle.c_str());
 	}
 }
 
@@ -1057,7 +1057,7 @@ void Framework::audioInitialise()
 	p->registeredSoundBackends["SDLRaw"].reset(getSDLSoundBackend());
 	p->registeredSoundBackends["null"].reset(getNullSoundBackend());
 
-	for (auto &soundBackendName : Options::audioBackendsOption.get().split(':'))
+	for (auto &soundBackendName : split(Options::audioBackendsOption.get(), ":"))
 	{
 		auto backendFactory = p->registeredSoundBackends.find(soundBackendName);
 		if (backendFactory == p->registeredSoundBackends.end())
@@ -1174,7 +1174,7 @@ void *Framework::getWindowHandle() const { return static_cast<void *>(p->window)
 
 void Framework::setupModDataPaths()
 {
-	auto mods = Options::modList.get().split(":");
+	auto mods = split(Options::modList.get(), ":");
 	for (const auto &modString : mods)
 	{
 		LogWarning("loading mod \"%s\"", modString);

--- a/framework/fs/physfs_archiver_cue.cpp
+++ b/framework/fs/physfs_archiver_cue.cpp
@@ -75,7 +75,7 @@ class CueParser
 	{
 		// Waiting for "FILE" command
 		UString cmd(command);
-		if (cmd.toUpper() != "FILE")
+		if (to_upper(cmd) != "FILE")
 		{
 			LogInfo("Encountered unexpected command: \"%s\", ignoring", cmd);
 			return false;
@@ -141,7 +141,7 @@ class CueParser
 
 		UString fileTypeStr(std::string(arg, first_char, last_char - first_char + 1));
 
-		if (fileTypeStr.toUpper() != "BINARY")
+		if (to_upper(fileTypeStr) != "BINARY")
 		{
 			LogError("Unsupported file type: \"%s\"", fileTypeStr);
 			parserState = PARSER_ERROR;
@@ -156,7 +156,7 @@ class CueParser
 	{
 		// Waiting for the "TRACK" command
 		UString cmd(command);
-		if (cmd.toUpper() != "TRACK")
+		if (to_upper(cmd) != "TRACK")
 		{
 			// According to
 			// https://www.gnu.org/software/ccd2cue/manual/html_node/FILE-_0028CUE-Command_0029.html#FILE-_0028CUE-Command_0029
@@ -198,7 +198,7 @@ class CueParser
 		}
 		UString modeStr(std::string(arg, first_char, last_char - first_char + 1));
 		trackMode = CueTrackMode::MODE_UNDEFINED;
-		modeStr = modeStr.toUpper();
+		modeStr = to_upper(modeStr);
 		if (modeStr == "MODE1/2048")
 			trackMode = CueTrackMode::MODE1_2048;
 		else if (modeStr == "MODE1/2352")
@@ -226,7 +226,7 @@ class CueParser
 		UString cmd(command);
 		// TODO: check for possible commands, put parser into an "error" state if command is not
 		// valid
-		if (cmd.toUpper() != "INDEX")
+		if (to_upper(cmd) != "INDEX")
 		{
 			LogInfo("Encountered unexpected/unknown command: \"%s\", ignoring", cmd);
 			return false;
@@ -237,9 +237,9 @@ class CueParser
 
 	bool parse(UString cueFilename)
 	{
-		fs::path cueFilePath(cueFilename.cStr());
+		fs::path cueFilePath(cueFilename.c_str());
 
-		std::ifstream cueFile(cueFilename.str(), std::ios::in);
+		std::ifstream cueFile(cueFilename, std::ios::in);
 		if (!cueFile)
 		{
 			// Stream is unusable, bail out
@@ -465,7 +465,7 @@ class CueIO
 	    : imageFile(fileName), lbaStart(lbaStart), lbaCurrent(lbaStart), posInLba(0),
 	      length(length), fileType(fileType), trackMode(trackMode)
 	{
-		fileStream.open(fileName.str(), std::ios::in | std::ios::binary);
+		fileStream.open(fileName, std::ios::in | std::ios::binary);
 		fileStream.seekg(lbaToByteOffset(lbaStart));
 	}
 
@@ -654,7 +654,7 @@ class CueIO
 	      posInLba(other.posInLba), length(other.length), fileType(other.fileType),
 	      trackMode(other.trackMode)
 	{
-		fileStream.open(imageFile.str(), std::ios::in | std::ios::binary);
+		fileStream.open(imageFile, std::ios::in | std::ios::binary);
 		fileStream.seekg(lbaToByteOffset(lbaStart) + posInLba);
 	}
 
@@ -872,7 +872,7 @@ class CueArchiver
 		} // Ignore the semicolon and everything after it
 		parent.name = dirRecord.fileName;
 		// As of commit 07a2fe9, we only use lower-case names
-		parent.name = parent.name.toLower();
+		parent.name = to_lower(parent.name);
 		parent.length = length;
 		parent.offset = location;
 		parent.timestamp = d_datetime.toUnixTime();
@@ -955,7 +955,7 @@ class CueArchiver
 	    : imageFile(fileName), fileType(ftype), trackMode(tmode)
 	{
 		// "Hey, a .cue-.bin file pair should be really easy to read!" - sfalexrog, 15.04.2016
-		fs::path filePath(fileName.cStr());
+		fs::path filePath(fileName.c_str());
 		// FIXME: This fsize is completely and utterly wrong - unless you're reading an actual iso
 		// (mode1_2048)
 		uint64_t fsize = fs::file_size(filePath);
@@ -991,7 +991,7 @@ class CueArchiver
 		UString dname = name;
 		if (dname.length() > 0)
 		{
-			auto pathParts = dname.split("/");
+			auto pathParts = split(dname, "/");
 			for (auto ppart = pathParts.begin(); ppart != pathParts.end(); ppart++)
 			{
 				auto subdir = current->children.find(*ppart);
@@ -1018,7 +1018,7 @@ class CueArchiver
 		{
 			for (auto entry = current->children.begin(); entry != current->children.end(); entry++)
 			{
-				auto ret = cb(callbackdata, origdir, entry->first.cStr());
+				auto ret = cb(callbackdata, origdir, entry->first.c_str());
 				switch (ret)
 				{
 					case PHYSFS_ENUM_ERROR:
@@ -1106,7 +1106,7 @@ class CueArchiver
 		fs::path cueFilePath(filename);
 
 		fs::path dataFilePath(cueFilePath.parent_path()); // parser.getDataFileName());
-		dataFilePath /= parser.getDataFileName().cStr();
+		dataFilePath /= parser.getDataFileName().c_str();
 
 		if (!fs::exists(dataFilePath))
 		{
@@ -1114,7 +1114,7 @@ class CueArchiver
 			           parser.getDataFileName());
 			LogWarning("Trying case-insensitive search...");
 			UString ucBin(parser.getDataFileName());
-			ucBin = ucBin.toLower();
+			ucBin = to_lower(ucBin);
 			// for (fs::directory_entry &dirent :
 			// fs::directory_iterator(cueFilePath.parent_path()))
 			for (auto dirent_it = fs::directory_iterator(cueFilePath.parent_path());
@@ -1123,7 +1123,7 @@ class CueArchiver
 				auto dirent = *dirent_it;
 				LogInfo("Trying %s", dirent.path().string());
 				UString ucDirent(dirent.path().filename().string());
-				ucDirent = ucDirent.toLower();
+				ucDirent = to_lower(ucDirent);
 				if (ucDirent == ucBin)
 				{
 					dataFilePath = cueFilePath.parent_path();

--- a/framework/logger_sdldialog.cpp
+++ b/framework/logger_sdldialog.cpp
@@ -25,7 +25,7 @@ void SDLDialogLogFunction(LogLevel level, UString prefix, const UString &text)
 		return;
 	}
 	auto message = OpenApoc::format("%s: %s", prefix, text);
-	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenApoc error", message.cStr(), parentWindow);
+	SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "OpenApoc error", message.c_str(), parentWindow);
 }
 
 } // namespace

--- a/framework/luaframework.cpp
+++ b/framework/luaframework.cpp
@@ -27,12 +27,6 @@ void getFromLua(lua_State *L, int argNum, UString &v)
 	const char *buf = luaL_checklstring(L, argNum, &len);
 	v = UString(buf, len);
 }
-void getFromLua(lua_State *L, int argNum, std::string &v)
-{
-	size_t len;
-	const char *buf = luaL_checklstring(L, argNum, &len);
-	v = std::string(buf, len);
-}
 // note: constructing a new sp from the underlying object type is UB
 // so we get these resources from lua through a string
 void getFromLua(lua_State *L, int argNum, sp<Image> &v)
@@ -48,9 +42,8 @@ void getFromLua(lua_State *L, int argNum, sp<Sample> &v)
 	v = fw().data->loadSample(path);
 }
 
-void pushToLua(lua_State *L, const UString &v) { lua_pushlstring(L, v.cStr(), v.cStrLength()); }
+void pushToLua(lua_State *L, const UString &v) { lua_pushlstring(L, v.c_str(), v.length()); }
 void pushToLua(lua_State *L, const char *v) { lua_pushstring(L, v); }
-void pushToLua(lua_State *L, const std::string &v) { lua_pushlstring(L, v.c_str(), v.size()); }
 void pushToLua(lua_State *L, bool v) { lua_pushboolean(L, v); }
 void pushToLua(lua_State *L, int v) { lua_pushinteger(L, v); }
 void pushToLua(lua_State *L, unsigned int v) { lua_pushinteger(L, v); }

--- a/framework/modinfo.cpp
+++ b/framework/modinfo.cpp
@@ -23,7 +23,7 @@ std::optional<ModInfo> ModInfo::getInfo(const UString &path)
 	ModInfo info;
 
 	auto filePath = path + "/modinfo.xml";
-	auto parseResult = doc.load_file(filePath.cStr());
+	auto parseResult = doc.load_file(filePath.c_str());
 	if (!parseResult)
 	{
 		LogWarning("Failed to parse ModInfo at \"%s\": %s at offset %u", filePath,
@@ -72,30 +72,30 @@ bool ModInfo::writeInfo(const UString &path)
 {
 	xml_document doc;
 	auto infoNode = doc.append_child("openapoc_modinfo");
-	infoNode.append_child("name").text() = name.cStr();
-	infoNode.append_child("author").text() = author.cStr();
-	infoNode.append_child("version").text() = version.cStr();
-	infoNode.append_child("description").text() = description.cStr();
-	infoNode.append_child("link").text() = link.cStr();
-	infoNode.append_child("id").text() = ID.cStr();
-	infoNode.append_child("datapath").text() = dataPath.cStr();
-	infoNode.append_child("statepath").text() = statePath.cStr();
-	infoNode.append_child("minversion").text() = minVersion.cStr();
-	infoNode.append_child("modloadscript").text() = modLoadScript.cStr();
+	infoNode.append_child("name").text() = name.c_str();
+	infoNode.append_child("author").text() = author.c_str();
+	infoNode.append_child("version").text() = version.c_str();
+	infoNode.append_child("description").text() = description.c_str();
+	infoNode.append_child("link").text() = link.c_str();
+	infoNode.append_child("id").text() = ID.c_str();
+	infoNode.append_child("datapath").text() = dataPath.c_str();
+	infoNode.append_child("statepath").text() = statePath.c_str();
+	infoNode.append_child("minversion").text() = minVersion.c_str();
+	infoNode.append_child("modloadscript").text() = modLoadScript.c_str();
 
 	auto requiresNode = infoNode.append_child("requires");
 	for (const auto &requirement : _requirements)
 	{
-		requiresNode.append_child("entry").text() = requirement.cStr();
+		requiresNode.append_child("entry").text() = requirement.c_str();
 	}
 	auto conflictsNode = infoNode.append_child("conflicts");
 	for (const auto &conflict : _conflicts)
 	{
-		conflictsNode.append_child("entry").text() = conflict.cStr();
+		conflictsNode.append_child("entry").text() = conflict.c_str();
 	}
 
 	auto filePath = path + "/modinfo.xml";
-	auto saveResult = doc.save_file(filePath.cStr());
+	auto saveResult = doc.save_file(filePath.c_str());
 	if (!saveResult)
 	{
 		LogWarning("Failed to save ModInfo to \"%s\"", filePath);

--- a/framework/musicloader/music.cpp
+++ b/framework/musicloader/music.cpp
@@ -130,7 +130,7 @@ class RawMusicLoader : public MusicLoader
 
 	sp<MusicTrack> loadMusic(UString path) override
 	{
-		auto strings = path.split(':');
+		auto strings = split(path, ":");
 		if (strings.size() != 2)
 		{
 			LogInfo("Invalid raw music path string \"%s\"", path);

--- a/framework/physfs_fs.cpp
+++ b/framework/physfs_fs.cpp
@@ -50,14 +50,14 @@ class PhysfsIFileImpl : public std::streambuf, public IFileImpl
 	PhysfsIFileImpl(const UString &path, size_t bufferSize = 512)
 	    : bufferSize(bufferSize), buffer(new char[bufferSize]), suppliedPath(path)
 	{
-		file = PHYSFS_openRead(path.cStr());
+		file = PHYSFS_openRead(path.c_str());
 		if (!file)
 		{
 			LogError("Failed to open file \"%s\" : \"%s\"", path,
 			         PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 			return;
 		}
-		systemPath = PHYSFS_getRealDir(path.cStr());
+		systemPath = PHYSFS_getRealDir(path.c_str());
 		systemPath += "/" + path;
 	}
 	~PhysfsIFileImpl() override
@@ -222,7 +222,7 @@ IFile::~IFile() = default;
 
 bool FileSystem::addPath(const UString &newPath)
 {
-	if (!PHYSFS_mount(newPath.cStr(), "/", 0))
+	if (!PHYSFS_mount(newPath.c_str(), "/", 0))
 	{
 		LogInfo("Failed to add resource dir \"%s\", error: %s", newPath,
 		        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
@@ -231,7 +231,7 @@ bool FileSystem::addPath(const UString &newPath)
 	else
 	{
 		LogInfo("Resource dir \"%s\" mounted to \"%s\"", newPath,
-		        PHYSFS_getMountPoint(newPath.cStr()));
+		        PHYSFS_getMountPoint(newPath.c_str()));
 		return true;
 	}
 }
@@ -245,14 +245,14 @@ FileSystem::FileSystem(std::vector<UString> paths)
 	// searched)
 	for (auto &p : paths)
 	{
-		if (!PHYSFS_mount(p.cStr(), "/", 0))
+		if (!PHYSFS_mount(p.c_str(), "/", 0))
 		{
 			LogInfo("Failed to add resource dir \"%s\", error: %s", p,
 			        PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
 			continue;
 		}
 		else
-			LogInfo("Resource dir \"%s\" mounted to \"%s\"", p, PHYSFS_getMountPoint(p.cStr()));
+			LogInfo("Resource dir \"%s\" mounted to \"%s\"", p, PHYSFS_getMountPoint(p.c_str()));
 	}
 	auto current_path = fs::current_path();
 	auto canonical_current_path = fs::canonical(current_path);
@@ -269,9 +269,9 @@ FileSystem::FileSystem(std::vector<UString> paths)
 
 	this->writeDir = PHYSFS_getPrefDir(PROGRAM_ORGANISATION, PROGRAM_NAME);
 	LogInfo("Setting write directory to \"%s\"", this->writeDir);
-	PHYSFS_setWriteDir(this->writeDir.cStr());
+	PHYSFS_setWriteDir(this->writeDir.c_str());
 	// Finally, the write directory trumps all
-	PHYSFS_mount(this->writeDir.cStr(), "/", 0);
+	PHYSFS_mount(this->writeDir.c_str(), "/", 0);
 }
 
 FileSystem::~FileSystem() = default;
@@ -280,13 +280,13 @@ IFile FileSystem::open(const UString &path) const
 {
 	IFile f;
 
-	auto lowerPath = path.toLower();
+	auto lowerPath = to_lower(path);
 	if (path != lowerPath)
 	{
 		LogError("Path \"%s\" contains CAPITAL - cut it out!", path);
 	}
 
-	if (!PHYSFS_exists(path.cStr()))
+	if (!PHYSFS_exists(path.c_str()))
 	{
 		LogInfo("Failed to find \"%s\"", path);
 		LogAssert(!f);
@@ -304,7 +304,7 @@ std::list<UString> FileSystem::enumerateDirectory(const UString &basePath,
 	std::list<UString> result;
 	bool filterByExtension = !extension.empty();
 
-	char **elements = PHYSFS_enumerateFiles(basePath.cStr());
+	char **elements = PHYSFS_enumerateFiles(basePath.c_str());
 	for (char **element = elements; *element != NULL; element++)
 	{
 		if (!filterByExtension)
@@ -314,7 +314,7 @@ std::list<UString> FileSystem::enumerateDirectory(const UString &basePath,
 		else
 		{
 			const UString elementString = (*element);
-			if (elementString.endsWith(extension))
+			if (ends_with(elementString, extension))
 			{
 				result.push_back(elementString);
 			}
@@ -331,7 +331,7 @@ static std::list<UString> recursiveFindFilesInDirectory(const FileSystem &fs, US
 	auto list = fs.enumerateDirectory(path, "");
 	for (auto &entry : list)
 	{
-		if (entry.endsWith(extension))
+		if (ends_with(entry, extension))
 		{
 			foundFiles.push_back(path + "/" + entry);
 		}
@@ -352,7 +352,7 @@ std::list<UString> FileSystem::enumerateDirectoryRecursive(const UString &basePa
 
 UString FileSystem::resolvePath(const UString &path) const
 {
-	UString realDir = PHYSFS_getRealDir(path.cStr());
+	UString realDir = PHYSFS_getRealDir(path.c_str());
 	return realDir + "/" + path;
 }
 

--- a/framework/render/gl20/ogl_2_0_renderer.cpp
+++ b/framework/render/gl20/ogl_2_0_renderer.cpp
@@ -34,7 +34,7 @@ class Program
 	static GLuint createShader(GLenum type, const UString source)
 	{
 		GLuint shader = gl20::CreateShader(type);
-		auto sourceString = source.str();
+		auto sourceString = source;
 		const GLchar *string = sourceString.c_str();
 		GLint stringLength = sourceString.length();
 		gl20::ShaderSource(shader, 1, &string, &stringLength);

--- a/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
+++ b/framework/render/gles30_v2/ogles_3_0_renderer_v2.cpp
@@ -45,7 +45,7 @@ static const auto SCRATCH_TEX_SLOT = GL::TEXTURE3;
 GL::GLuint CreateShader(GL::GLenum type, const UString &source)
 {
 	GL::GLuint shader = gl->CreateShader(type);
-	auto sourceString = source.str();
+	auto sourceString = source;
 	const GL::GLchar *string = sourceString.c_str();
 	GL::GLint stringLength = sourceString.length();
 	gl->ShaderSource(shader, 1, &string, &stringLength);

--- a/framework/sampleloader/rawsound.cpp
+++ b/framework/sampleloader/rawsound.cpp
@@ -27,7 +27,7 @@ class RawSampleLoader : public SampleLoader
 		// RAWSOUND:FILENAME:SAMPLERATE
 		// They are all assumed to be PCK_UINT8 1channel
 
-		auto splitString = path.split(':');
+		auto splitString = split(path, ":");
 		if (splitString.size() != 3)
 		{
 			LogInfo("String \"%s\" doesn't look like a rawsample - need 3 elements (got %zu)", path,

--- a/framework/sampleloader/wavsound.cpp
+++ b/framework/sampleloader/wavsound.cpp
@@ -37,7 +37,7 @@ class WavSampleLoader : public SampleLoader
 		// WAV:FILENAME
 		// They are all assumed to be PCK_UINT8 1channel
 
-		const auto splitString = path.split(':');
+		const auto splitString = split(path, ":");
 		if (splitString.size() != 2)
 		{
 			LogInfo("String \"%s\" doesn't look like a rawsample - need 2 elements (got %zu)", path,
@@ -63,7 +63,7 @@ class WavSampleLoader : public SampleLoader
 		uint8_t *buf;
 		uint32_t bufSize;
 
-		const auto *returnedSpec = SDL_LoadWAV(fullPath.cStr(), &spec, &buf, &bufSize);
+		const auto *returnedSpec = SDL_LoadWAV(fullPath.c_str(), &spec, &buf, &bufSize);
 		if (returnedSpec == nullptr)
 		{
 			LogWarning("Failed to open WAV file at \"%s\" - \"%s\"", fullPath, SDL_GetError());

--- a/framework/serialization/providers/filedataprovider.cpp
+++ b/framework/serialization/providers/filedataprovider.cpp
@@ -10,7 +10,7 @@ namespace OpenApoc
 bool FileDataProvider::openArchive(const UString &path, bool write)
 {
 	archivePath = path;
-	if (!write && !fs::exists(path.str()))
+	if (!write && !fs::exists(path))
 	{
 		LogWarning("Attempt to open not existing directory \"%s\"", path);
 		return false;
@@ -19,7 +19,7 @@ bool FileDataProvider::openArchive(const UString &path, bool write)
 }
 bool FileDataProvider::readDocument(const UString &path, UString &result)
 {
-	std::string documentPath = (static_cast<fs::path>(archivePath.str()) / path.str()).string();
+	std::string documentPath = (static_cast<fs::path>(archivePath) / path).string();
 	std::ifstream in(documentPath, std::ios::binary);
 	std::ostringstream oss;
 	oss << in.rdbuf();
@@ -29,7 +29,7 @@ bool FileDataProvider::readDocument(const UString &path, UString &result)
 
 bool FileDataProvider::saveDocument(const UString &path, const UString &contents)
 {
-	fs::path documentPath = (static_cast<fs::path>(archivePath.str()) / path.str());
+	fs::path documentPath = (static_cast<fs::path>(archivePath) / path);
 	fs::path directoryPath = documentPath.parent_path();
 	if (!fs::exists(directoryPath))
 	{

--- a/framework/serialization/providers/providerwithchecksum.cpp
+++ b/framework/serialization/providers/providerwithchecksum.cpp
@@ -37,7 +37,7 @@ static UString calculateSHA1Checksum(const std::string &str)
 			// FIXME: Probably need to do the reverse for big endian?
 			unsigned int byteHex = v & 0xff000000;
 			byteHex >>= 24;
-			hashString += format("%02x", byteHex).str();
+			hashString += format("%02x", byteHex);
 			v <<= 8;
 		}
 	}
@@ -84,12 +84,12 @@ std::string ProviderWithChecksum::serializeManifest()
 	{
 		auto node = root.append_child();
 		node.set_name("file");
-		node.text().set(p.first.cStr());
+		node.text().set(p.first.c_str());
 		for (auto &csum : p.second)
 		{
 			auto checksumNode = node.append_child();
-			checksumNode.set_name(csum.first.cStr());
-			checksumNode.text().set(csum.second.cStr());
+			checksumNode.set_name(csum.first.c_str());
+			checksumNode.text().set(csum.second.c_str());
 		}
 	}
 	std::stringstream ss;
@@ -157,7 +157,7 @@ bool ProviderWithChecksum::openArchive(const UString &path, bool write)
 			LogInfo("Missing manifest file in \"%s\"", path);
 			return true;
 		}
-		parseManifest(result.str());
+		parseManifest(result);
 	}
 	return true;
 }
@@ -165,10 +165,10 @@ bool ProviderWithChecksum::readDocument(const UString &path, UString &result)
 {
 	if (inner->readDocument(path, result))
 	{
-		for (auto &csum : checksums[path.str()])
+		for (auto &csum : checksums[path])
 		{
 			auto expectedCSum = csum.second;
-			auto calculatedCSum = calculateChecksum(csum.first, result.str());
+			auto calculatedCSum = calculateChecksum(csum.first, result);
 			if (expectedCSum != calculatedCSum)
 			{
 				LogWarning("File \"%s\" has incorrect \"%s\" checksum \"%s\", expected \"%s\"",
@@ -194,11 +194,11 @@ bool ProviderWithChecksum::saveDocument(const UString &path, const UString &cont
 		{
 			LogWarning("Multiple document entries for path \"%s\"", path);
 		}
-		this->checksums[path.str()] = {};
+		this->checksums[path] = {};
 		if (Options::useCRCChecksum.get())
-			this->checksums[path.str()]["CRC"] = calculateChecksum("CRC", contents.str()).str();
+			this->checksums[path]["CRC"] = calculateChecksum("CRC", contents);
 		if (Options::useSHA1Checksum.get())
-			this->checksums[path.str()]["SHA1"] = calculateChecksum("SHA1", contents.str()).str();
+			this->checksums[path]["SHA1"] = calculateChecksum("SHA1", contents);
 		return true;
 	}
 	return false;

--- a/framework/serialization/providers/zipdataprovider.cpp
+++ b/framework/serialization/providers/zipdataprovider.cpp
@@ -28,13 +28,13 @@ bool ZipDataProvider::openArchive(const UString &path, bool write)
 	writing = write;
 	if (write)
 	{
-		auto outPath = fs::path(path.str());
+		auto outPath = fs::path(path);
 		auto outDir = outPath.parent_path();
 		if (!outDir.empty())
 		{
 			fs::create_directories(outDir);
 		}
-		if (!mz_zip_writer_init_file(&archive, path.cStr(), 0))
+		if (!mz_zip_writer_init_file(&archive, path.c_str(), 0))
 		{
 			LogWarning("Failed to init zip file \"%s\" for writing", path);
 			return false;
@@ -42,7 +42,7 @@ bool ZipDataProvider::openArchive(const UString &path, bool write)
 	}
 	else
 	{
-		if (!mz_zip_reader_init_file(&archive, path.cStr(), 0))
+		if (!mz_zip_reader_init_file(&archive, path.c_str(), 0))
 		{
 			LogWarning("Failed to init zip file \"%s\" for reading", path);
 			return false;
@@ -64,7 +64,7 @@ bool ZipDataProvider::openArchive(const UString &path, bool write)
 bool ZipDataProvider::readDocument(const UString &filename, UString &result)
 {
 
-	auto it = fileLookup.find(filename.str());
+	auto it = fileLookup.find(filename);
 	if (it == fileLookup.end())
 	{
 		LogInfo("File \"%s\" not found in zip in zip \"%s\"", filename, zipPath);
@@ -99,7 +99,7 @@ bool ZipDataProvider::readDocument(const UString &filename, UString &result)
 }
 bool ZipDataProvider::saveDocument(const UString &path, const UString &contents)
 {
-	if (!mz_zip_writer_add_mem(&archive, path.cStr(), contents.cStr(), contents.cStrLength(),
+	if (!mz_zip_writer_add_mem(&archive, path.c_str(), contents.c_str(), contents.length(),
 	                           MZ_DEFAULT_COMPRESSION))
 	{
 		LogWarning("Failed to insert \"%s\" into zip file \"%s\"", path, this->zipPath);

--- a/framework/serialization/serialize.cpp
+++ b/framework/serialization/serialize.cpp
@@ -162,7 +162,7 @@ up<SerializationDataProvider> getProvider(bool pack)
 
 up<SerializationArchive> SerializationArchive::readArchive(const UString &path)
 {
-	up<SerializationDataProvider> dataProvider = getProvider(!fs::is_directory(path.str()));
+	up<SerializationDataProvider> dataProvider = getProvider(!fs::is_directory(path));
 	if (!dataProvider->openArchive(path, false))
 	{
 		LogWarning("Failed to open archive at \"%s\"", path);
@@ -202,7 +202,7 @@ SerializationNode *XMLSerializationArchive::getRoot(const UString &prefix, const
 		{
 			// FIXME: Make this actually read from the root and load the xinclude tags properly?
 			auto &doc = this->docRoots[path];
-			auto parse_result = doc.load_string(content.cStr());
+			auto parse_result = doc.load_string(content.c_str());
 			if (!parse_result)
 			{
 				LogInfo("Failed to parse \"%s\" : \"%s\" at \"%llu\"", path,
@@ -263,7 +263,7 @@ SerializationNode *XMLSerializationNode::addNode(const char *name, const UString
 {
 	auto newNode = this->node.append_child();
 	newNode.set_name(name);
-	newNode.text().set(value.cStr());
+	newNode.text().set(value.c_str());
 	return &this->archive->nodes.emplace_back(this->archive, newNode, this);
 }
 
@@ -294,7 +294,7 @@ SerializationNode *XMLSerializationNode::addSection(const char *name)
 	auto nsAttribute = includeNode->node.append_attribute("xmlns:xi");
 	nsAttribute.set_value("http://www.w3.org/2001/XInclude");
 	auto attribute = includeNode->node.append_attribute("href");
-	attribute.set_value(path.cStr());
+	attribute.set_value(path.c_str());
 	return this->archive->newRoot(this->getPrefix(), name);
 }
 
@@ -305,20 +305,20 @@ SerializationNode *XMLSerializationNode::getSectionOpt(const char *name)
 
 UString XMLSerializationNode::getName() { return node.name(); }
 
-void XMLSerializationNode::setName(const UString &str) { node.set_name(str.cStr()); }
+void XMLSerializationNode::setName(const UString &str) { node.set_name(str.c_str()); }
 
 UString XMLSerializationNode::getValue() { return node.text().get(); }
 
-void XMLSerializationNode::setValue(const UString &str) { node.text().set(str.cStr()); }
+void XMLSerializationNode::setValue(const UString &str) { node.text().set(str.c_str()); }
 
 UString XMLSerializationNode::getAttribute(const UString &attribute)
 {
-	return node.attribute(attribute.cStr()).value();
+	return node.attribute(attribute.c_str()).value();
 }
 
 void XMLSerializationNode::setAttribute(const UString &attribute, const UString &value)
 {
-	node.attribute(attribute.cStr()).set_value(value.cStr());
+	node.attribute(attribute.c_str()).set_value(value.c_str());
 }
 
 unsigned int XMLSerializationNode::getValueUInt() { return node.text().as_uint(); }
@@ -361,7 +361,7 @@ void XMLSerializationNode::setValueBool(bool b) { node.text().set(b); }
 std::vector<bool> XMLSerializationNode::getValueBoolVector()
 {
 	std::vector<bool> vec;
-	auto string = this->getValue().str();
+	auto string = this->getValue();
 
 	vec.resize(string.length());
 	for (size_t i = 0; i < string.length(); i++)

--- a/framework/serialization/serialize.h
+++ b/framework/serialization/serialize.h
@@ -80,7 +80,7 @@ class SerializationException : public std::runtime_error
 {
   public:
 	SerializationException(const UString &description, SerializationNode *node)
-	    : std::runtime_error(UString(description + " " + node->getFullPath()).cStr())
+	    : std::runtime_error(UString(description + " " + node->getFullPath()).c_str())
 	{
 	}
 };

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -22,9 +22,6 @@ int main(int argc, char *argv[])
 		fw->run(mksp<BootUp>());
 
 		UI::unload();
-#ifdef DUMP_TRANSLATION_STRINGS
-		dumpStrings();
-#endif
 	}
 
 	return 0;

--- a/game/state/city/agentmission.h
+++ b/game/state/city/agentmission.h
@@ -17,7 +17,6 @@ class Agent;
 class Tile;
 class TileMap;
 class Building;
-class UString;
 class SceneryTileType;
 class City;
 

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -25,7 +25,6 @@ class Vehicle;
 class Tile;
 class TileMap;
 class Building;
-class UString;
 class City;
 
 class FlyingVehicleTileHelper : public CanEnterTileHelper

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1317,7 +1317,7 @@ int GameScore::getTotal()
 
 void GameState::loadMods()
 {
-	auto mods = Options::modList.get().split(":");
+	auto mods = split(Options::modList.get(), ":");
 	for (const auto &modString : mods)
 	{
 		LogWarning("loading mod \"%s\"", modString);

--- a/game/state/gamestate_serialize.h
+++ b/game/state/gamestate_serialize.h
@@ -275,7 +275,7 @@ void serializeInSectionMap(const GameState *state, SerializationNode *node,
 			map.erase(key);
 		}
 
-		const auto sectionNode = entry->getSectionOpt(key.cStr());
+		const auto sectionNode = entry->getSectionOpt(key.c_str());
 		if (sectionNode)
 		{
 
@@ -611,7 +611,7 @@ void serializeOutSectionMap(SerializationNode *node, const std::map<UString, Val
 			{
 				auto entry = node->addNode("entry");
 				serializeOut(entry->addNode("key"), pair.first, defaultKey);
-				serializeOut(entry->addSection(pair.first.cStr()), pair.second, refIt->second);
+				serializeOut(entry->addSection(pair.first.c_str()), pair.second, refIt->second);
 			}
 			else
 			{
@@ -622,7 +622,7 @@ void serializeOutSectionMap(SerializationNode *node, const std::map<UString, Val
 		{
 			auto entry = node->addNode("entry");
 			serializeOut(entry->addNode("key"), pair.first, defaultKey);
-			serializeOut(entry->addSection(pair.first.cStr()), pair.second, defaultValue);
+			serializeOut(entry->addSection(pair.first.c_str()), pair.second, defaultValue);
 		}
 	}
 	// Find any removed entries

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -70,27 +70,23 @@ UString GameTime::getLongDateString() const
 		apoc_date_facet *dateFacet = new apoc_date_facet("%A, %E %B, %Y");
 		DATE_LONG_FORMAT = new std::locale(std::locale::classic(), dateFacet);
 
-		std::vector<std::string> months = {
-		    tr("January").str(), tr("February").str(), tr("March").str(),
-		    tr("April").str(),   tr("May").str(),      tr("June").str(),
-		    tr("July").str(),    tr("August").str(),   tr("September").str(),
-		    tr("October").str(), tr("November").str(), tr("December").str()};
+		std::vector<std::string> months = {tr("January"), tr("February"), tr("March"),
+		                                   tr("April"),   tr("May"),      tr("June"),
+		                                   tr("July"),    tr("August"),   tr("September"),
+		                                   tr("October"), tr("November"), tr("December")};
 		dateFacet->long_month_names(months);
 
-		std::vector<std::string> weekdays = {
-		    tr("Sunday").str(),   tr("Monday").str(), tr("Tuesday").str(), tr("Wednesday").str(),
-		    tr("Thursday").str(), tr("Friday").str(), tr("Saturday").str()};
+		std::vector<std::string> weekdays = {tr("Sunday"),    tr("Monday"),   tr("Tuesday"),
+		                                     tr("Wednesday"), tr("Thursday"), tr("Friday"),
+		                                     tr("Saturday")};
 		dateFacet->long_weekday_names(weekdays);
 
 		std::vector<std::string> days = {
-		    tr("1st").str(),  tr("2nd").str(),  tr("3rd").str(),  tr("4th").str(),
-		    tr("5th").str(),  tr("6th").str(),  tr("7th").str(),  tr("8th").str(),
-		    tr("9th").str(),  tr("10th").str(), tr("11th").str(), tr("12th").str(),
-		    tr("13th").str(), tr("14th").str(), tr("15th").str(), tr("16th").str(),
-		    tr("17th").str(), tr("18th").str(), tr("19th").str(), tr("20th").str(),
-		    tr("21st").str(), tr("22nd").str(), tr("23rd").str(), tr("24th").str(),
-		    tr("25th").str(), tr("26th").str(), tr("27th").str(), tr("28th").str(),
-		    tr("29th").str(), tr("30th").str(), tr("31st").str()};
+		    tr("1st"),  tr("2nd"),  tr("3rd"),  tr("4th"),  tr("5th"),  tr("6th"),  tr("7th"),
+		    tr("8th"),  tr("9th"),  tr("10th"), tr("11th"), tr("12th"), tr("13th"), tr("14th"),
+		    tr("15th"), tr("16th"), tr("17th"), tr("18th"), tr("19th"), tr("20th"), tr("21st"),
+		    tr("22nd"), tr("23rd"), tr("24th"), tr("25th"), tr("26th"), tr("27th"), tr("28th"),
+		    tr("29th"), tr("30th"), tr("31st")};
 		dateFacet->longDayNames(days);
 	}
 	ss.imbue(*DATE_LONG_FORMAT);
@@ -106,22 +102,18 @@ UString GameTime::getShortDateString() const
 		apoc_date_facet *dateFacet = new apoc_date_facet("%E %B, %Y");
 		DATE_SHORT_FORMAT = new std::locale(std::locale::classic(), dateFacet);
 
-		std::vector<std::string> months = {
-		    tr("January").str(), tr("February").str(), tr("March").str(),
-		    tr("April").str(),   tr("May").str(),      tr("June").str(),
-		    tr("July").str(),    tr("August").str(),   tr("September").str(),
-		    tr("October").str(), tr("November").str(), tr("December").str()};
+		std::vector<std::string> months = {tr("January"), tr("February"), tr("March"),
+		                                   tr("April"),   tr("May"),      tr("June"),
+		                                   tr("July"),    tr("August"),   tr("September"),
+		                                   tr("October"), tr("November"), tr("December")};
 		dateFacet->long_month_names(months);
 
 		std::vector<std::string> days = {
-		    tr("1st").str(),  tr("2nd").str(),  tr("3rd").str(),  tr("4th").str(),
-		    tr("5th").str(),  tr("6th").str(),  tr("7th").str(),  tr("8th").str(),
-		    tr("9th").str(),  tr("10th").str(), tr("11th").str(), tr("12th").str(),
-		    tr("13th").str(), tr("14th").str(), tr("15th").str(), tr("16th").str(),
-		    tr("17th").str(), tr("18th").str(), tr("19th").str(), tr("20th").str(),
-		    tr("21st").str(), tr("22nd").str(), tr("23rd").str(), tr("24th").str(),
-		    tr("25th").str(), tr("26th").str(), tr("27th").str(), tr("28th").str(),
-		    tr("29th").str(), tr("30th").str(), tr("31st").str()};
+		    tr("1st"),  tr("2nd"),  tr("3rd"),  tr("4th"),  tr("5th"),  tr("6th"),  tr("7th"),
+		    tr("8th"),  tr("9th"),  tr("10th"), tr("11th"), tr("12th"), tr("13th"), tr("14th"),
+		    tr("15th"), tr("16th"), tr("17th"), tr("18th"), tr("19th"), tr("20th"), tr("21st"),
+		    tr("22nd"), tr("23rd"), tr("24th"), tr("25th"), tr("26th"), tr("27th"), tr("28th"),
+		    tr("29th"), tr("30th"), tr("31st")};
 		dateFacet->longDayNames(days);
 	}
 	ss.imbue(*DATE_SHORT_FORMAT);

--- a/game/state/luagamestate.cpp
+++ b/game/state/luagamestate.cpp
@@ -63,13 +63,13 @@ void LuaGameState::init(GameState &game)
 	lua_setfield(L, LUA_REGISTRYINDEX, "OpenApoc.GameState");
 
 	pushLuaDebugTraceback(L);
-	for (const UString &s : config().getString("OpenApoc.Mod.ScriptsList").split(";"))
+	for (const UString &s : split(config().getString("OpenApoc.Mod.ScriptsList"), ";"))
 	{
 		if (s.empty())
 			continue;
 
 		// this is only true if loadfile or pcall raised an error
-		if (luaL_loadfile(L, s.cStr()) || lua_pcall(L, 0, 0, -2))
+		if (luaL_loadfile(L, s.c_str()) || lua_pcall(L, 0, 0, -2))
 		{
 			handleLuaError(L);
 		}
@@ -84,7 +84,7 @@ LuaGameState::operator bool() const { return this->L != nullptr && this->initOk;
 int LuaGameState::callHook(const UString &hookName, int nresults, int nargs)
 {
 	pushLuaDebugTraceback(L);
-	if (pushHook(hookName.str().c_str()))
+	if (pushHook(hookName.c_str()))
 	{
 		// rotate the stack so the arguments are at the top and the
 		// debug.traceback and hook functions are at the bottom
@@ -120,7 +120,7 @@ bool LuaGameState::runScript(const UString &scriptPath)
 	bool ret = true;
 	pushLuaDebugTraceback(L);
 	// this is only true if loadfile or pcall raised an error
-	if (luaL_loadfile(L, fullPath.cStr()) || lua_pcall(L, 0, 0, -2))
+	if (luaL_loadfile(L, fullPath.c_str()) || lua_pcall(L, 0, 0, -2))
 	{
 		handleLuaError(L);
 		LogWarning("Script \"%s\" failed", scriptPath);

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -84,7 +84,7 @@ std::shared_future<void> SaveManager::loadSpecialSave(const SaveType type,
 
 bool writeArchiveWithBackup(SerializationArchive *archive, const UString &path, bool pack)
 {
-	fs::path savePath = path.str();
+	fs::path savePath = path;
 	fs::path tempPath;
 	bool shouldCleanup = false;
 	try
@@ -162,12 +162,12 @@ bool writeArchiveWithBackup(SerializationArchive *archive, const UString &path, 
 bool SaveManager::findFreePath(UString &path, const UString &name) const
 {
 	path = createSavePath("save_" + name);
-	if (fs::exists(path.str()))
+	if (fs::exists(path))
 	{
 		for (int retries = 5; retries > 0; retries--)
 		{
 			path = createSavePath("save_" + name + std::to_string(rand()));
-			if (!fs::exists(path.str()))
+			if (!fs::exists(path))
 			{
 				return true;
 			}
@@ -198,7 +198,7 @@ bool SaveManager::overrideGame(const SaveMetadata &metadata, const UString &newN
 	SaveMetadata updatedMetadata(newName, metadata.getFile(), time(nullptr), metadata.getType(),
 	                             gameState);
 	bool result = saveGame(updatedMetadata, gameState);
-	if (result && newName != metadata.getName().str())
+	if (result && newName != metadata.getName())
 	{
 		// if renamed file move to path with new name
 		UString newFile;
@@ -206,7 +206,7 @@ bool SaveManager::overrideGame(const SaveMetadata &metadata, const UString &newN
 		{
 			try
 			{
-				fs::rename(metadata.getFile().str(), newFile.str());
+				fs::rename(metadata.getFile(), newFile);
 			}
 			catch (fs::filesystem_error &error)
 			{
@@ -257,7 +257,7 @@ bool SaveManager::specialSaveGame(SaveType type, const sp<GameState> gameState) 
 std::vector<SaveMetadata> SaveManager::getSaveList() const
 {
 	auto dirString = Options::saveDirOption.get();
-	fs::path saveDirectory = dirString.str();
+	fs::path saveDirectory = dirString;
 	std::vector<SaveMetadata> saveList;
 	try
 	{
@@ -269,7 +269,7 @@ std::vector<SaveMetadata> SaveManager::getSaveList() const
 
 		for (auto i = fs::directory_iterator(saveDirectory); i != fs::directory_iterator(); ++i)
 		{
-			if (i->path().extension().string() != saveFileExtension.str())
+			if (i->path().extension().string() != saveFileExtension)
 			{
 				continue;
 			}
@@ -308,13 +308,13 @@ bool SaveManager::deleteGame(const sp<SaveMetadata> &slot) const
 {
 	try
 	{
-		if (!fs::exists(slot->getFile().str()))
+		if (!fs::exists(slot->getFile()))
 		{
 			LogWarning("Attempt to delete not existing file");
 			return false;
 		}
 
-		fs::remove_all(slot->getFile().str());
+		fs::remove_all(slot->getFile());
 		return true;
 	}
 	catch (fs::filesystem_error &exception)
@@ -326,7 +326,7 @@ bool SaveManager::deleteGame(const sp<SaveMetadata> &slot) const
 
 bool SaveMetadata::deserializeManifest(SerializationArchive *archive, const UString &saveFileName)
 {
-	auto root = archive->getRoot("", saveManifestName.cStr());
+	auto root = archive->getRoot("", saveManifestName.c_str());
 	if (!root)
 	{
 		return false;
@@ -348,7 +348,7 @@ bool SaveMetadata::deserializeManifest(SerializationArchive *archive, const UStr
 	auto saveDateNode = root->getNodeOpt("save_date");
 	if (saveDateNode)
 	{
-		std::istringstream stream(saveDateNode->getValue().str());
+		std::istringstream stream(saveDateNode->getValue());
 		time_t timestamp;
 		stream >> timestamp;
 		this->creationDate = timestamp;
@@ -376,7 +376,7 @@ bool SaveMetadata::deserializeManifest(SerializationArchive *archive, const UStr
 
 bool SaveMetadata::serializeManifest(SerializationArchive *archive) const
 {
-	auto root = archive->newRoot("", saveManifestName.cStr());
+	auto root = archive->newRoot("", saveManifestName.c_str());
 	if (!root)
 	{
 		return false;

--- a/game/ui/general/messagebox.cpp
+++ b/game/ui/general/messagebox.cpp
@@ -26,7 +26,7 @@ MessageBox::MessageBox(const UString &title, const UString &text, ButtonOptions 
 	const Vec2<int> BUTTON_SIZE = {100, 28};
 	const Vec2<int> BUTTON_SIZE_2 = {70, 28};
 
-	auto lTitle = form->createChild<Label>(title.toUpper(), ui().getFont("smalfont"));
+	auto lTitle = form->createChild<Label>(to_upper(title), ui().getFont("smalfont"));
 	lTitle->Size.x = form->Size.x - MARGIN * 2;
 	lTitle->Size.y = ui().getFont("smalfont")->getFontHeight();
 	lTitle->Location = {MARGIN, MARGIN};

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -3706,7 +3706,7 @@ bool BattleView::handleMouseDown(Event *e)
 					if (uto)
 					{
 						auto u = uto->getUnit();
-						debug += format("\nContains unit %s.", u->id.cStr());
+						debug += format("\nContains unit %s.", u->id.c_str());
 						debug += format("\nMorale state: %d", (int)u->moraleState);
 						debug += format("\nPosition: %f, %f, %f", u->position.x, u->position.y,
 						                u->position.z);

--- a/library/colour.cpp
+++ b/library/colour.cpp
@@ -22,7 +22,7 @@ static const std::map<UString, Colour> html4Colours{
 
 Colour Colour::FromHtmlName(const UString &name)
 {
-	auto it = html4Colours.find(name.toLower());
+	auto it = html4Colours.find(to_lower(name));
 	if (it != html4Colours.end())
 		return it->second;
 	return {0, 0, 0, 0};
@@ -30,7 +30,7 @@ Colour Colour::FromHtmlName(const UString &name)
 
 Colour Colour::FromHex(const UString &hexcode)
 {
-	UString hexcode_lower = hexcode.toLower();
+	UString hexcode_lower = to_lower(hexcode);
 	if (hexcode_lower.empty())
 	{
 		return {0, 0, 0};

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -1,454 +1,134 @@
 #include "library/strings.h"
 #include "library/strings_format.h"
-#include <cctype>
-#include <iterator>
-#include <tuple> // used for std::ignore
-
 #include <boost/algorithm/string/predicate.hpp>
+#include <boost/locale/encoding_utf.hpp>
 #include <boost/locale/message.hpp>
-
-#ifdef DUMP_TRANSLATION_STRINGS
-#include <fstream>
-#include <iostream>
-#include <map>
-#include <set>
-#endif
+#include <cctype>
 
 namespace OpenApoc
 {
 
-static constexpr UniChar REPLACEMENT_CHARACTER = 0xfffd;
-
-static UniChar utf8_to_unichar(const char *str, size_t &num_bytes_read)
-{
-	/* This will pick up null bytes */
-	if ((str[0] & 0b10000000) == 0)
-	{
-		num_bytes_read = 1;
-		return static_cast<UniChar>(str[0]);
-	}
-	if ((str[0] & 0b11100000) == 0b11000000)
-	{
-		num_bytes_read = 2;
-		if ((str[1] & 0b11000000) != 0b10000000)
-		{
-			return REPLACEMENT_CHARACTER;
-		}
-		UniChar c = 0;
-		c = str[0] & 0b00011111;
-		c <<= 6;
-		c |= str[1] & 0b00111111;
-		return c;
-	}
-	if ((str[0] & 0b11110000) == 0b11100000)
-	{
-		num_bytes_read = 3;
-		if ((str[1] & 0b11000000) != 0b10000000 || (str[2] & 0b11000000) != 0b10000000)
-		{
-			return REPLACEMENT_CHARACTER;
-		}
-		UniChar c = 0;
-		c = str[0] & 0b00001111;
-		c <<= 6;
-		c |= str[1] & 0b00111111;
-		c <<= 6;
-		c |= str[2] & 0b00111111;
-		return c;
-	}
-	if ((str[0] & 0b11111000) == 0b11110000)
-	{
-		num_bytes_read = 4;
-		if ((str[1] & 0b11000000) != 0b10000000 || (str[2] & 0b11000000) != 0b10000000 ||
-		    (str[3] & 0b11000000) != 0b10000000)
-		{
-			return REPLACEMENT_CHARACTER;
-		}
-		UniChar c = 0;
-		c = str[0] & 0b00000111;
-		c <<= 6;
-		c |= str[1] & 0b00111111;
-		c <<= 6;
-		c |= str[2] & 0b00111111;
-		c <<= 6;
-		c |= str[3] & 0b00111111;
-		return c;
-	}
-	/* Invalid character start - return a replacement character and skip 1 char */
-	num_bytes_read = 1;
-	return REPLACEMENT_CHARACTER;
-}
-
-/* Returns the number of bytes used */
-static size_t unichar_to_utf8(const UniChar uc, char str[4])
-{
-	if (uc < 0x7F)
-	{
-		str[0] = static_cast<char>(uc);
-		return 1;
-	}
-	if (uc < 0x7FF)
-	{
-		UniChar c = uc;
-		str[1] = 0b10000000 | (0b00111111 & c);
-		c >>= 6;
-		str[0] = 0b11000000 | (0b00011111 & c);
-		return 2;
-	}
-	if (uc < 0xFFFF)
-	{
-		UniChar c = uc;
-		str[2] = 0b10000000 | (0b00111111 & c);
-		c >>= 6;
-		str[1] = 0b10000000 | (0b00111111 & c);
-		c >>= 6;
-		str[0] = 0b11100000 | (0b00001111 & c);
-		return 3;
-	}
-	if (uc < 0x10FFFF)
-	{
-		UniChar c = uc;
-		str[3] = 0b10000000 | (0b00111111 & c);
-		c >>= 6;
-		str[2] = 0b10000000 | (0b00111111 & c);
-		c >>= 6;
-		str[1] = 0b10000000 | (0b00111111 & c);
-		c >>= 6;
-		str[0] = 0b11110000 | (0b00000111 & c);
-		return 4;
-	}
-	return unichar_to_utf8(REPLACEMENT_CHARACTER, str);
-}
-
-#ifdef DUMP_TRANSLATION_STRINGS
-
-static std::map<UString, std::set<UString>> trStrings;
-
-void dumpStrings()
-{
-	for (auto &p : trStrings)
-	{
-		UString outFileName = p.first + ".po";
-		std::ofstream outFile(outFileName.str());
-		outFile << "msgid \"\"\n"
-		        << "msgstr \"\"\n"
-		        << "\"Project-Id-Version: Apocalypse\\n\"\n"
-		        << "\"MIME-Version: 1.0\\n\"\n"
-		        << "\"Content-Type: text/plain; charset=UTF-8\\n\"\n"
-		        << "\"Content-Transfer-Encoding: 8bit\\n\"\n"
-		        << "\"Language: en\\n\""
-		        << "\"Plural-Forms: nplurals=2; plural=(n != 1);\\n\"\n\n";
-		for (auto &str : p.second)
-		{
-			auto escapedStr = str;
-			outFile << "msgid \"" << str << "\"\n";
-			outFile << "msgstr \"" << str << "\"\n\n";
-		}
-	}
-}
-
-#endif
-
 UString tr(const UString &str, const UString domain)
 {
-#ifdef DUMP_TRANSLATION_STRINGS
-	if (str != "")
-	{
-		trStrings[domain].insert(str);
-	}
-#endif
-	return UString(boost::locale::translate(str.str()).str(domain.str()));
+	return UString(boost::locale::translate(str).str(domain));
 }
 
-UString::~UString() = default;
-
-UString::UString() : u8Str() {}
-
-UString::UString(const std::string &str) : u8Str(str) {}
-
-UString::UString(std::string &&str) : u8Str(std::move(str)) {}
-
-UString::UString(const char *cstr)
-
+U32String to_u32string(const UStringView str)
 {
-	// We have to handle this manually as some things thought UString(nullptr) was a good idea
-	if (cstr)
-	{
-		this->u8Str = cstr;
-	}
+	// FIXME: Boost api doesn't work with string views yet?
+	auto string_copy = UString(str);
+	return boost::locale::conv::utf_to_utf<char32_t>(string_copy);
 }
-UString::UString(const char *cstr, size_t count) : u8Str(cstr, count) {}
 
-UString::UString(const UString &) = default;
-
-UString::UString(UString &&other) noexcept { this->u8Str = std::move(other.u8Str); }
-
-UString::UString(UniChar uc) : u8Str()
+UString to_ustring(const std::u32string_view str)
 {
-	char buf[4];
-	auto bytes = unichar_to_utf8(uc, buf);
-	u8Str = {buf, bytes};
+	auto string_copy = U32String(str);
+	return boost::locale::conv::utf_to_utf<char>(string_copy);
 }
 
-UString::UString(UString::ConstIterator first, UString::ConstIterator last)
-    : UString(first.s.u8Str.substr(first.offset, last.offset - first.offset))
+char32_t to_char32(const char c)
 {
+	// All the codepoints <=127 are the same as ascii
+	return static_cast<char32_t>(c);
 }
 
-const std::string &UString::str() const { return this->u8Str; }
-
-const char *UString::cStr() const { return this->u8Str.c_str(); }
-
-size_t UString::cStrLength() const { return this->u8Str.length(); }
-
-bool UString::operator<(const UString &other) const { return (this->u8Str) < (other.u8Str); }
-
-bool UString::operator==(const UString &other) const { return (this->u8Str) == (other.u8Str); }
-
-UString UString::substr(size_t offset, size_t length) const
-{
-	auto sub_start = std::next(this->begin(), offset);
-	auto sub_end = sub_start;
-	while (length != 0 && sub_end != this->end())
-	{
-		++sub_end;
-		--length;
-	}
-	return UString{sub_start, sub_end};
-}
-
-UString UString::toUpper() const
+UString to_upper(const UStringView str)
 {
 	/* Only change the case on ascii range characters (codepoint <=0x7f)
 	 * As we know the top bit is set for any bytes outside this range no matter the position in the
 	 * utf8 stream, we can cheat a bit here */
-	UString upper_string = *this;
-	for (size_t i = 0; i < upper_string.cStrLength(); i++)
+	auto upper_string = UString(str);
+	for (size_t i = 0; i < upper_string.length(); i++)
 	{
-		if ((upper_string.u8Str[i] & 0b10000000) == 0)
-			upper_string.u8Str[i] = toupper(upper_string.u8Str[i]);
+		if ((upper_string[i] & 0b10000000) == 0)
+			upper_string[i] = toupper(upper_string[i]);
 	}
 	return upper_string;
 }
 
-UString UString::toLower() const
+UString to_lower(const UStringView str)
 {
 	/* Only change the case on ascii range characters (codepoint <=0x7f)
 	 * As we know the top bit is set for any bytes outside this range no matter the position in the
 	 * utf8 stream, we can cheat a bit here */
-	UString lower_string = *this;
-	for (size_t i = 0; i < lower_string.cStrLength(); i++)
+	auto lower_string = UString(str);
+	for (size_t i = 0; i < lower_string.length(); i++)
 	{
-		if ((lower_string.u8Str[i] & 0b10000000) == 0)
-			lower_string.u8Str[i] = tolower(lower_string.u8Str[i]);
+		if ((lower_string[i] & 0b10000000) == 0)
+			lower_string[i] = tolower(lower_string[i]);
 	}
 	return lower_string;
 }
 
-UString &UString::operator=(const UString &other) = default;
-
-UString &UString::operator+=(const UString &other)
+bool ends_with(const UStringView str, const UStringView ending)
 {
-	this->u8Str += other.u8Str;
-	return *this;
+	return boost::ends_with(str, ending);
 }
 
-size_t UString::length() const { return std::distance(this->begin(), this->end()); }
-
-void UString::insert(size_t offset, const UString &other)
+UString remove(const UStringView str, size_t offset, size_t count)
 {
-	auto it = this->begin();
-	while (offset && it != this->end())
-	{
-		++it;
-		offset--;
-	}
-	if (offset)
-	{
-		throw std::out_of_range("UString::insert() offset longer than string");
-	}
-	this->u8Str.insert(it.offset, other.u8Str);
+	auto u32str = to_u32string(str);
+
+	u32str.erase(offset, count);
+
+	return to_ustring(u32str);
 }
 
-void UString::remove(size_t offset, size_t count)
+U32String remove(const U32StringView str, size_t offset, size_t count)
 {
-	auto it = this->begin();
-	while (offset && it != this->end())
-	{
-		++it;
-		offset--;
-	}
-	while (count && it != this->end())
-	{
-		size_t num_bytes;
-		utf8_to_unichar(it.s.cStr() + it.offset, num_bytes);
-		this->u8Str.erase(it.offset, num_bytes);
-		count--;
-	}
+	auto str_copy = U32String(str);
+	return str_copy.erase(offset, count);
 }
 
-bool UString::operator!=(const UString &other) const { return this->u8Str != other.u8Str; }
-
-UString operator+(const UString &lhs, const UString &rhs)
-{
-	UString s;
-	s += lhs;
-	s += rhs;
-	return s;
-}
-
-std::ostream &operator<<(std::ostream &lhs, const UString &rhs)
-{
-	lhs << rhs.str();
-	return lhs;
-}
-
-// FIXME: This may not work with certain non-ascii characters
-std::istream &operator>>(std::istream &lhs, UString &rhs)
-{
-	lhs >> rhs.u8Str;
-	return lhs;
-}
-
-std::vector<UString> UString::split(const UString &delims) const
+std::vector<UString> split(const UStringView str, const UStringView delims)
 {
 	// FIXME: Probably won't work if any of 'delims' is outside the ASCII range
 	std::vector<UString> strings;
 	size_t pos = 0;
 	size_t prev = pos;
-	while ((pos = this->u8Str.find_first_of(delims.str(), prev)) != std::string::npos)
+	while ((pos = str.find_first_of(delims, prev)) != std::string::npos)
 	{
 		if (pos > prev)
-			strings.push_back(this->u8Str.substr(prev, pos - prev));
+			strings.push_back(UString(str.substr(prev, pos - prev)));
 		prev = pos + 1;
 	}
-	strings.push_back(this->u8Str.substr(prev, pos));
+	strings.push_back(UString(str.substr(prev, pos)));
 	return strings;
 }
 
-std::list<UString> UString::splitlist(const UString &delims) const
+UString insert_codepoints(const UStringView str, size_t offset, const UStringView insert)
 {
-	std::vector<UString> strings = split(delims);
-	return std::list<UString>(strings.begin(), strings.end());
+	auto u32str = to_u32string(str);
+	auto u32insert = to_u32string(insert);
+	u32str.insert(offset, u32insert);
+	return to_ustring(u32str);
 }
 
-UniChar UString::u8Char(char c)
+int Strings::toInteger(const UStringView s)
 {
-	// FIXME: I believe all the <256 codepoints just map?
-	return c;
-}
-
-int UString::compare(const UString &other) const { return this->u8Str.compare(other.u8Str); }
-
-bool UString::endsWith(const UString &suffix) const
-{
-	return boost::ends_with(str(), suffix.str());
-}
-
-UString UString::trimLeft() const
-{
-	auto first = begin();
-	auto last = end();
-	while (first != last && Strings::isWhiteSpace(*first))
-		++first;
-	return {first, last};
-}
-UString UString::trimRight() const
-{
-	auto first = begin();
-	auto last = end();
-	if (first == last)
-		return {};
-	--last;
-	while (first != last && Strings::isWhiteSpace(*last))
-		--last;
-	return {first, ++last};
-}
-UString UString::trim() const
-{
-	auto first = begin();
-	auto last = end();
-	while (first != last && Strings::isWhiteSpace(*first))
-		++first;
-	if (first == last)
-		return {};
-	--last;
-	while (first != last && Strings::isWhiteSpace(*last))
-		--last;
-	return {first, ++last};
-}
-
-UString::ConstIterator UString::begin() const { return UString::ConstIterator(*this, 0); }
-
-UString::ConstIterator UString::end() const
-{
-	return UString::ConstIterator(*this, this->u8Str.length());
-}
-
-UString::ConstIterator UString::ConstIterator::operator++()
-{
-	const char *ptr = s.cStr();
-	ptr += this->offset;
-	size_t num_bytes = 0;
-	utf8_to_unichar(ptr, num_bytes);
-
-	this->offset += num_bytes;
-	return *this;
-}
-
-UString::ConstIterator UString::ConstIterator::operator--()
-{
-	const char *ptr = s.cStr();
-	ptr += --this->offset;
-	while (static_cast<unsigned char>(*ptr) >= 0b10000000 &&
-	       static_cast<unsigned char>(*ptr) < 0b11000000)
-	{
-		--this->offset;
-		--ptr;
-	}
-	return *this;
-}
-
-bool UString::ConstIterator::operator!=(const UString::ConstIterator &other) const
-{
-	return (this->offset != other.offset || this->s != other.s);
-}
-
-bool UString::ConstIterator::operator==(const UString::ConstIterator &other) const
-{
-	return this->offset == other.offset && this->s == other.s;
-}
-
-UniChar UString::ConstIterator::operator*() const
-{
-	size_t num_bytes_unused;
-	return utf8_to_unichar(this->s.cStr() + this->offset, num_bytes_unused);
-}
-
-int Strings::toInteger(const UString &s)
-{
-	std::string u8str = s.str();
+	auto u8str = UString(s);
 	return static_cast<int>(strtol(u8str.c_str(), NULL, 0));
 }
 
-float Strings::toFloat(const UString &s)
+float Strings::toFloat(const UStringView s)
 {
-	std::string u8str = s.str();
+	auto u8str = UString(s);
 	return static_cast<float>(strtod(u8str.c_str(), NULL));
 }
 
-uint8_t Strings::toU8(const UString &s) { return static_cast<uint8_t>(toInteger(s)); }
+uint8_t Strings::toU8(const UStringView s) { return static_cast<uint8_t>(toInteger(s)); }
 
-bool Strings::isInteger(const UString &s)
+bool Strings::isInteger(const UStringView s)
 {
-	std::string u8str = s.str();
+	auto u8str = UString(s);
 	char *endpos;
 	std::ignore = strtol(u8str.c_str(), &endpos, 0);
 	return (endpos != u8str.c_str());
 }
 
-bool Strings::isFloat(const UString &s)
+bool Strings::isFloat(const UStringView s)
 {
-	std::string u8str = s.str();
+	auto u8str = UString(s);
 	char *endpos;
 	std::ignore = strtod(u8str.c_str(), &endpos);
 	return (endpos != u8str.c_str());
@@ -458,16 +138,12 @@ UString Strings::fromInteger(int i) { return format("%d", i); }
 
 UString Strings::fromFloat(float f) { return format("%f", f); }
 
-bool Strings::isWhiteSpace(UniChar c)
+bool Strings::isWhiteSpace(char32_t c)
 {
 	// FIXME: Only works on ASCII whitespace
 	return isspace(c) != 0;
 }
 
 UString Strings::fromU64(uint64_t i) { return format("%llu", i); }
-
-#ifdef __cpp_char8_t
-UString::UString(const char8_t *cstr) : u8Str(reinterpret_cast<const char *>(cstr)) {}
-#endif
 
 }; // namespace OpenApoc

--- a/library/strings.h
+++ b/library/strings.h
@@ -3,130 +3,57 @@
 #include <iterator>
 #include <list>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace OpenApoc
 {
 
-typedef uint32_t UniChar;
+//#ifdef __cpp_char8_t__not_in_this_castle
+//#warning Using char8_t
+// using UString = std::basic_string<char8_t>;
+// using ustring_view = std::basic_string_view<char8_t>;
+//#else
+//#warning Using char
+using UString = std::basic_string<char>;
+using UStringView = std::basic_string_view<char>;
+//#endif
 
-class UString
-{
-  private:
-	std::string u8Str;
+using U32String = std::basic_string<char32_t>;
+using U32StringView = std::basic_string_view<char32_t>;
 
-  public:
-	class ConstIterator
-	{
-	  private:
-		const UString &s;
-		size_t offset;
-		friend class UString;
-		ConstIterator(const UString &s, size_t initial_offset) : s(s), offset(initial_offset) {}
+[[nodiscard]] U32String to_u32string(const UStringView str);
+[[nodiscard]] UString to_ustring(const std::u32string_view str);
+[[nodiscard]] char32_t to_char32(const char c);
 
-	  public:
-		// Just enough to struggle through a range-based for
-		bool operator!=(const ConstIterator &other) const;
-		bool operator==(const ConstIterator &other) const;
-		ConstIterator operator++();
-		ConstIterator operator--();
-		UniChar operator*() const;
+[[nodiscard]] UString to_lower(const UStringView str);
+[[nodiscard]] UString to_upper(const UStringView str);
 
-		using iterator_category = std::forward_iterator_tag;
-		using value_type = UniChar;
-		using difference_type = ptrdiff_t;
-		using pointer = UniChar *;
-		using reference = UniChar &;
-	};
+[[nodiscard]] bool ends_with(const UStringView str, const UStringView ending);
 
-	// ASSUMPTIONS:
-	// All std::string/char are utf8
-	// All lengths/offsets are in unicode code-points (not bytes/anything)
-	UString(const std::string &str);
-	UString(std::string &&str);
-	UString(UniChar uc);
-	UString(const char *cstr);
-	UString(const char *cstr, size_t count);
-	UString(UString &&other) noexcept;
-	UString(ConstIterator first, ConstIterator last);
-	UString();
-	~UString();
+// Removes 'count' codepoints at 'offset' codepoints into the string (note: Not bytes!)
+[[nodiscard]] UString remove(const UStringView str, size_t offset, size_t count);
+[[nodiscard]] U32String remove(const U32StringView str, size_t offset, size_t count);
 
-#ifdef __cpp_char8_t
-	UString(const char8_t *cstr);
-#endif
+[[nodiscard]] std::vector<UString> split(const UStringView str, const UStringView delims);
 
-	UString(const UString &other);
-	UString &operator=(const UString &other);
-
-	const std::string &str() const;
-
-	const char *cStr() const;
-	size_t cStrLength() const;
-
-	/* Only changes case of ASCII-range characters */
-	UString toUpper() const;
-	/* Only changes case of ASCII-range characters */
-	UString toLower() const;
-	std::vector<UString> split(const UString &delims) const;
-	std::list<UString> splitlist(const UString &delims) const;
-
-	size_t length() const;
-	bool empty() const { return this->u8Str.empty(); }
-	UString substr(size_t offset, size_t length = npos) const;
-
-	static const size_t npos = static_cast<size_t>(-1);
-
-	UString &operator+=(const UString &ustr);
-	// UString& operator+=(const std::string& str);
-	// UString& operator+=(const char* cstr);
-	// UString& operator+=(const char& c);
-	// UString& operator+=(const UniChar& uc);
-
-	void remove(size_t offset, size_t count);
-	void insert(size_t offset, const UString &other);
-
-	int compare(const UString &str) const;
-
-	bool endsWith(const UString &suffix) const;
-
-	UString trimLeft() const;
-	UString trimRight() const;
-	UString trim() const;
-
-	bool operator==(const UString &other) const;
-	bool operator!=(const UString &other) const;
-	bool operator<(const UString &other) const;
-
-	ConstIterator begin() const;
-	ConstIterator end() const;
-
-	static UniChar u8Char(char c);
-
-	friend std::istream &operator>>(std::istream &lhs, UString &rhs);
-};
-
-UString operator+(const UString &lhs, const UString &rhs);
-std::ostream &operator<<(std::ostream &lhs, const UString &rhs);
-std::istream &operator>>(std::istream &lhs, UString &rhs);
+// Insert the 'insert' string at 'offset' codepoints into the string 'str' and returns the string
+[[nodiscard]] UString insert_codepoints(const UStringView str, size_t offset,
+                                        const UStringView insert);
 
 class Strings
 {
 
   public:
-	static bool isFloat(const UString &s);
-	static bool isInteger(const UString &s);
-	static int toInteger(const UString &s);
-	static uint8_t toU8(const UString &s);
-	static float toFloat(const UString &s);
-	static UString fromInteger(int i);
-	static UString fromU64(uint64_t i);
-	static UString fromFloat(float f);
-	static bool isWhiteSpace(UniChar c);
+	[[nodiscard]] static bool isFloat(const UStringView s);
+	[[nodiscard]] static bool isInteger(const UStringView s);
+	[[nodiscard]] static int toInteger(const UStringView s);
+	[[nodiscard]] static uint8_t toU8(const UStringView s);
+	[[nodiscard]] static float toFloat(const UStringView s);
+	[[nodiscard]] static UString fromInteger(int i);
+	[[nodiscard]] static UString fromU64(uint64_t i);
+	[[nodiscard]] static UString fromFloat(float f);
+	[[nodiscard]] static bool isWhiteSpace(char32_t c);
 };
-
-#ifdef DUMP_TRANSLATION_STRINGS
-void dumpStrings();
-#endif
 
 }; // namespace OpenApoc

--- a/library/strings_format.h
+++ b/library/strings_format.h
@@ -6,19 +6,11 @@
 namespace OpenApoc
 {
 
-template <typename... Args> static UString format(const UString &fmt, Args &&... args)
+template <typename... Args> static UString format(const UStringView fmt, Args &&... args)
 {
-	return fmt::sprintf(fmt.str(), std::forward<Args>(args)...);
+	return fmt::sprintf(fmt, std::forward<Args>(args)...);
 }
 
 UString tr(const UString &str, const UString domain = "ufo_string");
 
 } // namespace OpenApoc
-
-template <> struct fmt::formatter<OpenApoc::UString> : formatter<std::string>
-{
-	template <typename FormatContext> auto format(const OpenApoc::UString &s, FormatContext &ctx)
-	{
-		return formatter<std::string>::format(s.str(), ctx);
-	}
-};

--- a/tests/test_serialize.cpp
+++ b/tests/test_serialize.cpp
@@ -172,7 +172,7 @@ int main(int argc, char **argv)
 		}
 		LogInfo("Using vehicle map for \"%s\"", vType->name);
 		v->type = {state.get(), vType};
-		v->name = format("%s %d", v->type->name, ++v->type->numCreated);
+		v->name = OpenApoc::format("%s %d", v->type->name, ++v->type->numCreated);
 		state->vehicles[vID] = v;
 
 		OpenApoc::StateRef<OpenApoc::Vehicle> enemyVehicle = {state.get(), vID};

--- a/tests/test_unicode.cpp
+++ b/tests/test_unicode.cpp
@@ -4,12 +4,24 @@
 
 using namespace OpenApoc;
 
+static bool test_32_8_roundtrip(const UString &str)
+{
+	auto u32str = to_u32string(str);
+	auto u8str = to_ustring(u32str);
+	if (u8str != str)
+	{
+		LogError("String \"%s\" ended up as \"%s\" after utf8->utf32->utf8 roundtrip", str, u8str);
+		return false;
+	}
+	return true;
+}
+
 struct example_unicode
 {
 	const char *u8string;
-	std::vector<UniChar> expected_codepoints;
+	std::vector<char32_t> expected_codepoints;
 
-	example_unicode(const char *str, std::vector<UniChar> codepoints)
+	example_unicode(const char *str, std::vector<char32_t> codepoints)
 	    : u8string(str), expected_codepoints(codepoints){};
 #ifdef __cpp_char8_t
 	example_unicode(const char8_t *str, std::vector<UniChar> codepoints)
@@ -21,17 +33,18 @@ struct example_unicode
 		LogInfo("Testing string \"%s\"", u8string);
 		const auto num_codepoints = expected_codepoints.size();
 		UString string(u8string);
-		UString string2;
-		if (string.length() != num_codepoints)
+		U32String string2;
+		auto u32str = to_u32string(string);
+		if (u32str.length() != num_codepoints)
 		{
 			LogError("String \"%s\" has unexpected length %zu , expected %zu", u8string,
 			         string.length(), num_codepoints);
 			return false;
 		}
 
-		std::vector<UniChar> decoded_codepoints;
+		std::vector<char32_t> decoded_codepoints;
 
-		for (auto c : string)
+		for (auto c : u32str)
 			decoded_codepoints.push_back(c);
 
 		if (decoded_codepoints.size() != num_codepoints)
@@ -54,12 +67,17 @@ struct example_unicode
 			string2 += decoded_codepoints[i];
 		}
 
-		if (string != string2)
+		if (string != to_ustring(string2))
 		{
 			LogError(
 			    "String \"%s\" compared false after utf8->unichar->utf8 conversion - got \"%s\"",
-			    u8string, string2);
+			    u8string, to_ustring(string2));
 
+			return false;
+		}
+
+		if (!test_32_8_roundtrip(u8string))
+		{
 			return false;
 		}
 
@@ -72,8 +90,7 @@ struct example_unicode
 static bool test_remove(const UString &initial, const UString &expected, size_t offset,
                         size_t count)
 {
-	UString removed = initial;
-	removed.remove(offset, count);
+	auto removed = remove(initial, offset, count);
 	if (removed != expected)
 	{
 		LogError("\"%s\".remove(%zu, %zu) = \"%s\", expected \"%s\"", initial, offset, count,
@@ -86,8 +103,7 @@ static bool test_remove(const UString &initial, const UString &expected, size_t 
 static bool test_insert(const UString &initial, const UString &expected, size_t offset,
                         const UString &str)
 {
-	UString inserted = initial;
-	inserted.insert(offset, str);
+	auto inserted = insert_codepoints(initial, offset, str);
 	if (inserted != expected)
 	{
 		LogError("\"%s\".inserted(%zu, \"%s\") = \"%s\", expected \"%s\"", initial, offset, str,
@@ -122,8 +138,8 @@ int main(int argc, char **argv)
 	UString lower_example = u8"€uppa91£b\"#ð𐍈";
 	UString upper_example = u8"€UPPA91£B\"#ð𐍈";
 
-	auto lower = example.toLower();
-	auto upper = example.toUpper();
+	auto lower = to_lower(example);
+	auto upper = to_upper(example);
 	if (lower != lower_example)
 	{
 		LogError("toLower(\"%s\") returned \"%s\", expected \"%s\"", example, lower, lower_example);
@@ -151,10 +167,6 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	if (!test_remove(example, removed_example4, 8, 4))
 		return EXIT_FAILURE;
-	if (!test_remove(empty, empty, 8, 4))
-		return EXIT_FAILURE;
-	if (!test_remove(empty, empty, 0, 1))
-		return EXIT_FAILURE;
 
 	bool exception_caught = false;
 	try
@@ -178,6 +190,14 @@ int main(int argc, char **argv)
 	test_insert(example, insert_example1, 0, u8"Ayy");
 	test_insert(example, insert_example2, 5, u8"Þ");
 	test_insert(example, insert_example3, 13, example);
+
+	test_32_8_roundtrip(removed_example1);
+	test_32_8_roundtrip(removed_example2);
+	test_32_8_roundtrip(removed_example3);
+	test_32_8_roundtrip(removed_example4);
+	test_32_8_roundtrip(insert_example1);
+	test_32_8_roundtrip(insert_example2);
+	test_32_8_roundtrip(insert_example3);
 
 	return EXIT_SUCCESS;
 }

--- a/tools/extractors/common/canonstring.h
+++ b/tools/extractors/common/canonstring.h
@@ -21,11 +21,9 @@ static inline int canon_char(int c)
 	return '_';
 }
 
-static inline std::string canon_string(std::string s)
+static inline OpenApoc::UString canon_string(OpenApoc::UString s)
 {
 	std::transform(s.begin(), s.end(), s.begin(), canon_char);
 
 	return s;
 }
-
-static inline OpenApoc::UString canon_string(OpenApoc::UString &s) { return canon_string(s.str()); }

--- a/tools/extractors/extract_vehicles.cpp
+++ b/tools/extractors/extract_vehicles.cpp
@@ -360,7 +360,7 @@ void InitialGameStateExtractor::extractVehicles(GameState &state) const
 		memcpy((void *)&equipment_screen_filename[0], (void *)&v.equipment_screen_name[0], 8);
 		equipment_screen_filename[8] = '\0';
 		std::string equipment_screen_image =
-		    "xcom3/ufodata/" + UString(equipment_screen_filename).toLower().str() + ".pcx";
+		    "xcom3/ufodata/" + to_lower(UString(equipment_screen_filename)) + ".pcx";
 		// If it's all NULLs skip (as it might be an alien ship or something and therefore no
 		// equipment screen)
 		if (equipment_screen_filename[0] != '\0')

--- a/tools/extractors/main.cpp
+++ b/tools/extractors/main.cpp
@@ -281,7 +281,7 @@ int main(int argc, char *argv[])
 	}
 	else
 	{
-		auto list = extractListString.split(",");
+		auto list = split(extractListString, ",");
 		for (auto &extractorName : list)
 		{
 			auto extractor = thingsToExtract.find(extractorName);

--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -19,7 +19,7 @@ using namespace OpenApoc;
 
 static std::list<std::pair<UString, ModInfo>> enumerateMods()
 {
-	fs::path modPath = Options::modPath.get().str();
+	fs::path modPath = Options::modPath.get();
 	if (!fs::is_directory(modPath))
 	{
 		LogError("Mod path \"%s\" not a valid directory", modPath.string());
@@ -87,8 +87,8 @@ LauncherWindow::LauncherWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui
 	                                          : Qt::CheckState::Unchecked);
 	setupResolutionDisplay();
 
-	ui->cdPath->setText(QString::fromStdString(OpenApoc::Options::cdPathOption.get().str()));
-	ui->dataPath->setText(QString::fromStdString(OpenApoc::Options::dataPathOption.get().str()));
+	ui->cdPath->setText(QString::fromStdString(OpenApoc::Options::cdPathOption.get()));
+	ui->dataPath->setText(QString::fromStdString(OpenApoc::Options::dataPathOption.get()));
 
 	setupModList();
 }
@@ -276,7 +276,7 @@ void LauncherWindow::exit()
 void LauncherWindow::setupModList()
 {
 	auto foundMods = enumerateMods();
-	auto enabledMods = Options::modList.get().split(':');
+	auto enabledMods = split(Options::modList.get(), ":");
 
 	ui->enabledModsList->clear();
 	ui->disabledModsList->clear();
@@ -290,7 +290,7 @@ void LauncherWindow::setupModList()
 			if (modDir == enabledModName)
 			{
 				const auto &modName = modInfo.getName();
-				ui->enabledModsList->addItem(QString::fromStdString(modName.str()));
+				ui->enabledModsList->addItem(QString::fromStdString(modName));
 			}
 		}
 	}
@@ -311,7 +311,7 @@ void LauncherWindow::setupModList()
 		}
 		const auto &modName = modInfo.getName();
 		if (!enabled)
-			ui->disabledModsList->addItem(QString::fromStdString(modName.str()));
+			ui->disabledModsList->addItem(QString::fromStdString(modName));
 	}
 }
 
@@ -349,14 +349,14 @@ void LauncherWindow::disabledModSelected(const QString &itemName)
 
 void LauncherWindow::showModInfo(const ModInfo &info)
 {
-	ui->modName->setText(QString::fromStdString(info.getName().str()));
-	ui->modAuthor->setText(QString::fromStdString(info.getAuthor().str()));
-	ui->modVersion->setText(QString::fromStdString(info.getVersion().str()));
-	ui->modDescription->setText(QString::fromStdString(info.getDescription().str()));
+	ui->modName->setText(QString::fromStdString(info.getName()));
+	ui->modAuthor->setText(QString::fromStdString(info.getAuthor()));
+	ui->modVersion->setText(QString::fromStdString(info.getVersion()));
+	ui->modDescription->setText(QString::fromStdString(info.getDescription()));
 
 	auto linkText = format("<a href=\"%s\">%s</a>", info.getLink(), info.getLink());
 
-	ui->modLink->setText(QString::fromStdString(linkText.str()));
+	ui->modLink->setText(QString::fromStdString(linkText));
 }
 
 void LauncherWindow::rebuildModList()
@@ -398,21 +398,21 @@ void LauncherWindow::enableModClicked()
 	if (selectedModName == "")
 		return;
 
-	for (const auto &matchingItem : ui->enabledModsList->findItems(
-	         QString::fromStdString(selectedModName.str()), Qt::MatchExactly))
+	for (const auto &matchingItem :
+	     ui->enabledModsList->findItems(QString::fromStdString(selectedModName), Qt::MatchExactly))
 	{
 		auto matchingName = matchingItem->text();
 		// Already enabled
-		if (matchingName.toStdString() == selectedModName.str())
+		if (matchingName.toStdString() == selectedModName)
 		{
 			return;
 		}
 	}
 
-	ui->enabledModsList->addItem(QString::fromStdString(selectedModName.str()));
+	ui->enabledModsList->addItem(QString::fromStdString(selectedModName));
 
-	for (const auto &matchingItem : ui->disabledModsList->findItems(
-	         QString::fromStdString(selectedModName.str()), Qt::MatchExactly))
+	for (const auto &matchingItem :
+	     ui->disabledModsList->findItems(QString::fromStdString(selectedModName), Qt::MatchExactly))
 	{
 		delete matchingItem;
 	}
@@ -425,21 +425,21 @@ void LauncherWindow::disableModClicked()
 	if (selectedModName == "")
 		return;
 
-	for (const auto &matchingItem : ui->disabledModsList->findItems(
-	         QString::fromStdString(selectedModName.str()), Qt::MatchExactly))
+	for (const auto &matchingItem :
+	     ui->disabledModsList->findItems(QString::fromStdString(selectedModName), Qt::MatchExactly))
 	{
 		auto matchingName = matchingItem->text();
 		// Already disabled
-		if (matchingName.toStdString() == selectedModName.str())
+		if (matchingName.toStdString() == selectedModName)
 		{
 			return;
 		}
 	}
 
-	ui->disabledModsList->addItem(QString::fromStdString(selectedModName.str()));
+	ui->disabledModsList->addItem(QString::fromStdString(selectedModName));
 
-	for (const auto &matchingItem : ui->enabledModsList->findItems(
-	         QString::fromStdString(selectedModName.str()), Qt::MatchExactly))
+	for (const auto &matchingItem :
+	     ui->enabledModsList->findItems(QString::fromStdString(selectedModName), Qt::MatchExactly))
 	{
 		delete matchingItem;
 	}


### PR DESCRIPTION
We don't need to wrap the whole string, in c++20 we can use u8string
(std::basic_string<char8_t>) to ensure that it's a compile-time error to
assume that char (aka a 'byte') and char8_t (a utf8 code unit) are the
same.

Pull the few helper functions we implement on top of std::string into
loose functions.

If you want to use unicode codepoints (e.g. the font rendering or
textedit selection), use U32String instead.