### PR TITLE
Fix soldiers can call taxi from alert screen

### DIFF
--- a/game/ui/city/alertscreen.cpp
+++ b/game/ui/city/alertscreen.cpp
@@ -3,6 +3,7 @@
 #include "forms/graphic.h"
 #include "forms/label.h"
 #include "forms/ui.h"
+#include "framework/configfile.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/keycodes.h"
@@ -103,13 +104,15 @@ void AlertScreen::eventOccurred(Event *e)
 			}
 
 			// send agents on foot
+			bool useTaxi = config().getBool("OpenApoc.NewFeature.AllowSoldierTaxiUse");
 			for (auto &agent : agentAssignment->getSelectedAgents())
 			{
 				if (!agent->currentVehicle)
 				{
 					++building->pendingInvestigatorCount;
-					agent->setMission(*state, AgentMission::investigateBuilding(
-					                              *state, *agent, {state.get(), building}));
+					agent->setMission(*state,
+					                  AgentMission::investigateBuilding(
+					                      *state, *agent, {state.get(), building}, false, useTaxi));
 				}
 			}
 

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -616,7 +616,7 @@ void CityView::orderMove(StateRef<Building> building, bool alternative)
 	}
 	if (activeTab == uiTabs[2])
 	{
-		bool useTaxi = alternative && config().getBool("OpenApoc.NewFeature.AllowSoldierTaxiUse");
+		bool useTaxi = !alternative && config().getBool("OpenApoc.NewFeature.AllowSoldierTaxiUse");
 		for (auto &a : this->state->current_city->cityViewSelectedAgents)
 		{
 			if (a->type->role != AgentType::Role::Soldier)


### PR DESCRIPTION
Addresses #1195. 

So this is both an actual problem and a control problem. As for the first part, it was not possible for an agent to call a taxi from the alert screen when clicking on the investigate button. This PR fixes that issue. With the option on, all soldiers will now call a taxi to take them from the base to the target building. The second part was when the soldier was stuck at the building halfway to the target. If you hold either control and click the target building, the soldier will call a taxi. I think this is a bit obscure. Maybe a better option would be to alert the user and give an option to call the taxi from a messagebox? I thought about letting the soldier automatically call a taxi if the option is checked, but this would happen no matter how short the distance to the target and would make no sense in some cases.

Edit: On second read, I may be wrong about the ctrl key. From the controls:
```
Cityscape Mouse:

[Ctrl]
 - when giving move orders to Agents, forces Agents to move on foot (never call a taxi), and allows use of personal teleporter
 - when giving move orders to Vehicles, allows manual use of teleporter
 - when giving attack orders forces Vehicles to attack their target (instead of recovering UFOs or escorting owned vehicles)
 - note that in vanilla, attacking owned vehicles was impossible, as such, a feature toggle is required for it to work (on by default)
```