### PR TITLE
Fix gap between name and skill

### DIFF
--- a/data/forms/aequipscreen.form
+++ b/data/forms/aequipscreen.form
@@ -84,7 +84,7 @@
       </scroll>
       <listbox id="AGENT_SELECT_BOX" scrollbarid="AGENT_SELECT_SCROLL">
         <position x="463" y="70"/>
-        <size width="98" height="260"/>
+        <size width="96" height="260"/>
         <item size="0" spacing="5"/>
         <hovercolour r="255" g="255" b="255" a="0"/>
         <selcolour r="255" g="255" b="255" a="0"/>

--- a/data/forms/recruitscreen.form
+++ b/data/forms/recruitscreen.form
@@ -152,7 +152,7 @@
       </graphicbutton>
       <listbox id="LIST1" scrollbarid="LIST1_SCROLL">
         <position x="259" y="76"/>
-        <size width="121" height="389"/>
+        <size width="96" height="389"/>
         <orientation>vertical</orientation>
         <item size="0" spacing="2"/>
         <hovercolour r="255" g="255" b="255" a="255"/>
@@ -178,7 +178,7 @@
       </graphicbutton>
       <listbox id="LIST2" scrollbarid="LIST2_SCROLL">
         <position x="460" y="76"/>
-        <size width="105" height="389"/>
+        <size width="96" height="389"/>
         <orientation>vertical</orientation>
         <item size="0" spacing="2"/>
         <hovercolour r="255" g="255" b="255" a="255"/>

--- a/data/forms/researchscreen.form
+++ b/data/forms/researchscreen.form
@@ -187,7 +187,7 @@
       </graphicbutton>
       <listbox id="LIST_UNASSIGNED" scrollbarid="LIST_UNASSIGNED_SCROLL">
         <position x="20" y="183"/>
-        <size height="256" width="128"/>
+        <size height="256" width="96"/>
         <orientation>vertical</orientation>
         <hovercolour r="255" g="255" b="255" a="255"/>
         <autoselect>no</autoselect>


### PR DESCRIPTION
This addresses an issue that has been bothering me where the agent and scientist names have inconsistent spacing. 

![name2](https://user-images.githubusercontent.com/73447098/233537122-54faa194-7d90-4713-967d-a7ef21308142.png)
The research screen shows this problem.

My first idea was to simply insert a newline between the agent's first and last name upon creation:
```
agent->name = format("%s\n%s", firstName, secondName);
```

This worked, however a logwarning message was thrown each time a name was hovered:
![name3](https://user-images.githubusercontent.com/73447098/233537126-1f0d77c8-d085-41c5-8307-8c48c7bee1ad.png)

Not wanting to deal with that problem (if it is an actual problem) I simply changed the forms to shrink the width of the lists containing the names. This solves the problem, although I haven't seen every possible name combination, and does not have a negative impact on gameplay. You don't notice the smaller width because you always click directly on or very near the agent.

After:
![name1](https://user-images.githubusercontent.com/73447098/233537129-989cedb5-f7ee-4293-be7e-54c71e7800f7.png)

Note: This does not do any favors to the longer names in the weapons mod. There is very little room to work with, especially in the right side list of the recruit screen. The newline solution would work better for this because the forms could be widened to fit the longer last names. If the total length of a name gets too long, it will simply continue off the form and disappear. Even if the forms were widened to the max amount, it would be difficult to fit long names on the recruit screen as mentioned earlier. 
Unfortunately there may have to be a limit to the total name length based on the available space.
