### PR TITLE
In turn-based mode spotted units remain visible until the end of the turn

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -1825,6 +1825,33 @@ void Battle::updateTBEnd(GameState &state)
 			p->updateTB(state);
 		}
 	}
+
+	// Hide units no one in our organisation sees anymore.
+	for (auto it = visibleUnits[currentActiveOrganisation].begin();
+	     it != visibleUnits[currentActiveOrganisation].end();)
+	{
+		bool someoneSees = false;
+
+		for (const auto &u : this->units)
+		{
+			const auto &unit = u.second;
+			if ((unit->owner == currentActiveOrganisation) &&
+			    (unit->visibleUnits.find(*it) != unit->visibleUnits.end()))
+			{
+				someoneSees = true;
+				break;
+			}
+		}
+		if (!someoneSees)
+		{
+			visibleEnemies[currentActiveOrganisation].erase(*it);
+			it = visibleUnits[currentActiveOrganisation].erase(it);
+		}
+		else
+		{
+			it++;
+		}
+	}
 }
 
 int Battle::getLosBlockID(int x, int y, int z) const

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -626,29 +626,34 @@ void BattleUnit::refreshUnitVision(GameState &state, bool forceBlind,
 		}
 	}
 
-	// See if someone else sees a unit we stopped seeing
-	for (auto &lvu : lastVisibleUnits)
+	// In turn-based mode during player turn spotted units remain visible until the end of the turn
+	if ((battle.mode == Battle::Mode::RealTime) ||
+	    (battle.currentActiveOrganisation != state.getPlayer()))
 	{
-		if (visibleUnits.find(lvu) == visibleUnits.end())
+		// See if someone else sees a unit we stopped seeing
+		for (auto &lvu : lastVisibleUnits)
 		{
-			bool someoneElseSees = false;
-			for (auto &u : state.current_battle->units)
+			if (visibleUnits.find(lvu) == visibleUnits.end())
 			{
-				if (u.second->owner != owner)
+				bool someoneElseSees = false;
+				for (auto &u : state.current_battle->units)
 				{
-					continue;
+					if (u.second->owner != owner)
+					{
+						continue;
+					}
+					if (u.second->visibleUnits.find(lvu) != u.second->visibleUnits.end())
+					{
+						someoneElseSees = true;
+						break;
+					}
 				}
-				if (u.second->visibleUnits.find(lvu) != u.second->visibleUnits.end())
+				if (!someoneElseSees)
 				{
-					someoneElseSees = true;
-					break;
+					battle.visibleUnits[owner].erase(lvu);
+					battle.visibleEnemies[owner].erase(lvu);
+					battle.lastVisibleTime[owner][lvu] = ticks;
 				}
-			}
-			if (!someoneElseSees)
-			{
-				battle.visibleUnits[owner].erase(lvu);
-				battle.visibleEnemies[owner].erase(lvu);
-				battle.lastVisibleTime[owner][lvu] = ticks;
 			}
 		}
 	}


### PR DESCRIPTION
In turn-based mode spotted units remain visible until the end of the turn