### PR TITLE
Fix deprecated QProcess:startDetached() use

### DIFF
--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -219,7 +219,7 @@ void LauncherWindow::play()
 #endif
 
 	LogWarning("Running \"%s\"", path.toStdString());
-	const auto ret = QProcess::startDetached(path);
+	const auto ret = QProcess::startDetached(path, {});
 	if (!ret)
 	{
 		LogError("Failed to start OpenApoc process");


### PR DESCRIPTION
We don't want to give the launched process arguments, so empty second
arg seems good here?