### PR TITLE
Fix add X when returning to base

### DIFF
--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -149,7 +149,8 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 	t.passengers = std::min(13, v->getPassengers());
 	// Faded if in other dimension or if haven't left dimension gate yet
 	t.faded = v->city != state.current_city || (!v->tileObject && !v->currentBuilding);
-	t.headedHome = v->missions.back().targetBuilding.id == v->homeBuilding.id;
+	// Headed home if we have a mission and it's to our home building
+	t.headedHome = v->missions.back().targetBuilding == v->homeBuilding;
 
 	auto b = v->currentBuilding;
 	if (b)
@@ -793,7 +794,7 @@ bool VehicleTileInfo::operator==(const VehicleTileInfo &other) const
 	return (this->vehicle == other.vehicle && this->selected == other.selected &&
 	        this->healthProportion == other.healthProportion && this->shield == other.shield &&
 	        this->passengers == other.passengers && this->state == other.state &&
-	        this->faded == other.faded);
+	        this->faded == other.faded && this->headedHome == other.headedHome);
 }
 
 bool VehicleTileInfo::operator!=(const VehicleTileInfo &other) const { return !(*this == other); }

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -149,6 +149,7 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 	t.passengers = std::min(13, v->getPassengers());
 	// Faded if in other dimension or if haven't left dimension gate yet
 	t.faded = v->city != state.current_city || (!v->tileObject && !v->currentBuilding);
+	t.headedHome = v->missions.back().targetBuilding.id == v->homeBuilding.id;
 
 	auto b = v->currentBuilding;
 	if (b)
@@ -240,6 +241,23 @@ sp<Control> ControlGenerator::createVehicleControl(GameState &state, const Vehic
 		}
 		fadeIcon->Location = {1, 1};
 	}
+
+	sp<Graphic> baseGraphic;
+
+	if (info.headedHome)
+	{
+		baseGraphic = baseControl->createChild<Graphic>(singleton.icons[0]);
+		if (baseGraphic->getImage())
+		{
+			baseGraphic->Size = baseGraphic->getImage()->size;
+		}
+		else
+		{
+			baseGraphic->AutoSize = true;
+		}
+		baseGraphic->Location = {-5, 0};
+	}
+
 	if (info.passengers)
 	{
 		auto passengerGraphic = vehicleIcon->createChild<Graphic>(

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -134,7 +134,7 @@ class VehicleTileInfo
 	UnitSelectionState selected;
 	float healthProportion;
 	bool shield;
-	bool faded;     // Faded when they enter the alien dimension?
+	bool faded; // Faded when they enter the alien dimension?
 	bool headedHome;
 	int passengers; // 0-13, 0-12 having numbers, 13+ being '+'
 	CityUnitState state;

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -135,6 +135,7 @@ class VehicleTileInfo
 	float healthProportion;
 	bool shield;
 	bool faded;     // Faded when they enter the alien dimension?
+	bool headedHome;
 	int passengers; // 0-13, 0-12 having numbers, 13+ being '+'
 	CityUnitState state;
 	bool operator==(const VehicleTileInfo &other) const;


### PR DESCRIPTION
Fixes #306.

Checks if the vehicle target building is the home building and places the X as per vanilla.