### PR TITLE
Make Vehicle and Agent missions direct objects instead of up<Object>

### DIFF
--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -209,7 +209,7 @@ bool AgentTileHelper::isMoveAllowed(Scenery &scenery, int dir) const
 }
 
 AgentMission AgentMission::gotoBuilding(GameState &, Agent &a, StateRef<Building> target,
-                                         bool allowTeleporter, bool allowTaxi)
+                                        bool allowTeleporter, bool allowTaxi)
 {
 	AgentMission mission;
 	mission.type = MissionType::GotoBuilding;
@@ -244,7 +244,7 @@ AgentMission AgentMission::awaitPickup(GameState &, Agent &, StateRef<Building> 
 }
 
 AgentMission AgentMission::teleport(GameState &state [[maybe_unused]], Agent &a [[maybe_unused]],
-                                     StateRef<Building> b)
+                                    StateRef<Building> b)
 {
 	AgentMission mission;
 	mission.type = MissionType::Teleport;
@@ -253,7 +253,7 @@ AgentMission AgentMission::teleport(GameState &state [[maybe_unused]], Agent &a 
 }
 
 AgentMission AgentMission::investigateBuilding(GameState &, Agent &a, StateRef<Building> target,
-                                                bool allowTeleporter, bool allowTaxi)
+                                               bool allowTeleporter, bool allowTaxi)
 {
 	AgentMission mission;
 	mission.type = MissionType::InvestigateBuilding;

--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -208,58 +208,58 @@ bool AgentTileHelper::isMoveAllowed(Scenery &scenery, int dir) const
 	return false;
 }
 
-AgentMission *AgentMission::gotoBuilding(GameState &, Agent &a, StateRef<Building> target,
+AgentMission AgentMission::gotoBuilding(GameState &, Agent &a, StateRef<Building> target,
                                          bool allowTeleporter, bool allowTaxi)
 {
-	auto *mission = new AgentMission();
-	mission->type = MissionType::GotoBuilding;
-	mission->targetBuilding = target ? target : a.homeBuilding;
-	mission->allowTeleporter = allowTeleporter && a.type->role == AgentType::Role::Soldier;
-	mission->allowTaxi = allowTaxi || a.type->role != AgentType::Role::Soldier;
+	AgentMission mission;
+	mission.type = MissionType::GotoBuilding;
+	mission.targetBuilding = target ? target : a.homeBuilding;
+	mission.allowTeleporter = allowTeleporter && a.type->role == AgentType::Role::Soldier;
+	mission.allowTaxi = allowTaxi || a.type->role != AgentType::Role::Soldier;
 	return mission;
 }
 
-AgentMission *AgentMission::snooze(GameState &, Agent &, unsigned int snoozeTicks)
+AgentMission AgentMission::snooze(GameState &, Agent &, unsigned int snoozeTicks)
 {
-	auto *mission = new AgentMission();
-	mission->type = MissionType::Snooze;
-	mission->timeToSnooze = snoozeTicks;
+	AgentMission mission;
+	mission.type = MissionType::Snooze;
+	mission.timeToSnooze = snoozeTicks;
 	return mission;
 }
 
-AgentMission *AgentMission::restartNextMission(GameState &, Agent &)
+AgentMission AgentMission::restartNextMission(GameState &, Agent &)
 {
-	auto *mission = new AgentMission();
-	mission->type = MissionType::RestartNextMission;
+	AgentMission mission;
+	mission.type = MissionType::RestartNextMission;
 	return mission;
 }
 
-AgentMission *AgentMission::awaitPickup(GameState &, Agent &, StateRef<Building> target)
+AgentMission AgentMission::awaitPickup(GameState &, Agent &, StateRef<Building> target)
 {
-	auto *mission = new AgentMission();
-	mission->type = MissionType::AwaitPickup;
-	mission->timeToSnooze = PICKUP_TIMEOUT;
-	mission->targetBuilding = target;
+	AgentMission mission;
+	mission.type = MissionType::AwaitPickup;
+	mission.timeToSnooze = PICKUP_TIMEOUT;
+	mission.targetBuilding = target;
 	return mission;
 }
 
-AgentMission *AgentMission::teleport(GameState &state [[maybe_unused]], Agent &a [[maybe_unused]],
+AgentMission AgentMission::teleport(GameState &state [[maybe_unused]], Agent &a [[maybe_unused]],
                                      StateRef<Building> b)
 {
-	auto *mission = new AgentMission();
-	mission->type = MissionType::Teleport;
-	mission->targetBuilding = b;
+	AgentMission mission;
+	mission.type = MissionType::Teleport;
+	mission.targetBuilding = b;
 	return mission;
 }
 
-AgentMission *AgentMission::investigateBuilding(GameState &, Agent &a, StateRef<Building> target,
+AgentMission AgentMission::investigateBuilding(GameState &, Agent &a, StateRef<Building> target,
                                                 bool allowTeleporter, bool allowTaxi)
 {
-	auto *mission = new AgentMission();
-	mission->type = MissionType::InvestigateBuilding;
-	mission->targetBuilding = target;
-	mission->allowTeleporter = allowTeleporter && a.type->role == AgentType::Role::Soldier;
-	mission->allowTaxi = allowTaxi || a.type->role != AgentType::Role::Soldier;
+	AgentMission mission;
+	mission.type = MissionType::InvestigateBuilding;
+	mission.targetBuilding = target;
+	mission.allowTeleporter = allowTeleporter && a.type->role == AgentType::Role::Soldier;
+	mission.allowTaxi = allowTaxi || a.type->role != AgentType::Role::Soldier;
 	return mission;
 }
 
@@ -267,9 +267,9 @@ bool AgentMission::teleportCheck(GameState &state, Agent &a)
 {
 	if (allowTeleporter && a.canTeleport())
 	{
-		auto *teleportMission = AgentMission::teleport(state, a, targetBuilding);
+		auto teleportMission = AgentMission::teleport(state, a, targetBuilding);
 		a.missions.emplace_front(teleportMission);
-		teleportMission->start(state, a);
+		teleportMission.start(state, a);
 		return true;
 	}
 	return false;

--- a/game/state/city/agentmission.h
+++ b/game/state/city/agentmission.h
@@ -69,14 +69,14 @@ class AgentMission
 
 	// With no building goes home, allowTaxi auto set to true for non-soldiers
 	static AgentMission gotoBuilding(GameState &state, Agent &a,
-	                                  StateRef<Building> target = nullptr,
-	                                  bool allowTeleporter = false, bool allowTaxi = false);
+	                                 StateRef<Building> target = nullptr,
+	                                 bool allowTeleporter = false, bool allowTaxi = false);
 	static AgentMission awaitPickup(GameState &state, Agent &a, StateRef<Building> target);
 	static AgentMission snooze(GameState &state, Agent &a, unsigned int ticks);
 	static AgentMission restartNextMission(GameState &state, Agent &a);
 	static AgentMission teleport(GameState &state, Agent &a, StateRef<Building> b);
 	static AgentMission investigateBuilding(GameState &state, Agent &a, StateRef<Building> target,
-	                                         bool allowTeleporter = false, bool allowTaxi = false);
+	                                        bool allowTeleporter = false, bool allowTaxi = false);
 	UString getName();
 
 	enum class MissionType

--- a/game/state/city/agentmission.h
+++ b/game/state/city/agentmission.h
@@ -68,14 +68,14 @@ class AgentMission
 	// Methods to create new missions
 
 	// With no building goes home, allowTaxi auto set to true for non-soldiers
-	static AgentMission *gotoBuilding(GameState &state, Agent &a,
+	static AgentMission gotoBuilding(GameState &state, Agent &a,
 	                                  StateRef<Building> target = nullptr,
 	                                  bool allowTeleporter = false, bool allowTaxi = false);
-	static AgentMission *awaitPickup(GameState &state, Agent &a, StateRef<Building> target);
-	static AgentMission *snooze(GameState &state, Agent &a, unsigned int ticks);
-	static AgentMission *restartNextMission(GameState &state, Agent &a);
-	static AgentMission *teleport(GameState &state, Agent &a, StateRef<Building> b);
-	static AgentMission *investigateBuilding(GameState &state, Agent &a, StateRef<Building> target,
+	static AgentMission awaitPickup(GameState &state, Agent &a, StateRef<Building> target);
+	static AgentMission snooze(GameState &state, Agent &a, unsigned int ticks);
+	static AgentMission restartNextMission(GameState &state, Agent &a);
+	static AgentMission teleport(GameState &state, Agent &a, StateRef<Building> b);
+	static AgentMission investigateBuilding(GameState &state, Agent &a, StateRef<Building> target,
 	                                         bool allowTeleporter = false, bool allowTaxi = false);
 	UString getName();
 

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -420,8 +420,8 @@ void Building::updateCargo(GameState &state)
 			}
 			// Check if is a ferry
 			if (v.second->missions.empty() ||
-			    v.second->missions.back()->type != VehicleMission::MissionType::OfferService ||
-			    v.second->missions.back()->missionCounter > 0)
+			    v.second->missions.back().type != VehicleMission::MissionType::OfferService ||
+			    v.second->missions.back().missionCounter > 0)
 			{
 				continue;
 			}
@@ -434,7 +434,7 @@ void Building::updateCargo(GameState &state)
 					continue;
 				}
 				// Not bound for this building
-				if (v.second->missions.back()->targetBuilding != thisRef)
+				if (v.second->missions.back().targetBuilding != thisRef)
 				{
 					continue;
 				}

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -222,7 +222,7 @@ void Building::updateCargo(GameState &state)
 				for (auto &a : currentAgents)
 				{
 					if (a->missions.empty() ||
-					    a->missions.front()->type != AgentMission::MissionType::AwaitPickup)
+					    a->missions.front().type != AgentMission::MissionType::AwaitPickup)
 					{
 						continue;
 					}
@@ -296,7 +296,7 @@ void Building::updateCargo(GameState &state)
 			for (auto &a : currentAgents)
 			{
 				if (a->missions.empty() ||
-				    a->missions.front()->type != AgentMission::MissionType::AwaitPickup)
+				    a->missions.front().type != AgentMission::MissionType::AwaitPickup)
 				{
 					continue;
 				}
@@ -396,16 +396,16 @@ void Building::updateCargo(GameState &state)
 	for (auto &a : currentAgents)
 	{
 		if (a->missions.empty() ||
-		    a->missions.front()->type != AgentMission::MissionType::AwaitPickup)
+		    a->missions.front().type != AgentMission::MissionType::AwaitPickup)
 		{
 			continue;
 		}
 #ifdef DEBUG_VERBOSE_CARGO_SYSTEM
 		LogWarning("AGENT: %s needs to deliver to %s", thisRef.id,
-		           a->missions.front()->targetBuilding.id);
+		           a->missions.front().targetBuilding.id);
 #endif
-		spaceNeeded[a->missions.front()->targetBuilding][a->owner].resize(3);
-		spaceNeeded[a->missions.front()->targetBuilding][a->owner][2]++;
+		spaceNeeded[a->missions.front().targetBuilding][a->owner].resize(3);
+		spaceNeeded[a->missions.front().targetBuilding][a->owner][2]++;
 	}
 
 	// Step 04: Find if carrying capacity is satisfied by incoming ferries

--- a/game/state/city/scenery.cpp
+++ b/game/state/city/scenery.cpp
@@ -1196,7 +1196,7 @@ bool Scenery::handleCollision(GameState &state, Collision &c)
 		updateRelationWithAttacker(state, attackerOrg, false);
 		bool intentional =
 		    c.projectile->manualFire || (!c.projectile->firerVehicle->missions.empty() &&
-		                                 c.projectile->firerVehicle->missions.front()->type ==
+		                                 c.projectile->firerVehicle->missions.front().type ==
 		                                     VehicleMission::MissionType::AttackBuilding);
 		if (intentional || config().getBool("OpenApoc.NewFeature.ScrambleOnUnintentionalHit"))
 		{

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1669,12 +1669,12 @@ void Vehicle::provideServicePassengers(GameState &state, bool otherOrg)
 			}
 			// Agent doesn't want pickup
 			if (a->missions.empty() ||
-			    a->missions.front()->type != AgentMission::MissionType::AwaitPickup)
+			    a->missions.front().type != AgentMission::MissionType::AwaitPickup)
 			{
 				continue;
 			}
 			// Won't ferry other orgs
-			if (a->missions.front()->targetBuilding->owner != owner && !otherOrg)
+			if (a->missions.front().targetBuilding->owner != owner && !otherOrg)
 			{
 				continue;
 			}
@@ -1684,14 +1684,14 @@ void Vehicle::provideServicePassengers(GameState &state, bool otherOrg)
 				continue;
 			}
 			// Won't ferry if already picked destination and doesn't match
-			if (destination && a->missions.front()->targetBuilding != destination)
+			if (destination && a->missions.front().targetBuilding != destination)
 			{
 				continue;
 			}
 			// Here's where we're going
 			if (!destination)
 			{
-				destination = a->missions.front()->targetBuilding;
+				destination = a->missions.front().targetBuilding;
 			}
 			// Load up
 			a->enterVehicle(state, {&state, shared_from_this()});
@@ -1742,18 +1742,18 @@ StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 		}
 		// Skip agents that are just on this craft without a mission
 		if (a->missions.empty() ||
-		    a->missions.front()->type != AgentMission::MissionType::AwaitPickup)
+		    a->missions.front().type != AgentMission::MissionType::AwaitPickup)
 		{
 			continue;
 		}
-		if (a->missions.front()->targetBuilding == currentBuilding)
+		if (a->missions.front().targetBuilding == currentBuilding)
 		{
 			agentsToRemove.push_back(a);
 			continue;
 		}
 		if (!destination)
 		{
-			destination = a->missions.front()->targetBuilding;
+			destination = a->missions.front().targetBuilding;
 		}
 	}
 	for (auto &a : agentsToRemove)
@@ -2354,7 +2354,7 @@ void Vehicle::updateCargo(GameState &state)
 		for (auto &a : currentAgents)
 		{
 			if (!a->missions.empty() &&
-			    a->missions.front()->type == AgentMission::MissionType::AwaitPickup)
+			    a->missions.front().type == AgentMission::MissionType::AwaitPickup)
 			{
 				needFerry = true;
 				break;

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -2172,8 +2172,8 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 						sp<TileObjectVehicle> enemy;
 						if (!missions.empty() &&
 						    missions.front().type == VehicleMission::MissionType::AttackVehicle &&
-						    tileObject->getDistanceTo(
-						        missions.front().targetVehicle->tileObject) <= firingRange)
+						    tileObject->getDistanceTo(missions.front().targetVehicle->tileObject) <=
+						        firingRange)
 						{
 							enemy = missions.front().targetVehicle->tileObject;
 							if (enemy)
@@ -3278,7 +3278,7 @@ bool Vehicle::getNewGoal(GameState &state, int &turboTiles)
 		if (!missions.empty())
 		{
 			acquired = missions.front().getNextDestination(state, *this, goalPosition, goalFacing,
-			                                                turboTiles);
+			                                               turboTiles);
 		}
 		// Pop finished missions if present
 		popped = popFinishedMissions(state);

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -106,8 +106,8 @@ class FlyingVehicleMover : public VehicleMover
 		// Vehicles on take off mission don't do anything
 		if (!vehicle.missions.empty())
 		{
-			if (vehicle.missions.front()->type == VehicleMission::MissionType::TakeOff ||
-			    vehicle.missions.front()->type == VehicleMission::MissionType::Land)
+			if (vehicle.missions.front().type == VehicleMission::MissionType::TakeOff ||
+			    vehicle.missions.front().type == VehicleMission::MissionType::Land)
 			{
 				return;
 			}
@@ -149,11 +149,11 @@ class FlyingVehicleMover : public VehicleMover
 				if (!vehicle.missions.empty())
 				{
 					// Will need new path after moving
-					vehicle.missions.front()->currentPlannedPath.clear();
+					vehicle.missions.front().currentPlannedPath.clear();
 				}
 				auto adjustHeightMission = VehicleMission::gotoLocation(state, vehicle, targetPos);
-				adjustHeightMission->currentPlannedPath.emplace_front(targetPos);
-				adjustHeightMission->currentPlannedPath.emplace_front(vehicle.position);
+				adjustHeightMission.currentPlannedPath.emplace_front(targetPos);
+				adjustHeightMission.currentPlannedPath.emplace_front(vehicle.position);
 				vehicle.addMission(state, adjustHeightMission);
 				return;
 			}
@@ -348,11 +348,11 @@ class FlyingVehicleMover : public VehicleMover
 					if (!vehicle.missions.empty())
 					{
 						// Will need new path after moving
-						vehicle.missions.front()->currentPlannedPath.clear();
+						vehicle.missions.front().currentPlannedPath.clear();
 					}
 					auto dodgeMission = VehicleMission::gotoLocation(state, vehicle, targetPos);
-					dodgeMission->currentPlannedPath.emplace_front(targetPos);
-					dodgeMission->currentPlannedPath.emplace_front(vehicle.position);
+					dodgeMission.currentPlannedPath.emplace_front(targetPos);
+					dodgeMission.currentPlannedPath.emplace_front(vehicle.position);
 					vehicle.addMission(state, dodgeMission);
 					return;
 				}
@@ -1832,15 +1832,15 @@ void Vehicle::die(GameState &state, bool silent, StateRef<Vehicle> attacker)
 	{
 		for (auto &m : v.second->missions)
 		{
-			if (m->targetVehicle.id == id)
+			if (m.targetVehicle.id == id)
 			{
-				m->targetVehicle.clear();
+				m.targetVehicle.clear();
 			}
-			for (auto it = m->targets.begin(); it != m->targets.end();)
+			for (auto it = m.targets.begin(); it != m.targets.end();)
 			{
 				if ((*it).id == id)
 				{
-					it = m->targets.erase(it);
+					it = m.targets.erase(it);
 				}
 				else
 				{
@@ -1906,7 +1906,7 @@ void Vehicle::crash(GameState &state, StateRef<Vehicle> attacker)
 			bool found = false;
 			for (auto &m : missions)
 			{
-				if (m->type == VehicleMission::MissionType::SelfDestruct)
+				if (m.type == VehicleMission::MissionType::SelfDestruct)
 				{
 					found = true;
 					break;
@@ -2078,7 +2078,7 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 	IsIdle = this->missions.empty();
 	if (!IsIdle)
 	{
-		this->missions.front()->update(state, *this, ticks);
+		this->missions.front().update(state, *this, ticks);
 	}
 
 	popFinishedMissions(state);
@@ -2117,8 +2117,8 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 		bool attemptFire = true;
 		if (!type->isGround() && !missions.empty())
 		{
-			if (missions.front()->type == VehicleMission::MissionType::TakeOff ||
-			    missions.front()->type == VehicleMission::MissionType::Land)
+			if (missions.front().type == VehicleMission::MissionType::TakeOff ||
+			    missions.front().type == VehicleMission::MissionType::Land)
 			{
 				attemptFire = false;
 			}
@@ -2171,11 +2171,11 @@ void Vehicle::update(GameState &state, unsigned int ticks)
 						auto firingRange = getFiringRange();
 						sp<TileObjectVehicle> enemy;
 						if (!missions.empty() &&
-						    missions.front()->type == VehicleMission::MissionType::AttackVehicle &&
+						    missions.front().type == VehicleMission::MissionType::AttackVehicle &&
 						    tileObject->getDistanceTo(
-						        missions.front()->targetVehicle->tileObject) <= firingRange)
+						        missions.front().targetVehicle->tileObject) <= firingRange)
 						{
-							enemy = missions.front()->targetVehicle->tileObject;
+							enemy = missions.front().targetVehicle->tileObject;
 							if (enemy)
 							{
 								attackTarget(state, enemy);
@@ -2332,7 +2332,7 @@ void Vehicle::updateCargo(GameState &state)
 		return;
 	}
 	// Already ferrying
-	if (!missions.empty() && missions.back()->type == VehicleMission::MissionType::OfferService)
+	if (!missions.empty() && missions.back().type == VehicleMission::MissionType::OfferService)
 	{
 		return;
 	}
@@ -2771,9 +2771,9 @@ bool Vehicle::fireAtBuilding(
 	auto firingRange = getFiringRange();
 
 	// Attack buildings
-	if (!missions.empty() && missions.front()->type == VehicleMission::MissionType::AttackBuilding)
+	if (!missions.empty() && missions.front().type == VehicleMission::MissionType::AttackBuilding)
 	{
-		auto target = missions.front()->targetBuilding;
+		auto target = missions.front().targetBuilding;
 		if (!target->buildingParts.empty())
 		{
 			bool inRange = target->bounds.within(Vec2<int>{position.x, position.y});
@@ -3076,7 +3076,7 @@ void Vehicle::setManualFirePosition(const Vec3<float> &pos)
 }
 
 typename decltype(Vehicle::missions)::iterator
-Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
+Vehicle::addMission(GameState &state, VehicleMission mission, bool toBack)
 {
 	if (!hasEngine())
 	{
@@ -3085,11 +3085,10 @@ Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 			fw().pushEvent(
 			    new GameVehicleEvent(GameEventType::VehicleNoEngine, {&state, shared_from_this()}));
 		}
-		delete mission;
 		return missions.end();
 	}
 	bool canPlaceInFront = false;
-	switch (mission->type)
+	switch (mission.type)
 	{
 		// - Can place in front
 		// - Can place on crashed vehicles
@@ -3111,7 +3110,6 @@ Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 		case VehicleMission::MissionType::Land:
 			if (crashed || sliding || falling)
 			{
-				delete mission;
 				return missions.end();
 			}
 			break;
@@ -3134,21 +3132,20 @@ Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 		case VehicleMission::MissionType::ArriveFromDimensionGate:
 			if (crashed || sliding || falling || carriedVehicle)
 			{
-				delete mission;
 				return missions.end();
 			}
 			break;
 	}
 	if (!toBack && !canPlaceInFront && !missions.empty() &&
-	    (missions.front()->type == VehicleMission::MissionType::Land ||
-	     missions.front()->type == VehicleMission::MissionType::TakeOff))
+	    (missions.front().type == VehicleMission::MissionType::Land ||
+	     missions.front().type == VehicleMission::MissionType::TakeOff))
 	{
 		return missions.emplace(++missions.begin(), mission);
 	}
 	else if (!toBack || missions.empty())
 	{
 		missions.emplace_front(mission);
-		missions.front()->start(state, *this);
+		missions.front().start(state, *this);
 		return missions.begin();
 	}
 	else
@@ -3158,7 +3155,7 @@ Vehicle::addMission(GameState &state, VehicleMission *mission, bool toBack)
 	}
 }
 
-bool Vehicle::setMission(GameState &state, VehicleMission *mission)
+bool Vehicle::setMission(GameState &state, VehicleMission mission)
 {
 	if (!hasEngine())
 	{
@@ -3167,12 +3164,11 @@ bool Vehicle::setMission(GameState &state, VehicleMission *mission)
 			fw().pushEvent(
 			    new GameVehicleEvent(GameEventType::VehicleNoEngine, {&state, shared_from_this()}));
 		}
-		delete mission;
 		return false;
 	}
 
 	bool forceClear = false;
-	switch (mission->type)
+	switch (mission.type)
 	{
 		case VehicleMission::MissionType::Crash:
 			forceClear = true;
@@ -3199,7 +3195,6 @@ bool Vehicle::setMission(GameState &state, VehicleMission *mission)
 		case VehicleMission::MissionType::ArriveFromDimensionGate:
 			if (crashed || sliding || falling || carriedVehicle)
 			{
-				delete mission;
 				return false;
 			}
 			break;
@@ -3210,7 +3205,7 @@ bool Vehicle::setMission(GameState &state, VehicleMission *mission)
 	{
 		// A mission couldn't be cleared and the new mission was inserted behind it
 		// need to manually start the mission at the front
-		missions.front()->start(state, *this);
+		missions.front().start(state, *this);
 	}
 	return true;
 }
@@ -3219,8 +3214,8 @@ bool Vehicle::clearMissions(GameState &state, bool forced)
 {
 	for (auto it = missions.begin(); it != missions.end();)
 	{
-		if (((*it)->type == VehicleMission::MissionType::Land ||
-		     (*it)->type == VehicleMission::MissionType::TakeOff) &&
+		if (((*it).type == VehicleMission::MissionType::Land ||
+		     (*it).type == VehicleMission::MissionType::TakeOff) &&
 		    !forced)
 		{
 			it++;
@@ -3229,11 +3224,11 @@ bool Vehicle::clearMissions(GameState &state, bool forced)
 		{
 			// if we're removing an InvestigateBuilding mission
 			// decrease the investigate count so the other investigating vehicles won't dangle
-			if ((*it)->type == VehicleMission::MissionType::InvestigateBuilding)
+			if ((*it).type == VehicleMission::MissionType::InvestigateBuilding)
 			{
-				if (!(*it)->isFinished(state, *this))
+				if (!(*it).isFinished(state, *this))
 				{
-					(*it)->targetBuilding->decreasePendingInvestigatorCount(state);
+					(*it).targetBuilding->decreasePendingInvestigatorCount(state);
 				}
 			}
 			it = missions.erase(it);
@@ -3245,19 +3240,19 @@ bool Vehicle::clearMissions(GameState &state, bool forced)
 bool Vehicle::popFinishedMissions(GameState &state)
 {
 	bool popped = false;
-	while (missions.size() > 0 && missions.front()->isFinished(state, *this))
+	while (missions.size() > 0 && missions.front().isFinished(state, *this))
 	{
 		if (isDead())
 		{
 			return false;
 		}
-		LogInfo("Vehicle %s mission \"%s\" finished", name, missions.front()->getName());
+		LogInfo("Vehicle %s mission \"%s\" finished", name, missions.front().getName());
 		missions.pop_front();
 		popped = true;
 		if (!missions.empty())
 		{
-			LogInfo("Vehicle %s mission \"%s\" starting", name, missions.front()->getName());
-			missions.front()->start(state, *this);
+			LogInfo("Vehicle %s mission \"%s\" starting", name, missions.front().getName());
+			missions.front().start(state, *this);
 			continue;
 		}
 		else
@@ -3282,7 +3277,7 @@ bool Vehicle::getNewGoal(GameState &state, int &turboTiles)
 		// Try to get new destination
 		if (!missions.empty())
 		{
-			acquired = missions.front()->getNextDestination(state, *this, goalPosition, goalFacing,
+			acquired = missions.front().getNextDestination(state, *this, goalPosition, goalFacing,
 			                                                turboTiles);
 		}
 		// Pop finished missions if present
@@ -3293,7 +3288,7 @@ bool Vehicle::getNewGoal(GameState &state, int &turboTiles)
 		LogWarning("Vehicle %s at %s", name, position);
 		for (auto &m : missions)
 		{
-			LogWarning("Mission %s", m->getName());
+			LogWarning("Mission %s", m.getName());
 		}
 		LogError("Vehicle %s deadlocked, please send log to developers. Vehicle will self-destruct "
 		         "now...",

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -191,7 +191,7 @@ class Vehicle : public StateObject<Vehicle>,
 	StateRef<VehicleType> type;
 	StateRef<Organisation> owner;
 	UString name;
-	std::list<up<VehicleMission>> missions;
+	std::list<VehicleMission> missions;
 	std::list<sp<VEquipment>> equipment;
 	std::list<StateRef<VEquipmentType>> loot;
 	StateRef<City> city;
@@ -351,10 +351,10 @@ class Vehicle : public StateObject<Vehicle>,
 
 	// Adds mission to list of missions, returns iterator to mission if successful, missions.end()
 	// otherwise
-	typename decltype(missions)::iterator addMission(GameState &state, VehicleMission *mission,
+	typename decltype(missions)::iterator addMission(GameState &state, VehicleMission mission,
 	                                                 bool toBack = false);
 	// Replaces all missions with provided mission, returns true if successful
-	bool setMission(GameState &state, VehicleMission *mission);
+	bool setMission(GameState &state, VehicleMission mission);
 	bool clearMissions(GameState &state, bool forced = false);
 
 	// Pops all finished missions, returns true if popped

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -347,8 +347,8 @@ Vec3<float> FlyingVehicleTileHelper::findSidestep(GameState &state, sp<TileObjec
 }
 
 VehicleMission VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
-                                             bool allowTeleporter, bool pickNearest,
-                                             int attemptsToGiveUpAfter)
+                                            bool allowTeleporter, bool pickNearest,
+                                            int attemptsToGiveUpAfter)
 {
 	// TODO
 	// Pseudocode:
@@ -412,7 +412,7 @@ VehicleMission VehicleMission::departToSpace(GameState &state, Vehicle &v)
 }
 
 VehicleMission VehicleMission::gotoBuilding(GameState &, Vehicle &v, StateRef<Building> target,
-                                             bool allowTeleporter)
+                                            bool allowTeleporter)
 {
 	// TODO
 	// Pseudocode:
@@ -436,7 +436,7 @@ VehicleMission VehicleMission::gotoBuilding(GameState &, Vehicle &v, StateRef<Bu
 }
 
 VehicleMission VehicleMission::infiltrateOrSubvertBuilding(GameState &, Vehicle &, bool subvert,
-                                                            StateRef<Building> target)
+                                                           StateRef<Building> target)
 {
 	VehicleMission mission;
 	mission.type = MissionType::InfiltrateSubvert;
@@ -455,8 +455,8 @@ VehicleMission VehicleMission::attackVehicle(GameState &, Vehicle &, StateRef<Ve
 }
 
 VehicleMission VehicleMission::attackBuilding(GameState &state [[maybe_unused]],
-                                               Vehicle &v [[maybe_unused]],
-                                               StateRef<Building> target)
+                                              Vehicle &v [[maybe_unused]],
+                                              StateRef<Building> target)
 {
 	VehicleMission mission;
 	mission.type = MissionType::AttackBuilding;
@@ -473,7 +473,7 @@ VehicleMission VehicleMission::followVehicle(GameState &, Vehicle &, StateRef<Ve
 }
 
 VehicleMission VehicleMission::followVehicle(GameState &, Vehicle &,
-                                              std::list<StateRef<Vehicle>> &targets)
+                                             std::list<StateRef<Vehicle>> &targets)
 {
 	VehicleMission mission;
 	mission.type = MissionType::FollowVehicle;
@@ -487,8 +487,7 @@ VehicleMission VehicleMission::followVehicle(GameState &, Vehicle &,
 }
 
 VehicleMission VehicleMission::recoverVehicle(GameState &state [[maybe_unused]],
-                                               Vehicle &v [[maybe_unused]],
-                                               StateRef<Vehicle> target)
+                                              Vehicle &v [[maybe_unused]], StateRef<Vehicle> target)
 {
 	VehicleMission mission;
 	mission.type = MissionType::RecoverVehicle;
@@ -497,7 +496,7 @@ VehicleMission VehicleMission::recoverVehicle(GameState &state [[maybe_unused]],
 }
 
 VehicleMission VehicleMission::offerService(GameState &state [[maybe_unused]],
-                                             Vehicle &v [[maybe_unused]], StateRef<Building> target)
+                                            Vehicle &v [[maybe_unused]], StateRef<Building> target)
 {
 	VehicleMission mission;
 	mission.type = MissionType::OfferService;
@@ -586,7 +585,7 @@ VehicleMission VehicleMission::patrol(GameState &, Vehicle &, bool home, unsigne
 }
 
 VehicleMission VehicleMission::teleport(GameState &state [[maybe_unused]],
-                                         Vehicle &v [[maybe_unused]], Vec3<int> target)
+                                        Vehicle &v [[maybe_unused]], Vec3<int> target)
 {
 	VehicleMission mission;
 	mission.type = MissionType::Teleport;
@@ -614,7 +613,7 @@ VehicleMission VehicleMission::land(Vehicle &, StateRef<Building> b)
 }
 
 VehicleMission VehicleMission::investigateBuilding(GameState &, Vehicle &v [[maybe_unused]],
-                                                    StateRef<Building> target, bool allowTeleporter)
+                                                   StateRef<Building> target, bool allowTeleporter)
 {
 	VehicleMission mission;
 	mission.type = MissionType::InvestigateBuilding;

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -346,7 +346,7 @@ Vec3<float> FlyingVehicleTileHelper::findSidestep(GameState &state, sp<TileObjec
 	return bestPosition;
 }
 
-VehicleMission *VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
+VehicleMission VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
                                              bool allowTeleporter, bool pickNearest,
                                              int attemptsToGiveUpAfter)
 {
@@ -355,22 +355,22 @@ VehicleMission *VehicleMission::gotoLocation(GameState &state, Vehicle &v, Vec3<
 	// if (in building)
 	// 	prepend(TakeOff)
 	// routeClosestICanTo(target);
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::GotoLocation;
-	mission->pickNearest = pickNearest;
-	mission->reRouteAttempts = attemptsToGiveUpAfter;
-	mission->allowTeleporter = allowTeleporter;
+	VehicleMission mission;
+	mission.type = MissionType::GotoLocation;
+	mission.pickNearest = pickNearest;
+	mission.reRouteAttempts = attemptsToGiveUpAfter;
+	mission.allowTeleporter = allowTeleporter;
 	if (!VehicleTargetHelper::adjustTargetToClosest(state, v, target, VehicleAvoidance::Ignore,
 	                                                true)
 	         .foundSuitableTarget)
 	{
-		mission->cancelled = true;
+		mission.cancelled = true;
 	}
-	mission->targetLocation = target;
+	mission.targetLocation = target;
 	return mission;
 }
 
-VehicleMission *VehicleMission::gotoPortal(GameState &state, Vehicle &v)
+VehicleMission VehicleMission::gotoPortal(GameState &state, Vehicle &v)
 {
 	Vec3<int> target = {0, 0, 0};
 	auto vTile = v.tileObject;
@@ -394,24 +394,24 @@ VehicleMission *VehicleMission::gotoPortal(GameState &state, Vehicle &v)
 	return gotoPortal(state, v, target);
 }
 
-VehicleMission *VehicleMission::gotoPortal(GameState &, Vehicle &, Vec3<int> target)
+VehicleMission VehicleMission::gotoPortal(GameState &, Vehicle &, Vec3<int> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::GotoPortal;
-	mission->targetLocation = target;
+	VehicleMission mission;
+	mission.type = MissionType::GotoPortal;
+	mission.targetLocation = target;
 	return mission;
 }
 
-VehicleMission *VehicleMission::departToSpace(GameState &state, Vehicle &v)
+VehicleMission VehicleMission::departToSpace(GameState &state, Vehicle &v)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::DepartToSpace;
-	mission->pickNearest = true;
-	mission->targetLocation = getRandomMapEdgeCoordinates(state, v.city);
+	VehicleMission mission;
+	mission.type = MissionType::DepartToSpace;
+	mission.pickNearest = true;
+	mission.targetLocation = getRandomMapEdgeCoordinates(state, v.city);
 	return mission;
 }
 
-VehicleMission *VehicleMission::gotoBuilding(GameState &, Vehicle &v, StateRef<Building> target,
+VehicleMission VehicleMission::gotoBuilding(GameState &, Vehicle &v, StateRef<Building> target,
                                              bool allowTeleporter)
 {
 	// TODO
@@ -428,99 +428,99 @@ VehicleMission *VehicleMission::gotoBuilding(GameState &, Vehicle &v, StateRef<B
 	//     queue(gotoLocation(lowest cost of routes + estimated distance to closest pad))
 	//  }
 	//  queue(Land)
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::GotoBuilding;
-	mission->targetBuilding = target ? target : v.homeBuilding;
-	mission->allowTeleporter = allowTeleporter;
+	VehicleMission mission;
+	mission.type = MissionType::GotoBuilding;
+	mission.targetBuilding = target ? target : v.homeBuilding;
+	mission.allowTeleporter = allowTeleporter;
 	return mission;
 }
 
-VehicleMission *VehicleMission::infiltrateOrSubvertBuilding(GameState &, Vehicle &, bool subvert,
+VehicleMission VehicleMission::infiltrateOrSubvertBuilding(GameState &, Vehicle &, bool subvert,
                                                             StateRef<Building> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::InfiltrateSubvert;
-	mission->targetBuilding = target;
-	mission->subvert = subvert;
+	VehicleMission mission;
+	mission.type = MissionType::InfiltrateSubvert;
+	mission.targetBuilding = target;
+	mission.subvert = subvert;
 	return mission;
 }
 
-VehicleMission *VehicleMission::attackVehicle(GameState &, Vehicle &, StateRef<Vehicle> target)
+VehicleMission VehicleMission::attackVehicle(GameState &, Vehicle &, StateRef<Vehicle> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::AttackVehicle;
-	mission->targetVehicle = target;
-	mission->attackCrashed = target->crashed;
+	VehicleMission mission;
+	mission.type = MissionType::AttackVehicle;
+	mission.targetVehicle = target;
+	mission.attackCrashed = target->crashed;
 	return mission;
 }
 
-VehicleMission *VehicleMission::attackBuilding(GameState &state [[maybe_unused]],
+VehicleMission VehicleMission::attackBuilding(GameState &state [[maybe_unused]],
                                                Vehicle &v [[maybe_unused]],
                                                StateRef<Building> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::AttackBuilding;
-	mission->targetBuilding = target;
+	VehicleMission mission;
+	mission.type = MissionType::AttackBuilding;
+	mission.targetBuilding = target;
 	return mission;
 }
 
-VehicleMission *VehicleMission::followVehicle(GameState &, Vehicle &, StateRef<Vehicle> target)
+VehicleMission VehicleMission::followVehicle(GameState &, Vehicle &, StateRef<Vehicle> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::FollowVehicle;
-	mission->targetVehicle = target;
+	VehicleMission mission;
+	mission.type = MissionType::FollowVehicle;
+	mission.targetVehicle = target;
 	return mission;
 }
 
-VehicleMission *VehicleMission::followVehicle(GameState &, Vehicle &,
+VehicleMission VehicleMission::followVehicle(GameState &, Vehicle &,
                                               std::list<StateRef<Vehicle>> &targets)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::FollowVehicle;
+	VehicleMission mission;
+	mission.type = MissionType::FollowVehicle;
 	if (!targets.empty())
 	{
-		mission->targetVehicle = targets.front();
-		mission->targets = targets;
-		mission->targets.pop_front();
+		mission.targetVehicle = targets.front();
+		mission.targets = targets;
+		mission.targets.pop_front();
 	}
 	return mission;
 }
 
-VehicleMission *VehicleMission::recoverVehicle(GameState &state [[maybe_unused]],
+VehicleMission VehicleMission::recoverVehicle(GameState &state [[maybe_unused]],
                                                Vehicle &v [[maybe_unused]],
                                                StateRef<Vehicle> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::RecoverVehicle;
-	mission->targetVehicle = target;
+	VehicleMission mission;
+	mission.type = MissionType::RecoverVehicle;
+	mission.targetVehicle = target;
 	return mission;
 }
 
-VehicleMission *VehicleMission::offerService(GameState &state [[maybe_unused]],
+VehicleMission VehicleMission::offerService(GameState &state [[maybe_unused]],
                                              Vehicle &v [[maybe_unused]], StateRef<Building> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::OfferService;
+	VehicleMission mission;
+	mission.type = MissionType::OfferService;
 	if (target)
 	{
-		mission->targetBuilding = target;
+		mission.targetBuilding = target;
 	}
 	else
 	{
-		mission->missionCounter = 1;
+		mission.missionCounter = 1;
 	}
 	return mission;
 }
 
-VehicleMission *VehicleMission::snooze(GameState &, Vehicle &, unsigned int snoozeTicks)
+VehicleMission VehicleMission::snooze(GameState &, Vehicle &, unsigned int snoozeTicks)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::Snooze;
-	mission->timeToSnooze = snoozeTicks;
+	VehicleMission mission;
+	mission.type = MissionType::Snooze;
+	mission.timeToSnooze = snoozeTicks;
 	return mission;
 }
 
-VehicleMission *VehicleMission::selfDestruct(GameState &state, Vehicle &v)
+VehicleMission VehicleMission::selfDestruct(GameState &state, Vehicle &v)
 {
 	unsigned timer = TICKS_PER_HOUR;
 	auto timerUFO = selfDestructTimer.find(v.type.id);
@@ -529,16 +529,16 @@ VehicleMission *VehicleMission::selfDestruct(GameState &state, Vehicle &v)
 		timer = 5 * std::uniform_int_distribution<unsigned>(timerUFO->second.first,
 		                                                    timerUFO->second.second)(state.rng);
 	}
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::SelfDestruct;
-	mission->timeToSnooze = timer;
+	VehicleMission mission;
+	mission.type = MissionType::SelfDestruct;
+	mission.timeToSnooze = timer;
 	return mission;
 }
 
-VehicleMission *VehicleMission::arriveFromDimensionGate(GameState &state, Vehicle &v, int ticks)
+VehicleMission VehicleMission::arriveFromDimensionGate(GameState &state, Vehicle &v, int ticks)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::ArriveFromDimensionGate;
+	VehicleMission mission;
+	mission.type = MissionType::ArriveFromDimensionGate;
 	// find max delay arrival and increment
 	int lastTicks = -DIMENSION_GATE_DELAY;
 	for (auto &v2 : state.vehicles)
@@ -547,9 +547,9 @@ VehicleMission *VehicleMission::arriveFromDimensionGate(GameState &state, Vehicl
 		{
 			for (auto &m : v2.second->missions)
 			{
-				if (m->type == MissionType::ArriveFromDimensionGate)
+				if (m.type == MissionType::ArriveFromDimensionGate)
 				{
-					lastTicks = std::max(lastTicks, (int)m->timeToSnooze);
+					lastTicks = std::max(lastTicks, (int)m.timeToSnooze);
 				}
 			}
 		}
@@ -558,69 +558,68 @@ VehicleMission *VehicleMission::arriveFromDimensionGate(GameState &state, Vehicl
 	{
 		lastTicks += ticks;
 	}
-	mission->timeToSnooze = lastTicks + DIMENSION_GATE_DELAY;
+	mission.timeToSnooze = lastTicks + DIMENSION_GATE_DELAY;
 	return mission;
 }
 
-VehicleMission *VehicleMission::restartNextMission(GameState &, Vehicle &)
+VehicleMission VehicleMission::restartNextMission(GameState &, Vehicle &)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::RestartNextMission;
+	VehicleMission mission;
+	mission.type = MissionType::RestartNextMission;
 	return mission;
 }
 
-VehicleMission *VehicleMission::crashLand(GameState &, Vehicle &)
+VehicleMission VehicleMission::crashLand(GameState &, Vehicle &)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::Crash;
+	VehicleMission mission;
+	mission.type = MissionType::Crash;
 	return mission;
 }
 
-VehicleMission *VehicleMission::patrol(GameState &, Vehicle &, bool home, unsigned int counter)
+VehicleMission VehicleMission::patrol(GameState &, Vehicle &, bool home, unsigned int counter)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::Patrol;
-	mission->missionCounter = counter;
-	mission->patrolHome = home;
+	VehicleMission mission;
+	mission.type = MissionType::Patrol;
+	mission.missionCounter = counter;
+	mission.patrolHome = home;
 	return mission;
 }
 
-VehicleMission *VehicleMission::teleport(GameState &state [[maybe_unused]],
+VehicleMission VehicleMission::teleport(GameState &state [[maybe_unused]],
                                          Vehicle &v [[maybe_unused]], Vec3<int> target)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::Teleport;
-	mission->targetLocation = target;
+	VehicleMission mission;
+	mission.type = MissionType::Teleport;
+	mission.targetLocation = target;
 	return mission;
 }
 
-VehicleMission *VehicleMission::takeOff(Vehicle &v)
+VehicleMission VehicleMission::takeOff(Vehicle &v)
 {
 	if (!v.currentBuilding)
 	{
 		LogError("Trying to take off while not in a building");
-		return nullptr;
 	}
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::TakeOff;
+	VehicleMission mission;
+	mission.type = MissionType::TakeOff;
 	return mission;
 }
 
-VehicleMission *VehicleMission::land(Vehicle &, StateRef<Building> b)
+VehicleMission VehicleMission::land(Vehicle &, StateRef<Building> b)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::Land;
-	mission->targetBuilding = b;
+	VehicleMission mission;
+	mission.type = MissionType::Land;
+	mission.targetBuilding = b;
 	return mission;
 }
 
-VehicleMission *VehicleMission::investigateBuilding(GameState &, Vehicle &v [[maybe_unused]],
+VehicleMission VehicleMission::investigateBuilding(GameState &, Vehicle &v [[maybe_unused]],
                                                     StateRef<Building> target, bool allowTeleporter)
 {
-	auto *mission = new VehicleMission();
-	mission->type = MissionType::InvestigateBuilding;
-	mission->targetBuilding = target;
-	mission->allowTeleporter = allowTeleporter;
+	VehicleMission mission;
+	mission.type = MissionType::InvestigateBuilding;
+	mission.targetBuilding = target;
+	mission.allowTeleporter = allowTeleporter;
 	return mission;
 }
 
@@ -2108,8 +2107,8 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				                                                 allowTeleporter, false, 1));
 				// If we can't path to building then cancel
 				auto &gotoMission = v.missions.front();
-				if (gotoMission->cancelled || gotoMission->currentPlannedPath.empty() ||
-				    gotoMission->currentPlannedPath.back() == position)
+				if (gotoMission.cancelled || gotoMission.currentPlannedPath.empty() ||
+				    gotoMission.currentPlannedPath.back() == position)
 				{
 					cancelled = true;
 				}
@@ -2205,8 +2204,8 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 					                                                 allowTeleporter, false, 1));
 					// If we can't path to building's pad then snooze
 					auto &gotoMission = v.missions.front();
-					if (gotoMission->cancelled || gotoMission->currentPlannedPath.empty() ||
-					    gotoMission->currentPlannedPath.back() == position)
+					if (gotoMission.cancelled || gotoMission.currentPlannedPath.empty() ||
+					    gotoMission.currentPlannedPath.back() == position)
 					{
 						v.addMission(state, VehicleMission::snooze(state, v, TICKS_PER_SECOND));
 					}

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -160,9 +160,9 @@ class VehicleMission
 {
   private:
 	// INTERNAL: Not to be used directly (Only works when in building)
-	static VehicleMission *takeOff(Vehicle &v);
+	static VehicleMission takeOff(Vehicle &v);
 	// INTERNAL: Not to be used directly (Only works if directly above a pad)
-	static VehicleMission *land(Vehicle &v, StateRef<Building> b);
+	static VehicleMission land(Vehicle &v, StateRef<Building> b);
 	// INTERNAL: This checks if mission is actually finished. Called by isFinished.
 	// If it is finished, update() is called by isFinished so that any remaining work could be done
 	bool isFinishedInternal(GameState &state, Vehicle &v);
@@ -194,37 +194,37 @@ class VehicleMission
 
 	// Methods to create new missions
 
-	static VehicleMission *gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
+	static VehicleMission gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
 	                                    bool allowTeleporter = false, bool pickNearest = false,
 	                                    int attemptsToGiveUpAfter = 20);
-	static VehicleMission *gotoPortal(GameState &state, Vehicle &v);
-	static VehicleMission *gotoPortal(GameState &state, Vehicle &v, Vec3<int> target);
-	static VehicleMission *departToSpace(GameState &state, Vehicle &v);
+	static VehicleMission gotoPortal(GameState &state, Vehicle &v);
+	static VehicleMission gotoPortal(GameState &state, Vehicle &v, Vec3<int> target);
+	static VehicleMission departToSpace(GameState &state, Vehicle &v);
 	// With now building goes home
-	static VehicleMission *gotoBuilding(GameState &state, Vehicle &v,
+	static VehicleMission gotoBuilding(GameState &state, Vehicle &v,
 	                                    StateRef<Building> target = nullptr,
 	                                    bool allowTeleporter = false);
-	static VehicleMission *infiltrateOrSubvertBuilding(GameState &state, Vehicle &v,
+	static VehicleMission infiltrateOrSubvertBuilding(GameState &state, Vehicle &v,
 	                                                   bool subvert = false,
 	                                                   StateRef<Building> target = nullptr);
-	static VehicleMission *attackVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
-	static VehicleMission *attackBuilding(GameState &state, Vehicle &v,
+	static VehicleMission attackVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
+	static VehicleMission attackBuilding(GameState &state, Vehicle &v,
 	                                      StateRef<Building> target = nullptr);
-	static VehicleMission *followVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
-	static VehicleMission *followVehicle(GameState &state, Vehicle &v,
+	static VehicleMission followVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
+	static VehicleMission followVehicle(GameState &state, Vehicle &v,
 	                                     std::list<StateRef<Vehicle>> &targets);
-	static VehicleMission *recoverVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
-	static VehicleMission *offerService(GameState &state, Vehicle &v,
+	static VehicleMission recoverVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
+	static VehicleMission offerService(GameState &state, Vehicle &v,
 	                                    StateRef<Building> target = nullptr);
-	static VehicleMission *snooze(GameState &state, Vehicle &v, unsigned int ticks);
-	static VehicleMission *selfDestruct(GameState &state, Vehicle &v);
-	static VehicleMission *arriveFromDimensionGate(GameState &state, Vehicle &v, int ticks = 0);
-	static VehicleMission *restartNextMission(GameState &state, Vehicle &v);
-	static VehicleMission *crashLand(GameState &state, Vehicle &v);
-	static VehicleMission *patrol(GameState &state, Vehicle &v, bool home = false,
+	static VehicleMission snooze(GameState &state, Vehicle &v, unsigned int ticks);
+	static VehicleMission selfDestruct(GameState &state, Vehicle &v);
+	static VehicleMission arriveFromDimensionGate(GameState &state, Vehicle &v, int ticks = 0);
+	static VehicleMission restartNextMission(GameState &state, Vehicle &v);
+	static VehicleMission crashLand(GameState &state, Vehicle &v);
+	static VehicleMission patrol(GameState &state, Vehicle &v, bool home = false,
 	                              unsigned int counter = 10);
-	static VehicleMission *teleport(GameState &state, Vehicle &v, Vec3<int> target = {-1, -1, -1});
-	static VehicleMission *investigateBuilding(GameState &state, Vehicle &v,
+	static VehicleMission teleport(GameState &state, Vehicle &v, Vec3<int> target = {-1, -1, -1});
+	static VehicleMission investigateBuilding(GameState &state, Vehicle &v,
 	                                           StateRef<Building> target,
 	                                           bool allowTeleporter = false);
 	UString getName();

--- a/game/state/city/vehiclemission.h
+++ b/game/state/city/vehiclemission.h
@@ -195,38 +195,38 @@ class VehicleMission
 	// Methods to create new missions
 
 	static VehicleMission gotoLocation(GameState &state, Vehicle &v, Vec3<int> target,
-	                                    bool allowTeleporter = false, bool pickNearest = false,
-	                                    int attemptsToGiveUpAfter = 20);
+	                                   bool allowTeleporter = false, bool pickNearest = false,
+	                                   int attemptsToGiveUpAfter = 20);
 	static VehicleMission gotoPortal(GameState &state, Vehicle &v);
 	static VehicleMission gotoPortal(GameState &state, Vehicle &v, Vec3<int> target);
 	static VehicleMission departToSpace(GameState &state, Vehicle &v);
 	// With now building goes home
 	static VehicleMission gotoBuilding(GameState &state, Vehicle &v,
-	                                    StateRef<Building> target = nullptr,
-	                                    bool allowTeleporter = false);
+	                                   StateRef<Building> target = nullptr,
+	                                   bool allowTeleporter = false);
 	static VehicleMission infiltrateOrSubvertBuilding(GameState &state, Vehicle &v,
-	                                                   bool subvert = false,
-	                                                   StateRef<Building> target = nullptr);
+	                                                  bool subvert = false,
+	                                                  StateRef<Building> target = nullptr);
 	static VehicleMission attackVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission attackBuilding(GameState &state, Vehicle &v,
-	                                      StateRef<Building> target = nullptr);
+	                                     StateRef<Building> target = nullptr);
 	static VehicleMission followVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission followVehicle(GameState &state, Vehicle &v,
-	                                     std::list<StateRef<Vehicle>> &targets);
+	                                    std::list<StateRef<Vehicle>> &targets);
 	static VehicleMission recoverVehicle(GameState &state, Vehicle &v, StateRef<Vehicle> target);
 	static VehicleMission offerService(GameState &state, Vehicle &v,
-	                                    StateRef<Building> target = nullptr);
+	                                   StateRef<Building> target = nullptr);
 	static VehicleMission snooze(GameState &state, Vehicle &v, unsigned int ticks);
 	static VehicleMission selfDestruct(GameState &state, Vehicle &v);
 	static VehicleMission arriveFromDimensionGate(GameState &state, Vehicle &v, int ticks = 0);
 	static VehicleMission restartNextMission(GameState &state, Vehicle &v);
 	static VehicleMission crashLand(GameState &state, Vehicle &v);
 	static VehicleMission patrol(GameState &state, Vehicle &v, bool home = false,
-	                              unsigned int counter = 10);
+	                             unsigned int counter = 10);
 	static VehicleMission teleport(GameState &state, Vehicle &v, Vec3<int> target = {-1, -1, -1});
 	static VehicleMission investigateBuilding(GameState &state, Vehicle &v,
-	                                           StateRef<Building> target,
-	                                           bool allowTeleporter = false);
+	                                          StateRef<Building> target,
+	                                          bool allowTeleporter = false);
 	UString getName();
 
 	enum class MissionType

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -935,8 +935,8 @@ bool GameState::canTurbo() const
 			}
 			for (auto &m : v.second->missions)
 			{
-				if (m->type == VehicleMission::MissionType::AttackBuilding ||
-				    m->type == VehicleMission::MissionType::AttackVehicle)
+				if (m.type == VehicleMission::MissionType::AttackBuilding ||
+				    m.type == VehicleMission::MissionType::AttackVehicle)
 				{
 					return false;
 				}

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -839,12 +839,12 @@ void Agent::updateIsBrainsucker()
 	}
 }
 
-bool Agent::addMission(GameState &state, AgentMission *mission, bool toBack)
+bool Agent::addMission(GameState &state, AgentMission mission, bool toBack)
 {
 	if (missions.empty() || !toBack)
 	{
 		missions.emplace_front(mission);
-		missions.front()->start(state, *this);
+		missions.front().start(state, *this);
 	}
 	else
 	{
@@ -853,38 +853,38 @@ bool Agent::addMission(GameState &state, AgentMission *mission, bool toBack)
 	return true;
 }
 
-bool Agent::setMission(GameState &state, AgentMission *mission)
+bool Agent::setMission(GameState &state, AgentMission mission)
 {
 	for (auto &m : this->missions)
 	{
 		// if we're removing an InvestigateBuilding mission
 		// decrease the investigate count so the other investigating vehicles won't dangle
-		if (m->type == AgentMission::MissionType::InvestigateBuilding)
+		if (m.type == AgentMission::MissionType::InvestigateBuilding)
 		{
-			if (!m->isFinished(state, *this))
+			if (!m.isFinished(state, *this))
 			{
-				m->targetBuilding->decreasePendingInvestigatorCount(state);
+				m.targetBuilding->decreasePendingInvestigatorCount(state);
 			}
 		}
 	}
 	missions.clear();
 	missions.emplace_front(mission);
-	missions.front()->start(state, *this);
+	missions.front().start(state, *this);
 	return true;
 }
 
 bool Agent::popFinishedMissions(GameState &state)
 {
 	bool popped = false;
-	while (missions.size() > 0 && missions.front()->isFinished(state, *this))
+	while (missions.size() > 0 && missions.front().isFinished(state, *this))
 	{
-		LogWarning("Agent %s mission \"%s\" finished", name, missions.front()->getName());
+		LogWarning("Agent %s mission \"%s\" finished", name, missions.front().getName());
 		missions.pop_front();
 		popped = true;
 		if (!missions.empty())
 		{
-			LogWarning("Agent %s mission \"%s\" starting", name, missions.front()->getName());
-			missions.front()->start(state, *this);
+			LogWarning("Agent %s mission \"%s\" starting", name, missions.front().getName());
+			missions.front().start(state, *this);
 			continue;
 		}
 		else
@@ -907,7 +907,7 @@ bool Agent::getNewGoal(GameState &state)
 		// Try to get new destination
 		if (!missions.empty())
 		{
-			acquired = missions.front()->getNextDestination(state, *this, goalPosition);
+			acquired = missions.front().getNextDestination(state, *this, goalPosition);
 		}
 		// Pop finished missions if present
 		popped = popFinishedMissions(state);
@@ -1000,7 +1000,7 @@ void Agent::update(GameState &state, unsigned ticks)
 	{
 		if (!this->missions.empty())
 		{
-			this->missions.front()->update(state, *this, ticks);
+			this->missions.front().update(state, *this, ticks);
 		}
 		popFinishedMissions(state);
 		updateMovement(state, ticks);

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -144,7 +144,7 @@ class Agent : public StateObject<Agent>,
 
 	StateRef<BattleUnit> unit;
 
-	std::list<up<AgentMission>> missions;
+	std::list<AgentMission> missions;
 	std::list<sp<AEquipment>> equipment;
 	bool canAddEquipment(Vec2<int> pos, StateRef<AEquipmentType> equipmentType,
 	                     EquipmentSlotType &slotType) const;
@@ -178,9 +178,9 @@ class Agent : public StateObject<Agent>,
 	bool isBrainsucker = false;
 
 	// Adds mission to list of missions, returns true if successful
-	bool addMission(GameState &state, AgentMission *mission, bool toBack = false);
+	bool addMission(GameState &state, AgentMission mission, bool toBack = false);
 	// Replaces all missions with provided mission, returns true if successful
-	bool setMission(GameState &state, AgentMission *mission);
+	bool setMission(GameState &state, AgentMission mission);
 
 	// Pops all finished missions, returns true if popped
 	bool popFinishedMissions(GameState &state);

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -337,8 +337,8 @@ void Organisation::updateMissions(GameState &state)
 					{
 						for (auto &m : r.second->missions)
 						{
-							if (m->type == VehicleMission::MissionType::RecoverVehicle &&
-							    m->targetVehicle.id == v.first)
+							if (m.type == VehicleMission::MissionType::RecoverVehicle &&
+							    m.targetVehicle.id == v.first)
 							{
 								foundRescuer = true;
 								break;
@@ -371,8 +371,8 @@ void Organisation::updateMissions(GameState &state)
 					{
 						for (auto &m : r.second->missions)
 						{
-							if (m->type == VehicleMission::MissionType::RecoverVehicle &&
-							    m->targetVehicle.id == v.first)
+							if (m.type == VehicleMission::MissionType::RecoverVehicle &&
+							    m.targetVehicle.id == v.first)
 							{
 								foundRescuer = true;
 								break;

--- a/game/state/tilemap/tileobject_vehicle.cpp
+++ b/game/state/tilemap/tileobject_vehicle.cpp
@@ -277,7 +277,7 @@ void TileObjectVehicle::addToDrawnTiles(Tile *tile)
 	}
 	// Vehicles are also never drawn below level 1, so that when they take off they're drawn above
 	// landing pad's scenery
-	if (!v->missions.empty() && v->missions.front()->isTakingOff(*v))
+	if (!v->missions.empty() && v->missions.front().isTakingOff(*v))
 	{
 		tile = map.getTile(tile->position.x, tile->position.y, tile->position.z + 1);
 	}

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -339,21 +339,21 @@ void CityTileView::render()
 				}
 				for (auto &m : vehicle->missions)
 				{
-					if (m->type == VehicleMission::MissionType::AttackVehicle ||
-					    m->type == VehicleMission::MissionType::RecoverVehicle)
+					if (m.type == VehicleMission::MissionType::AttackVehicle ||
+					    m.type == VehicleMission::MissionType::RecoverVehicle)
 					{
-						if (m->targetVehicle)
+						if (m.targetVehicle)
 						{
-							vehiclesToDrawBrackets.insert(m->targetVehicle);
-							vehiclesBracketsIndex[m->targetVehicle] = 2;
+							vehiclesToDrawBrackets.insert(m.targetVehicle);
+							vehiclesBracketsIndex[m.targetVehicle] = 2;
 						}
 					}
-					else if (m->type == VehicleMission::MissionType::FollowVehicle)
+					else if (m.type == VehicleMission::MissionType::FollowVehicle)
 					{
-						if (m->targetVehicle)
+						if (m.targetVehicle)
 						{
-							vehiclesToDrawBrackets.insert(m->targetVehicle);
-							vehiclesBracketsIndex[m->targetVehicle] = 3;
+							vehiclesToDrawBrackets.insert(m.targetVehicle);
+							vehiclesBracketsIndex[m.targetVehicle] = 3;
 						}
 					}
 				}
@@ -729,23 +729,23 @@ void CityTileView::render()
 				// Destinations
 				for (auto &m : v.second->missions)
 				{
-					switch (m->type)
+					switch (m.type)
 					{
 						case VehicleMission::MissionType::AttackVehicle:
 						case VehicleMission::MissionType::RecoverVehicle:
 						{
-							if (!m->targetVehicle)
+							if (!m.targetVehicle)
 								break;
-							vehiclesUnderAttack.insert(m->targetVehicle);
-							targetLocationsToDraw.emplace_back(m->targetVehicle->position,
+							vehiclesUnderAttack.insert(m.targetVehicle);
+							targetLocationsToDraw.emplace_back(m.targetVehicle->position,
 							                                   v.second->position, false, true);
 							break;
 						}
 						case VehicleMission::MissionType::FollowVehicle:
 						{
-							if (!m->targetVehicle)
+							if (!m.targetVehicle)
 								break;
-							targetLocationsToDraw.emplace_back(m->targetVehicle->position,
+							targetLocationsToDraw.emplace_back(m.targetVehicle->position,
 							                                   v.second->position, false, false);
 							break;
 						}
@@ -754,17 +754,17 @@ void CityTileView::render()
 						case VehicleMission::MissionType::Land:
 						case VehicleMission::MissionType::OfferService:
 						case VehicleMission::MissionType::InvestigateBuilding:
-							if (m->targetBuilding)
+							if (m.targetBuilding)
 							{
-								buildingsSelected.insert(m->targetBuilding);
+								buildingsSelected.insert(m.targetBuilding);
 							}
 							[[fallthrough]];
 						case VehicleMission::MissionType::Crash:
 						{
-							if (!m->currentPlannedPath.empty())
+							if (!m.currentPlannedPath.empty())
 							{
 								targetLocationsToDraw.emplace_back(
-								    (Vec3<float>)m->currentPlannedPath.back() +
+								    (Vec3<float>)m.currentPlannedPath.back() +
 								        Vec3<float>{0.5f, 0.5f, 0.0f},
 								    v.second->position, true, false);
 							}
@@ -777,7 +777,7 @@ void CityTileView::render()
 						case VehicleMission::MissionType::Teleport:
 						case VehicleMission::MissionType::DepartToSpace:
 						{
-							targetLocationsToDraw.emplace_back((Vec3<float>)m->targetLocation +
+							targetLocationsToDraw.emplace_back((Vec3<float>)m.targetLocation +
 							                                       Vec3<float>{0.5f, 0.5f, 0.0f},
 							                                   v.second->position, true, false);
 							break;

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -694,9 +694,9 @@ void CityTileView::render()
 				}
 				for (auto &m : a.second->missions)
 				{
-					if (m->type == AgentMission::MissionType::GotoBuilding)
+					if (m.type == AgentMission::MissionType::GotoBuilding)
 					{
-						targetLocationsToDraw.emplace_back(m->targetBuilding->crewQuarters,
+						targetLocationsToDraw.emplace_back(m.targetBuilding->crewQuarters,
 						                                   a.second->position, true, false);
 						break;
 					}

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1638,7 +1638,7 @@ void CityView::render()
 				{
 					continue;
 				}
-				auto &path = v->missions.front()->currentPlannedPath;
+				auto &path = v->missions.front().currentPlannedPath;
 				Vec3<float> prevPos = vTile->getPosition();
 				for (auto &pos : path)
 				{
@@ -2090,15 +2090,15 @@ void CityView::update()
 						}
 						else if (agent->currentVehicle &&
 						         !agent->currentVehicle->missions.empty() &&
-						         agent->currentVehicle->missions.front()->targetBuilding)
+						         agent->currentVehicle->missions.front().targetBuilding)
 						{
-							if (agent->currentVehicle->missions.front()->targetBuilding ==
+							if (agent->currentVehicle->missions.front().targetBuilding ==
 							    agent->homeBuilding)
 								agentAssignment->setText(tr("Returning to base"));
 							else
 								agentAssignment->setText(tr("Traveling to:") + UString(" ") +
 								                         tr(agent->currentVehicle->missions.front()
-								                                ->targetBuilding->name));
+								                                .targetBuilding->name));
 						}
 						else
 							agentAssignment->setText(tr("Traveling to:") + UString(" ") +
@@ -3336,7 +3336,7 @@ bool CityView::handleMouseDown(Event *e)
 					LogWarning("CLICKED VEHICLE %s at %s", vehicle->name, vehicle->position);
 					for (auto &m : vehicle->missions)
 					{
-						LogWarning("Mission %s", m->getName());
+						LogWarning("Mission %s", m.getName());
 					}
 					for (auto &c : vehicle->cargo)
 					{
@@ -3385,7 +3385,7 @@ bool CityView::handleMouseDown(Event *e)
 					           vehicle->position);
 					for (auto &m : vehicle->missions)
 					{
-						LogWarning("Mission %s", m->getName());
+						LogWarning("Mission %s", m.getName());
 					}
 					for (auto &c : vehicle->cargo)
 					{

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -2078,8 +2078,7 @@ void CityView::update()
 							agentAssignment->setText(
 							    tr("At") + UString(" ") +
 							    tr(agent->currentVehicle->currentBuilding->name));
-						else if (!agent->missions.empty() &&
-						         agent->missions.front().targetBuilding)
+						else if (!agent->missions.empty() && agent->missions.front().targetBuilding)
 						{
 							if (agent->missions.front().targetBuilding == agent->homeBuilding)
 								agentAssignment->setText(tr("Returning to base"));

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -2079,14 +2079,14 @@ void CityView::update()
 							    tr("At") + UString(" ") +
 							    tr(agent->currentVehicle->currentBuilding->name));
 						else if (!agent->missions.empty() &&
-						         agent->missions.front()->targetBuilding)
+						         agent->missions.front().targetBuilding)
 						{
-							if (agent->missions.front()->targetBuilding == agent->homeBuilding)
+							if (agent->missions.front().targetBuilding == agent->homeBuilding)
 								agentAssignment->setText(tr("Returning to base"));
 							else
 								agentAssignment->setText(
 								    tr("Traveling to:") + UString(" ") +
-								    tr(agent->missions.front()->targetBuilding->name));
+								    tr(agent->missions.front().targetBuilding->name));
 						}
 						else if (agent->currentVehicle &&
 						         !agent->currentVehicle->missions.empty() &&


### PR DESCRIPTION
We don't need this indirection, and the mission classes are relatively easy to copy anyway.