### PR TITLE
Implement borderless window mode and multi-display support

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -710,6 +710,32 @@ void Framework::shutdownFramework()
 	p->quitProgram = true;
 }
 
+enum class ScreenMode
+{
+	Unknown,
+	Windowed,
+	FullScreen,
+	Borderless
+};
+static ScreenMode optionsScreenMode();
+
+static ScreenMode optionsScreenMode()
+{
+	constexpr std::array<std::pair<std::string_view, ScreenMode>, 3> mode_names = {
+	    {{"windowed", ScreenMode::Windowed},
+	     {"fullscreen", ScreenMode::FullScreen},
+	     {"borderless", ScreenMode::Borderless}}};
+
+	for (const auto &mode_name : mode_names)
+	{
+		if (Options::screenModeOption.get() == mode_name.first)
+		{
+			return mode_name.second;
+		}
+	}
+	return ScreenMode::Unknown;
+}
+
 void Framework::displayInitialise()
 {
 	if (!this->createWindow)
@@ -741,9 +767,27 @@ void Framework::displayInitialise()
 
 	SDL_GL_SetSwapInterval(Options::swapInterval.get());
 
+	ScreenMode mode = optionsScreenMode();
+	if (mode == ScreenMode::Unknown)
+	{
+		LogError("Unknown screen mode specified: {%s}", Options::screenModeOption.get());
+		mode = ScreenMode::Windowed;
+	}
+
+	if (mode == ScreenMode::FullScreen)
+		display_flags |= SDL_WINDOW_FULLSCREEN;
+	else if (mode == ScreenMode::Borderless)
+		display_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+
+	int displayNumber = Options::screenDisplayNumberOption.get();
+	if (displayNumber >= SDL_GetNumVideoDisplays())
+	{
+		LogWarning("Requested display number (%d) does not exist. Using display 0", displayNumber);
+		displayNumber = 0;
+	}
+
 	int scrW = Options::screenWidthOption.get();
 	int scrH = Options::screenHeightOption.get();
-	bool scrFS = Options::screenFullscreenOption.get();
 
 	if (scrW < 640 || scrH < 480)
 	{
@@ -752,13 +796,9 @@ void Framework::displayInitialise()
 		    scrW, scrH);
 	}
 
-	if (scrFS)
-	{
-		display_flags |= SDL_WINDOW_FULLSCREEN;
-	}
-
-	p->window = SDL_CreateWindow("OpenApoc", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, scrW,
-	                             scrH, display_flags);
+	p->window =
+	    SDL_CreateWindow("OpenApoc", SDL_WINDOWPOS_UNDEFINED_DISPLAY(displayNumber),
+	                     SDL_WINDOWPOS_UNDEFINED_DISPLAY(displayNumber), scrW, scrH, display_flags);
 
 	if (!p->window)
 	{

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -38,6 +38,8 @@ void dumpOptionsToLog()
 	dumpOption(screenWidthOption);
 	dumpOption(screenHeightOption);
 	dumpOption(screenFullscreenOption);
+	dumpOption(screenModeOption);
+	dumpOption(screenDisplayNumberOption);
 	dumpOption(screenScaleXOption);
 	dumpOption(screenScaleYOption);
 	dumpOption(screenAutoScale);
@@ -212,8 +214,12 @@ ConfigOptionInt screenWidthOption("Framework.Screen", "Width", "Initial screen w
                                   1280);
 ConfigOptionInt screenHeightOption("Framework.Screen", "Height",
                                    "Initial screen height (in pixels)", 720);
-ConfigOptionBool screenFullscreenOption("Framework.Screen", "Fullscreen", "Enable fullscreen mode",
-                                        false);
+ConfigOptionBool screenFullscreenOption("Framework.Screen", "Fullscreen",
+                                        "Deprecated: use ScreenMode instead", false);
+ConfigOptionString screenModeOption("Framework.Screen", "Mode",
+                                    "Mode: {windowed,fullscreen,borderless}", "windowed");
+ConfigOptionInt screenDisplayNumberOption("Framework.Screen", "Display",
+                                          "Display number in multi-monitor setup (0..n)", 0);
 ConfigOptionInt screenScaleXOption("Framework.Screen", "ScaleX",
                                    "Scale screen in X direction by (percent)", 100);
 ConfigOptionInt screenScaleYOption("Framework.Screen", "ScaleY",

--- a/framework/options.h
+++ b/framework/options.h
@@ -16,6 +16,8 @@ extern ConfigOptionInt audioMusicGainOption;
 extern ConfigOptionInt screenWidthOption;
 extern ConfigOptionInt screenHeightOption;
 extern ConfigOptionBool screenFullscreenOption;
+extern ConfigOptionString screenModeOption;
+extern ConfigOptionInt screenDisplayNumberOption;
 extern ConfigOptionInt screenScaleXOption;
 extern ConfigOptionInt screenScaleYOption;
 extern ConfigOptionBool screenAutoScale;

--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -87,11 +87,10 @@ LauncherWindow::LauncherWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui
 	ui->customResolutionY->setValidator(
 	    new QIntValidator(MINIMUM_RESOLUTION.height(), MAXIMUM_RESOLUTION.height(), this));
 
-	ui->fullscreenCheckBox->setCheckState(OpenApoc::Options::screenFullscreenOption.get()
-	                                          ? Qt::CheckState::Checked
-	                                          : Qt::CheckState::Unchecked);
 	setupResolutionDisplay();
 	setupScaling();
+	setupScreenModes();
+	setupDisplayNum();
 
 	ui->cdPath->setText(QString::fromStdString(OpenApoc::Options::cdPathOption.get()));
 	ui->dataPath->setText(QString::fromStdString(OpenApoc::Options::dataPathOption.get()));
@@ -182,6 +181,43 @@ void LauncherWindow::setResolutionSelection(int index)
 	{
 		widthBox.setEnabled(false);
 		heightBox.setEnabled(false);
+	}
+}
+
+void LauncherWindow::setupScreenModes()
+{
+	constexpr std::array<std::string_view, 3> screen_modes = {"windowed", "fullscreen",
+	                                                          "borderless"};
+
+	auto &comboBox = *ui->screenModeBox;
+	comboBox.clear();
+	int index = 0;
+	for (const auto &option : screen_modes)
+	{
+		comboBox.addItem(option.data());
+		if (option == Options::screenModeOption.get())
+		{
+			comboBox.setCurrentIndex(index);
+		}
+		++index;
+	}
+};
+
+void LauncherWindow::setupDisplayNum()
+{
+	constexpr int MAX_DISPLAYS = 4;
+	auto &comboBox = *ui->displayNumBox;
+	comboBox.clear();
+
+	for (int i = 0; i < MAX_DISPLAYS; ++i)
+	{
+		comboBox.addItem(QString("Display #%1").arg(i));
+	}
+
+	int curDisplayValue = Options::screenDisplayNumberOption.get();
+	if (curDisplayValue < MAX_DISPLAYS)
+	{
+		comboBox.setCurrentIndex(curDisplayValue);
 	}
 }
 
@@ -302,8 +338,8 @@ void LauncherWindow::saveConfig()
 		OpenApoc::Options::screenHeightOption.set(size.height());
 	}
 
-	OpenApoc::Options::screenFullscreenOption.set(ui->fullscreenCheckBox->checkState() ==
-	                                              Qt::CheckState::Checked);
+	OpenApoc::Options::screenModeOption.set(ui->screenModeBox->currentText().toStdString());
+	OpenApoc::Options::screenDisplayNumberOption.set(ui->displayNumBox->currentIndex());
 	OpenApoc::Options::cdPathOption.set(ui->cdPath->text().toStdString());
 	OpenApoc::Options::dataPathOption.set(ui->dataPath->text().toStdString());
 	OpenApoc::Options::languageOption.set(selectedLanguageID);

--- a/tools/launcher/launcherwindow.h
+++ b/tools/launcher/launcherwindow.h
@@ -41,6 +41,8 @@ class LauncherWindow : public QMainWindow
   private:
 	void setupResolutionDisplay();
 	void setupScaling();
+	void setupScreenModes();
+	void setupDisplayNum();
 	void saveScalingOptions();
 	void saveConfig();
 	void setupModList();

--- a/tools/launcher/launcherwindow.ui
+++ b/tools/launcher/launcherwindow.ui
@@ -44,11 +44,7 @@
         <widget class="QComboBox" name="resolutionBox"/>
        </item>
        <item row="2" column="1">
-        <widget class="QCheckBox" name="fullscreenCheckBox">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
+        <widget class="QComboBox" name="screenModeBox"/>
        </item>
        <item row="1" column="1">
         <layout class="QHBoxLayout" name="horizontalLayout">
@@ -76,9 +72,9 @@
         </layout>
        </item>
        <item row="2" column="0">
-        <widget class="QLabel" name="fullscreenLabel">
+        <widget class="QLabel" name="screenModeLabel">
          <property name="text">
-          <string>Fullscreen</string>
+          <string>Mode</string>
          </property>
         </widget>
        </item>
@@ -89,7 +85,7 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="1">
+       <item row="6" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -102,7 +98,7 @@
          </property>
         </spacer>
        </item>
-       <item row="4" column="0">
+       <item row="5" column="0">
         <widget class="QLabel" name="languageLabel">
          <property name="text">
           <string>Language</string>
@@ -116,7 +112,7 @@
          </property>
         </widget>
        </item>
-       <item row="4" column="1">
+       <item row="5" column="1">
         <widget class="QComboBox" name="languageBox"/>
        </item>
        <item row="3" column="0">
@@ -132,6 +128,16 @@
           <string>Scale up game viewport to accomidate modern screen resolution.</string>
          </property>
         </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="displayNumLabel">
+         <property name="text">
+          <string>Show on:</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QComboBox" name="displayNumBox"/>
        </item>
       </layout>
      </widget>


### PR DESCRIPTION
- Implement support for borderless window mode (resolution derived from selected display)
- Implement ability to choose display to show game window on in multiple monitors setup
- New config value to choose screen mode replaces old "Fullscreen" flag, which is left for backwards compatibility
- Added UI to launcher to choose window mode and display number
- Fixes #1033
