### PR TITLE
Avoid opening agent/vehicle equip screens if player has no soliders/vehicles

### DIFF
--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -15,6 +15,7 @@
 #include "game/state/city/base.h"
 #include "game/state/city/building.h"
 #include "game/state/city/facility.h"
+#include "game/state/city/vehicle.h"
 #include "game/state/gamestate.h"
 #include "game/state/rules/city/ufopaedia.h"
 #include "game/ui/base/aliencontainmentscreen.h"
@@ -123,13 +124,38 @@ void BaseScreen::begin()
 	    });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPAGENT")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    // FIXME: If you don't have any vehicles this button should do nothing
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
+		    bool playerHasAgents = false;
+		    for (auto &a : this->state->agents)
+		    {
+			    auto agent = a.second;
+			    if (agent->owner == this->state->getPlayer() &&
+			        agent->type->role == AgentType::Role::Soldier)
+			    {
+				    playerHasAgents = true;
+				    break;
+			    }
+		    }
+		    if (playerHasAgents)
+		    {
+			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
+		    }
 	    });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPVEHICLE")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    // FIXME: If you don't have any vehicles this button should do nothing
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
+		    bool playerHasVehicles = false;
+		    for (auto &v : this->state->vehicles)
+		    {
+			    auto vehicle = v.second;
+			    if (vehicle->owner == this->state->getPlayer())
+			    {
+				    playerHasVehicles = true;
+				    break;
+			    }
+		    }
+		    if (playerHasVehicles)
+		    {
+			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
+		    }
 	    });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_RES_AND_MANUF")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -124,18 +124,18 @@ void BaseScreen::begin()
 	    });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPAGENT")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    bool playerHasAgents = false;
+		    bool playerHasSoldiers = false;
 		    for (auto &a : this->state->agents)
 		    {
 			    auto agent = a.second;
 			    if (agent->owner == this->state->getPlayer() &&
 			        agent->type->role == AgentType::Role::Soldier)
 			    {
-				    playerHasAgents = true;
+				    playerHasSoldiers = true;
 				    break;
 			    }
 		    }
-		    if (playerHasAgents)
+		    if (playerHasSoldiers)
 		    {
 			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
 		    }

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -65,10 +65,6 @@ VEquipScreen::VEquipScreen(sp<GameState> state)
 		VehicleSheet(formVehicleItem).display(vehicle);
 		break;
 	}
-	if (!this->selected)
-	{
-		LogError("No vehicles found - the original apoc didn't open the equip screen in this case");
-	}
 
 	// Vehicle name edit
 	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1281,19 +1281,19 @@ CityView::CityView(sp<GameState> state)
 	    });
 	agentForm->findControl("BUTTON_EQUIP_AGENT")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    bool playerHasAgents = false;
+		    bool playerHasSoldiers = false;
 		    for (auto &a : this->state->agents)
 		    {
 			    auto agent = a.second;
 			    if (agent->owner == this->state->getPlayer() &&
 			        agent->type->role == AgentType::Role::Soldier)
 			    {
-				    playerHasAgents = true;
+				    playerHasSoldiers = true;
 				    break;
 			    }
 		    }
 		    // avoid attempting to open agent equip screen if player has no agents
-		    if (playerHasAgents)
+		    if (playerHasSoldiers)
 		    {
 			    fw().stageQueueCommand(
 			        {StageCmd::Command::PUSH,

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1104,16 +1104,30 @@ CityView::CityView(sp<GameState> state)
 	}
 	vehicleForm->findControl("BUTTON_EQUIP_VEHICLE")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    auto equipScreen = mksp<VEquipScreen>(this->state);
-		    for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		    bool playerHasVehicles = false;
+		    for (auto &v : this->state->vehicles)
 		    {
-			    if (v && v->owner == this->state->getPlayer())
+			    auto vehicle = v.second;
+			    if (vehicle->owner == this->state->getPlayer())
 			    {
-				    equipScreen->setSelectedVehicle(v);
+				    playerHasVehicles = true;
 				    break;
 			    }
 		    }
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
+		    // avoid attempting to open vehicle equip screen if player has no vehicles
+		    if (playerHasVehicles)
+		    {
+			    auto equipScreen = mksp<VEquipScreen>(this->state);
+			    for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+			    {
+				    if (v && v->owner == this->state->getPlayer())
+				    {
+					    equipScreen->setSelectedVehicle(v);
+					    break;
+				    }
+			    }
+			    fw().stageQueueCommand({StageCmd::Command::PUSH, equipScreen});
+		    }
 	    });
 	vehicleForm->findControl("BUTTON_VEHICLE_BUILDING")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1281,6 +1281,28 @@ CityView::CityView(sp<GameState> state)
 	    });
 	agentForm->findControl("BUTTON_EQUIP_AGENT")
 	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
+		    bool playerHasAgents = false;
+		    for (auto &a : this->state->agents)
+		    {
+			    auto agent = a.second;
+			    if (agent->owner == this->state->getPlayer() &&
+			        agent->type->role == AgentType::Role::Soldier)
+			    {
+				    playerHasAgents = true;
+				    break;
+			    }
+		    }
+		    // avoid attempting to open agent equip screen if player has no agents
+		    if (playerHasAgents)
+		    {
+			    fw().stageQueueCommand(
+			        {StageCmd::Command::PUSH,
+			         mksp<AEquipScreen>(
+			             this->state,
+			             !this->state->current_city->cityViewSelectedAgents.empty()
+			                 ? this->state->current_city->cityViewSelectedAgents.front()
+			                 : nullptr)});
+		    }
 		    fw().stageQueueCommand(
 		        {StageCmd::Command::PUSH,
 		         mksp<AEquipScreen>(this->state,


### PR DESCRIPTION
At current trying to open the vehicle equip screen with no vehicles leads to an error message and seg fault, and trying to open the agent equip screen with no soldiers leads to issue #1100. I have attempted to fix this by adding preliminary checks to the callback functions for opening the equip screens that check if the player has soldiers/vehicles that they can equip before letting them be opened.

In terms of the implementation I'm not the biggest fan of the duplicated code in the callbacks but I'm not sure how I would go about puling it out into a separate function. Could perhaps be generalized and thrown in gamestate or organisation file but I am not sure if it would be worth it.