### PR TITLE
Fix transaction screen scrollbar multiple items per click

### DIFF
--- a/forms/graphicbutton.cpp
+++ b/forms/graphicbutton.cpp
@@ -62,6 +62,16 @@ void GraphicButton::eventOccured(Event *e)
 		{
 			ScrollBarNext->scrollNext();
 		}
+
+		if (ScrollBarPrevHorizontal != nullptr)
+		{
+			ScrollBarPrevHorizontal->scrollPrev(1);
+		}
+
+		if (ScrollBarNextHorizontal != nullptr)
+		{
+			ScrollBarNextHorizontal->scrollNext(1);
+		}
 	}
 }
 
@@ -166,6 +176,16 @@ sp<Control> GraphicButton::copyTo(sp<Control> CopyParent)
 	{
 		copy->ScrollBarNext =
 		    std::dynamic_pointer_cast<ScrollBar>(ScrollBarNext->lastCopiedTo.lock());
+	}
+	if (this->ScrollBarPrevHorizontal)
+	{
+		copy->ScrollBarPrevHorizontal =
+		    std::dynamic_pointer_cast<ScrollBar>(ScrollBarPrevHorizontal->lastCopiedTo.lock());
+	}
+	if (this->ScrollBarNextHorizontal)
+	{
+		copy->ScrollBarNextHorizontal =
+		    std::dynamic_pointer_cast<ScrollBar>(ScrollBarNextHorizontal->lastCopiedTo.lock());
 	}
 	copyControlData(copy);
 	return copy;

--- a/forms/graphicbutton.h
+++ b/forms/graphicbutton.h
@@ -24,7 +24,7 @@ class GraphicButton : public Control
 	void onRender() override;
 
   public:
-	sp<ScrollBar> ScrollBarPrev, ScrollBarNext;
+	sp<ScrollBar> ScrollBarPrev, ScrollBarNext, ScrollBarPrevHorizontal, ScrollBarNextHorizontal;
 
 	GraphicButton(sp<Image> image = nullptr, sp<Image> imageDepressed = nullptr,
 	              sp<Image> imageHover = nullptr);

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -675,11 +675,11 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 	auto buttonScrollLeft = control->createChild<GraphicButton>(nullptr, scrollLeft);
 	buttonScrollLeft->Size = scrollLeft->size;
 	buttonScrollLeft->Location = {87, 24};
-	buttonScrollLeft->ScrollBarPrev = control->scrollBar;
+	buttonScrollLeft->ScrollBarPrevHorizontal = control->scrollBar;
 	auto buttonScrollRight = control->createChild<GraphicButton>(nullptr, scrollRight);
 	buttonScrollRight->Size = scrollRight->size;
 	buttonScrollRight->Location = {247, 24};
-	buttonScrollRight->ScrollBarNext = control->scrollBar;
+	buttonScrollRight->ScrollBarNextHorizontal = control->scrollBar;
 	// Callback
 	control->setupCallbacks();
 	// Finally set the values
@@ -690,7 +690,8 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 
 void TransactionControl::setupCallbacks()
 {
-	std::function<void(FormsEvent * e)> onScrollChange = [this](FormsEvent *) {
+	std::function<void(FormsEvent * e)> onScrollChange = [this](FormsEvent *)
+	{
 		if (!this->suspendUpdates)
 		{
 			this->updateValues();


### PR DESCRIPTION
In the original game, the horizontal scroll bars in the transaction screen moved one item at a time when clicked. In OpenApoc, the scrollbars move depending on the amount of items in the list. This PR fixes this issue by separating the vertical and horizontal scrollbars in the transaction screen and setting the button click to move add or remove exactly one item each time.