### PR TITLE
Add <thread> header to test_serialize

### DIFF
--- a/tests/test_serialize.cpp
+++ b/tests/test_serialize.cpp
@@ -6,6 +6,7 @@
 #include "game/state/gamestate_serialize.h"
 #include <iostream>
 #include <sstream>
+#include <thread>
 
 // We can't just use 'using namespace OpenApoc;' as:
 // On windows VS it says


### PR DESCRIPTION
This was missing and breaks build on gcc 11 (likely due to some other
library header no longer including it)