### PR TITLE
Reformat using clang-format 10

### DIFF
--- a/CODE_STYLE.md
+++ b/CODE_STYLE.md
@@ -15,7 +15,7 @@ GCCIsntMuchBetter
 
 C++11 features are heavily encouraged - patterns from 'older' c++ versions that have been superceded should be avoided.
 
-The formatting sections of this document are enforced by the [clang-format tool](http://llvm.org/releases/8.0.0/tools/clang/docs/ClangFormat.html). Currently, version '8.0' of ``clang-format`` is to be used. The configuration file ``.clang-format`` in the root of the OpenApoc source repository should match the formatting guidelines specified below.
+The formatting sections of this document are enforced by the [clang-format tool](http://llvm.org/releases/8.0.0/tools/clang/docs/ClangFormat.html). Currently, version '10.0' of ``clang-format`` is to be used. The configuration file ``.clang-format`` in the root of the OpenApoc source repository should match the formatting guidelines specified below.
 
 With this, it is highly recommended to run ``clang-format`` on all modified files before check-in. This can be run on source files with the following command:
 

--- a/framework/fs/physfs_archiver_cue.cpp
+++ b/framework/fs/physfs_archiver_cue.cpp
@@ -762,7 +762,8 @@ class CueArchiver
 		uint8_t _padding; // This field is here to avoid alignment issues.
 		                  // It's only used in the boot volume descriptor, and
 		                  // therefore not interesting to us.
-		union {
+		union
+		{
 			// Better not even try this one
 			/*struct
 			{

--- a/tools/lint.sh
+++ b/tools/lint.sh
@@ -15,6 +15,9 @@ if [ -z "$(command -v ${CLANG_FORMAT})" ]; then
   exit 1;
 fi;
 
+echo "Clang-format version:"
+${CLANG_FORMAT} --version
+
 # Default to 'cached', or the revision passed as an argument
 GIT_REVISION=${1:---cached}
 


### PR DESCRIPTION
Now the travis-ci build uses clang-format-10 we need to reformat everything for the linting pass' sanity.