### PR TITLE
Fix skirmish mode map list

### DIFF
--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -62,7 +62,7 @@ void ListBox::onRender()
 				{
 					case Orientation::Vertical:
 						ctrl->Size.x = (scroller_is_internal ? scroller->Location.x : this->Size.x);
-						ctrl->Size.y = ItemSize;
+						ctrl->Size.y;
 						break;
 					case Orientation::Horizontal:
 						ctrl->Size.x = ItemSize;

--- a/game/ui/general/optionsmenu.cpp
+++ b/game/ui/general/optionsmenu.cpp
@@ -54,6 +54,7 @@ sp<Control> OptionsMenu::createOptionRow(const ConfigOption &option)
 	control->ToolTipText = option.getDescription();
 	control->ToolTipFont = ui().getFont("smallset");
 
+	control->Size.y = HEIGHT;
 	return control;
 }
 

--- a/game/ui/skirmish/mapselector.cpp
+++ b/game/ui/skirmish/mapselector.cpp
@@ -73,12 +73,15 @@ sp<Control> MapSelector::createMapRowBuilding(StateRef<Building> building, sp<Ga
 		auto btnLocation = control->createChild<GraphicButton>(btnImage, btnImage);
 		btnLocation->Location = text->Location + Vec2<int>{text->Size.x, 0};
 		btnLocation->Size = {22, HEIGHT};
-		btnLocation->addCallback(FormEventType::ButtonClick, [building, state, this](Event *) {
-			skirmish.setLocation(building);
-			fw().stageQueueCommand({StageCmd::Command::POP});
-		});
+		btnLocation->addCallback(FormEventType::ButtonClick,
+		                         [building, state, this](Event *)
+		                         {
+			                         skirmish.setLocation(building);
+			                         fw().stageQueueCommand({StageCmd::Command::POP});
+		                         });
 	}
 
+	control->Size.y = HEIGHT;
 	return control;
 }
 
@@ -100,12 +103,15 @@ sp<Control> MapSelector::createMapRowVehicle(StateRef<VehicleType> vehicle, sp<G
 		auto btnLocation = control->createChild<GraphicButton>(btnImage, btnImage);
 		btnLocation->Location = text->Location + Vec2<int>{text->Size.x, 0};
 		btnLocation->Size = {22, HEIGHT};
-		btnLocation->addCallback(FormEventType::ButtonClick, [vehicle, state, this](Event *) {
-			skirmish.setLocation(vehicle);
-			fw().stageQueueCommand({StageCmd::Command::POP});
-		});
+		btnLocation->addCallback(FormEventType::ButtonClick,
+		                         [vehicle, state, this](Event *)
+		                         {
+			                         skirmish.setLocation(vehicle);
+			                         fw().stageQueueCommand({StageCmd::Command::POP});
+		                         });
 	}
 
+	control->Size.y = HEIGHT;
 	return control;
 }
 
@@ -127,12 +133,15 @@ sp<Control> MapSelector::createMapRowBase(StateRef<Base> base, sp<GameState> sta
 		auto btnLocation = control->createChild<GraphicButton>(btnImage, btnImage);
 		btnLocation->Location = text->Location + Vec2<int>{text->Size.x, 0};
 		btnLocation->Size = {22, HEIGHT};
-		btnLocation->addCallback(FormEventType::ButtonClick, [base, state, this](Event *) {
-			skirmish.setLocation(base);
-			fw().stageQueueCommand({StageCmd::Command::POP});
-		});
+		btnLocation->addCallback(FormEventType::ButtonClick,
+		                         [base, state, this](Event *)
+		                         {
+			                         skirmish.setLocation(base);
+			                         fw().stageQueueCommand({StageCmd::Command::POP});
+		                         });
 	}
 
+	control->Size.y = HEIGHT;
 	return control;
 }
 


### PR DESCRIPTION
Since the latest merge broke the multi line history message I figured I'd fix up what I missed. This removes the ItemSize again and fixes the problem with the skirmish map selector not showing up. It also takes care of items in the now defunct options menu not appearing. Apologies for not catching this earlier, all instances of listbox should now be taken care of.