### PR TITLE
Fix soldier transfer

### DIFF
--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -386,11 +386,11 @@ void AgentMission::start(GameState &state, Agent &a)
 					                                  {&state, a.shared_from_this()}));
 					a.recentlyHired = false;
 				}
-				if (a.recentryTransferred)
+				if (a.recentlyTransferred)
 				{
 					fw().pushEvent(new GameAgentEvent(GameEventType::AgentArrived,
 					                                  {&state, a.shared_from_this()}, true));
-					a.recentryTransferred = false;
+					a.recentlyTransferred = false;
 				}
 				return;
 			}

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -244,7 +244,7 @@
 		<member>trainingPsiTicksAccumulated</member>
 		<member>trainingAssignment</member>
 		<member>recentlyHired</member>
-		<member>recentryTransferred</member>
+		<member>recentlyTransferred</member>
 		<member>recentlyFought</member>
 		<member>healingProgress</member>
 		<member>owner</member>

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -397,7 +397,7 @@ void Agent::transfer(GameState &state, StateRef<Building> newHome)
 {
 	homeBuilding = newHome;
 	recentlyHired = false;
-	recentryTransferred = true;
+	recentlyTransferred = true;
 	assigned_to_lab = false;
 	setMission(state, AgentMission::gotoBuilding(state, *this, newHome, false, true));
 }

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -96,7 +96,7 @@ class Agent : public StateObject<Agent>,
 	TrainingAssignment trainingAssignment = TrainingAssignment::None;
 
 	bool recentlyHired = false;
-	bool recentryTransferred = false;
+	bool recentlyTransferred = false;
 	bool recentlyFought = false;
 	float healingProgress = 0.0f;
 

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -517,22 +517,7 @@ void TransferScreen::executeOrders()
 					case TransactionControl::Type::Soldier:
 					{
 						StateRef<Agent> agent{state.get(), c->itemId};
-						if (agent->homeBuilding != newBase->building)
-						{
-							agent->homeBuilding = newBase->building;
-							if (agent->currentBuilding != agent->homeBuilding ||
-							    (agent->currentVehicle &&
-							     agent->currentVehicle->currentBuilding != agent->homeBuilding))
-							{
-								if (agent->currentVehicle)
-								{
-									agent->enterBuilding(*state,
-									                     agent->currentVehicle->currentBuilding);
-								}
-								agent->setMission(*state,
-								                  AgentMission::gotoBuilding(*state, *agent));
-							}
-						}
+						agent->transfer(*state, newBase->building);
 						break;
 					}
 					case TransactionControl::Type::Vehicle:
@@ -673,25 +658,31 @@ void TransferScreen::initViewSecondBase()
 		view->setImage(viewImage);
 		view->setDepressedImage(viewImage);
 		wp<GraphicButton> weakView(view);
-		view->addCallback(FormEventType::ButtonClick, [this, weakView](FormsEvent *e) {
-			auto base = e->forms().RaisedBy->getData<Base>();
-			if (this->second_base != base)
-			{
-				this->changeSecondBase(base);
-				this->currentSecondView = weakView.lock();
-			}
-		});
-		view->addCallback(FormEventType::MouseEnter, [this](FormsEvent *e) {
-			auto base = e->forms().RaisedBy->getData<Base>();
-			this->textViewSecondBase->setText(base->name);
-			this->textViewSecondBase->setVisible(true);
-			this->textViewSecondBaseStatic->setVisible(false);
-		});
-		view->addCallback(FormEventType::MouseLeave, [this](FormsEvent *) {
-			// this->textViewSecondBase->setText("");
-			this->textViewSecondBase->setVisible(false);
-			this->textViewSecondBaseStatic->setVisible(true);
-		});
+		view->addCallback(FormEventType::ButtonClick,
+		                  [this, weakView](FormsEvent *e)
+		                  {
+			                  auto base = e->forms().RaisedBy->getData<Base>();
+			                  if (this->second_base != base)
+			                  {
+				                  this->changeSecondBase(base);
+				                  this->currentSecondView = weakView.lock();
+			                  }
+		                  });
+		view->addCallback(FormEventType::MouseEnter,
+		                  [this](FormsEvent *e)
+		                  {
+			                  auto base = e->forms().RaisedBy->getData<Base>();
+			                  this->textViewSecondBase->setText(base->name);
+			                  this->textViewSecondBase->setVisible(true);
+			                  this->textViewSecondBaseStatic->setVisible(false);
+		                  });
+		view->addCallback(FormEventType::MouseLeave,
+		                  [this](FormsEvent *)
+		                  {
+			                  // this->textViewSecondBase->setText("");
+			                  this->textViewSecondBase->setVisible(false);
+			                  this->textViewSecondBaseStatic->setVisible(true);
+		                  });
 	}
 	textViewSecondBase = form->findControlTyped<Label>("TEXT_BUTTON_SECOND_BASE");
 	textViewSecondBase->setVisible(false);


### PR DESCRIPTION
The transfer screen was teleporting the soldier to Warehouse 2 and then from there he was assigned to move to the correct base. This PR fixes this issue.

Also fixes some typos and lint errors.