### PR TITLE
Github action: Fix quoting of strings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -52,7 +52,7 @@ jobs:
       shell: bash
       run: |
         cd $GITHUB_WORKSPACE
-        if [[ -z ${{ github.event.before }} ]]
+        if [[ -z "${{ github.event.before }}" ]]
         then
           echo '$GITHUB_WORKSPACE/tools/lint.sh ${{ github.sha }}'
           $GITHUB_WORKSPACE/tools/lint.sh ${{ github.sha }}
@@ -67,7 +67,7 @@ jobs:
       shell: bash
       run: |
         cd $GITHUB_WORKSPACE
-        if [[ -z ${{ github.event.before }} ]]
+        if [[ -z "${{ github.event.before }}" ]]
         then
           echo 'CLANG_TIDY=clang-tidy-10 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${{ github.sha }} || true;'
           CLANG_TIDY=clang-tidy-10 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${{ github.sha }} || true;


### PR DESCRIPTION
If the string was empty (e.g. no range available in the action), the resulting "if [[ -z ]]" is invalid