### PR TITLE
Fix crash when agent in cityscape dies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,7 +80,7 @@ CMakeSettings.json
 [Dd]ata/UFOPAEDI/
 [Dd]ata/MUSIC
 [Dd]ata/cd.iso
-[Dd]ata/XCOM.BIN
+[Dd]ata/[Xx][Cc][Oo][Mm].[Bb][Ii][Nn]
 [Dd]ata.old/
 [Dd]ata/mods/
 

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2834,7 +2834,7 @@ void Battle::finishBattle(GameState &state)
 	{
 		u->agent->die(state, true);
 		u->agent->destroy();
-		state.agents.erase(u->agent.id);
+		state.agentsDeathNote.insert(u->agent.id);
 		u->destroy();
 		state.current_battle->units.erase(u->id);
 	}
@@ -2937,7 +2937,6 @@ void Battle::exitBattle(GameState &state)
 	if (state.current_battle->skirmish)
 	{
 		// Erase agents
-		std::list<UString> agentsToRemove;
 		for (auto &a : state.agents)
 		{
 			if (!a.second->city)
@@ -2950,12 +2949,8 @@ void Battle::exitBattle(GameState &state)
 				{
 					a.second->currentVehicle->currentAgents.erase({&state, a.first});
 				}
-				agentsToRemove.push_back(a.first);
+				state.agentsDeathNote.insert(a.first);
 			}
-		}
-		for (auto &a : agentsToRemove)
-		{
-			state.agents.erase(a);
 		}
 
 		// Erase base and building

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1000,6 +1000,15 @@ void OpenApoc::GameState::cleanUpDeathNote()
 		}
 		vehiclesDeathNote.clear();
 	}
+
+	if (!agentsDeathNote.empty())
+	{
+		for (auto &name : this->agentsDeathNote)
+		{
+			agents.erase(name);
+		}
+		agentsDeathNote.clear();
+	}
 }
 
 void GameState::update(unsigned int ticks)
@@ -1031,7 +1040,6 @@ void GameState::update(unsigned int ticks)
 				v.second->update(*this, ticks);
 			}
 		}
-		cleanUpDeathNote();
 
 		for (auto &a : this->agents)
 		{
@@ -1040,6 +1048,8 @@ void GameState::update(unsigned int ticks)
 				a.second->update(*this, ticks);
 			}
 		}
+
+		cleanUpDeathNote();
 
 		gameTime.addTicks(ticks);
 

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -118,6 +118,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 	StateRefMap<AgentBodyType> agent_body_types;
 	StateRefMap<AgentEquipmentLayout> agent_equipment_layouts;
 	StateRefMap<Agent> agents;
+	std::set<UString> agentsDeathNote;
 	AgentGenerator agent_generator;
 	OrganisationRaid organisation_raid_rules;
 

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -1290,7 +1290,7 @@ void BattleMap::fillSquads(sp<Battle> b, bool spawnCivilians, GameState &state,
 		if (!spawnCivilians && a->owner == state.getCivilian())
 		{
 			// Delete agent
-			state.agents.erase(a.id);
+			state.agentsDeathNote.insert(a.id);
 			a->destroy();
 			continue;
 		}
@@ -1391,6 +1391,7 @@ void BattleMap::fillSquads(sp<Battle> b, bool spawnCivilians, GameState &state,
 			}
 		}
 	}
+	state.cleanUpDeathNote();
 }
 
 void BattleMap::initNewMap(sp<Battle> b)

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -975,7 +975,7 @@ void Agent::update(GameState &state, unsigned ticks)
 		// In city we remove agent
 		if (!state.current_battle)
 		{
-			state.agents.erase(getId(state, shared_from_this()));
+			state.agentsDeathNote.insert(getId(state, shared_from_this()));
 		}
 
 		return;


### PR DESCRIPTION
- Fix crash caused by agent being removed during GameState::update by delaying agents removal and avoid modifying STL container while iterating over it. TODO: check if any other containers might be handled incorrectly.
- Updated .gitignrore to ignore case for xcom.bin