### PR TITLE
Implement a cap on number of concurrent samples

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -961,6 +961,7 @@ void Framework::audioInitialise()
 			continue;
 		}
 		this->soundBackend.reset(backend);
+		this->soundBackend->setConcurrentSamples(Options::audioConcurrentSampleCount.get());
 		LogInfo("Using sound backend %s", soundBackendName);
 		break;
 	}

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -946,6 +946,8 @@ void Framework::audioInitialise()
 	p->registeredSoundBackends["SDLRaw"].reset(getSDLSoundBackend());
 	p->registeredSoundBackends["null"].reset(getNullSoundBackend());
 
+	auto concurrent_sample_count = Options::audioConcurrentSampleCount.get();
+
 	for (auto &soundBackendName : split(Options::audioBackendsOption.get(), ":"))
 	{
 		auto backendFactory = p->registeredSoundBackends.find(soundBackendName);
@@ -954,14 +956,13 @@ void Framework::audioInitialise()
 			LogInfo("Sound backend %s not in supported list", soundBackendName);
 			continue;
 		}
-		SoundBackend *backend = backendFactory->second->create();
+		SoundBackend *backend = backendFactory->second->create(concurrent_sample_count);
 		if (!backend)
 		{
 			LogInfo("Sound backend %s failed to init", soundBackendName);
 			continue;
 		}
 		this->soundBackend.reset(backend);
-		this->soundBackend->setConcurrentSamples(Options::audioConcurrentSampleCount.get());
 		LogInfo("Using sound backend %s", soundBackendName);
 		break;
 	}

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -35,6 +35,7 @@ void dumpOptionsToLog()
 	dumpOption(audioGlobalGainOption);
 	dumpOption(audioSampleGainOption);
 	dumpOption(audioMusicGainOption);
+	dumpOption(audioConcurrentSampleCount);
 	dumpOption(screenWidthOption);
 	dumpOption(screenHeightOption);
 	dumpOption(screenFullscreenOption);
@@ -207,6 +208,9 @@ ConfigOptionInt audioGlobalGainOption("Framework.Audio", "GlobalGain", "Global a
 ConfigOptionInt audioSampleGainOption("Framework.Audio", "SampleGain", "Sample audio gain (0-20)",
                                       20);
 ConfigOptionInt audioMusicGainOption("Framework.Audio", "MusicGain", "Music audio gain (0-20)", 20);
+ConfigOptionInt audioConcurrentSampleCount("Framework.Audio", "ConcurrentSamples",
+                                           "The number of concurrent samples to play at one time",
+                                           10);
 ConfigOptionInt screenWidthOption("Framework.Screen", "Width", "Initial screen width (in pixels)",
                                   1280);
 ConfigOptionInt screenHeightOption("Framework.Screen", "Height",

--- a/framework/options.h
+++ b/framework/options.h
@@ -13,6 +13,7 @@ extern ConfigOptionString audioBackendsOption;
 extern ConfigOptionInt audioGlobalGainOption;
 extern ConfigOptionInt audioSampleGainOption;
 extern ConfigOptionInt audioMusicGainOption;
+extern ConfigOptionInt audioConcurrentSampleCount;
 extern ConfigOptionInt screenWidthOption;
 extern ConfigOptionInt screenHeightOption;
 extern ConfigOptionBool screenFullscreenOption;

--- a/framework/sound.h
+++ b/framework/sound.h
@@ -88,6 +88,7 @@ class SoundBackend
 	int concurrent_samples = 0;
 
   public:
+	SoundBackend(int concurrent_sample_count) : concurrent_samples(concurrent_sample_count) {}
 	virtual ~SoundBackend() = default;
 	virtual void playSample(sp<Sample> sample, float gain = 1.0f) = 0;
 	virtual void playMusic(std::function<void(void *)> finishedCallback,

--- a/framework/sound.h
+++ b/framework/sound.h
@@ -84,6 +84,9 @@ class MusicTrack : public ResObject
 
 class SoundBackend
 {
+  protected:
+	int concurrent_samples = 0;
+
   public:
 	virtual ~SoundBackend() = default;
 	virtual void playSample(sp<Sample> sample, float gain = 1.0f) = 0;
@@ -92,6 +95,8 @@ class SoundBackend
 	virtual void stopMusic() = 0;
 
 	virtual void setTrack(sp<MusicTrack> track) = 0;
+
+	virtual void setConcurrentSamples(int count) { this->concurrent_samples = count; }
 
 	/* Gain - a float scale (from 1.0 to 0.0) in 'linear intensity' (IE samples
 	 * are simply multiplied by the 'volume')

--- a/framework/sound/null_backend.cpp
+++ b/framework/sound/null_backend.cpp
@@ -12,7 +12,7 @@ class NullSoundBackend : public SoundBackend
 	AudioFormat preferredFormat;
 
   public:
-	NullSoundBackend()
+	NullSoundBackend(int concurrent_sample_count) : SoundBackend(concurrent_sample_count)
 	{
 		preferredFormat.channels = 2;
 		preferredFormat.format = AudioFormat::SampleFormat::PCM_SINT16;
@@ -59,10 +59,10 @@ class NullSoundBackend : public SoundBackend
 class NullSoundBackendFactory : public SoundBackendFactory
 {
   public:
-	SoundBackend *create() override
+	SoundBackend *create(int concurrent_sample_count) override
 	{
 		LogWarning("Creating NULL sound backend (Sound disabled)");
-		return new NullSoundBackend();
+		return new NullSoundBackend(concurrent_sample_count);
 	}
 
 	~NullSoundBackendFactory() override = default;

--- a/framework/sound/sdlraw_backend.cpp
+++ b/framework/sound/sdlraw_backend.cpp
@@ -317,6 +317,12 @@ class SDLRawBackend : public SoundBackend
 		}
 		{
 			std::lock_guard<std::recursive_mutex> l(this->audio_lock);
+			if (this->live_samples.size() > this->concurrent_samples)
+			{
+				LogInfo("Skipping sound %s as we already have %d on queue", sample->path,
+				        this->live_samples.size());
+				return;
+			}
 			this->live_samples.emplace_back(sample, gain);
 		}
 		LogInfo("Placed sound %s on queue", sample->path);

--- a/framework/sound/sdlraw_backend.cpp
+++ b/framework/sound/sdlraw_backend.cpp
@@ -264,9 +264,10 @@ class SDLRawBackend : public SoundBackend
 		}
 	}
 
-	SDLRawBackend()
-	    : overall_volume(1.0f), music_volume(1.0f), sound_volume(1.0f), music_playing(false),
-	      music_callback_data(nullptr), music_queue_size(2)
+	SDLRawBackend(int concurrent_sample_count)
+	    : SoundBackend(concurrent_sample_count), overall_volume(1.0f), music_volume(1.0f),
+	      sound_volume(1.0f), music_playing(false), music_callback_data(nullptr),
+	      music_queue_size(2)
 	{
 		SDL_Init(SDL_INIT_AUDIO);
 		preferred_format.channels = 2;
@@ -425,7 +426,7 @@ void unwrap_callback(void *userdata, Uint8 *stream, int len)
 class SDLRawBackendFactory : public SoundBackendFactory
 {
   public:
-	SoundBackend *create() override
+	SoundBackend *create(int concurrent_sample_count) override
 	{
 		LogWarning("Creating SDLRaw sound backend (Might have issues!)");
 		int ret = SDL_InitSubSystem(SDL_INIT_AUDIO);
@@ -434,7 +435,9 @@ class SDLRawBackendFactory : public SoundBackendFactory
 			LogWarning("Failed to init SDL_AUDIO (%d) - %s", ret, SDL_GetError());
 			return nullptr;
 		}
-		return new SDLRawBackend();
+		// We do sw mixing so can support "any" concurrent sample count (though realistically
+		// limited by cpu performance)
+		return new SDLRawBackend(concurrent_sample_count);
 	}
 
 	~SDLRawBackendFactory() override = default;

--- a/framework/sound_interface.h
+++ b/framework/sound_interface.h
@@ -7,7 +7,7 @@ namespace OpenApoc
 class SoundBackendFactory
 {
   public:
-	virtual SoundBackend *create() = 0;
+	virtual SoundBackend *create(int concurrent_sample_count) = 0;
 	virtual ~SoundBackendFactory() = default;
 };
 


### PR DESCRIPTION
Lots of samples together just sound like noise, and can have bad corner cases (e.g. after unpausing multiple of the same sample could perfectly overlap making it super loud and clip)