### PR TITLE
Clear vehicles from Building::currentVehicles when dieing

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1851,6 +1851,11 @@ void Vehicle::die(GameState &state, bool silent, StateRef<Vehicle> attacker)
 	}
 	removeFromMap(state);
 
+	if (currentBuilding)
+	{
+		currentBuilding->currentVehicles.erase(StateRef<Vehicle>(&state, shared_from_this()));
+	}
+
 	// Dying will remove agent from current agents list
 	for (auto agent : currentAgents)
 	{


### PR DESCRIPTION
This would previously leave a dangling reference if the vehicle was inside a building and it "died" (e.g. sold or otherwise removed from the game)