### PR TITLE
Fix CTD when selecting X-Com Vehicle Tab

### DIFF
--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -155,6 +155,10 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 		t.headedHome = v->missions.back().targetBuilding == v->homeBuilding ||
 		               v->missions.back().type == VehicleMission::MissionType::OfferService;
 	}
+	else
+	{
+		t.headedHome = false;
+	}
 
 	auto b = v->currentBuilding;
 	if (b)

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -150,11 +150,11 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 	// Faded if in other dimension or if haven't left dimension gate yet
 	t.faded = v->city != state.current_city || (!v->tileObject && !v->currentBuilding);
 	// Headed home if we have a mission and it's to our home building
-	//if (!v->missions.empty())
-	//{
+	if (!v->missions.empty())
+	{
 		t.headedHome = v->missions.back().targetBuilding == v->homeBuilding ||
 		               v->missions.back().type == VehicleMission::MissionType::OfferService;
-	//}
+	}
 
 	auto b = v->currentBuilding;
 	if (b)

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -150,8 +150,11 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 	// Faded if in other dimension or if haven't left dimension gate yet
 	t.faded = v->city != state.current_city || (!v->tileObject && !v->currentBuilding);
 	// Headed home if we have a mission and it's to our home building
-	t.headedHome = v->missions.back().targetBuilding == v->homeBuilding ||
-	               v->missions.back().type == VehicleMission::MissionType::OfferService;
+	//if (!v->missions.empty())
+	//{
+		t.headedHome = v->missions.back().targetBuilding == v->homeBuilding ||
+		               v->missions.back().type == VehicleMission::MissionType::OfferService;
+	//}
 
 	auto b = v->currentBuilding;
 	if (b)


### PR DESCRIPTION
Fix #1171 the CDT part but now the UI incorrectly displays two green "X"'s instead of One.
![image](https://user-images.githubusercontent.com/15697480/232318380-c5b17532-d052-483d-887a-fdc1bceed268.png)

Maybe @Kurtsley could have a look into this