### PR TITLE
Fix cargo limits not being enforced in the cityscape

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -763,29 +763,29 @@ class GroundVehicleMover : public VehicleMover
 								vehicle.goalPosition.z = vehicle.position.z;
 							}
 							else
-							    // If we're on flat surface then first move to midpoint then start
-							    // to
-							    // change Z
-							    if (fromFlat)
-							{
-								vehicle.goalWaypoints.push_back(vehicle.goalPosition);
-								// Add midpoint waypoint at target z level
-								vehicle.goalPosition.x =
-								    (vehicle.position.x + vehicle.goalPosition.x) / 2.0f;
-								vehicle.goalPosition.y =
-								    (vehicle.position.y + vehicle.goalPosition.y) / 2.0f;
-								vehicle.goalPosition.z = vehicle.position.z;
-							}
-							// Else if we end on flat surface first change Z then move flat
-							else if (toFlat)
-							{
-								vehicle.goalWaypoints.push_back(vehicle.goalPosition);
-								// Add midpoint waypoint at current z level
-								vehicle.goalPosition.x =
-								    (vehicle.position.x + vehicle.goalPosition.x) / 2.0f;
-								vehicle.goalPosition.y =
-								    (vehicle.position.y + vehicle.goalPosition.y) / 2.0f;
-							}
+								// If we're on flat surface then first move to midpoint then start
+								// to
+								// change Z
+								if (fromFlat)
+								{
+									vehicle.goalWaypoints.push_back(vehicle.goalPosition);
+									// Add midpoint waypoint at target z level
+									vehicle.goalPosition.x =
+									    (vehicle.position.x + vehicle.goalPosition.x) / 2.0f;
+									vehicle.goalPosition.y =
+									    (vehicle.position.y + vehicle.goalPosition.y) / 2.0f;
+									vehicle.goalPosition.z = vehicle.position.z;
+								}
+								// Else if we end on flat surface first change Z then move flat
+								else if (toFlat)
+								{
+									vehicle.goalWaypoints.push_back(vehicle.goalPosition);
+									// Add midpoint waypoint at current z level
+									vehicle.goalPosition.x =
+									    (vehicle.position.x + vehicle.goalPosition.x) / 2.0f;
+									vehicle.goalPosition.y =
+									    (vehicle.position.y + vehicle.goalPosition.y) / 2.0f;
+								}
 							// If we're moving from nonflat to nonflat then we need no midpoint at
 							// all
 						}
@@ -1633,7 +1633,10 @@ void Vehicle::provideServiceCargo(GameState &state, bool bio, bool otherOrg)
 			continue;
 		}
 		// How much can we pick up
-		int maxAmount = std::min(spaceRemaining / c.space * c.divisor, c.count);
+		int maxAmount = (!config().getBool("OpenApoc.NewFeature.EnforceCargoLimits") &&
+		                 this->owner == state.getPlayer())
+		                    ? c.count
+		                    : std::min(spaceRemaining / c.space * c.divisor, c.count);
 		if (maxAmount == 0)
 		{
 			continue;

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -5,6 +5,7 @@
 #include "game/state/gamestate.h"
 #include "game/state/rules/battle/damage.h"
 #include "game/state/tilemap/tilemap.h"
+#include <framework/configfile.h>
 #include <list>
 
 namespace OpenApoc
@@ -113,9 +114,18 @@ void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> ve
 	form->findControlTyped<Label>("LABEL_8_R")
 	    ->setText(vehicle ? format("%d / %d", vehicle->getPassengers(), vehicle->getMaxPassengers())
 	                      : format("%d", vehicleType->getMaxPassengers(it1, it2)));
-	form->findControlTyped<Label>("LABEL_9_R")
-	    ->setText(vehicle ? format("%d / %d", vehicle->getCargo(), vehicle->getMaxCargo())
-	                      : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	if (!config().getBool("OpenApoc.NewFeature.EnforceCargoLimits"))
+	{
+		form->findControlTyped<Label>("LABEL_9_R")
+		    ->setText(vehicle ? format("%d", vehicle->getCargo())
+		                      : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	}
+	else
+	{
+		form->findControlTyped<Label>("LABEL_9_R")
+		    ->setText(vehicle ? format("%d / %d", vehicle->getCargo(), vehicle->getMaxCargo())
+		                      : format("%d", vehicleType->getMaxCargo(it1, it2)));
+	}
 }
 
 void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> type)


### PR DESCRIPTION
Fixes #1164.

When enforce cargo limits is turned off, it only counts cargo coming back from a mission. This PR extends the option to include picking up cargo in the cityscape. When off, a single vehicle can pick up an unlimited amount of cargo from a building. This is limited to only player owned vehicles and not the transtellar transports in the city. When cargo limits are disabled, the vehicle will only show the cargo that is onboard and no max cargo number.