### PR TITLE
Prices change correctly end of the week

### DIFF
--- a/data/scripts/openapoc_base.lua
+++ b/data/scripts/openapoc_base.lua
@@ -7,7 +7,7 @@ local CFG = OpenApoc.Framework.Config
 function pickRandom(t)
 	return t[GS.rng:randBoundsInclusive(1, #t)]
 end
-function math.clamp(v, max, min)
+function math.clamp(v, min, max)
 	return math.min(math.max(v, min), max)
 end
 function math.round(v)

--- a/data/scripts/update_economy.lua
+++ b/data/scripts/update_economy.lua
@@ -27,11 +27,11 @@ function updateEconomy()
 			end
 
 			if soldThisWeek > 2 * eco.maxStock then
-				eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsReal(0.85, 0.95))
+				eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsInclusive(math.round(85), math.round(95)) / 100)
 			elseif soldThisWeek > eco.maxStock then
-				eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsReal(0.9, 0.95))
+				eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsInclusive(math.round(9), math.round(95)) / 100)
 			elseif soldThisWeek > eco.maxStock/2 then
-				eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsReal(0.95, 0.97))
+				eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsInclusive(math.round(95), math.round(97)) / 100)
 			end
 			eco.currentPrice = math.round(math.clamp(eco.currentPrice, eco.basePrice / 2, eco.basePrice))
 		elseif eco.weekAvailable ~= 0 then
@@ -39,11 +39,11 @@ function updateEconomy()
 			eco.currentStock = math.clamp(GS.rng:randBoundsInclusive(0, averageStock + eco.lastStock), eco.minStock, eco.maxStock)
 			if week > 1 then
 				if eco.currentStock > averageStock then
-					eco.currentPrice = eco.currentPrice * GS.rng:randBoundsReal(0.97, 1.0)
+					eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsInclusive(math.round(97), math.round(100)) / 100)
 				elseif eco.currentStock < averageStock then
-					eco.currentPrice = eco.currentPrice * GS.rng:randBoundsReal(1.0, 1.03)
+					eco.currentPrice = math.round(eco.currentPrice * GS.rng:randBoundsInclusive(math.round(100), math.round(103)) / 100)
 				end
-				eco.currentPrice = math.round(math.clamp(eco.currentPrice, eco.basePrice / 2, eco.basePrice * 2))
+				eco.currentPrice = math.round(math.clamp(eco.currentPrice, eco.basePrice * 0.5, eco.basePrice * 2.0))
 			end
 		end
 		return week ~= 1 and week == eco.weekAvailable

--- a/game/state/city/economyinfo.cpp
+++ b/game/state/city/economyinfo.cpp
@@ -5,14 +5,14 @@
 
 namespace OpenApoc
 {
-bool EconomyInfo::update(GameState &state, bool xcom)
+bool EconomyInfo::update(GameState &state, const bool xcom)
 {
 	if (currentPrice == 0)
 	{
 		currentPrice = basePrice;
 	}
 	// According to Wong's Guide, let's hope he's not wong here as he often is, lol
-	int week = state.gameTime.getWeek();
+	const int week = static_cast<int>(state.gameTime.getWeek());
 	if (weekAvailable > week)
 	{
 		return false;
@@ -21,9 +21,9 @@ bool EconomyInfo::update(GameState &state, bool xcom)
 	if (xcom)
 	{
 		// Stock update
-		int soldThisWeek = std::max(0, currentStock - lastStock);
+		const int soldThisWeek = std::max(0, currentStock - lastStock);
 		lastStock = currentStock;
-		int rnd = randBoundsExclusive(state.rng, 0, 100);
+		const int rnd = randBoundsExclusive(state.rng, 0, 100);
 		if (rnd < 30)
 		{
 			currentStock = lastStock * 80 / 100;
@@ -35,7 +35,7 @@ bool EconomyInfo::update(GameState &state, bool xcom)
 		// Price update
 		if (soldThisWeek > 2 * maxStock)
 		{
-			currentPrice = currentPrice * randBoundsInclusive(state.rng, 85, 5);
+			currentPrice = currentPrice * randBoundsInclusive(state.rng, 85, 95);
 		}
 		else if (soldThisWeek > maxStock)
 		{
@@ -52,7 +52,7 @@ bool EconomyInfo::update(GameState &state, bool xcom)
 	{
 		// Stock update
 		lastStock = currentStock;
-		int averageStock = (minStock + maxStock) / 2;
+		const int averageStock = (minStock + maxStock) / 2;
 		currentStock =
 		    clamp(randBoundsInclusive(state.rng, 0, averageStock + lastStock), minStock, maxStock);
 		// Price update


### PR DESCRIPTION
Fix to #939
Economy update appears to be moved to Lua.
Current price was always multiplied by 1.0.
I am guessing math.clamp function parameters were in wrong order based on how the clamp was called.
Fixed typo in economyinfo.cpp (is it used anymore?).