### PR TITLE
Fix raid vehicle number now variable up to 5

### DIFF
--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -1331,7 +1331,6 @@
 	<object>
 		<name>OrganisationRaid</name>
 		<member>nextRaidTimer</member>
-		<member>attack_vehicle_count</member>
 		<member>attack_vehicle_types</member>
 		<member>neutral_low_manpower</member>
 		<member>neutral_normal</member>

--- a/game/state/rules/city/organisationraid.h
+++ b/game/state/rules/city/organisationraid.h
@@ -23,7 +23,7 @@ class OrganisationRaid
 
 	int nextRaidTimer = 0;
 
-	int attack_vehicle_count = 2;
+	int max_attack_vehicles = 5;
 	std::vector<StateRef<VehicleType>> attack_vehicle_types;
 	std::map<Type, float> neutral_low_manpower;
 	std::map<Type, float> neutral_normal;

--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -14,7 +14,7 @@
 #include "library/strings.h"
 
 // Uncomment to turn off org missions
-//#define DEBUG_TURN_OFF_ORG_MISSIONS
+// #define DEBUG_TURN_OFF_ORG_MISSIONS
 
 namespace OpenApoc
 {
@@ -1074,7 +1074,14 @@ void Organisation::RaidMission::execute(GameState &state, StateRef<City> city,
 			}
 
 			StateRef<Vehicle> firstVehicleSent;
-			int requiredVehicleCount = state.organisation_raid_rules.attack_vehicle_count;
+
+			int requiredVehicleCount =
+			    (owner->buildings.size() + availableVehicles.size() - 1) / owner->buildings.size();
+
+			if (requiredVehicleCount > state.organisation_raid_rules.max_attack_vehicles)
+			{
+				requiredVehicleCount = state.organisation_raid_rules.max_attack_vehicles;
+			}
 
 			// Send vehicles on mission
 			for (auto &type : state.organisation_raid_rules.attack_vehicle_types)


### PR DESCRIPTION
Addresses #999.

This implements the formula layed out in this issue. The vehicle count in a raid is now an orgs number of buildings plus number of vehicles -1 divided by number of buildings. The max amount of vehicles in a raid is 5. As for opening this up to modding, I'm not exactly sure about that process and could use some advice.