### PR TITLE
Civilians should not appear hostile and not cause reaction fire

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2367,7 +2367,7 @@ void Battle::giveInterruptChanceToUnit(GameState &state, StateRef<BattleUnit> gi
                                        StateRef<BattleUnit> receiver, int reactionValue)
 {
 	if (mode != Mode::TurnBased || receiver->owner == currentActiveOrganisation ||
-	    receiver->getAIType() == AIType::None ||
+	    receiver->getAIType() == AIType::None || receiver->getAIType() == AIType::Civilian ||
 	    interruptQueue.find(receiver) != interruptQueue.end())
 	{
 		return;

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -617,8 +617,9 @@ void BattleUnit::refreshUnitVision(GameState &state, bool forceBlind,
 				state.current_battle->notifyAction(vu->position, vu);
 			}
 		}
-		// battle and units's visible enemies list
-		if (owner->isRelatedTo(vu->owner) == Organisation::Relation::Hostile)
+		// battle and units's visible enemies list (Do not count civilians as enemy)
+		if (owner->isRelatedTo(vu->owner) == Organisation::Relation::Hostile &&
+		    vu->getAIType() != AIType::Civilian)
 		{
 			visibleEnemies.insert(vu);
 			battle.visibleEnemies[owner].insert(vu);


### PR DESCRIPTION
Fix to #849

Civilians are never considered enemies.
Added check for reaction fire to not shoot civilians.