### PR TITLE
Fix add X to vehicle icon when ferrying cargo to base

### DIFF
--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -150,7 +150,8 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 	// Faded if in other dimension or if haven't left dimension gate yet
 	t.faded = v->city != state.current_city || (!v->tileObject && !v->currentBuilding);
 	// Headed home if we have a mission and it's to our home building
-	t.headedHome = v->missions.back().targetBuilding == v->homeBuilding;
+	t.headedHome = v->missions.back().targetBuilding == v->homeBuilding ||
+	               v->missions.back().type == VehicleMission::MissionType::OfferService;
 
 	auto b = v->currentBuilding;
 	if (b)


### PR DESCRIPTION
Fixes #1154.

 The green X was not being added when a vehicle returned from a mission, or more specifically, when it was ferrying cargo. This PR fixes that by checking if the vehicle is on a ferry mission and adds the X.