### PR TITLE
Fix build issue on new MSVC compilers

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -552,20 +552,22 @@ void Battle::initialMapPartLinkUp()
 	LogWarning("Link up finished!");
 }
 
+enum class UnitSize
+{
+	Small,
+	Large,
+	Any
+};
+enum class UnitMovement
+{
+	Walking,
+	Flying,
+	Any
+};
+
+
 void Battle::initialUnitSpawn(GameState &state)
 {
-	enum class UnitSize
-	{
-		Small,
-		Large,
-		Any
-	};
-	enum class UnitMovement
-	{
-		Walking,
-		Flying,
-		Any
-	};
 	class SpawnBlock
 	{
 	  public:


### PR DESCRIPTION
At least MSVC 19.29.30133 classes defined local to functions no longer see enum class types defined in the same parent function.

Not sure if this is an MSVC bug, or we were running fast and loose with the c++ spec other compilers aren't as strict about, but a small bit of file-local namespace pollution is probably fine.