### PR TITLE
Add time related cheats

### DIFF
--- a/data/forms/cheatoptions.form
+++ b/data/forms/cheatoptions.form
@@ -55,6 +55,21 @@
           <position x="290" y="282"/>
           <size width="140" height="28"/>
         </textbutton>
+        <textbutton text="Go to end of day" id="BUTTON_SET_TIME_BEFORE_MIDNIGHT">
+          <font>smalfont</font>
+          <position x="290" y="320"/>
+          <size width="140" height="28"/>
+        </textbutton>
+        <textbutton text="Go to end of week" id="BUTTON_FAST_FORWARD_END_WEEK">
+          <font>smalfont</font>
+          <position x="290" y="350"/>
+          <size width="140" height="28"/>
+        </textbutton>
+        <textbutton text="Go to end of month" id="BUTTON_FAST_FORWARD_END_MONTH">
+          <font>smalfont</font>
+          <position x="290" y="380"/>
+          <size width="140" height="28"/>
+        </textbutton>
         <checkbox id="CHECKBOX_INFINITE_AMMO">
           <position x="440" y="100"/>
           <size width="150" height="16"/>

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -123,6 +123,15 @@ UString GameTime::getShortDateString() const
 
 UString GameTime::getWeekString() const { return format("%s %d", tr("Week"), getWeek()); }
 
+unsigned int GameTime::getMonth() const
+{
+	date currentDate = getPtime(this->ticks).date();
+
+	int months = (currentDate.year() - GAME_START.date().year()) * 12 + currentDate.month() -
+	             GAME_START.date().month();
+	return months;
+}
+
 unsigned int GameTime::getWeek() const
 {
 	date firstMonday = previous_weekday(GAME_START.date(), greg_weekday(Monday));
@@ -131,11 +140,48 @@ unsigned int GameTime::getWeek() const
 	return duration.days() / 7 + 1;
 }
 
+unsigned int GameTime::getLastDayOfCurrentWeek() const {
+	unsigned int daysBeforeWeekEnd = 7 - getPtime(this->ticks).date().day_of_week();
+	return getPtime(this->ticks + (daysBeforeWeekEnd * TICKS_PER_DAY)).date().year_month_day().day;
+}
+
+unsigned int GameTime::getLastDayOfCurrentMonth() const
+{
+	return getPtime(this->ticks).date().end_of_month().year_month_day().day;
+}
+
 unsigned int GameTime::getDay() const { return (this->ticks + TICKS_PER_DAY - 1) / TICKS_PER_DAY; }
+
+unsigned int GameTime::getMonthDay() const
+{
+	return getPtime(this->ticks).date().year_month_day().day;
+}
 
 unsigned int GameTime::getHours() const { return getPtime(this->ticks).time_of_day().hours(); }
 
 unsigned int GameTime::getMinutes() const { return getPtime(this->ticks).time_of_day().minutes(); }
+
+unsigned int GameTime::getSeconds() const { return getPtime(this->ticks).time_of_day().seconds(); }
+
+unsigned int GameTime::getTicksBetween(unsigned int fromDays, unsigned int fromHours,
+                                       unsigned int fromMinutes, unsigned int fromSeconds,
+                                       unsigned int toDays, unsigned int toHours,
+                                       unsigned int toMinutes, unsigned int toSeconds) const
+{
+	if (fromDays <= toDays && fromHours <= toHours && fromMinutes <= toMinutes &&
+	    fromSeconds < toSeconds)
+	{
+		unsigned int days_diff_in_ticks = (toDays - fromDays) * TICKS_PER_DAY;
+		unsigned int hours_diff_in_ticks = (toHours - fromHours) * TICKS_PER_HOUR;
+		unsigned int minutes_diff_in_ticks = (toMinutes - fromMinutes) * TICKS_PER_MINUTE;
+		unsigned int seconds_diff_in_ticks = (toSeconds - fromSeconds) * TICKS_PER_SECOND;
+
+		return days_diff_in_ticks + hours_diff_in_ticks + minutes_diff_in_ticks +
+		       seconds_diff_in_ticks;
+	}
+	else
+		return 0;
+}
 
 uint64_t GameTime::getTicks() const { return ticks; }
 

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -140,7 +140,8 @@ unsigned int GameTime::getWeek() const
 	return duration.days() / 7 + 1;
 }
 
-unsigned int GameTime::getLastDayOfCurrentWeek() const {
+unsigned int GameTime::getLastDayOfCurrentWeek() const
+{
 	unsigned int daysBeforeWeekEnd = 7 - getPtime(this->ticks).date().day_of_week();
 	return getPtime(this->ticks + (daysBeforeWeekEnd * TICKS_PER_DAY)).date().year_month_day().day;
 }

--- a/game/state/gametime.h
+++ b/game/state/gametime.h
@@ -34,10 +34,24 @@ class GameTime
 
 	unsigned int getMinutes() const;
 
+	unsigned int getSeconds() const;
+
+	unsigned int getMonthDay() const;
+
 	unsigned int getDay() const;
 
 	unsigned int getWeek() const;
 
+	unsigned int getMonth() const;
+
+	unsigned int getLastDayOfCurrentWeek() const;
+
+	unsigned int getLastDayOfCurrentMonth() const;
+
+	unsigned int getTicksBetween(unsigned int fromDays, unsigned int fromHours,
+	                             unsigned int fromMinutes, unsigned int fromSeconds,
+	                             unsigned int toDays, unsigned int toHours, unsigned int toMinutes,
+	                             unsigned int toSeconds) const;
 	uint64_t getTicks() const;
 
 	// returns week with prefix

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -181,6 +181,27 @@ void CheatOptions::eventOccurred(Event *e)
 			    menuform->findControlTyped<ScrollBar>("MODIFY_FUNDS")->getValue() * 1000;
 			menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 		}
+		else if (e->forms().RaisedBy->Name == "BUTTON_SET_TIME_BEFORE_MIDNIGHT")
+		{
+			GameTime gt = state->gameTime;
+			state->gameTime.addTicks(gt.getTicksBetween(gt.getMonthDay(), gt.getHours(),
+			                                            gt.getMinutes(), gt.getSeconds(),
+			                                            gt.getMonthDay(), 23, 59, 59));
+		}
+		else if (e->forms().RaisedBy->Name == "BUTTON_FAST_FORWARD_END_WEEK")
+		{
+			GameTime gt = state->gameTime;
+			state->gameTime.addTicks(gt.getTicksBetween(gt.getMonthDay(), gt.getHours(),
+			                                            gt.getMinutes(), gt.getSeconds(),
+			                                            gt.getLastDayOfCurrentWeek(), 23, 59, 59));
+		}
+		else if (e->forms().RaisedBy->Name == "BUTTON_FAST_FORWARD_END_MONTH")
+		{
+			GameTime gt = state->gameTime;
+			state->gameTime.addTicks(gt.getTicksBetween(
+			    gt.getMonthDay(), gt.getHours(), gt.getMinutes(),gt.getSeconds(), 
+				gt.getLastDayOfCurrentMonth(), 23, 59, 59));
+		}
 		else if (e->forms().RaisedBy->Name == "BUTTON_FAST_FORWARD_DAY")
 		{
 			state->gameTime.addTicks(TICKS_PER_DAY);

--- a/game/ui/general/cheatoptions.cpp
+++ b/game/ui/general/cheatoptions.cpp
@@ -198,9 +198,9 @@ void CheatOptions::eventOccurred(Event *e)
 		else if (e->forms().RaisedBy->Name == "BUTTON_FAST_FORWARD_END_MONTH")
 		{
 			GameTime gt = state->gameTime;
-			state->gameTime.addTicks(gt.getTicksBetween(
-			    gt.getMonthDay(), gt.getHours(), gt.getMinutes(),gt.getSeconds(), 
-				gt.getLastDayOfCurrentMonth(), 23, 59, 59));
+			state->gameTime.addTicks(gt.getTicksBetween(gt.getMonthDay(), gt.getHours(),
+			                                            gt.getMinutes(), gt.getSeconds(),
+			                                            gt.getLastDayOfCurrentMonth(), 23, 59, 59));
 		}
 		else if (e->forms().RaisedBy->Name == "BUTTON_FAST_FORWARD_DAY")
 		{


### PR DESCRIPTION
In order to simplify some time related events (e.g: end of day/end of week) I propose to add 3 cheats that forwards in-game time directly to one second before the selected time period:
- Go to end of day
- Go to end of week
- Go to end of month