### PR TITLE
Workaround appveyor nsis install failure

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,11 +34,8 @@ before_build:
   - git submodule update --init --recursive
   - curl http://s2.jonnyh.net/pub/cd_minimal.iso.xz -o temp\cd.iso.xz
   - 7z e temp\cd.iso.xz -odata\
-# nsis 3.5.0-20200106 from choco 10.15 hardcodes a sourceforge mirror (astuteinternet.dl.sourceforge.net) - which at time of writing (2020/08/13) has an expired ssl cert
-# so override it with a modified version that uses sourceforge's mirror selector
-  - mkdir choco-download-cache
-  - curl http://sourceforge.net/projects/nsis/files/NSIS%203/3.05/nsis-3.05-setup.exe -o choco-download-cache/nsis-3.05-setup.exe
-  - choco install nsis -pre -c choco-download-cache
+  - choco upgrade chocolatey
+  - choco install nsis -pre
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,9 @@ before_build:
   - git submodule update --init --recursive
   - curl http://s2.jonnyh.net/pub/cd_minimal.iso.xz -o temp\cd.iso.xz
   - 7z e temp\cd.iso.xz -odata\
+# nsis 3.5.0-20200106 from choco 10.15 hardcodes a sourceforge mirror (astuteinternet.dl.sourceforge.net) - which at time of writing (2020/08/13) has an expired ssl cert
+# so override it with a modified version that uses sourceforge's mirror selector
+  - copy tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1 C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
   - choco install nsis -pre
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,7 +34,7 @@ before_build:
   - git submodule update --init --recursive
   - curl http://s2.jonnyh.net/pub/cd_minimal.iso.xz -o temp\cd.iso.xz
   - 7z e temp\cd.iso.xz -odata\
-  - choco upgrade chocolatey
+    #  - choco upgrade chocolatey
   - choco install nsis -pre
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,8 +38,9 @@ before_build:
 # so override it with a modified version that uses sourceforge's mirror selector
   - dir tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1
   - dir C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
-  - copy tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1 C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
-  - choco install nsis -pre
+  - mkdir choco-download-cache
+  - curl http://sourceforge.net/projects/nsis/files/NSIS%203/3.05/nsis-3.05-setup.exe -o choco-download-cache/nsis-3.05-setup.exe
+  - choco install nsis -pre -c choco-download-cache
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,8 @@ before_build:
   - 7z e temp\cd.iso.xz -odata\
 # nsis 3.5.0-20200106 from choco 10.15 hardcodes a sourceforge mirror (astuteinternet.dl.sourceforge.net) - which at time of writing (2020/08/13) has an expired ssl cert
 # so override it with a modified version that uses sourceforge's mirror selector
-  - Get-ChildItem -file tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1
-  - Get-ChildItem -file C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
+  - dir tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1
+  - dir C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
   - copy tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1 C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
   - choco install nsis -pre
   - choco install ninja

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,6 +36,8 @@ before_build:
   - 7z e temp\cd.iso.xz -odata\
 # nsis 3.5.0-20200106 from choco 10.15 hardcodes a sourceforge mirror (astuteinternet.dl.sourceforge.net) - which at time of writing (2020/08/13) has an expired ssl cert
 # so override it with a modified version that uses sourceforge's mirror selector
+  - Get-ChildItem -file tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1
+  - Get-ChildItem -file C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
   - copy tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1 C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
   - choco install nsis -pre
   - choco install ninja

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,8 +36,6 @@ before_build:
   - 7z e temp\cd.iso.xz -odata\
 # nsis 3.5.0-20200106 from choco 10.15 hardcodes a sourceforge mirror (astuteinternet.dl.sourceforge.net) - which at time of writing (2020/08/13) has an expired ssl cert
 # so override it with a modified version that uses sourceforge's mirror selector
-  - dir tools\chocolatey\nsis\nsis-sourceforge-mirror-chocolateyInstall.ps1
-  - dir C:\ProgramData\chocolatey\lib\nsis.install\tools\chocolateyInstall.ps1
   - mkdir choco-download-cache
   - curl http://sourceforge.net/projects/nsis/files/NSIS%203/3.05/nsis-3.05-setup.exe -o choco-download-cache/nsis-3.05-setup.exe
   - choco install nsis -pre -c choco-download-cache

--- a/tools/chocolatey/nsis/nsis-sourceforge-mirror-chocolateyInstall.ps1
+++ b/tools/chocolatey/nsis/nsis-sourceforge-mirror-chocolateyInstall.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop';
+
+$toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$url          = 'http://sourceforge.net/projects/nsis/files/NSIS%203/3.05/nsis-3.05-setup.exe'
+$checksum     = '1a3cc9401667547b9b9327a177b13485f7c59c2303d4b6183e7bc9e6c8d6bfdb'
+$checksumType = 'sha256'
+
+$packageArgs = @{
+  packageName    = $env:ChocolateyPackageName
+  unzipLocation  = $toolsDir
+  fileType       = 'exe'
+  url            = $url
+  checksum       = $checksum
+  checksumType   = $checksumType
+  softwareName   = 'Nullsoft Install System*'
+  silentArgs     = '/S'
+  validExitCodes = @(0,3010)
+}
+
+Install-ChocolateyPackage @packageArgs


### PR DESCRIPTION
nsis 3.5.0-20200106 from choco 10.15 hardcodes a sourceforge mirror (astuteinternet.dl.sourceforge.net) - which at time of writing (2020/08/13) has an expired ssl cert.

So override it with a modified version that uses sourceforge's mirror selector