### PR TITLE
Use invoke_result_t instead  of result_of<>::type

### DIFF
--- a/framework/framework.h
+++ b/framework/framework.h
@@ -103,9 +103,9 @@ class Framework
 	// add new work item to the pool
 	template <class F, class... Args>
 	auto threadPoolEnqueue(F &&f, Args &&...args)
-	    -> std::shared_future<typename std::result_of<F(Args...)>::type>
+	    -> std::shared_future<typename std::invoke_result_t<F, Args...>>
 	{
-		using return_type = typename std::result_of<F(Args...)>::type;
+		using return_type = typename std::invoke_result_t<F, Args...>;
 
 		auto task = std::make_shared<std::packaged_task<return_type()>>(
 		    std::bind(std::forward<F>(f), std::forward<Args>(args)...));


### PR DESCRIPTION
std::result_of<> has been deprecated in c++17