### PR TITLE
Fix switched arguments when extracting strafing when aiming animations

### DIFF
--- a/tools/extractors/extract_unit_animation_pack_unit.cpp
+++ b/tools/extractors/extract_unit_animation_pack_unit.cpp
@@ -707,18 +707,18 @@ void extractAnimationPackUnitInternal(sp<BattleUnitAnimationPack> p,
 		// Hand Aiming -> Ease standing overlay strafing animation: 79, 83
 		p->hand_state_animations[{ItemWieldMode::OneHanded, HandState::Aiming, HandState::AtEase,
 		                          MovementState::Strafing, BodyState::Standing}][{x, y}] =
-		    e.getAnimationEntry(dataAD, dataUA, dataUF, 79, {x, y}, true, sFrames);
+		    e.getAnimationEntry(dataAD, dataUA, dataUF, 79, {x, y}, sFrames, true);
 		p->hand_state_animations[{ItemWieldMode::TwoHanded, HandState::Aiming, HandState::AtEase,
 		                          MovementState::Strafing, BodyState::Standing}][{x, y}] =
-		    e.getAnimationEntry(dataAD, dataUA, dataUF, 83, {x, y}, true, sFrames);
+		    e.getAnimationEntry(dataAD, dataUA, dataUF, 83, {x, y}, sFrames, true);
 
 		// Hand Ease -> Aiming standing overlay strafing animation: 76, 80
 		p->hand_state_animations[{ItemWieldMode::OneHanded, HandState::AtEase, HandState::Aiming,
 		                          MovementState::Strafing, BodyState::Standing}][{x, y}] =
-		    e.getAnimationEntry(dataAD, dataUA, dataUF, 76, {x, y}, true, sFrames);
+		    e.getAnimationEntry(dataAD, dataUA, dataUF, 76, {x, y}, sFrames, true);
 		p->hand_state_animations[{ItemWieldMode::TwoHanded, HandState::AtEase, HandState::Aiming,
 		                          MovementState::Strafing, BodyState::Standing}][{x, y}] =
-		    e.getAnimationEntry(dataAD, dataUA, dataUF, 80, {x, y}, true, sFrames);
+		    e.getAnimationEntry(dataAD, dataUA, dataUF, 80, {x, y}, sFrames, true);
 	}
 }
 


### PR DESCRIPTION
This looks wrong, passing an integer to a bool argument and bool to integer argument - noticed when looking over the code.

Not 100% on what this actually does or could break, but the types make it look wrong.