### PR TITLE
Use absolute library path for libunwind

### DIFF
--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -68,7 +68,7 @@ if(ENABLE_BACKTRACE)
 			#HACK - this assumes the library path is already searched?
 		else()
 			find_path(UNWIND_INCLUDE_DIR libunwind.h HINTS ${PC_UNWIND_INCLUDEDIR})
-			target_link_libraries(OpenApoc_Library PUBLIC ${PC_UNWIND_LIBRARIES} ${CMAKE_DL_LIBS})
+			target_link_libraries(OpenApoc_Library PUBLIC ${PC_UNWIND_LINK_LIBRARIES} ${CMAKE_DL_LIBS})
 		endif()
 		target_compile_definitions(OpenApoc_Library PUBLIC -DBACKTRACE_LIBUNWIND)
 		target_include_directories(OpenApoc_Library PUBLIC ${UNWIND_INCLUDE_DIR})


### PR DESCRIPTION
Use `PC_UNWIND_LINK_LIBRARIES` instead of `PC_UNWIND_LIBRARIES`: the former provides absolute path to .so which is consistent to how other libraries are handled and "always works", while the latter only provides library name which may not (and does not on e.g. FreeBSD) work without taking `PC_UNWIND_LIBRARY_DIRS` into account as well.