### PR TITLE
Fix grenade related crashes

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2546,12 +2546,14 @@ void Battle::finishBattle(GameState &state)
 	state.current_battle->unloadResources(state);
 
 	// Remove active battle scanners and deactivate medikits and motion scanners
+	// and unprime any grenades or proximity mines
 	for (auto &u : state.current_battle->units)
 	{
 		for (auto &e : u.second->agent->equipment)
 		{
 			e->battleScanner.clear();
 			e->inUse = false;
+			e->primed = false;
 		}
 	}
 

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -1930,7 +1930,8 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 
 	// Update Items
 	bool updatedShield = false;
-	for (auto &item : agent->equipment)
+	auto equipmentCopy = agent->equipment;
+	for (auto &item : equipmentCopy)
 	{
 		if (item->type->type == AEquipmentType::Type::DisruptorShield &&
 		    item->ammo < item->getPayloadType()->max_ammo)


### PR DESCRIPTION
Addresses #1218.

There are two problems happening here. If you prime a grenade for any amount of time, drop it, then pick it up the game will crash when the timer runs out. If you pick up the grenade before it explodes and then end the mission, it will crash the game at the beginning of the next mission unless unequipped. The main problem stems from a unit update function in battleunit.cpp and the explode function in aequipment.cpp. It appears the update function is called every tick and iterates through each units inventory as part of the update process. The explode function will remove the grenade once it has exploded. When the grenade is place back into the inventory and explodes, the explode function will remove the equipment from the inventory and cause the crash.

The update function now iterates over a copy of the inventory instead of the actual inventory. This is a pretty broad change and could possibly lead to a slight performance hit or unintended results. Feedback appreciated.

The second fix was to simply unprime all grenades when the battle ends.