### PR TITLE
Update vcpkg in appveyor

### DIFF
--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -25,7 +25,7 @@ cache: C:\Users\appveyor\AppData\Local\vcpkg\archives -> appveyor-dev.yml
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2022.02.02
+  - git checkout 2022.03.10
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ cache: C:\Users\appveyor\AppData\Local\vcpkg\archives -> appveyor.yml
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2022.02.02
+  - git checkout 2022.03.10
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install


### PR DESCRIPTION
Looks like the version we used has had some download links removed so libiconv (or msys2 that it's build uses) no longer works.