### PR TITLE
Fix enforce cargo limits not working in cityscape

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1633,11 +1633,15 @@ void Vehicle::provideServiceCargo(GameState &state, bool bio, bool otherOrg)
 			continue;
 		}
 		// How much can we pick up
-		int maxAmount = std::min(spaceRemaining / c.space * c.divisor, c.count);
+		int maxAmount = (!config().getBool("OpenApoc.NewFeature.EnforceCargoLimits") && this->owner == state.getPlayer())
+		                    ? c.count
+		                    : std::min(spaceRemaining / c.space * c.divisor, c.count);
+
 		if (maxAmount == 0)
 		{
 			continue;
 		}
+
 		// Here's where we're going
 		if (!destination)
 		{

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -6,6 +6,7 @@
 #include "game/state/rules/battle/damage.h"
 #include "game/state/tilemap/tilemap.h"
 #include <list>
+#include <framework/configfile.h>
 
 namespace OpenApoc
 {
@@ -113,9 +114,17 @@ void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> ve
 	form->findControlTyped<Label>("LABEL_8_R")
 	    ->setText(vehicle ? format("%d / %d", vehicle->getPassengers(), vehicle->getMaxPassengers())
 	                      : format("%d", vehicleType->getMaxPassengers(it1, it2)));
-	form->findControlTyped<Label>("LABEL_9_R")
-	    ->setText(vehicle ? format("%d / %d", vehicle->getCargo(), vehicle->getMaxCargo())
-	                      : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	if (!config().getBool("OpenApoc.NewFeature.EnforceCargoLimits"))
+	{
+		form->findControlTyped<Label>("LABEL_9_R")
+		    ->setText(vehicle ? format("%d", vehicle->getCargo()) : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	}
+	else
+	{
+		form->findControlTyped<Label>("LABEL_9_R")
+		    ->setText(vehicle ? format("%d / %d", vehicle->getCargo(), vehicle->getMaxCargo())
+		                      : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	}
 }
 
 void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> type)


### PR DESCRIPTION
When enforce cargo limits is turned off, it only counts cargo coming back from a mission. This PR extends the option to include picking up cargo in the cityscape. When off, a single vehicle can pick up an unlimited amount of cargo from a building. I'm looking for some feedback on how exactly this should work. At the moment, the vehicle that is carrying the extra cargo shows exactly how much cargo they have on board.

Example:
![cargo](https://user-images.githubusercontent.com/73447098/230538874-c8c9a813-bd01-4ff1-a2a5-ca6f0d8a1291.png)
You can see the number shows a larger number than is possible for the vehicle. 

While this makes sense in a way, I wonder if it would be better to cap the cargo number to the max capacity of the vehicle.

Secondly, I took the liberty to limit this ability to only vehicles owned by the player. If not, a small transtellar transport will be able to pick up everything in one trip. Thoughts?
