### PR TITLE
Remove trailing space from comment

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1231,7 +1231,7 @@ void GameState::updateEndOfDay()
 	}
 
 	luaGameState.callHook("updateEndOfDay", 0, 0);
-	// Check if today is the first day of the week (monday). 
+	// Check if today is the first day of the week (monday).
 	// In that case, do not show the daily report as it's already part of the weekly report event
 	if (this->gameTime.getMonthDay() != this->gameTime.getFirstDayOfCurrentWeek())
 		fw().pushEvent(new GameEvent(GameEventType::DailyReport));


### PR DESCRIPTION
Don't know why this wasn't picked up in the PR lint - maybe clang-format change behind the scenes?