### PR TITLE
Fix vehicle destroyed message too long

### DIFF
--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -391,8 +391,7 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 		case GameEventType::VehicleDestroyed:
 			if (actor.length() > 0)
 			{
-				messageInner = format("%s %s %s: %s", tr("Vehicle destroyed:"), name,
-				                      tr("destroyed by"), actor);
+				messageInner = format("%s %s: %s", name, tr("destroyed by"), actor);
 			}
 			else
 			{


### PR DESCRIPTION
Addresses #1131.

This PR shortens the "Vehicle Destroyed" message to match the original game.