### PR TITLE
Entry Point for #1141

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -10,6 +10,11 @@ assignees: ''
 **BEFORE POSTING, HAVE YOU SEARCHED THE TRACKER FOR EXISTING COPIES OF THE PROBLEM?**
 If so, please add the following details to those existing reports. Use broad phrases and keywords when searching for maximal results - not all related issues may use the same terminology as you
 
+**Desktop (please complete the following information):**
+ - OS: [e.g. Windows 10 x64 2020H2]
+ - OpenApoc Version [e.g. 0.386-42 - the number attached to the AppVeyor build]
+ - List of Mod files in use *and their version* separated by commas [e.g. Extended Weapons Mod v9.0I PREVIEW, Falcon LWP Mod v1.4]
+
 **Describe the bug**
 A clear and concise description of what the bug is.
 
@@ -29,10 +34,6 @@ Save's can be found under the appropriate directory of the route folder where yo
 
 **Screenshots**
 If applicable, add screenshots to help explain your problem. GitHub supports direct pasting if necessary.
-
-**Desktop (please complete the following information):**
- - OS: [e.g. Windows 10 x64 2020H2]
- - OpenApoc Version [e.g. 0.386-42 - the number attached to the AppVeyor build]
 
 **Additional context**
 Add any other context about the problem here.

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -62,7 +62,7 @@ void ListBox::onRender()
 				{
 					case Orientation::Vertical:
 						ctrl->Size.x = (scroller_is_internal ? scroller->Location.x : this->Size.x);
-						ctrl->Size.y = ItemSize;
+						ctrl->Size.y;
 						break;
 					case Orientation::Horizontal:
 						ctrl->Size.x = ItemSize;
@@ -202,15 +202,8 @@ void ListBox::update()
 		{
 			case Orientation::Vertical:
 			{
-				if (ItemSize == 0)
-				{
-					for (const auto &i : Controls)
-						scrollerLength += i->Size.y;
-				}
-				else
-				{
-					scrollerLength += Controls.size() * ItemSize;
-				}
+				for (const auto &i : Controls)
+					scrollerLength += i->Size.y;
 				scrollerLength = scrollerLength > Size.y ? scrollerLength - Size.y : 0;
 				break;
 			}

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -482,6 +482,7 @@ void City::repairScenery(GameState &state)
 			}
 		}
 
+
 		// check if sufficient funds are available
 		auto initialType = initial_tiles[lowestLevel.get()->initialPosition];
 		auto owner = lowestLevel->building && !initialType->commonProperty

--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -471,44 +471,36 @@ void City::repairScenery(GameState &state)
 				} // for every supportedBy position
 			}     // for every repairedTogether scenery
 		} while (addedMore);
-		// Try to repair all or none
-		std::map<StateRef<Organisation>, int> repairCost;
-		for (auto &deadScenery : repairedTogether)
+
+		// find lowest part of scenery column which needs to be repaired
+		sp<OpenApoc::Scenery> lowestLevel = NULL;
+		for (auto &s : repairedTogether)
 		{
-			auto initialType = initial_tiles[deadScenery->initialPosition];
-			auto owner = deadScenery->building && !initialType->commonProperty
-			                 ? deadScenery->building->owner
-			                 : state.getGovernment();
-			repairCost[owner] += initialType->value;
-		}
-		bool canAfford = true;
-		for (auto &entry : repairCost)
-		{
-			if (entry.first->balance < entry.second)
+			if (lowestLevel == NULL || lowestLevel->currentPosition.z > s->currentPosition.z)
 			{
-				canAfford = false;
-				break;
+				lowestLevel = s;
 			}
 		}
-		if (canAfford)
+
+		// check if sufficient funds are available
+		auto initialType = initial_tiles[lowestLevel.get()->initialPosition];
+		auto owner = lowestLevel->building && !initialType->commonProperty
+		                 ? lowestLevel.get()->building->owner
+		                 : state.getGovernment();
+		if (owner->balance < initialType->value)
+		{
+			break;
+		}
+		else
 		{
 			// pay
-			for (auto &entry : repairCost)
-			{
-				auto org = entry.first;
-				org->balance -= entry.second;
-			}
+			owner->balance -= initialType->value;
 			// repair
-			for (auto &deadScenery : repairedTogether)
-			{
-				// remove from scenery to repair
-				if (sceneryToRepair.find(deadScenery) != sceneryToRepair.end())
-				{
-					sceneryToRepair.erase(deadScenery);
-				}
-				// repair actually
-				deadScenery->repair(state);
-			}
+			lowestLevel->repair(state);
+			// delete out of list to prevent repairing again
+			auto pointer = sceneryToRepair.find(lowestLevel);
+			if (sceneryToRepair.end() != pointer)
+				sceneryToRepair.erase(pointer);
 		}
 	}
 }

--- a/game/ui/general/messagelogscreen.cpp
+++ b/game/ui/general/messagelogscreen.cpp
@@ -71,7 +71,7 @@ sp<Control> MessageLogScreen::createMessageRow(EventMessage message,
 {
 	auto control = mksp<Control>();
 
-	const int HEIGHT = 21;
+	int HEIGHT = message.text.size() > 55 ? 44 : 21;
 
 	auto date =
 	    control->createChild<Label>(message.time.getShortDateString(), ui().getFont("smalfont"));
@@ -95,11 +95,14 @@ sp<Control> MessageLogScreen::createMessageRow(EventMessage message,
 		auto btnImage = fw().data->loadImage(
 		    "PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:57:ui/menuopt.pal");
 		auto btnLocation = control->createChild<GraphicButton>(btnImage, btnImage);
-		btnLocation->Location = text->Location + Vec2<int>{text->Size.x, 0};
-		btnLocation->Size = {22, HEIGHT};
+		btnLocation->Location = message.text.size() > 55
+		                            ? text->Location + Vec2<int>{text->Size.x, HEIGHT / 4}
+		                            : text->Location + Vec2<int>{text->Size.x, 0};
+		btnLocation->Size = {22, 21};
 		btnLocation->addCallback(FormEventType::ButtonClick, callback);
 	}
 
+	control->Size.y = HEIGHT;
 	return control;
 }
 


### PR DESCRIPTION
This is the initial Entry Point for the Incremental Repair of the Cityscape as mentioned in issue #1141 going from fixing als Blocks of a Building at once per night, it will now only repair one single level per night (as per [UFOPaedia](https://www.ufopaedia.org/index.php/Talk:Organizations#Alliance_effects)) to create some sort of incremental repair effect.
Next Step will be to research the repair strategy used by the OG Game and implement it step by step plus add. further improvements as mentioned by @FilmBoy84 in #1141 