### PR TITLE
Fix multi-line messages being cut-off

### DIFF
--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -62,7 +62,7 @@ void ListBox::onRender()
 				{
 					case Orientation::Vertical:
 						ctrl->Size.x = (scroller_is_internal ? scroller->Location.x : this->Size.x);
-						ctrl->Size.y = ItemSize;
+						ctrl->Size.y;
 						break;
 					case Orientation::Horizontal:
 						ctrl->Size.x = ItemSize;
@@ -202,15 +202,8 @@ void ListBox::update()
 		{
 			case Orientation::Vertical:
 			{
-				if (ItemSize == 0)
-				{
-					for (const auto &i : Controls)
-						scrollerLength += i->Size.y;
-				}
-				else
-				{
-					scrollerLength += Controls.size() * ItemSize;
-				}
+				for (const auto &i : Controls)
+					scrollerLength += i->Size.y;
 				scrollerLength = scrollerLength > Size.y ? scrollerLength - Size.y : 0;
 				break;
 			}

--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -71,7 +71,7 @@ sp<Control> MessageLogScreen::createMessageRow(EventMessage message,
 {
 	auto control = mksp<Control>();
 
-	const int HEIGHT = 21;
+	int HEIGHT = message.text.size() > 55 ? 44 : 21;
 
 	auto date =
 	    control->createChild<Label>(message.time.getShortDateString(), ui().getFont("smalfont"));
@@ -95,11 +95,14 @@ sp<Control> MessageLogScreen::createMessageRow(EventMessage message,
 		auto btnImage = fw().data->loadImage(
 		    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:57:ui/menuopt.pal");
 		auto btnLocation = control->createChild<GraphicButton>(btnImage, btnImage);
-		btnLocation->Location = text->Location + Vec2<int>{text->Size.x, 0};
-		btnLocation->Size = {22, HEIGHT};
+		btnLocation->Location = message.text.size() > 55
+		                            ? text->Location + Vec2<int>{text->Size.x, HEIGHT / 4}
+		                            : text->Location + Vec2<int>{text->Size.x, 0};
+		btnLocation->Size = {22, 21};
 		btnLocation->addCallback(FormEventType::ButtonClick, callback);
 	}
 
+	control->Size.y = HEIGHT;
 	return control;
 }
 


### PR DESCRIPTION
Addresses #1131.

This is the solution that I have come up with so far, but I would like to get some feedback. The ideal solution would be to figure out a way to do this without editing the listbox file. While I haven't found any obvious bugs or changes to the game, editing this file opens up a can of worms that I feel needs more testing. 

Here are the changes:

---
```
	case Orientation::Vertical:
		ctrl->Size.x = (scroller_is_internal ? scroller->Location.x : this->Size.x);
		ctrl->Size.y;
		break;
```
In the listbox.cpp file, this section renders the individual items in the list. In the vertical orientation, this set the y value of the items to a variable called ItemSize. The entire point of this is to be able to have multiple items of different sizes in a listbox, attaching the ItemSize variable to the y value of the list items made this impossible in my view. This became clear when changing the ItemSize value in the messagelogscreen.cpp file. Even in a loop like so:
```
	auto listbox = menuform->findControlTyped<ListBox>("LISTBOX_MESSAGES");
	for (EventMessage message : state->messages)
	{
                ItemSize = HEIGHT;
		listbox->addItem(createMessageRow(message, state, cityView));
	}
```
This is just a rough example of what was tried, the point is I tried to change the ItemSize value while looping through each message. The result was not correct, whatever value was last, e.g. a value of 44 for the double size message, was the item size for the entire message history list. Since the listbox is rendering every item according to the ItemSize value, having multiple sized items did not work. 

Update func:
```
		if (ItemSize == 0)
		{
			for (const auto &i : Controls)
				scrollerLength += i->Size.y;
		}
		else
		{
			scrollerLength += Controls.size() * ItemSize;
		}
```
In the update function of the listbox.cpp file, this code determines the total length of the scroller. There is even a helpful comment:
```
// assume item sizes are variable if ItemSize is 0 (ie: need to calculate manually)
```
In my experience, if the ItemSize is set to 0, nothing shows up in the list. I'm not sure where this is used, so I changed it to calculate by Size.y every time. Without this change, the scroller size was not correct.

The messagelogscreen.cpp changes are more straightforward. The HEIGHT variable is changed depending on the size of the message.text string. There should be a better way to do this as I picked 55 through trial and error. Maybe some way to tell if the string has wrapped to the next line. The location button location is also changed depending on if the message.text string size is over 55. The important part is last, the size of the control is changed to the HEIGHT value. Since the listbox is rendering each item according to the ctrl->Size.y value, each item can be a different size in the list.

As stated earlier, I have not noticed any problems with any other vertical list in the game. That being said, I haven't played the game very much.

Sorry for the rant. Comments are appreciated!