### PR TITLE
Update lint workflow to use latest action version

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -66,11 +66,11 @@ jobs:
         cd $GITHUB_WORKSPACE
         if [[ -z "${{ github.event.before }}" ]]
         then
-          echo '$GITHUB_WORKSPACE/tools/lint.sh ${LAST_COMMIT_SHA}'
-          $GITHUB_WORKSPACE/tools/lint.sh ${LAST_COMMIT_SHA}
-        else
           echo '$GITHUB_WORKSPACE/tools/lint.sh ${{ github.event.before }}..${{ github.event.after }}'
           $GITHUB_WORKSPACE/tools/lint.sh ${{ github.event.before }}..${{ github.event.after }}
+        else
+          echo '$GITHUB_WORKSPACE/tools/lint.sh ${LAST_COMMIT_SHA}'
+          $GITHUB_WORKSPACE/tools/lint.sh ${LAST_COMMIT_SHA}
         fi
         
 
@@ -81,10 +81,9 @@ jobs:
         cd $GITHUB_WORKSPACE
         if [[ -z "${{ github.event.before }}" ]]
         then
-          echo 'CLANG_TIDY=clang-tidy-14 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${LAST_COMMIT_SHA} || true;'
-          CLANG_TIDY=clang-tidy-14 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${LAST_COMMIT_SHA} || true;
-        else
           echo 'CLANG_TIDY=clang-tidy-14 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${{ github.event.before }}..${{ github.event.after }} || true;'
           CLANG_TIDY=clang-tidy-14 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${{ github.event.before }}..${{ github.event.after }} || true;
-        fi
-        
+        else
+          echo 'CLANG_TIDY=clang-tidy-14 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${LAST_COMMIT_SHA} || true;'
+          CLANG_TIDY=clang-tidy-14 BUILD_DIR=${{runner.workspace}}/build $GITHUB_WORKSPACE/tools/lint-tidy.sh ${LAST_COMMIT_SHA} || true;
+        fi      

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@main
       with:
         submodules: recursive
         fetch-depth: 0


### PR DESCRIPTION
With this change we shouldn't see this warning anymore.

Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.