### PR TITLE
fix: Prevent either equip screen from closing when an item is picked up.

### DIFF
--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -171,10 +171,15 @@ void VEquipScreen::eventOccurred(Event *e)
 			return;
 		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
 		    e->keyboard().KeyCode == SDLK_KP_ENTER)
-		{
-			form->findControl("BUTTON_OK")->click();
-			return;
-		}
+			if (EVENT_MOUSE_DOWN && draggedEquipment)
+			{
+				return;
+			}
+			else
+			{
+				form->findControl("BUTTON_OK")->click();
+				return;
+			}
 	}
 	if (e->type() == EVENT_FORM_INTERACTION && e->forms().EventFlag == FormEventType::MouseDown)
 	{

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -50,10 +50,12 @@ VEquipScreen::VEquipScreen(sp<GameState> state)
 	    paperDollPlaceholder->Location, paperDollPlaceholder->Size, EQUIP_GRID_SLOT_SIZE);
 
 	// when hovering the paperdoll, display the selected vehicle stats
-	paperDoll->addCallback(FormEventType::MouseEnter, [this](FormsEvent *e [[maybe_unused]]) {
-		highlightedVehicle = selected;
-		VehicleSheet(formVehicleItem).display(selected);
-	});
+	paperDoll->addCallback(FormEventType::MouseEnter,
+	                       [this](FormsEvent *e [[maybe_unused]])
+	                       {
+		                       highlightedVehicle = selected;
+		                       VehicleSheet(formVehicleItem).display(selected);
+	                       });
 
 	for (auto &v : state->vehicles)
 	{
@@ -68,21 +70,26 @@ VEquipScreen::VEquipScreen(sp<GameState> state)
 
 	// Vehicle name edit
 	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")
-	    ->addCallback(FormEventType::TextEditFinish, [this](FormsEvent *e) {
-		    if (this->selected)
-		    {
-			    this->selected->name =
-			        std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
-		    }
-	    });
+	    ->addCallback(
+	        FormEventType::TextEditFinish,
+	        [this](FormsEvent *e)
+	        {
+		        if (this->selected)
+		        {
+			        this->selected->name =
+			            std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
+		        }
+	        });
 	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")
-	    ->addCallback(FormEventType::TextEditCancel, [this](FormsEvent *e) {
-		    if (this->selected)
-		    {
-			    std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
-			        ->setText(this->selected->name);
-		    }
-	    });
+	    ->addCallback(FormEventType::TextEditCancel,
+	                  [this](FormsEvent *e)
+	                  {
+		                  if (this->selected)
+		                  {
+			                  std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
+			                      ->setText(this->selected->name);
+		                  }
+	                  });
 
 	this->paperDoll->setNonHighlightColour(EQUIP_GRID_COLOUR);
 	this->setHighlightedSlotType(EquipmentSlotType::VehicleWeapon);
@@ -105,12 +112,14 @@ void VEquipScreen::begin()
 
 		// when entering a selectbox item, display that vehicle's stats
 		graphic->addCallback(FormEventType::MouseEnter,
-		                     [this, vehicle](FormsEvent *e [[maybe_unused]]) {
+		                     [this, vehicle](FormsEvent *e [[maybe_unused]])
+		                     {
 			                     highlightedVehicle = vehicle;
 			                     VehicleSheet(formVehicleItem).display(vehicle);
 		                     });
 		vehicleSelectBox->addCallback(FormEventType::MouseLeave,
-		                              [this](FormsEvent *e [[maybe_unused]]) {
+		                              [this](FormsEvent *e [[maybe_unused]])
+		                              {
 			                              highlightedVehicle = selected;
 			                              VehicleSheet(formVehicleItem).display(selected);
 		                              });

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -65,41 +65,51 @@ AEquipScreen::AEquipScreen(sp<GameState> state, sp<Agent> firstAgent)
 
 	// Agent list functionality
 	auto agentList = formMain->findControlTyped<ListBox>("AGENT_SELECT_BOX");
-	agentList->addCallback(FormEventType::ListBoxChangeSelected, [this](FormsEvent *e) {
-		auto list = std::static_pointer_cast<ListBox>(e->forms().RaisedBy);
-		auto agent = list->getSelectedData<Agent>();
-		if (!agent)
-		{
-			LogError("No agent in selected data");
-			return;
-		}
-		if (agent->unit && !agent->unit->isConscious())
-		{
-			return;
-		}
-		selectAgent(agent, Event::isPressed(e->forms().MouseInfo.Button, Event::MouseButton::Right),
-		            modifierLCtrl || modifierRCtrl);
-	});
+	agentList->addCallback(
+	    FormEventType::ListBoxChangeSelected,
+	    [this](FormsEvent *e)
+	    {
+		    auto list = std::static_pointer_cast<ListBox>(e->forms().RaisedBy);
+		    auto agent = list->getSelectedData<Agent>();
+		    if (!agent)
+		    {
+			    LogError("No agent in selected data");
+			    return;
+		    }
+		    if (agent->unit && !agent->unit->isConscious())
+		    {
+			    return;
+		    }
+		    selectAgent(agent,
+		                Event::isPressed(e->forms().MouseInfo.Button, Event::MouseButton::Right),
+		                modifierLCtrl || modifierRCtrl);
+	    });
 
 	// Agent name edit
 	formAgentStats->findControlTyped<TextEdit>("AGENT_NAME")
-	    ->addCallback(FormEventType::TextEditFinish, [this](FormsEvent *e) {
-		    auto currentAgent = selectedAgents.empty() ? nullptr : selectedAgents.front();
-		    if (currentAgent)
-		    {
-			    currentAgent->name =
-			        std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
-		    }
-	    });
+	    ->addCallback(
+	        FormEventType::TextEditFinish,
+	        [this](FormsEvent *e)
+	        {
+		        auto currentAgent = selectedAgents.empty() ? nullptr : selectedAgents.front();
+		        if (currentAgent)
+		        {
+			        currentAgent->name =
+			            std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
+		        }
+	        });
 	formAgentStats->findControlTyped<TextEdit>("AGENT_NAME")
-	    ->addCallback(FormEventType::TextEditCancel, [this](FormsEvent *e) {
-		    auto currentAgent = selectedAgents.empty() ? nullptr : selectedAgents.front();
-		    if (currentAgent)
-		    {
-			    std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
-			        ->setText(currentAgent->name);
-		    }
-	    });
+	    ->addCallback(FormEventType::TextEditCancel,
+	                  [this](FormsEvent *e)
+	                  {
+		                  auto currentAgent =
+		                      selectedAgents.empty() ? nullptr : selectedAgents.front();
+		                  if (currentAgent)
+		                  {
+			                  std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
+			                      ->setText(currentAgent->name);
+		                  }
+	                  });
 
 	woundImage = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
 	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
@@ -1980,16 +1990,22 @@ void AEquipScreen::updateAgentControl(sp<Agent> agent)
 	auto agentList = formMain->findControlTyped<ListBox>("AGENT_SELECT_BOX");
 	auto control = ControlGenerator::createLargeAgentControl(
 	    *state, agent, agentList->Size.x, UnitSkillState::Hidden, selstate, !isInVicinity(agent));
-	control->addCallback(FormEventType::MouseEnter, [this, agent](FormsEvent *e [[maybe_unused]]) {
-		AgentSheet(formAgentStats).display(*agent, bigUnitRanks, isTurnBased());
-		formAgentStats->setVisible(true);
-		formAgentItem->setVisible(false);
-	});
-	control->addCallback(FormEventType::MouseLeave, [this](FormsEvent *e [[maybe_unused]]) {
-		AgentSheet(formAgentStats).display(*selectedAgents.front(), bigUnitRanks, isTurnBased());
-		formAgentStats->setVisible(true);
-		formAgentItem->setVisible(false);
-	});
+	control->addCallback(
+	    FormEventType::MouseEnter,
+	    [this, agent](FormsEvent *e [[maybe_unused]])
+	    {
+		    AgentSheet(formAgentStats).display(*agent, bigUnitRanks, isTurnBased());
+		    formAgentStats->setVisible(true);
+		    formAgentItem->setVisible(false);
+	    });
+	control->addCallback(FormEventType::MouseLeave,
+	                     [this](FormsEvent *e [[maybe_unused]])
+	                     {
+		                     AgentSheet(formAgentStats)
+		                         .display(*selectedAgents.front(), bigUnitRanks, isTurnBased());
+		                     formAgentStats->setVisible(true);
+		                     formAgentItem->setVisible(false);
+	                     });
 	agentList->replaceItem(control);
 }
 

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -299,8 +299,16 @@ void AEquipScreen::eventOccurred(Event *e)
 		switch (e->keyboard().KeyCode)
 		{
 			case SDLK_ESCAPE:
-				attemptCloseScreen();
-				return;
+				if (EVENT_MOUSE_DOWN && draggedEquipment)
+				{
+					return;
+				}
+				else
+				{
+					attemptCloseScreen();
+					return;
+				}
+
 			case SDLK_RETURN:
 			case SDLK_KP_ENTER:
 				formMain->findControl("BUTTON_OK")->click();


### PR DESCRIPTION
Fixes #627. This PR makes the equip screens function as they did in the original game by making it impossible to exit the screen if an item is picked up.