### PR TITLE
Change the cursor to normal when inventory or options menu are opened

### DIFF
--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -958,6 +958,8 @@ BattleView::BattleView(sp<GameState> gameState)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
+		                  selectionState = BattleSelectionState::Normal;
+		                  this->refresh();
 		                  fw().stageQueueCommand(
 		                      {StageCmd::Command::PUSH,
 		                       mksp<InGameOptions>(this->state->shared_from_this())});
@@ -2697,6 +2699,8 @@ void BattleView::openAgentInventory()
 	{
 		return;
 	}
+	selectionState = BattleSelectionState::Normal;
+	this->refresh();
 	fw().stageQueueCommand(
 	    {StageCmd::Command::PUSH,
 	     mksp<AEquipScreen>(state, battle.battleViewSelectedUnits.front()->agent)});


### PR DESCRIPTION
Just a small UI tweak that changes the battlescape cursor to normal when the inventory screen is opened. This also does the same when the options menu is opened using the button instead of the escape key.