### PR TITLE
Fix message history screen scrolling

### DIFF
--- a/game/state/city/agentmission.cpp
+++ b/game/state/city/agentmission.cpp
@@ -386,11 +386,11 @@ void AgentMission::start(GameState &state, Agent &a)
 					                                  {&state, a.shared_from_this()}));
 					a.recentlyHired = false;
 				}
-				if (a.recentryTransferred)
+				if (a.recentlyTransferred)
 				{
 					fw().pushEvent(new GameAgentEvent(GameEventType::AgentArrived,
 					                                  {&state, a.shared_from_this()}, true));
-					a.recentryTransferred = false;
+					a.recentlyTransferred = false;
 				}
 				return;
 			}

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -244,7 +244,7 @@
 		<member>trainingPsiTicksAccumulated</member>
 		<member>trainingAssignment</member>
 		<member>recentlyHired</member>
-		<member>recentryTransferred</member>
+		<member>recentlyTransferred</member>
 		<member>recentlyFought</member>
 		<member>healingProgress</member>
 		<member>owner</member>

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -397,7 +397,7 @@ void Agent::transfer(GameState &state, StateRef<Building> newHome)
 {
 	homeBuilding = newHome;
 	recentlyHired = false;
-	recentryTransferred = true;
+	recentlyTransferred = true;
 	assigned_to_lab = false;
 	setMission(state, AgentMission::gotoBuilding(state, *this, newHome, false, true));
 }

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -96,7 +96,7 @@ class Agent : public StateObject<Agent>,
 	TrainingAssignment trainingAssignment = TrainingAssignment::None;
 
 	bool recentlyHired = false;
-	bool recentryTransferred = false;
+	bool recentlyTransferred = false;
 	bool recentlyFought = false;
 	float healingProgress = 0.0f;
 

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -517,22 +517,7 @@ void TransferScreen::executeOrders()
 					case TransactionControl::Type::Soldier:
 					{
 						StateRef<Agent> agent{state.get(), c->itemId};
-						if (agent->homeBuilding != newBase->building)
-						{
-							agent->homeBuilding = newBase->building;
-							if (agent->currentBuilding != agent->homeBuilding ||
-							    (agent->currentVehicle &&
-							     agent->currentVehicle->currentBuilding != agent->homeBuilding))
-							{
-								if (agent->currentVehicle)
-								{
-									agent->enterBuilding(*state,
-									                     agent->currentVehicle->currentBuilding);
-								}
-								agent->setMission(*state,
-								                  AgentMission::gotoBuilding(*state, *agent));
-							}
-						}
+						agent->transfer(*state, newBase->building);
 						break;
 					}
 					case TransactionControl::Type::Vehicle:
@@ -673,25 +658,31 @@ void TransferScreen::initViewSecondBase()
 		view->setImage(viewImage);
 		view->setDepressedImage(viewImage);
 		wp<GraphicButton> weakView(view);
-		view->addCallback(FormEventType::ButtonClick, [this, weakView](FormsEvent *e) {
-			auto base = e->forms().RaisedBy->getData<Base>();
-			if (this->second_base != base)
-			{
-				this->changeSecondBase(base);
-				this->currentSecondView = weakView.lock();
-			}
-		});
-		view->addCallback(FormEventType::MouseEnter, [this](FormsEvent *e) {
-			auto base = e->forms().RaisedBy->getData<Base>();
-			this->textViewSecondBase->setText(base->name);
-			this->textViewSecondBase->setVisible(true);
-			this->textViewSecondBaseStatic->setVisible(false);
-		});
-		view->addCallback(FormEventType::MouseLeave, [this](FormsEvent *) {
-			// this->textViewSecondBase->setText("");
-			this->textViewSecondBase->setVisible(false);
-			this->textViewSecondBaseStatic->setVisible(true);
-		});
+		view->addCallback(FormEventType::ButtonClick,
+		                  [this, weakView](FormsEvent *e)
+		                  {
+			                  auto base = e->forms().RaisedBy->getData<Base>();
+			                  if (this->second_base != base)
+			                  {
+				                  this->changeSecondBase(base);
+				                  this->currentSecondView = weakView.lock();
+			                  }
+		                  });
+		view->addCallback(FormEventType::MouseEnter,
+		                  [this](FormsEvent *e)
+		                  {
+			                  auto base = e->forms().RaisedBy->getData<Base>();
+			                  this->textViewSecondBase->setText(base->name);
+			                  this->textViewSecondBase->setVisible(true);
+			                  this->textViewSecondBaseStatic->setVisible(false);
+		                  });
+		view->addCallback(FormEventType::MouseLeave,
+		                  [this](FormsEvent *)
+		                  {
+			                  // this->textViewSecondBase->setText("");
+			                  this->textViewSecondBase->setVisible(false);
+			                  this->textViewSecondBaseStatic->setVisible(true);
+		                  });
 	}
 	textViewSecondBase = form->findControlTyped<Label>("TEXT_BUTTON_SECOND_BASE");
 	textViewSecondBase->setVisible(false);

--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -25,6 +25,7 @@ MessageLogScreen::MessageLogScreen(sp<GameState> state, CityView &cityView)
 	{
 		listbox->addItem(createMessageRow(message, state, cityView));
 	}
+	this->update();
 	listbox->scroller->scrollMax();
 }
 
@@ -36,6 +37,7 @@ MessageLogScreen::MessageLogScreen(sp<GameState> state, BattleView &battleView)
 	{
 		listbox->addItem(createMessageRow(message, state, battleView));
 	}
+	this->update();
 	listbox->scroller->scrollMax();
 }
 
@@ -44,19 +46,23 @@ MessageLogScreen::~MessageLogScreen() = default;
 sp<Control> MessageLogScreen::createMessageRow(EventMessage message, sp<GameState> state,
                                                CityView &cityView)
 {
-	return createMessageRow(message, state, [message, state, &cityView](Event *) {
-		cityView.setScreenCenterTile(message.location);
-		fw().stageQueueCommand({StageCmd::Command::POP});
-	});
+	return createMessageRow(message, state,
+	                        [message, state, &cityView](Event *)
+	                        {
+		                        cityView.setScreenCenterTile(message.location);
+		                        fw().stageQueueCommand({StageCmd::Command::POP});
+	                        });
 }
 
 sp<Control> MessageLogScreen::createMessageRow(EventMessage message, sp<GameState> state,
                                                BattleView &battleView)
 {
-	return createMessageRow(message, state, [message, state, &battleView](Event *) {
-		battleView.setScreenCenterTile(message.location);
-		fw().stageQueueCommand({StageCmd::Command::POP});
-	});
+	return createMessageRow(message, state,
+	                        [message, state, &battleView](Event *)
+	                        {
+		                        battleView.setScreenCenterTile(message.location);
+		                        fw().stageQueueCommand({StageCmd::Command::POP});
+	                        });
 }
 
 sp<Control> MessageLogScreen::createMessageRow(EventMessage message,


### PR DESCRIPTION
Fixes #546. 

It would appear that when the ScrollBar is created in the MessageLogScreen, it uses the original Maximum value of 10 that is assigned by default. When calling the scrollMax function, it was only scrolling down by 10. This was verified by increasing this initial Maximum value and observing the ScrollBar scroll further down the message history screen. This PR fixes this problem by calling the MessageLogScreen::update function to obtain the correct Maximum value before calling scrollMax.