### PR TITLE
fix: move the passenger number icon one pixel left.

### DIFF
--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -594,16 +594,18 @@ sp<Control> ControlGenerator::createDoubleListControl(const int controlLength)
 {
 	auto rubberItem = mksp<Control>();
 	rubberItem->Size = Vec2<int>{controlLength, 1};
-	rubberItem->setFuncPreRender([](sp<Control> control) {
-		int sizeY = 1;
-		for (auto &c : control->Controls)
-		{
-			if (!c->isVisible())
-				continue;
-			sizeY = std::max(sizeY, c->Location.y + c->Size.y);
-		}
-		control->Size.y = sizeY;
-	});
+	rubberItem->setFuncPreRender(
+	    [](sp<Control> control)
+	    {
+		    int sizeY = 1;
+		    for (auto &c : control->Controls)
+		    {
+			    if (!c->isVisible())
+				    continue;
+			    sizeY = std::max(sizeY, c->Location.y + c->Size.y);
+		    }
+		    control->Size.y = sizeY;
+	    });
 
 	auto leftList = rubberItem->createChild<MultilistBox>();
 	leftList->Name = LEFT_LIST_NAME;

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -252,7 +252,7 @@ sp<Control> ControlGenerator::createVehicleControl(GameState &state, const Vehic
 		{
 			passengerGraphic->AutoSize = true;
 		}
-		passengerGraphic->Location = {0, 0};
+		passengerGraphic->Location = {-1, 0};
 		passengerGraphic->Name = "OWNED_VEHICLE_PASSENGERS_" + info.vehicle->name;
 	}
 


### PR DESCRIPTION
As mentioned in #993, the icon showing the number of passengers in a vehicle was off by one pixel. This PR fixes that.