### PR TITLE
Disable autoscale for macOS

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -226,7 +226,7 @@ ConfigOptionInt screenScaleYOption("Framework.Screen", "ScaleY",
                                    "Scale screen in Y direction by (percent)", 100);
 ConfigOptionBool screenAutoScale(
     "Framework.Screen", "AutoScale",
-    "Automatically scale up game viewport for modern screens (overrides ScaleX and ScaleY)", true);
+    "Automatically scale up game viewport for modern screens (overrides ScaleX and ScaleY)", false);
 ConfigOptionString languageOption("Framework", "Language",
                                   "The language used ingame (empty for system default)", "");
 


### PR DESCRIPTION
Disabled autoscale. With this option all visible. Without only black screen.