### PR TITLE
Fix removing passenger module left excess passengers on vehicle

### DIFF
--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -51,10 +51,12 @@ VEquipScreen::VEquipScreen(sp<GameState> state)
 	    paperDollPlaceholder->Location, paperDollPlaceholder->Size, EQUIP_GRID_SLOT_SIZE);
 
 	// when hovering the paperdoll, display the selected vehicle stats
-	paperDoll->addCallback(FormEventType::MouseEnter, [this](FormsEvent *e [[maybe_unused]]) {
-		highlightedVehicle = selected;
-		VehicleSheet(formVehicleItem).display(selected);
-	});
+	paperDoll->addCallback(FormEventType::MouseEnter,
+	                       [this](FormsEvent *e [[maybe_unused]])
+	                       {
+		                       highlightedVehicle = selected;
+		                       VehicleSheet(formVehicleItem).display(selected);
+	                       });
 
 	for (auto &v : state->vehicles)
 	{
@@ -69,21 +71,26 @@ VEquipScreen::VEquipScreen(sp<GameState> state)
 
 	// Vehicle name edit
 	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")
-	    ->addCallback(FormEventType::TextEditFinish, [this](FormsEvent *e) {
-		    if (this->selected)
-		    {
-			    this->selected->name =
-			        std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
-		    }
-	    });
+	    ->addCallback(
+	        FormEventType::TextEditFinish,
+	        [this](FormsEvent *e)
+	        {
+		        if (this->selected)
+		        {
+			        this->selected->name =
+			            std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
+		        }
+	        });
 	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")
-	    ->addCallback(FormEventType::TextEditCancel, [this](FormsEvent *e) {
-		    if (this->selected)
-		    {
-			    std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
-			        ->setText(this->selected->name);
-		    }
-	    });
+	    ->addCallback(FormEventType::TextEditCancel,
+	                  [this](FormsEvent *e)
+	                  {
+		                  if (this->selected)
+		                  {
+			                  std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
+			                      ->setText(this->selected->name);
+		                  }
+	                  });
 
 	this->paperDoll->setNonHighlightColour(EQUIP_GRID_COLOUR);
 	this->setHighlightedSlotType(EquipmentSlotType::VehicleWeapon);
@@ -106,12 +113,14 @@ void VEquipScreen::begin()
 
 		// when entering a selectbox item, display that vehicle's stats
 		graphic->addCallback(FormEventType::MouseEnter,
-		                     [this, vehicle](FormsEvent *e [[maybe_unused]]) {
+		                     [this, vehicle](FormsEvent *e [[maybe_unused]])
+		                     {
 			                     highlightedVehicle = vehicle;
 			                     VehicleSheet(formVehicleItem).display(vehicle);
 		                     });
 		vehicleSelectBox->addCallback(FormEventType::MouseLeave,
-		                              [this](FormsEvent *e [[maybe_unused]]) {
+		                              [this](FormsEvent *e [[maybe_unused]])
+		                              {
 			                              highlightedVehicle = selected;
 			                              VehicleSheet(formVehicleItem).display(selected);
 		                              });
@@ -283,7 +292,8 @@ void VEquipScreen::eventOccurred(Event *e)
 			    (this->highlightedVehicle->getMaxPassengers() - equipment->type->passengers))
 			{
 				UString title(tr("EQUIPMENT IN USE"));
-				UString message(tr("Passenger module cannot be removed as it is currently in use."));
+				UString message(
+				    tr("Passenger module cannot be removed as it is currently in use."));
 
 				fw().stageQueueCommand(
 				    {StageCmd::Command::PUSH,

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -24,6 +24,7 @@
 #include "game/ui/general/vehiclesheet.h"
 #include "library/strings_format.h"
 #include <cmath>
+#include <game/ui/general/messagebox.h>
 
 namespace OpenApoc
 {
@@ -277,6 +278,20 @@ void VEquipScreen::eventOccurred(Event *e)
 		    std::dynamic_pointer_cast<VEquipment>(this->selected->getEquipmentAt(mouseSlotPos));
 		if (equipment)
 		{
+			// Check if a passenger module can be removed
+			if (this->highlightedVehicle->getPassengers() >
+			    (this->highlightedVehicle->getMaxPassengers() - 4))
+			{
+				UString title(tr("EQUIPMENT IN USE"));
+				UString message(tr("Passenger module cannot be removed as it is currently in use."));
+
+				fw().stageQueueCommand(
+				    {StageCmd::Command::PUSH,
+				     mksp<MessageBox>(title, message, MessageBox::ButtonOptions::Ok)});
+
+				return;
+			}
+
 			// FIXME: base->addBackToInventory(item); vehicle->unequip(item);
 			this->draggedEquipment = equipment->type;
 			this->draggedEquipmentOffset = {0, 0};

--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -280,7 +280,7 @@ void VEquipScreen::eventOccurred(Event *e)
 		{
 			// Check if a passenger module can be removed
 			if (this->highlightedVehicle->getPassengers() >
-			    (this->highlightedVehicle->getMaxPassengers() - 4))
+			    (this->highlightedVehicle->getMaxPassengers() - equipment->type->passengers))
 			{
 				UString title(tr("EQUIPMENT IN USE"));
 				UString message(tr("Passenger module cannot be removed as it is currently in use."));


### PR DESCRIPTION
Fixes #694. My OG experience differs from what is explained in the issue. When trying to remove the passenger module with extra soldiers on board, the game throws up a dialog box explaining that you can't remove the module while in use.

Example from OG:
![xcomremove](https://user-images.githubusercontent.com/73447098/224890886-381efcee-b56d-4749-a709-97f0b4b91b8f.png)

With that being the case, this PR implements this in OpenApoc by checking if the new number of passengers will be higher than the max passengers when the module is removed. If this is the case, the same dialog box is shown.

Example from OpenApoc:
![openapocremove](https://user-images.githubusercontent.com/73447098/224891203-4c5fa363-6e21-489a-8e17-b7591edc134f.png)

