### PR TITLE
Add support to the launcher to select languages

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -68,7 +68,7 @@ set (FRAMEWORK_HEADER_FILES
 	logger_sdldialog.h
 	logger_file.h
 	options.h
-	modinfo.h)
+	modinfo.h translation.h)
 
 source_group(framework\\headers FILES ${FRAMEWORK_HEADER_FILES})
 list(APPEND ALL_HEADER_FILES ${FRAMEWORK_HEADER_FILES})

--- a/framework/modinfo.cpp
+++ b/framework/modinfo.cpp
@@ -65,6 +65,15 @@ std::optional<ModInfo> ModInfo::getInfo(const UString &path)
 			info.conflicts().push_back(node.value());
 		}
 	}
+
+	auto languagesNode = infoNode.child("languages");
+	if (languagesNode)
+	{
+		for (const auto node : languagesNode.children("entry"))
+		{
+			info.supported_languages.push_back(node.text().get());
+		}
+	}
 	return info;
 }
 
@@ -92,6 +101,12 @@ bool ModInfo::writeInfo(const UString &path)
 	for (const auto &conflict : _conflicts)
 	{
 		conflictsNode.append_child("entry").text() = conflict.c_str();
+	}
+
+	auto languagesNode = infoNode.append_child("languages");
+	for (const auto &language : supported_languages)
+	{
+		languagesNode.append_child("entry").text() = language.c_str();
 	}
 
 	auto filePath = path + "/modinfo.xml";

--- a/framework/modinfo.h
+++ b/framework/modinfo.h
@@ -20,6 +20,7 @@ class ModInfo
 	UString statePath;
 	UString minVersion;
 	UString modLoadScript;
+	std::list<UString> supported_languages;
 
   public:
 	// The user-visible name of the mod
@@ -71,5 +72,11 @@ class ModInfo
 
 	const UString &getModLoadScript() const { return modLoadScript; }
 	void setModLoadScript(const UString &newScript) { modLoadScript = newScript; }
+
+	const std::list<UString> getSupportedLanguages() const { return supported_languages; }
+	void setSupportedLanguage(const std::list<UString> &newLanguages)
+	{
+		supported_languages = newLanguages;
+	}
 };
 } // namespace OpenApoc

--- a/framework/translation.h
+++ b/framework/translation.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "library/framework.h"
+#include "library/strings.h"
+
+namespace OpenApoc
+{
+
+class LocalizedString
+{
+  public:
+	UStringView _id;
+	UStringView _pleural;
+	UStringView _context;
+	int _n;
+
+	LocalizedString(UStringView id) : _id(id){};
+	LocalizedString(UStringView context, UStringView id) : _id(id), _context(context){};
+	LocalizedString(UStringView id, UStringView pleural, int n)
+	    : _id(id), _pleural(pleural), _n(n){};
+	LocalizedString(UStringView context, UStringView id, UStringView pleural, int n)
+	    : _id(id), _pleural(pleural), _context(context), _n(n){};
+};
+
+} // namespace OpenApoc

--- a/tools/extractors/main.cpp
+++ b/tools/extractors/main.cpp
@@ -12,6 +12,15 @@
 
 using namespace OpenApoc;
 
+// FIXME: Make this dynamic?
+
+std::vector<UString> supported_languages = {
+    "cs.UTF-8",    "de_DE.UTF-8", "en.UTF-8",     "en_GB.UTF-8", "es.UTF-8",
+    "et_EE.UTF-8", "fi.UTF-8",    "fil_PH.UTF-8", "fr_FR.UTF-8", "hu_HU.UTF-8",
+    "it.UTF-8",    "ja.UTF-8",    "ja_JP.UTF-8",  "lt.UTF-8",    "nb_NO.UTF-8",
+    "pl.UTF-8",    "pt_BR.UTF-8", "pt_PT.UTF-8",  "ro_RO.UTF-8", "ru_RU.UTF-8",
+    "sk.UTF-8",    "sl_SI.UTF-8", "tr_TR.UTF-8",  "uk.UTF-8",    "zh_TW.UTF-8"};
+
 static ConfigOptionString outputPath("Extractor", "output",
                                      "Path to the extractor output directory", "./data");
 
@@ -76,6 +85,13 @@ std::map<UString, std::function<void(const InitialGameStateExtractor &e)>> thing
 	     info.setStatePath("base_gamestate");
 	     info.setDataPath("data");
 	     info.setModLoadScript("scripts/org.openapoc.base/onload.lua");
+
+	     std::list<UString> languages;
+	     for (const auto &name : supported_languages)
+	     {
+		     languages.push_back(name);
+	     }
+	     info.setSupportedLanguage(languages);
 
 	     info.writeInfo(outputPath.get() + "/mods/base");
      }},

--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -185,7 +185,6 @@ void LauncherWindow::setResolutionSelection(int index)
 void LauncherWindow::setLanguageSelection(int index)
 {
 	selectedLanguageID = ui->languageBox->itemData(index).toString().toStdString();
-	LogWarning("Set selected language to %s", selectedLanguageID);
 }
 
 void LauncherWindow::saveConfig()

--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -476,7 +476,7 @@ void LauncherWindow::updateAvailableLanguages()
 		if (selectedLanguageID.empty())
 		{
 			// Just default to american english if not set
-			selectedLanguageID = "en";
+			selectedLanguageID = "en.UTF-8";
 		}
 	}
 

--- a/tools/launcher/launcherwindow.h
+++ b/tools/launcher/launcherwindow.h
@@ -27,6 +27,7 @@ class LauncherWindow : public QMainWindow
 	void exit();
 	void play();
 	void setResolutionSelection(int index);
+	void setLanguageSelection(int index);
 
 	void browseCDFile();
 	void browseCDDir();
@@ -43,9 +44,11 @@ class LauncherWindow : public QMainWindow
 	void setupModList();
 	void showModInfo(const OpenApoc::ModInfo &info);
 	void rebuildModList();
+	void updateAvailableLanguages();
 
 	std::unique_ptr<OpenApoc::Framework> currentFramework;
 	std::unique_ptr<Ui::LauncherWindow> ui;
 
 	OpenApoc::UString selectedModName;
+	OpenApoc::UString selectedLanguageID;
 };

--- a/tools/launcher/launcherwindow.ui
+++ b/tools/launcher/launcherwindow.ui
@@ -40,6 +40,13 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
+       <item row="2" column="1">
+        <widget class="QCheckBox" name="fullscreenCheckBox">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
        <item row="1" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
@@ -65,13 +72,6 @@
          </item>
         </layout>
        </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="resolutionLabel">
-         <property name="text">
-          <string>Resolution</string>
-         </property>
-        </widget>
-       </item>
        <item row="2" column="0">
         <widget class="QLabel" name="fullscreenLabel">
          <property name="text">
@@ -79,24 +79,14 @@
          </property>
         </widget>
        </item>
-       <item row="1" column="0">
-        <widget class="QLabel" name="customResolutionLabel">
+       <item row="0" column="0">
+        <widget class="QLabel" name="resolutionLabel">
          <property name="text">
-          <string>Custom Resolution</string>
+          <string>Resolution</string>
          </property>
         </widget>
        </item>
-       <item row="0" column="1">
-        <widget class="QComboBox" name="resolutionBox"/>
-       </item>
-       <item row="2" column="1">
-        <widget class="QCheckBox" name="fullscreenCheckBox">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="3" column="1">
+       <item row="4" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -108,6 +98,26 @@
           </size>
          </property>
         </spacer>
+       </item>
+       <item row="0" column="1">
+        <widget class="QComboBox" name="resolutionBox"/>
+       </item>
+       <item row="3" column="0">
+        <widget class="QLabel" name="languageLabel">
+         <property name="text">
+          <string>Language</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="customResolutionLabel">
+         <property name="text">
+          <string>Custom Resolution</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QComboBox" name="languageBox"/>
        </item>
       </layout>
      </widget>

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,8 @@
     "boost-program-options",
     "boost-uuid",
     "boost-crc",
-    "libvorbis"
+    "libvorbis",
+	"gettext"
   ],
   "features": {
     "launcher": {


### PR DESCRIPTION
ModInfos can now list a set of supported languages.
Currently, only the first enabled mod is used to populate this list.