### PR TITLE
Prevent rescuing vehicles not visible on the map

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1362,19 +1362,8 @@ void Vehicle::enterBuilding(GameState &state, StateRef<Building> b)
 	crashed = false;
 	if (this->currentBuilding)
 	{
-		// eveluate if tgt building is same as building currently located
-		if (this->currentBuilding.id.compare(b.id) == 0)
-		{
-			LogError("Vehicle already in a building?");
-			return;
-		}
-		// if not create mission to send vehicle to actual tgt building
-		else
-		{
-			this->addMission(state, VehicleMission::gotoBuilding(state, *this, b));
-			LogWarning("Vehicle was already in a building, rerouting");
-			return;
-		}
+		LogError("Vehicle already in a building?");
+		return;
 	}
 	this->currentBuilding = b;
 	b->currentVehicles.insert({&state, shared_from_this()});

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -2290,7 +2290,10 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						// Recovering crashed non-ufo
 						else
 						{
-							if (targetVehicle->homeBuilding && !targetVehicle->currentBuilding && targetVehicle->tileObject)
+							// Check if vehicle a homebuilding, is not within any building and
+							// visible on the map
+							if (targetVehicle->homeBuilding && !targetVehicle->currentBuilding &&
+							    targetVehicle->tileObject)
 							{
 								auto target = targetVehicle;
 								v.addMission(state, VehicleMission::gotoBuilding(

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -2290,7 +2290,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 						// Recovering crashed non-ufo
 						else
 						{
-							if (targetVehicle->homeBuilding)
+							if (targetVehicle->homeBuilding && !targetVehicle->currentBuilding && targetVehicle->tileObject)
 							{
 								auto target = targetVehicle;
 								v.addMission(state, VehicleMission::gotoBuilding(


### PR DESCRIPTION
Fix #1168 
Reverted changes from PR #1169 and added check if a vehicle to be rescued is visible on the map and not within a building. If so the vehicle to be rescued will die and not rescued. Prevents errors observed. Add. might only be an issue when using a savegame created w/ earlier versions, still has to be confirmed by OG Bug Reporter