### PR TITLE
Forward unhandled game state events to previous stage

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -483,6 +483,21 @@ void Framework::processEvents()
 			case EVENT_WINDOW_CLOSED:
 				shutdownFramework();
 				return;
+			case EVENT_GAME_STATE:
+			{
+				auto currentStage = p->ProgramStages.current();
+				while (currentStage != nullptr)
+				{
+					currentStage->eventOccurred(e.get());
+
+					if (e->Handled)
+					{
+						break;
+					}
+					currentStage = p->ProgramStages.previous(currentStage);
+				}
+			}
+			break;
 			default:
 				p->ProgramStages.current()->eventOccurred(e.get());
 				break;

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -4003,6 +4003,7 @@ bool BattleView::handleGameStateEvent(Event *e)
 		default:
 			break;
 	}
+	e->Handled = true;
 	return true;
 }
 

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3864,6 +3864,7 @@ bool CityView::handleGameStateEvent(Event *e)
 		default:
 			break;
 	}
+	e->Handled = true;
 	return true;
 }
 


### PR DESCRIPTION
Sometimes game state events are being ignored if currently open Stage isn't Battleview or Cityview.

Simplified fix for the issue. Suggestions?