### PR TITLE
Fix message history screen scrolling

### DIFF
--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -25,6 +25,7 @@ MessageLogScreen::MessageLogScreen(sp<GameState> state, CityView &cityView)
 	{
 		listbox->addItem(createMessageRow(message, state, cityView));
 	}
+	this->update();
 	listbox->scroller->scrollMax();
 }
 
@@ -36,6 +37,7 @@ MessageLogScreen::MessageLogScreen(sp<GameState> state, BattleView &battleView)
 	{
 		listbox->addItem(createMessageRow(message, state, battleView));
 	}
+	this->update();
 	listbox->scroller->scrollMax();
 }
 
@@ -44,19 +46,23 @@ MessageLogScreen::~MessageLogScreen() = default;
 sp<Control> MessageLogScreen::createMessageRow(EventMessage message, sp<GameState> state,
                                                CityView &cityView)
 {
-	return createMessageRow(message, state, [message, state, &cityView](Event *) {
-		cityView.setScreenCenterTile(message.location);
-		fw().stageQueueCommand({StageCmd::Command::POP});
-	});
+	return createMessageRow(message, state,
+	                        [message, state, &cityView](Event *)
+	                        {
+		                        cityView.setScreenCenterTile(message.location);
+		                        fw().stageQueueCommand({StageCmd::Command::POP});
+	                        });
 }
 
 sp<Control> MessageLogScreen::createMessageRow(EventMessage message, sp<GameState> state,
                                                BattleView &battleView)
 {
-	return createMessageRow(message, state, [message, state, &battleView](Event *) {
-		battleView.setScreenCenterTile(message.location);
-		fw().stageQueueCommand({StageCmd::Command::POP});
-	});
+	return createMessageRow(message, state,
+	                        [message, state, &battleView](Event *)
+	                        {
+		                        battleView.setScreenCenterTile(message.location);
+		                        fw().stageQueueCommand({StageCmd::Command::POP});
+	                        });
 }
 
 sp<Control> MessageLogScreen::createMessageRow(EventMessage message,


### PR DESCRIPTION
Fixes https://github.com/OpenApoc/OpenApoc/issues/546.

It would appear that when the ScrollBar is created in the MessageLogScreen, it uses the original Maximum value of 10 that is assigned by default. When calling the scrollMax function, it was only scrolling down by 10. This was verified by increasing this initial Maximum value and observing the ScrollBar scroll further down the message history screen. This PR fixes this problem by calling the MessageLogScreen::update function to obtain the correct Maximum value before calling scrollMax.