### PR TITLE
Fix agents on init

### DIFF
--- a/data/common_patch/gamestate.xml
+++ b/data/common_patch/gamestate.xml
@@ -95,8 +95,7 @@
   <initial_agents>
     <entry>
       <key>Soldier</key>
-      <!-- Should be 10 -->
-      <value>12</value>
+      <value>10</value>
     </entry>
     <entry>
       <key>Physicist</key>

--- a/data/common_patch/gamestate/agent_types.xml
+++ b/data/common_patch/gamestate/agent_types.xml
@@ -537,6 +537,7 @@
 	  <canTrain>true</canTrain>
       <immuneToBrainsuckers>false</immuneToBrainsuckers>
       <playable>true</playable>
+      <availableAtTheGameStart>true</availableAtTheGameStart>
       <allowsDirectControl>true</allowsDirectControl>
       <aiType>Group</aiType>
       <equipment_layout>AGENTEQUIPMENTLAYOUT_FULL</equipment_layout>

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -717,7 +717,7 @@ void GameState::fillPlayerStartingProperty()
 		auto it = initial_agent_equipment.begin();
 		while (count > 0)
 		{
-			auto agent = this->agent_generator.createAgent(*this, this->getPlayer(), type);
+			auto agent = this->agent_generator.createInitAgent(*this, this->getPlayer(), type);
 			if (agent->type->canTrain)
 			{
 				agent->trainingAssignment = agent->initial_stats.psi_energy > 30

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -138,6 +138,7 @@
 		<member>improvementPercentagePsi</member>
 		<member>canTrain</member>
 		<member>playable</member>
+		<member>availableAtTheGameStart</member>
 		<member>allowsDirectControl</member>
 		<member>aiType</member>
 		<member>immuneToFatalWounds</member>

--- a/game/state/rules/agenttype.h
+++ b/game/state/rules/agenttype.h
@@ -191,6 +191,7 @@ class AgentType : public StateObject<AgentType>
 	bool immuneToBrainsuckers = false;
 	// Can this be generated for the player
 	bool playable = false;
+	bool availableAtTheGameStart = false;
 	// Can this be controlled by a player (if false, even when control is gained, AI will act)
 	// For example, X-Com base turrets behave this way (yours, give you sight, but can't control)
 	bool allowsDirectControl = false;

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -60,7 +60,7 @@ template <> const UString &StateObject<Agent>::getId(const GameState &state, con
 }
 
 StateRef<Agent> AgentGenerator::createInitAgent(GameState &state, StateRef<Organisation> org,
-                                            AgentType::Role role) const
+                                                AgentType::Role role) const
 {
 	std::list<sp<AgentType>> types;
 	for (auto &t : state.agent_types)

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -59,6 +59,18 @@ template <> const UString &StateObject<Agent>::getId(const GameState &state, con
 	return emptyString;
 }
 
+StateRef<Agent> AgentGenerator::createInitAgent(GameState &state, StateRef<Organisation> org,
+                                            AgentType::Role role) const
+{
+	std::list<sp<AgentType>> types;
+	for (auto &t : state.agent_types)
+		if (t.second->role == role && t.second->playable && t.second->availableAtTheGameStart)
+			types.insert(types.begin(), t.second);
+	auto type = pickRandom(state.rng, types);
+
+	return createAgent(state, org, {&state, AgentType::getId(state, type)});
+}
+
 StateRef<Agent> AgentGenerator::createAgent(GameState &state, StateRef<Organisation> org,
                                             AgentType::Role role) const
 {

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -246,7 +246,7 @@ class AgentGenerator
 
 	// Create an agent of specified role available at the beginning of the game
 	StateRef<Agent> createInitAgent(GameState &state, StateRef<Organisation> org,
-	                            AgentType::Role role) const;
+	                                AgentType::Role role) const;
 	// Create an agent of specified role
 	StateRef<Agent> createAgent(GameState &state, StateRef<Organisation> org,
 	                            AgentType::Role role) const;

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -244,6 +244,9 @@ class AgentGenerator
 	std::map<AgentType::Gender, std::list<UString>> first_names;
 	std::list<UString> second_names;
 
+	// Create an agent of specified role available at the beginning of the game
+	StateRef<Agent> createInitAgent(GameState &state, StateRef<Organisation> org,
+	                            AgentType::Role role) const;
 	// Create an agent of specified role
 	StateRef<Agent> createAgent(GameState &state, StateRef<Organisation> org,
 	                            AgentType::Role role) const;

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1374,11 +1374,15 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  auto a = this->state->current_city->cityViewSelectedAgents.front();
-		                  // Don't return to base if in a vehicle
-		                  if (!a->currentVehicle)
+		                  if (!this->state->current_city->cityViewSelectedAgents.empty())
 		                  {
-			                  orderGoToBase();
+
+			                  auto a = this->state->current_city->cityViewSelectedAgents.front();
+			                  // Don't return to base if in a vehicle
+			                  if (!a->currentVehicle)
+			                  {
+				                  orderGoToBase();
+			                  }
 		                  }
 	                  });
 	agentForm->findControl("BUTTON_AGENT_PHYSICAL")

--- a/tools/extractors/extract_agent_types.cpp
+++ b/tools/extractors/extract_agent_types.cpp
@@ -165,14 +165,17 @@ void InitialGameStateExtractor::extractAgentTypes(GameState &state) const
 			case UNIT_TYPE_BIOCHEMIST:
 				a->role = AgentType::Role::BioChemist;
 				a->playable = true;
+				a->availableAtTheGameStart = true;
 				break;
 			case UNIT_TYPE_ENGINEER:
 				a->role = AgentType::Role::Engineer;
 				a->playable = true;
+				a->availableAtTheGameStart = true;
 				break;
 			case UNIT_TYPE_QUANTUM_PHYSIST:
 				a->role = AgentType::Role::Physicist;
 				a->playable = true;
+				a->availableAtTheGameStart = true;
 				break;
 			default:
 				a->role = AgentType::Role::Soldier;


### PR DESCRIPTION
This MR solves issues #1110  and #573 

- back to former 10 soldiers at the new game start (no missing equipment for soldiers #573)
- only humans as soldiers at the new game start (like in OG - solves #1110 