### PR TITLE
Fix crash when clicking on a projectile in the cityscape

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3365,7 +3365,7 @@ bool CityView::handleMouseDown(Event *e)
 		{
 			projectile =
 			    std::dynamic_pointer_cast<TileObjectProjectile>(projCollision.obj)->getProjectile();
-			LogInfo("CLICKED PROJECTILE %s at %s", projectile->damage, projectile->position);
+			LogInfo("CLICKED PROJECTILE %d at %s", projectile->damage, projectile->position);
 
 			if (!vehicle && !scenery && !portal)
 			{


### PR DESCRIPTION
Another formatting issue - %s can't handle anything that isn't a string
or a custom formatted type.

Fixes #1060