### PR TITLE
Weekly report fix

### DIFF
--- a/data/forms/city/weekly_funding.form
+++ b/data/forms/city/weekly_funding.form
@@ -55,7 +55,7 @@
       </label>
       <label id="FUNDING_ADJUSTMENT">
         <position x="52" y="212"/>
-        <size width="200" height="15"/>
+        <size width="0" height="15"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/weekly_funding.form
+++ b/data/forms/city/weekly_funding.form
@@ -37,7 +37,13 @@
 	  
       <label id="FUNDING_CURRENT" text="Current income>">
         <position x="52" y="140"/>
-        <size width="400" height="15"/>
+        <size width="0" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+      <label id="FUNDING_CURRENT_VALUE">
+        <position x="0" y="0"/>
+        <size width="0" height="15"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>
@@ -49,17 +55,29 @@
       </label>
       <label id="FUNDING_ADJUSTMENT">
         <position x="52" y="212"/>
-        <size width="400" height="15"/>
+        <size width="200" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+      <label id="FUNDING_ADJUSTMENT_VALUE">
+        <position x="0" y="0"/>
+        <size width="0" height="15"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>
       <label id="FUNDING_NEW">
         <position x="52" y="240"/>
-        <size width="400" height="15"/>
+        <size width="0" height="15"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>
-
+      <label id="FUNDING_NEW_VALUE">
+        <position x="0" y="0"/>
+        <size width="0" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+      
       <graphicbutton id="BUTTON_OK">
         <position x="602" y="443"/>
         <size width="35" height="34"/>

--- a/game/state/CMakeLists.txt
+++ b/game/state/CMakeLists.txt
@@ -88,6 +88,7 @@ set (GAMESTATE_SOURCE_FILES
 	luagamestate_support_generated.cpp
 	message.cpp
 	savemanager.cpp
+	playerstatesnapshot.cpp
 
 	tilemap/collision.cpp
 	tilemap/pathfinding.cpp
@@ -188,6 +189,7 @@ set (GAMESTATE_HEADER_FILES
 	message.h
 	savemanager.h
 	stateobject.h
+	playerstatesnapshot.h
 
 	tilemap/collision.h
 	tilemap/tile.h

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -4,6 +4,7 @@
 #include "game/state/battle/battle.h"
 #include "game/state/city/base.h"
 #include "game/state/city/building.h"
+#include "game/state/playerstatesnapshot.h"
 #include "game/state/rules/city/vehicletype.h"
 #include "game/state/shared/agent.h"
 #include "game/state/shared/organisation.h"
@@ -412,5 +413,11 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 			break;
 	}
 }
+
+GameStatusUpdateEvent::GameStatusUpdateEvent(GameEventType type, PlayerStateSnapshot state)
+    : GameEvent(type), state(PlayerStateSnapshot(state))
+{
+}
+
 UString GameSomethingDiedEvent::message() { return messageInner; }
 } // namespace OpenApoc

--- a/game/state/gameevent.h
+++ b/game/state/gameevent.h
@@ -2,6 +2,7 @@
 
 #include "framework/event.h"
 #include "game/state/gameeventtypes.h"
+#include "game/state/playerstatesnapshot.h"
 #include "game/state/stateobject.h"
 #include "library/sp.h"
 #include "library/strings.h"
@@ -163,5 +164,14 @@ class GameLocationEvent : public GameEvent
 
 	GameLocationEvent(GameEventType type, Vec3<int> location);
 	~GameLocationEvent() override = default;
+};
+
+class GameStatusUpdateEvent : public GameEvent
+{
+  public:
+	PlayerStateSnapshot state;
+
+	GameStatusUpdateEvent(GameEventType type, PlayerStateSnapshot state);
+	~GameStatusUpdateEvent() override = default;
 };
 } // namespace OpenApoc

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -253,7 +253,11 @@ class GameState : public std::enable_shared_from_this<GameState>
 	void updateEndOfWeek();
 
 	void updateHumanEconomy();
-	void weeklyPlayerUpdate();
+
+	void updateFundingModifier();
+	void governmentPaysPlayer();
+	void playerPaysTheBills();
+
 	int calculateFundingModifier() const;
 
 	void logEvent(GameEvent *ev);

--- a/game/state/playerstatesnapshot.cpp
+++ b/game/state/playerstatesnapshot.cpp
@@ -1,0 +1,63 @@
+#include "game/state/playerstatesnapshot.h"
+#include "game/state/city/base.h"
+#include "game/state/city/facility.h"
+#include "game/state/shared/organisation.h"
+
+namespace OpenApoc
+{
+
+PlayerStateSnapshot::PlayerStateSnapshot(sp<GameState> stateToSnap)
+    : fundingModifier(stateToSnap->calculateFundingModifier()),
+      fundingTerminated(stateToSnap->fundingTerminated), gameTime(stateToSnap->gameTime),
+      totalScore(stateToSnap->totalScore), weekScore(stateToSnap->weekScore),
+      weekly_rating_rules(stateToSnap->weekly_rating_rules),
+      agent_salary(stateToSnap->agent_salary), playerBalance(stateToSnap->player->balance),
+      playerIncome(stateToSnap->player->income),
+      governmentBalance(stateToSnap->government->balance),
+      government_player_relationship(stateToSnap->government->isRelatedTo(stateToSnap->player))
+{
+	int soldiers = 0, biochemists = 0, engineers = 0, physicists = 0;
+	for (auto &a : stateToSnap->agents)
+	{
+		if (a.second->owner == stateToSnap->player)
+		{
+			switch (a.second->type->role)
+			{
+				case AgentType::Role::BioChemist:
+					biochemists++;
+					break;
+				case AgentType::Role::Engineer:
+					engineers++;
+					break;
+				case AgentType::Role::Physicist:
+					physicists++;
+					break;
+				case AgentType::Role::Soldier:
+					soldiers++;
+					break;
+			}
+		}
+		agent_qty.insert_or_assign(AgentType::Role::BioChemist, biochemists);
+		agent_qty.insert_or_assign(AgentType::Role::Engineer, engineers);
+		agent_qty.insert_or_assign(AgentType::Role::Physicist, physicists);
+		agent_qty.insert_or_assign(AgentType::Role::Soldier, soldiers);
+	}
+
+	for (auto &base : stateToSnap->player_bases)
+	{
+		int basesCosts = 0;
+		for (auto &f : base.second->facilities)
+		{
+			basesCosts += f->type->weeklyCost;
+			playerBasesWeeklyCosts.insert_or_assign(base.first, basesCosts);
+		}
+	}
+}
+
+PlayerStateSnapshot::~PlayerStateSnapshot() {}
+
+const UString PlayerStateSnapshot::getPlayerBalance()
+{
+	return Strings::fromInteger(playerBalance);
+};
+} // namespace OpenApoc

--- a/game/state/playerstatesnapshot.h
+++ b/game/state/playerstatesnapshot.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include "game/state/gamestate.h"
+#include "game/state/gametime.h"
+#include "game/state/shared/organisation.h"
+#include "library/strings.h"
+#include "library/sp.h"
+
+namespace OpenApoc
+{
+
+class PlayerStateSnapshot : public std::enable_shared_from_this<PlayerStateSnapshot>
+{
+  public:
+	PlayerStateSnapshot(sp<GameState> stateToSnap);
+	~PlayerStateSnapshot();
+
+	bool fundingTerminated = false;
+	const int fundingModifier = 0;
+
+	GameTime gameTime;
+	GameScore totalScore;
+	GameScore weekScore;
+
+	const int playerIncome = 0;
+	int playerBalance = 0;
+
+	const UString getPlayerBalance();
+
+	const int governmentBalance = 0;
+	Organisation::Relation government_player_relationship;
+
+	std::vector<std::pair<int, int>> weekly_rating_rules;
+
+	std::map<UString, int> playerBasesWeeklyCosts;
+	std::map<AgentType::Role, int> agent_salary;
+	std::map<AgentType::Role, int> agent_qty;
+};
+
+}; // namespace OpenApoc

--- a/game/ui/city/scorescreen.h
+++ b/game/ui/city/scorescreen.h
@@ -2,6 +2,7 @@
 
 #include "framework/stage.h"
 #include "library/sp.h"
+#include "game/state/playerstatesnapshot.h"
 
 namespace OpenApoc
 {
@@ -18,7 +19,7 @@ class ScoreScreen : public Stage
 	sp<Form> formFinance;
 	sp<Label> title;
 
-	sp<GameState> state;
+	PlayerStateSnapshot state;
 
 	// Default form state
 	bool isWeeklyUpkeep = false;
@@ -33,7 +34,7 @@ class ScoreScreen : public Stage
 	void setFinanceMode();
 
   public:
-	ScoreScreen(sp<GameState> state, bool showWeeklyUpkeep = false);
+	ScoreScreen(PlayerStateSnapshot state, bool showWeeklyUpkeep = false);
 	~ScoreScreen() override;
 
 	// Stage control

--- a/game/ui/city/weeklyfundingscreen.cpp
+++ b/game/ui/city/weeklyfundingscreen.cpp
@@ -7,14 +7,14 @@
 #include "framework/font.h"
 #include "framework/framework.h"
 #include "framework/keycodes.h"
-#include "game/state/gamestate.h"
+#include "game/state/playerstatesnapshot.h"
 #include "game/state/shared/organisation.h"
 #include "game/ui/city/scorescreen.h"
 
 namespace OpenApoc
 {
 
-WeeklyFundingScreen::WeeklyFundingScreen(sp<GameState> state)
+WeeklyFundingScreen::WeeklyFundingScreen(PlayerStateSnapshot state)
     : Stage(), menuform(ui().getForm("city/weekly_funding")), state(state)
 {
 	labelCurrentIncome = menuform->findControlTyped<Label>("FUNDING_CURRENT");
@@ -38,15 +38,15 @@ WeeklyFundingScreen::~WeeklyFundingScreen() = default;
 void WeeklyFundingScreen::begin()
 {
 	// Validate that we can recieve funding
-	if (state->fundingTerminated)
+	if (state.fundingTerminated)
 	{
 		fw().stageQueueCommand({StageCmd::Command::POP});
 		return;
 	}
 
-	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
-	menuform->findControlTyped<Label>("TEXT_DATE")->setText(state->gameTime.getLongDateString());
-	menuform->findControlTyped<Label>("TEXT_WEEK")->setText(state->gameTime.getWeekString());
+	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state.getPlayerBalance());
+	menuform->findControlTyped<Label>("TEXT_DATE")->setText(state.gameTime.getLongDateString());
+	menuform->findControlTyped<Label>("TEXT_WEEK")->setText(state.gameTime.getWeekString());
 
 	menuform->findControlTyped<Label>("TITLE")->setText(tr("WEEKLY FUNDING ASSESSMENT"));
 
@@ -54,11 +54,9 @@ void WeeklyFundingScreen::begin()
 	const Colour deepBlueColor = {4, 73, 130, 255};
 	const Colour cyanColor = {113, 219, 255, 255};
 
-	const auto player = state->getPlayer();
-	const auto government = state->getGovernment();
-	int currentIncome = player->income;
+	int currentIncome = state.playerIncome;
 
-	if (government->isRelatedTo(player) == Organisation::Relation::Hostile)
+	if (state.government_player_relationship == Organisation::Relation::Hostile)
 	{
 		ratingDescription =
 		    tr("The Senate has declared total hostility to X-COM and there will be no further "
@@ -67,7 +65,7 @@ void WeeklyFundingScreen::begin()
 
 		currentIncome = 0;
 	}
-	else if (state->totalScore.getTotal() < -2400)
+	else if (state.totalScore.getTotal() < -2400)
 	{
 		ratingDescription = tr("The Senate considers the performance of X-COM to be so abysmal "
 		                       "that it will cease funding from now on.");
@@ -76,17 +74,17 @@ void WeeklyFundingScreen::begin()
 	}
 	else
 	{
-		const int rating = state->weekScore.getTotal();
-		const int modifier = state->calculateFundingModifier();
+		const int rating = state.weekScore.getTotal();
+		const int modifier = state.fundingModifier;
 
 		int neutralRatingThreshold = 0;
-		if (!state->weekly_rating_rules.empty())
+		if (!state.weekly_rating_rules.empty())
 		{
 			// last entry should be smallest positive value that gives funding increase
-			neutralRatingThreshold = state->weekly_rating_rules.back().first;
+			neutralRatingThreshold = state.weekly_rating_rules.back().first;
 		}
 
-		const int availableGovFunds = government->balance / 2;
+		const int availableGovFunds = state.governmentBalance / 2;
 
 		if (availableGovFunds < currentIncome)
 		{
@@ -114,7 +112,7 @@ void WeeklyFundingScreen::begin()
 		}
 
 		// Income adjustment is still based on base player funding, not current one
-		const int adjustment = (modifier == 0) ? 0 : player->income / modifier;
+		const int adjustment = (modifier == 0) ? 0 : state.playerIncome / modifier;
 
 		setLabel(labelAdjustment, tr("Funding adjustment>"), deepBlueColor);
 		setValueField(valueAdjustment, labelAdjustment, adjustment, cyanColor);
@@ -136,7 +134,7 @@ void WeeklyFundingScreen::resume() {}
 
 void WeeklyFundingScreen::finish()
 {
-	fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ScoreScreen>(this->state, true)});
+	fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ScoreScreen>(state, true)});
 }
 
 void WeeklyFundingScreen::eventOccurred(Event *e)

--- a/game/ui/city/weeklyfundingscreen.h
+++ b/game/ui/city/weeklyfundingscreen.h
@@ -3,6 +3,7 @@
 #include "framework/stage.h"
 #include "game/state/stateobject.h"
 #include "library/sp.h"
+#include "library/colour.h"
 
 namespace OpenApoc
 {
@@ -18,9 +19,19 @@ class WeeklyFundingScreen : public Stage
 	sp<GameState> state;
 
 	sp<Label> labelCurrentIncome;
+	sp<Label> valueCurrentIncome;
+
 	sp<Label> labelRatingDescription;
+
 	sp<Label> labelAdjustment;
+	sp<Label> valueAdjustment;
+
 	sp<Label> labelNextWeekIncome;
+	sp<Label> valueNextWeekIncome;
+
+	void setLabel(sp<Label> label, UString text, const Colour color);
+	void setValueField(sp<Label> valueField, sp<Label> labelField, unsigned int amount,
+	                  const Colour color);
 
   public:
 	WeeklyFundingScreen(sp<GameState> state);

--- a/game/ui/city/weeklyfundingscreen.h
+++ b/game/ui/city/weeklyfundingscreen.h
@@ -2,6 +2,7 @@
 
 #include "framework/stage.h"
 #include "game/state/stateobject.h"
+#include "game/state/playerstatesnapshot.h"
 #include "library/sp.h"
 #include "library/colour.h"
 
@@ -16,7 +17,7 @@ class WeeklyFundingScreen : public Stage
 {
   private:
 	sp<Form> menuform;
-	sp<GameState> state;
+	PlayerStateSnapshot state;
 
 	sp<Label> labelCurrentIncome;
 	sp<Label> valueCurrentIncome;
@@ -34,7 +35,7 @@ class WeeklyFundingScreen : public Stage
 	                  const Colour color);
 
   public:
-	WeeklyFundingScreen(sp<GameState> state);
+	WeeklyFundingScreen(PlayerStateSnapshot state);
 	~WeeklyFundingScreen() override;
 	// Stage control
 	void begin() override;

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -483,9 +483,9 @@ bool CityView::handleClickedOrganisation(StateRef<Organisation> organisation, bo
 	return true;
 }
 
-void CityView::showWeeklyFundingReport()
+void CityView::showWeeklyFundingReport(PlayerStateSnapshot state_snapshot)
 {
-	fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<WeeklyFundingScreen>(this->state)});
+	fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<WeeklyFundingScreen>(state_snapshot)});
 }
 
 void CityView::tryOpenUfopaediaEntry(StateRef<UfopaediaEntry> ufopaediaEntry)
@@ -1052,7 +1052,7 @@ CityView::CityView(sp<GameState> state)
 	    });
 	this->baseForm->findControl("BUTTON_SHOW_SCORE")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ScoreScreen>(this->state)});
+		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ScoreScreen>(PlayerStateSnapshot(this->state))});
 	    });
 	this->baseForm->findControl("BUTTON_SHOW_UFOPAEDIA")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
@@ -3831,8 +3831,13 @@ bool CityView::handleGameStateEvent(Event *e)
 		break;
 		case GameEventType::WeeklyReport:
 		{
+			auto ev = dynamic_cast<GameStatusUpdateEvent *>(e);
+			if (!ev)
+			{
+				LogError("Invalid GameStatusUpdateEvent event");
+			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);
-			showWeeklyFundingReport();
+			showWeeklyFundingReport(ev->state);
 		}
 		break;
 		default:

--- a/game/ui/tileview/cityview.h
+++ b/game/ui/tileview/cityview.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "game/state/playerstatesnapshot.h"
 #include "game/state/stateobject.h"
 #include "game/ui/tileview/citytileview.h"
 #include "library/sp.h"
@@ -103,7 +104,7 @@ class CityView : public CityTileView
 	bool handleClickedOrganisation(StateRef<Organisation> organisation, bool rightClick,
 	                               CitySelectionState selState);
 
-	void showWeeklyFundingReport();
+	void showWeeklyFundingReport(PlayerStateSnapshot state_snapshot);
 	void tryOpenUfopaediaEntry(StateRef<UfopaediaEntry> ufopaediaEntry);
 
 	// Orders


### PR DESCRIPTION
There are some issues with the weekly report due to racing conditions of the update of the GameState that is used as reference in the weekly report. 

The idea is to create a small snapshot of the GameState that can be used to fix this issue.
In order to do that we need to add a new event, update the WeeklyFundingScreen and ScoreScreen, and refactor the GameState handling of the weeklyUpdate event.

Please, double check if what i've done is legit/correct from a c++ point of view (pointers etc...) as I still have a lot to learn.

Ps: in this PR i've added also the label coloring in WeeklyFundingScreen that was depending on.