### PR TITLE
Added the option to select squads with a single click.

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -132,6 +132,7 @@ void dumpOptionsToLog()
 	dumpOption(optionAutoReload);
 	dumpOption(optionLeftClickIcon);
 	dumpOption(optionBattlescapeVertScroll);
+	dumpOption(optionSingleSquadSelect);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -415,6 +416,8 @@ ConfigOptionBool optionLeftClickIcon("OpenApoc.NewFeature", "LeftClickIconEquip"
 ConfigOptionBool optionBattlescapeVertScroll("OpenApoc.NewFeature", "BattlescapeVertScroll",
                                              "Mousewheel changes vertical level in battlescape",
                                              true);
+ConfigOptionBool optionSingleSquadSelect("OpenApoc.NewFeature", "SingleSquadSelect",
+                                         "Select squad with single click", false);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -110,6 +110,7 @@ extern ConfigOptionBool optionSeedRng;
 extern ConfigOptionBool optionAutoReload;
 extern ConfigOptionBool optionLeftClickIcon;
 extern ConfigOptionBool optionBattlescapeVertScroll;
+extern ConfigOptionBool optionSingleSquadSelect;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -109,6 +109,7 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.NewFeature", "AutoReload"},
     {"OpenApoc.NewFeature", "LeftClickIconEquip"},
     {"OpenApoc.NewFeature", "BattlescapeVertScroll"},
+    {"OpenApoc.NewFeature", "SingleSquadSelect"},
 
     {"OpenApoc.Mod", "StunHostileAction"},
     {"OpenApoc.Mod", "RaidHostileAction"},

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -633,6 +633,10 @@ BattleView::BattleView(sp<GameState> gameState)
 				}
 			}
 		}
+		if (config().getBool("OpenApoc.NewFeature.SingleSquadSelect"))
+		{
+			this->battle.battleViewSquadIndex = index;
+		}
 		if (this->battle.battleViewSquadIndex != index)
 		{
 			this->battle.battleViewSquadIndex = index;


### PR DESCRIPTION
Addresses #1208.

Adds the option to select squads with a single click. This not quite what the vanilla game did however... In OG Apoc, clicking a squad with the mouse acted as OpenApoc does now while using the number keys instantly zoomed to the squad. In this case, I felt it wasn't necessary to bring this functionality back as we can have the best of both worlds with the in-game options.