### PR TITLE
Fix center count label under equipment

### DIFF
--- a/game/ui/base/vequipscreen.cpp
+++ b/game/ui/base/vequipscreen.cpp
@@ -460,7 +460,8 @@ void VEquipScreen::render()
 
 			Vec2<int> countLabelPosition = inventoryPosition;
 			countLabelPosition.y += INVENTORY_COUNT_Y_GAP + equipmentImage->size.y;
-			// FIXME: Center in X?
+			countLabelPosition.x += equipmentImage->size.x / 2 - countImage->size.x / 2;
+
 			fw().renderer->draw(countImage, countLabelPosition);
 
 			Vec2<int> inventoryEndPosition = inventoryPosition;


### PR DESCRIPTION
As mentioned in the recent stream, the count labels in the vehicle equip screen are not centered. This PR fixes that.

Before:
![item1](https://user-images.githubusercontent.com/73447098/230538545-39f3fa75-c3e5-457c-9768-4b007c5a7078.png)
After:
![item2](https://user-images.githubusercontent.com/73447098/230538547-d1a1b16d-aba4-452f-8797-d5227a5b7f68.png)
