### PR TITLE
Decouple fps tps

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -311,9 +311,8 @@ void Framework::run(sp<Stage> initialStage)
 	auto target_frame_duration =
 	    std::chrono::duration<int64_t, std::micro>(1000000 / Options::targetFPS.get());
 
-	//to do: replace magic number 36 with a constant -- this is for testing purposes only.
-	auto target_tick_duration = 
-		std::chrono::duration<int64_t, std::micro>(1000000 / TICKS_PER_SECOND);
+	auto target_tick_duration =
+	    std::chrono::duration<int64_t, std::micro>(1000000 / TICKS_PER_SECOND);
 
 	p->ProgramStages.push(initialStage);
 
@@ -351,15 +350,15 @@ void Framework::run(sp<Stage> initialStage)
 		{
 			break;
 		}
-		//trying to update this on a different timer than the rest of framework.run()
-		//specifically, trying to update this at 36 hz.  
-		//this might not work, depending on exactly the type of work that needs to get done in stage.update
-		//this might also give problems with commands, though it appears commands occur only in response to 
-		//events, which will remain at the once per frame rate.
+		// trying to update this on a different timer than the rest of framework.run()
+		// specifically, trying to update this at 36 hz.
+		// this might not work, depending on exactly the type of work that needs to get done in
+		// stage.update this might also give problems with commands, though it appears commands
+		// occur only in response to events, which will remain at the once per frame rate.
 
-		//algorithm for decoupling this will be: keep a time point of last time we updated.  if 
-		//now minus last update is greater than tps, then update and increment last update.  if not, skip.
-		//could be done in a while loop
+		// algorithm for decoupling this will be: keep a time point of last time we updated.  if
+		// now minus last update is greater than tps, then update and increment last update.  if
+		// not, skip. could be done in a while loop
 		while (expected_tick_time <= frame_time_now)
 		{
 			p->ProgramStages.current()->update();

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -311,10 +311,15 @@ void Framework::run(sp<Stage> initialStage)
 	auto target_frame_duration =
 	    std::chrono::duration<int64_t, std::micro>(1000000 / Options::targetFPS.get());
 
+	//to do: replace magic number 36 with a constant -- this is for testing purposes only.
+	auto target_tick_duration = 
+		std::chrono::duration<int64_t, std::micro>(1000000 / TICKS_PER_SECOND);
+
 	p->ProgramStages.push(initialStage);
 
 	this->renderer->setPalette(this->data->loadPalette("xcom3/ufodata/pal_06.dat"));
 	auto expected_frame_time = std::chrono::steady_clock::now();
+	auto expected_tick_time = std::chrono::steady_clock::now();
 
 	bool frame_time_limited_warning_shown = false;
 
@@ -346,8 +351,19 @@ void Framework::run(sp<Stage> initialStage)
 		{
 			break;
 		}
+		//trying to update this on a different timer than the rest of framework.run()
+		//specifically, trying to update this at 36 hz.  
+		//this might not work, depending on exactly the type of work that needs to get done in stage.update
+		//this might also give problems with commands, though it appears commands occur only in response to 
+		//events, which will remain at the once per frame rate.
+
+		//algorithm for decoupling this will be: keep a time point of last time we updated.  if 
+		//now minus last update is greater than tps, then update and increment last update.  if not, skip.
+		//could be done in a while loop
+		while (expected_tick_time <= frame_time_now)
 		{
 			p->ProgramStages.current()->update();
+			expected_tick_time += target_tick_duration;
 		}
 
 		for (StageCmd cmd : stageCommands)

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -14,8 +14,8 @@ static constexpr unsigned VANILLA_TICKS_PER_SECOND = 36;
 static constexpr unsigned VANILLA_ANIMATION_FRAMES_PER_SECOND = 18;
 static constexpr unsigned TICKS_MULTIPLIER = 1;
 static constexpr unsigned TICKS_PER_SECOND = VANILLA_TICKS_PER_SECOND * TICKS_MULTIPLIER;
-static constexpr unsigned ANIMATION_FRAMES_MULTIPLIER = TICKS_PER_SECOND / 
-							  (VANILLA_ANIMATION_FRAMES_PER_SECOND * TICKS_MULTIPLIER);
+static constexpr unsigned ANIMATION_FRAMES_MULTIPLIER =
+    TICKS_PER_SECOND / (VANILLA_ANIMATION_FRAMES_PER_SECOND * TICKS_MULTIPLIER);
 static constexpr unsigned TICKS_PER_MINUTE = TICKS_PER_SECOND * 60;
 static constexpr unsigned TICKS_PER_HOUR = TICKS_PER_MINUTE * 60;
 static constexpr unsigned TICKS_PER_DAY = TICKS_PER_HOUR * 24;
@@ -34,8 +34,6 @@ class JukeBox;
 class StageCmd;
 class Stage;
 class RGBImage;
-
-
 
 class Framework
 {
@@ -122,11 +120,13 @@ class Framework
 		    std::bind(std::forward<F>(f), std::forward<Args>(args)...));
 
 		std::shared_future<return_type> res = task->get_future().share();
-		this->threadPoolTaskEnqueue([task, res]() {
-			(*task)();
-			// Without a future.get() any exceptions are dropped on the floor
-			res.get();
-		});
+		this->threadPoolTaskEnqueue(
+		    [task, res]()
+		    {
+			    (*task)();
+			    // Without a future.get() any exceptions are dropped on the floor
+			    res.get();
+		    });
 		return res;
 	}
 

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -10,6 +10,14 @@
 namespace OpenApoc
 {
 
+static constexpr unsigned VANILLA_TICKS_PER_SECOND = 36;
+static constexpr unsigned TICKS_MULTIPLIER = 1;
+static constexpr unsigned TICKS_PER_SECOND = VANILLA_TICKS_PER_SECOND * TICKS_MULTIPLIER;
+static constexpr unsigned TICKS_PER_MINUTE = TICKS_PER_SECOND * 60;
+static constexpr unsigned TICKS_PER_HOUR = TICKS_PER_MINUTE * 60;
+static constexpr unsigned TICKS_PER_DAY = TICKS_PER_HOUR * 24;
+static constexpr unsigned TURBO_TICKS = 5 * 60 * TICKS_PER_SECOND;
+
 class Shader;
 class GameCore;
 class FrameworkPrivate;
@@ -24,7 +32,7 @@ class StageCmd;
 class Stage;
 class RGBImage;
 
-#define FRAMES_PER_SECOND 100
+
 
 class Framework
 {

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -11,8 +11,11 @@ namespace OpenApoc
 {
 
 static constexpr unsigned VANILLA_TICKS_PER_SECOND = 36;
+static constexpr unsigned VANILLA_ANIMATION_FRAMES_PER_SECOND = 18;
 static constexpr unsigned TICKS_MULTIPLIER = 1;
 static constexpr unsigned TICKS_PER_SECOND = VANILLA_TICKS_PER_SECOND * TICKS_MULTIPLIER;
+static constexpr unsigned ANIMATION_FRAMES_MULTIPLIER = TICKS_PER_SECOND / 
+							  (VANILLA_ANIMATION_FRAMES_PER_SECOND * TICKS_MULTIPLIER);
 static constexpr unsigned TICKS_PER_MINUTE = TICKS_PER_SECOND * 60;
 static constexpr unsigned TICKS_PER_HOUR = TICKS_PER_MINUTE * 60;
 static constexpr unsigned TICKS_PER_DAY = TICKS_PER_HOUR * 24;

--- a/game/state/battle/ai/tacticalai.cpp
+++ b/game/state/battle/ai/tacticalai.cpp
@@ -2,11 +2,12 @@
 #include "game/state/battle/ai/tacticalaivanilla.h"
 #include "game/state/battle/battle.h"
 #include "game/state/gamestate.h"
+#include "framework/framework.h"
 
 namespace OpenApoc
 {
 
-static const uint64_t TACTICAL_AI_THINK_INTERVAL = TICKS_PER_SECOND / 4;
+static const uint64_t TACTICAL_AI_THINK_INTERVAL = TICKS_PER_SECOND / TICKS_MULTIPLIER;
 
 const UString TacticalAI::getName()
 {

--- a/game/state/battle/ai/tacticalai.cpp
+++ b/game/state/battle/ai/tacticalai.cpp
@@ -1,8 +1,8 @@
 #include "game/state/battle/ai/tacticalai.h"
+#include "framework/framework.h"
 #include "game/state/battle/ai/tacticalaivanilla.h"
 #include "game/state/battle/battle.h"
 #include "game/state/gamestate.h"
-#include "framework/framework.h"
 
 namespace OpenApoc
 {

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "framework/framework.h"
 #include "game/state/battle/ai/aitype.h"
 #include "game/state/battle/ai/tacticalai.h"
 #include "game/state/battle/battleforces.h"
@@ -9,7 +10,6 @@
 #include "game/state/stateobject.h"
 #include "library/sp.h"
 #include "library/vec.h"
-#include "framework/framework.h"
 #include <list>
 #include <map>
 #include <set>

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -9,6 +9,7 @@
 #include "game/state/stateobject.h"
 #include "library/sp.h"
 #include "library/vec.h"
+#include "framework/framework.h"
 #include <list>
 #include <map>
 #include <set>

--- a/game/state/battle/battleexplosion.cpp
+++ b/game/state/battle/battleexplosion.cpp
@@ -71,7 +71,7 @@ void BattleExplosion::update(GameState &state, unsigned int ticks)
 	ticksUntilExpansion -= ticks;
 	while (ticksUntilExpansion <= 0)
 	{
-		ticksUntilExpansion += TICKS_MULTIPLIER * 2;
+		ticksUntilExpansion += TICKS_PER_EXPLOSION_EXPANSION;
 		grow(state);
 		if (locationsToExpand[0].empty() && locationsToExpand[1].empty() &&
 		    locationsToExpand[2].empty())

--- a/game/state/battle/battleexplosion.h
+++ b/game/state/battle/battleexplosion.h
@@ -7,6 +7,8 @@
 
 namespace OpenApoc
 {
+static constexpr unsigned TICKS_PER_EXPLOSION_EXPANSION = 4;
+
 class GameState;
 class TileMap;
 class Battle;

--- a/game/state/battle/battlehazard.h
+++ b/game/state/battle/battlehazard.h
@@ -15,7 +15,7 @@
 
 namespace OpenApoc
 {
-static const unsigned TICKS_PER_HAZARD_UPDATE = TICKS_PER_TURN / 2;
+static const unsigned TICKS_PER_HAZARD_UPDATE = TICKS_PER_TURN;
 
 class TileObjectBattleHazard;
 class DamageType;

--- a/game/state/battle/battlemappart.h
+++ b/game/state/battle/battlemappart.h
@@ -8,12 +8,14 @@
 #include <list>
 #include <set>
 
-#define TICKS_PER_FRAME_MAP_PART 8
+//#define TICKS_PER_FRAME_MAP_PART 8
 #define FALLING_ACCELERATION_MAP_PART 0.16666667f // 1/6th
 #define FALLING_MAP_PART_DAMAGE_TO_UNIT 50
 
 namespace OpenApoc
 {
+static constexpr unsigned TICKS_PER_FRAME_MAP_PART = ANIMATION_FRAMES_MULTIPLIER;
+
 class Battle;
 class Collision;
 class TileObjectBattleMapPart;

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -2,6 +2,7 @@
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
 #endif
+#include "framework/framework.h"
 #include "game/state/battle/ai/unitai.h"
 #include "game/state/battle/battle.h"
 #include "game/state/battle/battleunitmission.h"

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "framework/framework.h"
 #include "game/state/gametime.h"
 #include "game/state/stateobject.h"
 #include "library/rect.h"
 #include "library/vec.h"
-#include "framework/framework.h"
 #include <set>
 #include <vector>
 

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -4,6 +4,7 @@
 #include "game/state/stateobject.h"
 #include "library/rect.h"
 #include "library/vec.h"
+#include "framework/framework.h"
 #include <set>
 #include <vector>
 

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -1,6 +1,7 @@
 #include "game/state/gametime.h"
 #include "game/state/gametime_facet.h"
 #include "library/strings_format.h"
+#include "framework/framework.h"
 #include <locale>
 #include <sstream>
 

--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -1,7 +1,7 @@
 #include "game/state/gametime.h"
+#include "framework/framework.h"
 #include "game/state/gametime_facet.h"
 #include "library/strings_format.h"
-#include "framework/framework.h"
 #include <locale>
 #include <sstream>
 

--- a/game/state/gametime.h
+++ b/game/state/gametime.h
@@ -6,14 +6,6 @@
 namespace OpenApoc
 {
 
-static constexpr unsigned VANILLA_TICKS_PER_SECOND = 36;
-static constexpr unsigned TICKS_MULTIPLIER = 4;
-static constexpr unsigned TICKS_PER_SECOND = VANILLA_TICKS_PER_SECOND * TICKS_MULTIPLIER;
-static constexpr unsigned TICKS_PER_MINUTE = TICKS_PER_SECOND * 60;
-static constexpr unsigned TICKS_PER_HOUR = TICKS_PER_MINUTE * 60;
-static constexpr unsigned TICKS_PER_DAY = TICKS_PER_HOUR * 24;
-static constexpr unsigned TURBO_TICKS = 5 * 60 * TICKS_PER_SECOND;
-
 class GameTime
 {
   private:

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "framework/image.h"
 #include "framework/framework.h"
+#include "framework/image.h"
 #include "game/state/gametime.h"
 #include "game/state/rules/aequipmenttype.h"
 #include "game/state/rules/agenttype.h"

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "framework/image.h"
+#include "framework/framework.h"
 #include "game/state/gametime.h"
 #include "game/state/rules/aequipmenttype.h"
 #include "game/state/rules/agenttype.h"

--- a/game/state/shared/doodad.cpp
+++ b/game/state/shared/doodad.cpp
@@ -17,10 +17,10 @@ Doodad::Doodad(Vec3<float> position, Vec2<int> imageOffset, bool temporary, int 
       lifetime(lifetime), sprite(image)
 {
 }
-// FIXME: MOVED FROM TICKS MULTIPLIER TO 4 FOR CORRECTNESS, NOT SURE THIS IS WHAT IT SHOULD BE
+
 Doodad::Doodad(Vec3<float> position, StateRef<DoodadType> type)
     : position(position), imageOffset(type->imageOffset), temporary(true), age(0),
-      lifetime(type->lifetime * 4), type(type)
+      lifetime(type->lifetime * DOODAD_LIFETIME_TICK_MULTIPLIER), type(type)
 {
 }
 

--- a/game/state/shared/doodad.cpp
+++ b/game/state/shared/doodad.cpp
@@ -17,10 +17,10 @@ Doodad::Doodad(Vec3<float> position, Vec2<int> imageOffset, bool temporary, int 
       lifetime(lifetime), sprite(image)
 {
 }
-
+// FIXME: MOVED FROM TICKS MULTIPLIER TO 4 FOR CORRECTNESS, NOT SURE THIS IS WHAT IT SHOULD BE
 Doodad::Doodad(Vec3<float> position, StateRef<DoodadType> type)
     : position(position), imageOffset(type->imageOffset), temporary(true), age(0),
-      lifetime(type->lifetime * TICKS_MULTIPLIER), type(type)
+      lifetime(type->lifetime * 4), type(type)
 {
 }
 

--- a/game/state/shared/doodad.h
+++ b/game/state/shared/doodad.h
@@ -6,6 +6,8 @@
 
 namespace OpenApoc
 {
+static constexpr unsigned DOODAD_LIFETIME_TICK_MULTIPLIER = 4;
+
 class TileObjectDoodad;
 class TileMap;
 class DoodadType;

--- a/game/state/shared/organisation.h
+++ b/game/state/shared/organisation.h
@@ -4,6 +4,7 @@
 #include "game/state/rules/city/organisationraid.h"
 #include "game/state/stateobject.h"
 #include "library/strings.h"
+#include "framework/framework.h"
 #include <list>
 #include <map>
 #include <set>

--- a/game/state/shared/organisation.h
+++ b/game/state/shared/organisation.h
@@ -1,10 +1,10 @@
 #pragma once
 
+#include "framework/framework.h"
 #include "game/state/gametime.h"
 #include "game/state/rules/city/organisationraid.h"
 #include "game/state/stateobject.h"
 #include "library/strings.h"
-#include "framework/framework.h"
 #include <list>
 #include <map>
 #include <set>

--- a/game/state/shared/projectile.h
+++ b/game/state/shared/projectile.h
@@ -19,7 +19,10 @@
 // For some reason, advancing projectiles using their speed produces improper results
 // With a multiplier of four, it seems to match.
 // Tests with cityscape shown this to work similar to vanilla
-#define PROJECTILE_VELOCITY_MULTIPLIER 1.0f
+// Hambones|Josh: On the assumption that this reflected the old 144:36 tick speed ratio, i changed this to 1.0f
+// but that does not work.  The manner in which this value controls projectile speed is not straightforward
+// and needs to be further investigated.
+#define PROJECTILE_VELOCITY_MULTIPLIER 4.0f
 
 namespace OpenApoc
 {

--- a/game/state/shared/projectile.h
+++ b/game/state/shared/projectile.h
@@ -19,7 +19,7 @@
 // For some reason, advancing projectiles using their speed produces improper results
 // With a multiplier of four, it seems to match.
 // Tests with cityscape shown this to work similar to vanilla
-#define PROJECTILE_VELOCITY_MULTIPLIER 4.0f
+#define PROJECTILE_VELOCITY_MULTIPLIER 1.0f
 
 namespace OpenApoc
 {

--- a/game/state/shared/projectile.h
+++ b/game/state/shared/projectile.h
@@ -19,9 +19,9 @@
 // For some reason, advancing projectiles using their speed produces improper results
 // With a multiplier of four, it seems to match.
 // Tests with cityscape shown this to work similar to vanilla
-// Hambones|Josh: On the assumption that this reflected the old 144:36 tick speed ratio, i changed this to 1.0f
-// but that does not work.  The manner in which this value controls projectile speed is not straightforward
-// and needs to be further investigated.
+// Hambones|Josh: On the assumption that this reflected the old 144:36 tick speed ratio, i changed
+// this to 1.0f but that does not work.  The manner in which this value controls projectile speed is
+// not straightforward and needs to be further investigated.
 #define PROJECTILE_VELOCITY_MULTIPLIER 4.0f
 
 namespace OpenApoc

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "framework/logger.h"
+#include "framework/framework.h"
 #include "game/state/gametime.h"
 #include "game/state/stateobject.h"
 #include "game/state/tilemap/tile.h"

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "framework/logger.h"
 #include "framework/framework.h"
+#include "framework/logger.h"
 #include "game/state/gametime.h"
 #include "game/state/stateobject.h"
 #include "game/state/tilemap/tile.h"
@@ -12,7 +12,6 @@
 #include <map>
 #include <set>
 #include <vector>
-
 
 static constexpr float VELOCITY_SCALE_CITY_X = 32.0f;
 static constexpr float VELOCITY_SCALE_CITY_Y = 32.0f;
@@ -25,7 +24,6 @@ static constexpr float VELOCITY_SCALE_BATTLE_Y = 24;
 static constexpr float VELOCITY_SCALE_BATTLE_Z = 20;
 static const OpenApoc::Vec3<float> VELOCITY_SCALE_BATTLE{
     VELOCITY_SCALE_BATTLE_X, VELOCITY_SCALE_BATTLE_Y, VELOCITY_SCALE_BATTLE_Z};
-
 
 namespace OpenApoc
 {

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -13,6 +13,7 @@
 #include <set>
 #include <vector>
 
+
 static constexpr float VELOCITY_SCALE_CITY_X = 32.0f;
 static constexpr float VELOCITY_SCALE_CITY_Y = 32.0f;
 static constexpr float VELOCITY_SCALE_CITY_Z = 16.0f;
@@ -25,11 +26,12 @@ static constexpr float VELOCITY_SCALE_BATTLE_Z = 20;
 static const OpenApoc::Vec3<float> VELOCITY_SCALE_BATTLE{
     VELOCITY_SCALE_BATTLE_X, VELOCITY_SCALE_BATTLE_Y, VELOCITY_SCALE_BATTLE_Z};
 
+
 namespace OpenApoc
 {
 
 // FIXME: Alexey Andronov: Does anyone know why we divide by 4 here?
-static const unsigned TICK_SCALE = TICKS_PER_SECOND / 4;
+static const unsigned TICK_SCALE = TICKS_PER_SECOND / TICKS_MULTIPLIER;
 
 class Image;
 class TileMap;


### PR DESCRIPTION
This pull request attempts to address https://github.com/OpenApoc/OpenApoc/issues/997.  First, in framework.cpp, a new whileloop is added around currentstage.update() which runs on a ticks per second basis, rather than being in lockstep with stage.render().  The code also includes various changes related to ticks_per_second and related constants, throughout a number of files.  The code also moves the ticks_per_second constants into framework.h, in order to allow the state update loop to run on a ticks_per_second basis.  This assumes a 1:1 correspondence between in-game seconds at the slowest speed and real-time seconds.  Later, we might consider moving the time constants back into gametime.h and having a single number that is ticks per real second (or something), as well as ticks_per_sim_second, with a relation between the two.

Re the change to doodad, it now has a magic number which is bad.  I'm not sure what it should be, though...  It was originally ticks_multiplier, which I thought I knew what it meant but now I'm not so sure.