### PR TITLE
Fix usage formatting string in transfer screen

### DIFF
--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -170,7 +170,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -183,7 +183,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -196,7 +196,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%s%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		default:


### PR DESCRIPTION
This causes an unhandled exception since the {fmt} rework, as it uses the "%s" format specifier for an integer when rendering the usage of stores.

Fixes #961 