### PR TITLE
Fix alien containment screen opening when empty or gone

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -426,6 +426,21 @@ void Base::destroyFacility(GameState &state, Vec2<int> pos)
 	}
 }
 
+bool Base::containmentEmpty(GameState &state)
+{
+	for (auto &f : facilities)
+	{
+		if (f->type->capacityType == FacilityType::Capacity::Aliens)
+		{
+			if (getCapacityUsed(state, f->type->capacityType) != 0)
+			{
+				return false;
+			}
+		}
+	}
+	return true;
+}
+
 int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 {
 	int total = 0;

--- a/game/state/city/base.h
+++ b/game/state/city/base.h
@@ -55,6 +55,7 @@ class Base : public StateObject<Base>, public std::enable_shared_from_this<Base>
 	                   bool free = false);
 	BuildError canDestroyFacility(GameState &state, Vec2<int> pos) const;
 	void destroyFacility(GameState &state, Vec2<int> pos);
+	bool containmentEmpty(GameState &state);
 	int getCapacityUsed(GameState &state, FacilityType::Capacity type) const;
 	int getCapacityTotal(FacilityType::Capacity type) const;
 	int getUsage(GameState &state, sp<Facility> facility, int delta = 0) const;

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -95,84 +95,119 @@ void BaseScreen::begin()
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [](Event *) { fw().stageQueueCommand({StageCmd::Command::POP}); });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_BUYSELL")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BuyAndSellScreen>(state)});
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *) {
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BuyAndSellScreen>(state)});
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_HIREFIRESTAFF")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<RecruitScreen>(state)});
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *) {
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<RecruitScreen>(state)});
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_TRANSFER")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    if (this->state->player_bases.size() <= 1)
-		    {
-			    fw().stageQueueCommand(
-			        {StageCmd::Command::PUSH,
-			         mksp<MessageBox>(
-			             tr("Transfer"),
-			             tr("At least two bases are required before transfers become possible."),
-			             MessageBox::ButtonOptions::Ok)});
-		    }
-		    else
-		    {
-			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<TransferScreen>(state)});
-		    }
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        if (this->state->player_bases.size() <= 1)
+		        {
+			        fw().stageQueueCommand(
+			            {StageCmd::Command::PUSH,
+			             mksp<MessageBox>(tr("Transfer"),
+			                              tr("At least two bases are required before transfers "
+			                                 "become possible."),
+			                              MessageBox::ButtonOptions::Ok)});
+		        }
+		        else
+		        {
+			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<TransferScreen>(state)});
+		        }
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_ALIEN_CONTAINMENT")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AlienContainmentScreen>(state)});
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        if (this->state->current_base->containmentEmpty(*state))
+		        {
+			        fw().stageQueueCommand(
+			            {StageCmd::Command::PUSH,
+			             mksp<MessageBox>(tr("Alien Containment"),
+			                              tr("Alien Containment is not in use at this base."),
+			                              MessageBox::ButtonOptions::Ok)});
+		        }
+		        else
+		        {
+			        fw().stageQueueCommand(
+			            {StageCmd::Command::PUSH, mksp<AlienContainmentScreen>(state)});
+		        }
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPAGENT")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    bool playerHasSoldiers = false;
-		    for (auto &a : this->state->agents)
-		    {
-			    auto agent = a.second;
-			    if (agent->owner == this->state->getPlayer() &&
-			        agent->type->role == AgentType::Role::Soldier)
-			    {
-				    playerHasSoldiers = true;
-				    break;
-			    }
-		    }
-		    if (playerHasSoldiers)
-		    {
-			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
-		    }
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        bool playerHasSoldiers = false;
+		        for (auto &a : this->state->agents)
+		        {
+			        auto agent = a.second;
+			        if (agent->owner == this->state->getPlayer() &&
+			            agent->type->role == AgentType::Role::Soldier)
+			        {
+				        playerHasSoldiers = true;
+				        break;
+			        }
+		        }
+		        if (playerHasSoldiers)
+		        {
+			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
+		        }
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPVEHICLE")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    bool playerHasVehicles = false;
-		    for (auto &v : this->state->vehicles)
-		    {
-			    auto vehicle = v.second;
-			    if (vehicle->owner == this->state->getPlayer())
-			    {
-				    playerHasVehicles = true;
-				    break;
-			    }
-		    }
-		    if (playerHasVehicles)
-		    {
-			    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
-		    }
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        bool playerHasVehicles = false;
+		        for (auto &v : this->state->vehicles)
+		        {
+			        auto vehicle = v.second;
+			        if (vehicle->owner == this->state->getPlayer())
+			        {
+				        playerHasVehicles = true;
+				        break;
+			        }
+		        }
+		        if (playerHasVehicles)
+		        {
+			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
+		        }
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_RES_AND_MANUF")
-	    ->addCallback(FormEventType::ButtonClick, [this](Event *) {
-		    // FIXME: If you don't have any facilities this button should do nothing
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ResearchScreen>(state)});
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        // FIXME: If you don't have any facilities this button should do nothing
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ResearchScreen>(state)});
+	        });
 	// Base name edit
 	form->findControlTyped<TextEdit>("TEXT_BASE_NAME")
-	    ->addCallback(FormEventType::TextEditFinish, [this](FormsEvent *e) {
-		    this->state->current_base->name =
-		        std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
-	    });
+	    ->addCallback(FormEventType::TextEditFinish,
+	                  [this](FormsEvent *e)
+	                  {
+		                  this->state->current_base->name =
+		                      std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)->getText();
+	                  });
 	form->findControlTyped<TextEdit>("TEXT_BASE_NAME")
-	    ->addCallback(FormEventType::TextEditCancel, [this](FormsEvent *e) {
-		    std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
-		        ->setText(this->state->current_base->name);
-	    });
+	    ->addCallback(FormEventType::TextEditCancel,
+	                  [this](FormsEvent *e)
+	                  {
+		                  std::dynamic_pointer_cast<TextEdit>(e->forms().RaisedBy)
+		                      ->setText(this->state->current_base->name);
+	                  });
 }
 
 void BaseScreen::pause() {}
@@ -384,7 +419,9 @@ void BaseScreen::eventOccurred(Event *e)
 							fw().stageQueueCommand(
 							    {StageCmd::Command::PUSH,
 							     mksp<MessageBox>(tr("Destroy facility"), tr("Are you sure?"),
-							                      MessageBox::ButtonOptions::YesNo, [this] {
+							                      MessageBox::ButtonOptions::YesNo,
+							                      [this]
+							                      {
 								                      this->state->current_base->destroyFacility(
 								                          *this->state, this->selection);
 								                      this->refreshView();


### PR DESCRIPTION
Fixes #571.

Adds a check to make sure the alien containment facility is either empty or missing and alerts the user as per vanilla.