### PR TITLE
Use binary QT5 package for appveyor builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,9 @@ CMAKE_MINIMUM_REQUIRED(VERSION 3.9)
 
 # This changes the vcpkg features, so needs to be set before the first PROJECT() call
 option(BUILD_LAUNCHER "Build the launcher" ON)
-if (BUILD_LAUNCHER)
+option(USE_SYSTEM_QT "Use the system-provided QT5 instead of installing the vcpkg package" OFF)
+
+if (BUILD_LAUNCHER AND NOT USE_SYSTEM_QT)
 		list(APPEND VCPKG_MANIFEST_FEATURES "launcher")
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,12 @@
 # check cmake version
 CMAKE_MINIMUM_REQUIRED(VERSION 3.9)
 
+# This changes the vcpkg features, so needs to be set before the first PROJECT() call
+option(BUILD_LAUNCHER "Build the launcher" ON)
+if (BUILD_LAUNCHER)
+		list(APPEND VCPKG_MANIFEST_FEATURES "launcher")
+endif()
+
 # project name, and type
 PROJECT(OpenApoc CXX C)
 

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -36,7 +36,7 @@ before_build:
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
-  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH% -DENABLE_LAUNCHER=OFF
+  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH% -USE_SYSTEM_QT=ON
   - cmake --build .
 after_build:
   - git describe --tags > build-id

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -28,7 +28,6 @@ before_build:
   - git checkout 2020.11
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc libvorbis
   - vcpkg upgrade --no-dry-run
   - vcpkg remove --outdated
   - git submodule update --init --recursive

--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -37,7 +37,7 @@ before_build:
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
-  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH%
+  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH% -DENABLE_LAUNCHER=OFF
   - cmake --build .
 after_build:
   - git describe --tags > build-id

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -37,7 +37,7 @@ before_build:
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
-  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH% -DENABLE_LAUNCHER=OFF
+  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH% -DUSE_SYSTEM_QT=ON
   - cmake --build .
 after_build:
   - git describe --tags > build-id

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ before_build:
   - choco install ninja
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Community\VC\Auxiliary\Build\vcvarsall.bat" %VCVARS_ARCH%
 build_script:
-  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH%
+  - cmake -DMSVC_PDB=ON . -GNinja -DCMAKE_TOOLCHAIN_FILE=c:/tools/vcpkg/scripts/buildsystems/vcpkg.cmake -DCMAKE_BUILD_TYPE="%CONFIGURATION%" -DCMAKE_PREFIX_PATH=%QTPATH% -DENABLE_LAUNCHER=OFF
   - cmake --build .
 after_build:
   - git describe --tags > build-id

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,7 +28,6 @@ before_build:
   - git checkout 2020.11
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
-  - vcpkg install sdl2 boost-locale boost-program-options boost-uuid boost-crc libvorbis
   - vcpkg upgrade --no-dry-run
   - vcpkg remove --outdated
   - git submodule update --init --recursive

--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -8,7 +8,7 @@ option(BUILD_EDITOR "Build the gamestate editor tool" OFF)
 option(BUILD_DUMPEVERYTHING "Tool that dumps all known images" OFF)
 option(BUILD_SERIALIZATIONTOOL "Tool to work with serialized gamestate
 archives" ON)
-option(BUILD_LAUNCHER "Build the launcher" ON)
+
 
 if(BUILD_EXTRACTOR)
 		add_subdirectory(extractors)
@@ -32,7 +32,6 @@ endif()
 
 if (BUILD_LAUNCHER)
 		add_subdirectory(launcher)
-		list(APPEND VCPKG_MANIFEST_FEATURES "launcher")
 endif()
 
 # GameState serialization code generator isn't optional


### PR DESCRIPTION
Disable the launcher for now - I think the appveyor CI is timing out trying to build qt5, which is only required for the launcher.