### PR TITLE
Empty weapons reload at start of battle

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2503,6 +2503,8 @@ void Battle::enterBattle(GameState &state)
 	for (auto &u : state.current_battle->units)
 	{
 		u.second->updateCheckBeginFalling(state);
+		// Reload empty weapons at start of battle if needed
+		u.second->reloadWeapons(state);
 	}
 
 	// Find first player unit

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2556,6 +2556,16 @@ void Battle::finishBattle(GameState &state)
 			e->battleScanner.clear();
 			e->inUse = false;
 			e->primed = false;
+
+			// Recharge all equipment
+			auto payload = e->getPayloadType();
+			if (payload->recharge)
+			{
+				if (e->ammo < payload->max_ammo)
+				{
+					e->ammo = payload->max_ammo;
+				}
+			}
 		}
 	}
 

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2504,7 +2504,10 @@ void Battle::enterBattle(GameState &state)
 	{
 		u.second->updateCheckBeginFalling(state);
 		// Reload empty weapons at start of battle if needed
-		u.second->reloadWeapons(state);
+		if (config().getBool("OpenApoc.NewFeature.AutoReload"))
+		{
+			u.second->reloadWeapons(state);
+		}
 	}
 
 	// Find first player unit

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -213,6 +213,24 @@ bool BattleUnit::isFatallyWounded()
 	return false;
 }
 
+void BattleUnit::reloadWeapons(GameState &state)
+{
+	// FIXME: Only reload player agents?
+	if (agent->owner == state.getPlayer())
+	{
+		auto weaponRight = agent->getFirstItemInSlot(EquipmentSlotType::RightHand);
+		auto weaponLeft = agent->getFirstItemInSlot(EquipmentSlotType::LeftHand);
+		if (weaponRight && weaponRight->needsReload())
+		{
+			weaponRight->loadAmmo(state);
+		}
+		if (weaponLeft && weaponLeft->needsReload())
+		{
+			weaponLeft->loadAmmo(state);
+		}
+	}
+}
+
 void BattleUnit::setPosition(GameState &state, const Vec3<float> &pos, bool goal)
 {
 	auto oldPosition = position;

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -367,6 +367,8 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	void init(GameState &state);
 	// Clears all possible cases of circular refs
 	void destroy() override;
+	// Reload weapons before the battle begins
+	void reloadWeapons(GameState &state);
 
 	// Squad
 


### PR DESCRIPTION
Looking at the weapon and ammo related bugs.

- [x] Empty weapons at start of battle (if actually a bug)
- [x] Shields not recharging

I didn't see a final decision regarding if clips should be filled after a mission or left partially filled and dealt with accordingly. I see there is an advanced inventory controls option that mentions unloading clips, but I don't see this put to use.

This would reload empty weapons at the start of the battle, which would solve #1210. Is this OG behaviour? If not it could be an option.

This also addresses #607 by recharging all equipment that needs to be recharged after a mission. I tested this on the disruptor shields and the rechargeable sniper from the EWM. 

