### PR TITLE
Fix the confusing naming of proximity mine delay

### DIFF
--- a/data/forms/battle/battle_rt_tab3.form
+++ b/data/forms/battle/battle_rt_tab3.form
@@ -62,7 +62,7 @@
       <scroll id="DELAY_SLIDER">
         <position x="263" y="75"/>
         <size width="116" height="15"/>
-        <range min="0" max="29"/>
+        <range min="0" max="30"/>
         <gripperimage>PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/icons.tab:84:xcom3/tacdata/tactical.pal</gripperimage>
       </scroll>
       <graphic id="RANGE_SLIDER_LEFT">

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2230,8 +2230,8 @@ void BattleView::refreshDelayText()
 	UString text;
 	if (delay == 0)
 	{
-		// FIXME: This will need to be translated
-		text = format(tr("Detonates now."));
+		// FIXME Change to Detonates now?
+		text = format(tr("Activates now."));
 	}
 	else
 	{

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2230,7 +2230,8 @@ void BattleView::refreshDelayText()
 	UString text;
 	if (delay == 0)
 	{
-		text = format(tr("Activates now."));
+		// FIXME: This will need to be translated
+		text = format(tr("Detonates now."));
 	}
 	else
 	{
@@ -2247,7 +2248,15 @@ void BattleView::refreshDelayText()
 		}
 		else
 		{
-			text = format(tr("Delay = %i"), (int)((float)delay / 4.0f));
+			// Check if number is whole, if so don't show decimal places
+			if ((delay & 3) == 0)
+			{
+				text = format("Delay = %d%s", (delay / 4), "s");
+			}
+			else
+			{
+				text = format(tr("Delay = %.3g%s"), ((float)delay / 4.0f), "s");
+			}
 		}
 	}
 	primingTab->findControlTyped<Label>("DELAY_TEXT")->setText(text);


### PR DESCRIPTION
Addresses #1072.

I'm putting this PR forward as a step in the right direction, but more work has to be done. As discussed in issue 1072, the wording of the proximity mines is a bit confusing. This changes the wording of Activates Now to Detonates Now.

Ex.
![det1](https://user-images.githubusercontent.com/73447098/228133856-68c6e1ed-aa45-48df-8b7c-13c103f682bc.png)

 The issue of delay == 0 was some sort of rounding or math error and has been corrected. The delay slider now reads correctly in seconds and counts up by one quarter second until 7.5. To match the original game timer length of 7.5 seconds, I had to add one to the max value of the delay slider. The delay slider now maxes out at 30 instead of 29.

Ex.
![det2](https://user-images.githubusercontent.com/73447098/228135072-84d98e36-48fe-46e2-a616-4505725a0762.png)


I noticed that the "Activates Now" string is present in the ufo_string translation files and adding another phrase without translating it could be a problem. This was not tested in another language, so using the tr() function with the new string may cause a crash. If this change is permanent, "Detonates Now" will probably have to be translated and added to those files. I left a comment that addresses this.
