### PR TITLE
Fixes for destroyed bases #915

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -121,14 +121,11 @@ void Base::die(GameState &state, bool collapse)
 	}
 	for (auto a : building->currentAgents)
 	{
-		auto agent = a;
-		agent->die(state, true);
+		a->die(state, true);
 	}
-	auto vehicles = building->currentVehicles;
-	for (auto v : vehicles)
+	for (auto v : building->currentVehicles)
 	{
-		auto vehicle = v;
-		vehicle->die(state, true);
+		v->die(state, true);
 	}
 	building->base.clear();
 	building->owner = state.getGovernment();

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -1016,11 +1016,8 @@ void Building::buildingPartChange(GameState &state, Vec3<int> part, bool intact)
 		buildingParts.erase(part);
 		if (buildingParts.find(crewQuarters) == buildingParts.end())
 		{
-			while (!currentAgents.empty())
+			for (auto agent : currentAgents)
 			{
-				// For some reason need to assign first before calling die()
-				auto agent = *currentAgents.begin();
-				// Dying will remove agent from current agents list
 				agent->die(state, true);
 			}
 		}

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1851,17 +1851,10 @@ void Vehicle::die(GameState &state, bool silent, StateRef<Vehicle> attacker)
 	}
 	removeFromMap(state);
 
-	while (!currentAgents.empty())
+	// Dying will remove agent from current agents list
+	for (auto agent : currentAgents)
 	{
-		// For some reason need to assign first before calling die()
-		auto agent = *currentAgents.begin();
-		// Dying will remove agent from current agents list
 		agent->die(state, true);
-	}
-	// Remove from building
-	if (currentBuilding)
-	{
-		currentBuilding->currentVehicles.erase({&state, shared_from_this()});
 	}
 
 	// Adjust relationships
@@ -2030,6 +2023,22 @@ Vec3<float> Vehicle::getMuzzleLocation() const
 
 void Vehicle::update(GameState &state, unsigned int ticks)
 {
+	if (isDead() && status == VehicleStatus::Operational)
+	{
+		status = VehicleStatus::Destroyed;
+
+		// Remove from building
+		if (currentBuilding)
+		{
+			currentBuilding->currentVehicles.erase({&state, shared_from_this()});
+		}
+	}
+
+	if (isDead())
+	{
+		return;
+	}
+
 	bool turbo = ticks > TICKS_PER_SECOND;
 	bool IsIdle;
 

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -174,6 +174,14 @@ class Vehicle : public StateObject<Vehicle>,
 		Low = 3
 	};
 	Altitude altitude = Altitude::Standard;
+
+	enum class VehicleStatus
+	{
+		Operational,
+		Destroyed
+	};
+	VehicleStatus status = VehicleStatus::Operational;
+
 	// Adjusts position by altitude preference
 	Vec3<int> getPreferredPosition(Vec3<int> position) const;
 	Vec3<int> getPreferredPosition(int x, int y, int z = 0) const;

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -55,6 +55,12 @@ enum class TrainingAssignment
 	Psi
 };
 
+enum class AgentStatus
+{
+	Alive,
+	Dead
+};
+
 class Agent : public StateObject<Agent>,
               public std::enable_shared_from_this<Agent>,
               public EquippableObject
@@ -78,6 +84,7 @@ class Agent : public StateObject<Agent>,
 	                           // to equipment weight, used stamina etc)
 	bool overEncumbred = false;
 	Rank rank = Rank::Rookie;
+	AgentStatus status = AgentStatus::Alive;
 
 	unsigned int teleportTicksAccumulated = 0;
 	bool canTeleport() const;


### PR DESCRIPTION
The agents and vehicles are marked dead/destroyed and they are cleaned up on next update after they die.
Should fix removing agents and vehicles during iterating through the lists.