### PR TITLE
Fixed bug exiting battle with no rechargable weapons

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2562,11 +2562,14 @@ void Battle::finishBattle(GameState &state)
 
 			// Recharge all equipment
 			auto payload = e->getPayloadType();
-			if (payload->recharge)
+			if (payload)
 			{
-				if (e->ammo < payload->max_ammo)
+				if (payload->recharge)
 				{
-					e->ammo = payload->max_ammo;
+					if (e->ammo < payload->max_ammo)
+					{
+						e->ammo = payload->max_ammo;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Exception could be thrown if exiting battle with no rechargable weapons.