### PR TITLE
Remove options menu from main menu

### DIFF
--- a/data/forms/mainmenu.form
+++ b/data/forms/mainmenu.form
@@ -33,18 +33,19 @@
         <size width="300" height="32"/>
         <font>smalfont</font>
       </textbutton>
-      <textbutton id="BUTTON_OPTIONS" text="Options">
+  <!-- Options menu commented out until useful -->
+	<!-- <textbutton id="BUTTON_OPTIONS" text="Options">
+        <position x="centre" y="290"/>
+        <size width="300" height="32"/>
+        <font>smalfont</font>
+      </textbutton> -->
+      <textbutton id="BUTTON_QUIT" text="Quit">
         <position x="centre" y="290"/>
         <size width="300" height="32"/>
         <font>smalfont</font>
       </textbutton>
-      <textbutton id="BUTTON_QUIT" text="Quit">
-        <position x="centre" y="340"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton>
       <textbutton id="BUTTON_DEBUG" text="Debug Menu" visible="N">
-        <position x="centre" y="390"/>
+        <position x="centre" y="340"/>
         <size width="300" height="32"/>
         <font>smalfont</font>
       </textbutton>

--- a/game/ui/general/mainmenu.cpp
+++ b/game/ui/general/mainmenu.cpp
@@ -57,11 +57,12 @@ void MainMenu::eventOccurred(Event *e)
 
 	if (e->type() == EVENT_FORM_INTERACTION && e->forms().EventFlag == FormEventType::ButtonClick)
 	{
-		if (e->forms().RaisedBy->Name == "BUTTON_OPTIONS")
-		{
-			fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<OptionsMenu>()});
-			return;
-		}
+		/* Options menu commented out until useful
+		* if (e->forms().RaisedBy->Name == "BUTTON_OPTIONS")
+		*{
+		*	fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<OptionsMenu>()});
+		*	return;
+		} */
 		if (e->forms().RaisedBy->Name == "BUTTON_QUIT")
 		{
 			fw().stageQueueCommand({StageCmd::Command::QUIT});


### PR DESCRIPTION
Removes options menu from main menu. Since I didn't get a ton of feedback on this issue, I'll just drop this here in case a consensus is reached. Code commented out instead of deleted to seem more temporary.