### PR TITLE
fix to listbox.cpp error

### DIFF
--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -62,7 +62,7 @@ void ListBox::onRender()
 				{
 					case Orientation::Vertical:
 						ctrl->Size.x = (scroller_is_internal ? scroller->Location.x : this->Size.x);
-						ctrl->Size.y;
+						ctrl->Size.y = ItemSize;
 						break;
 					case Orientation::Horizontal:
 						ctrl->Size.x = ItemSize;


### PR DESCRIPTION
On the previous version of master, I could not enter any skirmishes as the list of maps was empty.  This pull request fixes an error in listbox.cpp that was introduced in the last merge into master.  That previous merge had changed the line
> ctrl->Size.y = ItemSize;
to
> ctrl->Size.y;
but this second version doesn't do anything, so I reverted it back.  After this change, I can again enter skirmish mode.