### PR TITLE
Appveyor: Cache the vcpkg archive directory

### DIFF
--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -21,7 +21,7 @@ init:
   - if "%PLATFORM%"=="Win32" (set VCVARS_ARCH=amd64_x86)
   - if "%PLATFORM%"=="Win32" (set QTPATH=C:\Qt\5.15\msvc2019)
 #clone_depth: 10
-cache: c:\tools\vcpkg\installed
+cache: C:\Users\appveyor\AppData\Local\vcpkg\archives -> appveyor-dev.yml
 before_build:
   - cd c:\tools\vcpkg
   - git pull

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,7 +21,7 @@ init:
   - if "%PLATFORM%"=="Win32" (set VCVARS_ARCH=amd64_x86)
   - if "%PLATFORM%"=="Win32" (set QTPATH=C:\Qt\5.15\msvc2019)
 #clone_depth: 10
-cache: c:\tools\vcpkg\installed
+cache: C:\Users\appveyor\AppData\Local\vcpkg\archives -> appveyor.yml
 before_build:
   - cd c:\tools\vcpkg
   - git pull


### PR DESCRIPTION
Manifest-installed vcpkg packages don't seem to go to the "global" c:\tools\vcpkg - and it looks like vcpkg caches installed packages in an archive directory, so should be a good target for cache?