### PR TITLE
Add tooltip message to the in game options menu

### DIFF
--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -166,6 +166,8 @@ void InGameOptions::loadList(int id)
 		auto label = checkBox->createChild<Label>(tr(config().describe(p.first, p.second)), font);
 		label->Size = {216, listControl->ItemSize};
 		label->Location = {24, 0};
+		label->ToolTipText = tr(config().describe(p.first, p.second));
+		label->ToolTipFont = font;
 		listControl->addItem(checkBox);
 	}
 }


### PR DESCRIPTION
Partially fixes #1148.

Adds tooltip text to the in game options menu. Tooltips for agents and vehicles still a work in progress.