### PR TITLE
Empty base will now be destroyed with message

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -74,7 +74,6 @@ void dumpOptionsToLog()
 	dumpOption(optionPauseOnVehicleRefuelled);
 	dumpOption(optionPauseOnNotEnoughFuel);
 	dumpOption(optionPauseOnUnauthorizedVehicle);
-	dumpOption(optionPauseOnBaseDestroyed);
 	dumpOption(optionPauseOnHostileSpotted);
 	dumpOption(optionPauseOnHostileDied);
 	dumpOption(optionPauseOnUnknownDied);
@@ -292,9 +291,6 @@ ConfigOptionBool optionPauseOnNotEnoughFuel("Notifications.City", "NotEnoughFuel
                                             "Not enough fuel to refuel vehicle", true);
 ConfigOptionBool optionPauseOnUnauthorizedVehicle("Notifications.City", "UnauthorizedVehicle",
                                                   "Unauthorized vehicle detected", true);
-ConfigOptionBool optionPauseOnBaseDestroyed("Notifications.City", "BaseDestroyed",
-                                            "X-COM base destroyed by hostile forces.", true);
-
 ConfigOptionBool optionPauseOnHostileSpotted("Notifications.Battle", "HostileSpotted",
                                              "Hostile unit spotted", true);
 ConfigOptionBool optionPauseOnHostileDied("Notifications.Battle", "HostileDied",

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -74,6 +74,7 @@ void dumpOptionsToLog()
 	dumpOption(optionPauseOnVehicleRefuelled);
 	dumpOption(optionPauseOnNotEnoughFuel);
 	dumpOption(optionPauseOnUnauthorizedVehicle);
+	dumpOption(optionPauseOnBaseDestroyed);
 	dumpOption(optionPauseOnHostileSpotted);
 	dumpOption(optionPauseOnHostileDied);
 	dumpOption(optionPauseOnUnknownDied);
@@ -291,6 +292,9 @@ ConfigOptionBool optionPauseOnNotEnoughFuel("Notifications.City", "NotEnoughFuel
                                             "Not enough fuel to refuel vehicle", true);
 ConfigOptionBool optionPauseOnUnauthorizedVehicle("Notifications.City", "UnauthorizedVehicle",
                                                   "Unauthorized vehicle detected", true);
+ConfigOptionBool optionPauseOnBaseDestroyed("Notifications.City", "BaseDestroyed",
+                                            "X-COM base destroyed by hostile forces.", true);
+
 ConfigOptionBool optionPauseOnHostileSpotted("Notifications.Battle", "HostileSpotted",
                                              "Hostile unit spotted", true);
 ConfigOptionBool optionPauseOnHostileDied("Notifications.Battle", "HostileDied",

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -74,6 +74,7 @@ void dumpOptionsToLog()
 	dumpOption(optionPauseOnVehicleRefuelled);
 	dumpOption(optionPauseOnNotEnoughFuel);
 	dumpOption(optionPauseOnUnauthorizedVehicle);
+	dumpOption(optionPauseOnBaseDestroyed);
 	dumpOption(optionPauseOnHostileSpotted);
 	dumpOption(optionPauseOnHostileDied);
 	dumpOption(optionPauseOnUnknownDied);
@@ -291,6 +292,8 @@ ConfigOptionBool optionPauseOnNotEnoughFuel("Notifications.City", "NotEnoughFuel
                                             "Not enough fuel to refuel vehicle", true);
 ConfigOptionBool optionPauseOnUnauthorizedVehicle("Notifications.City", "UnauthorizedVehicle",
                                                   "Unauthorized vehicle detected", true);
+ConfigOptionBool optionPauseOnBaseDestroyed("Notifications.City", "BaseDestroyed",
+                                            "X-COM base destroyed by hostile forces.", true);
 ConfigOptionBool optionPauseOnHostileSpotted("Notifications.Battle", "HostileSpotted",
                                              "Hostile unit spotted", true);
 ConfigOptionBool optionPauseOnHostileDied("Notifications.Battle", "HostileDied",

--- a/framework/options.h
+++ b/framework/options.h
@@ -52,6 +52,7 @@ extern ConfigOptionBool optionPauseOnNotEnoughAmmo;
 extern ConfigOptionBool optionPauseOnVehicleRefuelled;
 extern ConfigOptionBool optionPauseOnNotEnoughFuel;
 extern ConfigOptionBool optionPauseOnUnauthorizedVehicle;
+extern ConfigOptionBool optionPauseOnBaseDestroyed;
 extern ConfigOptionBool optionPauseOnHostileSpotted;
 extern ConfigOptionBool optionPauseOnHostileDied;
 extern ConfigOptionBool optionPauseOnUnknownDied;

--- a/framework/options.h
+++ b/framework/options.h
@@ -52,7 +52,6 @@ extern ConfigOptionBool optionPauseOnNotEnoughAmmo;
 extern ConfigOptionBool optionPauseOnVehicleRefuelled;
 extern ConfigOptionBool optionPauseOnNotEnoughFuel;
 extern ConfigOptionBool optionPauseOnUnauthorizedVehicle;
-extern ConfigOptionBool optionPauseOnBaseDestroyed;
 extern ConfigOptionBool optionPauseOnHostileSpotted;
 extern ConfigOptionBool optionPauseOnHostileDied;
 extern ConfigOptionBool optionPauseOnUnknownDied;

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -13,7 +13,6 @@
 #include "game/state/rules/city/vequipmenttype.h"
 #include "game/state/shared/organisation.h"
 #include "library/strings_format.h"
-#include <game/ui/general/messagebox.h>
 #include <random>
 
 namespace OpenApoc
@@ -83,11 +82,6 @@ void Base::die(GameState &state, bool collapse)
 	fw().pushEvent(new GameSomethingDiedEvent(
 	    GameEventType::BaseDestroyed, name,
 	    collapse ? /*by collapsing building*/ "" : "byEnemyForces", building->crewQuarters));
-
-	auto message_box =
-	    mksp<MessageBox>(format("%s", name), tr("X-COM base destroyed by hostile forces."),
-	                     MessageBox::ButtonOptions::Ok);
-	fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 
 	for (auto &b : building->city->buildings)
 	{

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -13,6 +13,7 @@
 #include "game/state/rules/city/vequipmenttype.h"
 #include "game/state/shared/organisation.h"
 #include "library/strings_format.h"
+#include <game/ui/general/messagebox.h>
 #include <random>
 
 namespace OpenApoc
@@ -82,6 +83,12 @@ void Base::die(GameState &state, bool collapse)
 	fw().pushEvent(new GameSomethingDiedEvent(
 	    GameEventType::BaseDestroyed, name,
 	    collapse ? /*by collapsing building*/ "" : "byEnemyForces", building->crewQuarters));
+
+	auto message_box =
+	    mksp<MessageBox>(format("%s", name), tr("X-COM base destroyed by hostile forces."),
+	                     MessageBox::ButtonOptions::Ok);
+	fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+
 	for (auto &b : building->city->buildings)
 	{
 		for (auto &c : b.second->cargo)

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -817,7 +817,7 @@ void Building::detect(GameState &state, bool forced)
 	ticksDetectionTimeOut = TICKS_DETECTION_TIMEOUT;
 	if (base)
 	{
-		if (base->building->currentAgents.empty())
+		if (!base->building->occupied())
 		{
 			base->die(state, false);
 		}
@@ -968,7 +968,7 @@ void Building::alienMovement(GameState &state)
 	if (bld->base)
 	{
 		// Destroy base if its empty
-		if (bld->currentAgents.empty())
+		if (!bld->occupied())
 		{
 			bld->base->die(state, false);
 		}
@@ -1076,6 +1076,25 @@ int Building::getAverageConstitution() const
 		}
 	}
 	return (relevantTiles > 0) ? totalConst / relevantTiles : 0;
+}
+
+bool Building::occupied() const
+{
+	if (!this->currentAgents.empty())
+	{
+		return true;
+	}
+	if (!this->currentVehicles.empty())
+	{
+		for (auto &v : this->currentVehicles)
+		{
+			if (!v->currentAgents.empty())
+			{
+				return true;
+			}
+		}
+	}
+	return false;
 }
 
 bool Building::isAlive() const { return countActiveTiles() > 0; }

--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -817,7 +817,15 @@ void Building::detect(GameState &state, bool forced)
 	ticksDetectionTimeOut = TICKS_DETECTION_TIMEOUT;
 	if (base)
 	{
-		fw().pushEvent(new GameDefenseEvent(GameEventType::DefendTheBase, base, state.getAliens()));
+		if (base->building->currentAgents.empty())
+		{
+			base->die(state, false);
+		}
+		else
+		{
+			fw().pushEvent(
+			    new GameDefenseEvent(GameEventType::DefendTheBase, base, state.getAliens()));
+		}
 	}
 	else
 	{

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -108,6 +108,7 @@ class Building : public StateObject<Building>, public std::enable_shared_from_th
 	void buildingPartChange(GameState &state, Vec3<int> part, bool intact);
 	int getAverageConstitution() const;
 	bool isAlive() const;
+	bool occupied() const;
 
 	// Following members are not serialized, but rather are set in City::initCity method
 

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -33,6 +33,7 @@ const std::map<GameEventType, UString> GameEvent::optionsMap = {
     {GameEventType::NotEnoughFuel, "Notifications.City.NotEnoughFuel"},
     {GameEventType::CommenceInvestigation, "Notifications.City.CommenceInvestigation"},
     {GameEventType::UnauthorizedVehicle, "Notifications.City.UnauthorizedVehicle"},
+    {GameEventType::BaseDestroyed, "Notifications.City.BaseDestroyed"},
 
     {GameEventType::HostileSpotted, "Notifications.Battle.HostileSpotted"},
     {GameEventType::HostileDied, "Notifications.Battle.HostileDied"},

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -33,7 +33,6 @@ const std::map<GameEventType, UString> GameEvent::optionsMap = {
     {GameEventType::NotEnoughFuel, "Notifications.City.NotEnoughFuel"},
     {GameEventType::CommenceInvestigation, "Notifications.City.CommenceInvestigation"},
     {GameEventType::UnauthorizedVehicle, "Notifications.City.UnauthorizedVehicle"},
-    {GameEventType::BaseDestroyed, "Notifications.City.BaseDestroyed"},
 
     {GameEventType::HostileSpotted, "Notifications.Battle.HostileSpotted"},
     {GameEventType::HostileDied, "Notifications.Battle.HostileDied"},

--- a/game/state/rules/battle/battlemap.cpp
+++ b/game/state/rules/battle/battlemap.cpp
@@ -204,9 +204,21 @@ sp<Battle> BattleMap::createBattle(GameState &state, StateRef<Organisation> oppo
 
 		// Add combat personnel
 		int playerAgentsCount = 0;
+
+		for (auto &v : base->building->currentVehicles)
+		{
+			for (auto &agent : v->currentAgents)
+			{
+				player_agents.emplace_back(&state, agent);
+				if (++playerAgentsCount >= MAX_UNITS_PER_SIDE)
+				{
+					break;
+				}
+			}
+		}
 		for (auto &agent : state.agents)
 		{
-			if (agent.second->homeBuilding->base != base)
+			if (agent.second->currentBuilding != base->building)
 			{
 				continue;
 			}

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -68,6 +68,7 @@ std::list<std::pair<UString, UString>> cityNotificationList = {
     {"Notifications.City", "VehicleRefuelled"},
     {"Notifications.City", "NotEnoughFuel"},
     {"Notifications.City", "UnauthorizedVehicle"},
+    {"Notifications.City", "BaseDestroyed"},
 };
 
 std::list<std::pair<UString, UString>> openApocList = {

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -68,7 +68,6 @@ std::list<std::pair<UString, UString>> cityNotificationList = {
     {"Notifications.City", "VehicleRefuelled"},
     {"Notifications.City", "NotEnoughFuel"},
     {"Notifications.City", "UnauthorizedVehicle"},
-    {"Notifications.City", "BaseDestroyed"},
 };
 
 std::list<std::pair<UString, UString>> openApocList = {


### PR DESCRIPTION
Partially fixes #1067.

Every case of an empty base being attacked was covered except the case in Building::detect. This adds a check for an empty agent list and automatically destroys the base if true. I also added a city notification to alert the player that the base has been destroyed. I believe this adds the same functionality as the original game.