### PR TITLE
Moreoptions menu

### DIFF
--- a/data/forms/moreoptions.form
+++ b/data/forms/moreoptions.form
@@ -68,40 +68,6 @@
 					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:15:ui/menuopt.pal</image>
 					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:16:ui/menuopt.pal</imagedepressed>
 				</graphicbutton>
-				<label text="Map Scroll Speed">
-					<position x="56" y="166"/>
-					<font>smalfont</font>
-					<size width="148" height="16"/>
-					<alignment horizontal="left" vertical="centre"/>
-				</label>
-				<graphic>
-					<position x="42" y="182"/>
-					<size width="224" height="18"/>
-					<image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:61:xcom3/ufodata/research.pcx</image>
-					<scroll id="MAP_SCROLL_SPEED">
-						<position x="14" y="2"/>
-						<size width="148" height="15"/>
-						<range min="0" max="50"/>
-					</scroll>
-					<graphicbutton scrollprev="MAP_SCROLL_SPEED">
-						<position x="0" y="0"/>
-						<size width="16" height="20"/>
-						<image/>
-						<imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
-					</graphicbutton>
-					<graphicbutton scrollnext="MAP_SCROLL_SPEED">
-						<position x="161" y="0"/>
-						<size width="17" height="20"/>
-						<image/>
-						<imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
-					</graphicbutton>
-					<label id="TEXT_MAP_SCROLL_SPEED" text="1">
-						<position x="184" y="2"/>
-						<size width="36" height="14"/>
-						<alignment horizontal="centre" vertical="centre"/>
-						<font>smalfont</font>
-					</label>
-				</graphic>
 			</graphic>
 		</style>
 	</form>

--- a/data/forms/moreoptions.form
+++ b/data/forms/moreoptions.form
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openapoc>
+  <form id="FORM_MOREOPTIONS">
+    <style minwidth="640" minheight="480">
+      <position x="centre" y="centre"/>
+      <size width="640" height="480"/>
+      <graphic>
+        <image>xcom3/ufodata/fundadj.pcx</image>
+        <position x="0" y="0"/>
+        <size width="640" height="480"/>
+        <label text="MORE OPTIONS">
+          <position x="113" y="0"/>
+          <size width="420" height="32"/>
+          <alignment horizontal="centre" vertical="centre"/>
+          <font>bigfont</font>
+        </label>
+        <graphicbutton id="BUTTON_OK">
+          <position x="602" y="443"/>
+          <size width="35" height="34"/>
+          <image/>
+          <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
+        </graphicbutton>
+      </graphic>
+    </style>
+  </form>
+</openapoc>

--- a/data/forms/moreoptions.form
+++ b/data/forms/moreoptions.form
@@ -1,26 +1,108 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openapoc>
-  <form id="FORM_MOREOPTIONS">
-    <style minwidth="640" minheight="480">
-      <position x="centre" y="centre"/>
-      <size width="640" height="480"/>
-      <graphic>
-        <image>xcom3/ufodata/fundadj.pcx</image>
-        <position x="0" y="0"/>
-        <size width="640" height="480"/>
-        <label text="MORE OPTIONS">
-          <position x="113" y="0"/>
-          <size width="420" height="32"/>
-          <alignment horizontal="centre" vertical="centre"/>
-          <font>bigfont</font>
-        </label>
-        <graphicbutton id="BUTTON_OK">
-          <position x="602" y="443"/>
-          <size width="35" height="34"/>
-          <image/>
-          <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
-        </graphicbutton>
-      </graphic>
-    </style>
-  </form>
+	<form id="FORM_MOREOPTIONS">
+		<style minwidth="640" minheight="480">
+			<position x="centre" y="centre"/>
+			<size width="640" height="480"/>
+			<graphic>
+				<image>xcom3/ufodata/fundadj.pcx</image>
+				<position x="0" y="0"/>
+				<size width="640" height="480"/>
+				<label text="MORE OPTIONS">
+					<position x="113" y="0"/>
+					<size width="420" height="32"/>
+					<alignment horizontal="centre" vertical="centre"/>
+					<font>bigfont</font>
+				</label>
+				<label id="TEXT_FUNDS">
+					<position x="572" y="11"/>
+					<size width="60" height="10"/>
+					<alignment horizontal="left" vertical="centre"/>
+					<font>smalfont</font>
+				</label>
+				<graphicbutton id="BUTTON_OK">
+					<position x="602" y="443"/>
+					<size width="35" height="34"/>
+					<image/>
+					<imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
+				</graphicbutton>
+				<label id="LIST_NAME" text="OpenApoc Features">
+					<position x="305" y="70"/>
+					<font>smalfont</font>
+					<size width="270" height="16"/>
+					<alignment horizontal="centre" vertical="centre"/>
+				</label>
+				<checkbox id="VANILLA_TOGGLE">
+					<position x="42" y="96"/>
+					<size width="120" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Vanilla Toggle">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="90" height="16"/>
+					</label>
+				</checkbox>
+				<scroll id="NOTIFICATIONS_SCROLL">
+					<position x="550" y="116"/>
+					<size width="16" height="290"/>
+				</scroll>
+				<listbox id="NOTIFICATIONS_LIST" scrollbarid="NOTIFICATIONS_SCROLL">
+					<position x="311" y="96"/>
+					<size width="240" height="330"/>
+					<item size="16" spacing="4"/>
+					<hovercolour r="255" g="255" b="255" a="0"/>
+					<selcolour r="255" g="255" b="255" a="0"/>
+				</listbox>
+				<graphicbutton id="NOTIFICATIONS_SCROLL_UP" scrollprev="NOTIFICATIONS_SCROLL">
+					<tooltip text="Scroll Up" font="smallset"/>
+					<position x="550" y="96"/>
+					<size width="17" height="16"/>
+					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:13:ui/menuopt.pal</image>
+					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:14:ui/menuopt.pal</imagedepressed>
+				</graphicbutton>
+				<graphicbutton id="NOTIFICATIONS_SCROLL_DOWN" scrollnext="NOTIFICATIONS_SCROLL">
+					<tooltip text="Scroll Down" font="smallset"/>
+					<position x="550" y="410"/>
+					<size width="17" height="16"/>
+					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:15:ui/menuopt.pal</image>
+					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:16:ui/menuopt.pal</imagedepressed>
+				</graphicbutton>
+				<label text="Map Scroll Speed">
+					<position x="56" y="166"/>
+					<font>smalfont</font>
+					<size width="148" height="16"/>
+					<alignment horizontal="left" vertical="centre"/>
+				</label>
+				<graphic>
+					<position x="42" y="182"/>
+					<size width="224" height="18"/>
+					<image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:61:xcom3/ufodata/research.pcx</image>
+					<scroll id="MAP_SCROLL_SPEED">
+						<position x="14" y="2"/>
+						<size width="148" height="15"/>
+						<range min="0" max="50"/>
+					</scroll>
+					<graphicbutton scrollprev="MAP_SCROLL_SPEED">
+						<position x="0" y="0"/>
+						<size width="16" height="20"/>
+						<image/>
+						<imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
+					</graphicbutton>
+					<graphicbutton scrollnext="MAP_SCROLL_SPEED">
+						<position x="161" y="0"/>
+						<size width="17" height="20"/>
+						<image/>
+						<imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
+					</graphicbutton>
+					<label id="TEXT_MAP_SCROLL_SPEED" text="1">
+						<position x="184" y="2"/>
+						<size width="36" height="14"/>
+						<alignment horizontal="centre" vertical="centre"/>
+						<font>smalfont</font>
+					</label>
+				</graphic>
+			</graphic>
+		</style>
+	</form>
 </openapoc>

--- a/data/forms/moreoptions.form
+++ b/data/forms/moreoptions.form
@@ -27,9 +27,9 @@
 					<imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
 				</graphicbutton>
 				<label id="GENERAL_TEXT" text="General Options">
-					<position x="centre" y="270"/>
+					<position x="200" y="270"/>
 					<font>smalfont</font>
-					<size width="600" height="16"/>
+					<size width="200" height="16"/>
 					<alignment horizontal="centre" vertical="centre"/>
 				</label>
 				<graphic>
@@ -44,6 +44,7 @@
 					<size width="280" height="1"/>
 					<alignment horizontal="centre"/>
 				</graphic>
+				<!-- TODO: Add this option
 				<checkbox id="VANILLA_TOGGLE">
 					<position x="40" y="296"/>
 					<size width="250" height="16"/>
@@ -54,7 +55,7 @@
 						<font>smalfont</font>
 						<size width="250" height="16"/>
 					</label>
-				</checkbox>
+				</checkbox> -->
 				<checkbox id="DEBUGVIS_TOGGLE">
 					<position x="40" y="316"/>
 					<size width="270" height="16"/>

--- a/data/forms/moreoptions.form
+++ b/data/forms/moreoptions.form
@@ -26,44 +26,169 @@
 					<image/>
 					<imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
 				</graphicbutton>
-				<label id="LIST_NAME" text="OpenApoc Features">
+				<label id="GENERAL_TEXT" text="General Options">
+					<position x="centre" y="270"/>
+					<font>smalfont</font>
+					<size width="600" height="16"/>
+					<alignment horizontal="centre" vertical="centre"/>
+				</label>
+				<graphic>
+					<image>city/menu-hr.png</image>
+					<position x="30" y="288"/>
+					<size width="280" height="1"/>
+					<alignment horizontal="centre"/>
+				</graphic>
+				<graphic>
+					<image>city/menu-hr.png</image>
+					<position x="280" y="288"/>
+					<size width="280" height="1"/>
+					<alignment horizontal="centre"/>
+				</graphic>
+				<checkbox id="VANILLA_TOGGLE">
+					<position x="40" y="296"/>
+					<size width="250" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Toggle vanilla mode">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="250" height="16"/>
+					</label>
+				</checkbox>
+				<checkbox id="DEBUGVIS_TOGGLE">
+					<position x="40" y="316"/>
+					<size width="270" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Show debug menu">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="270" height="16"/>
+					</label>
+				</checkbox>
+				<checkbox id="SCROLLSOUND_TOGGLE">
+					<position x="40" y="336"/>
+					<size width="250" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Disable scrolling sounds">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="250" height="16"/>
+					</label>
+				</checkbox>
+				<checkbox id="MOREICONS_TOGGLE">
+					<position x="40" y="356"/>
+					<size width="250" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Display additional unit icons (fatal, psi)">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="250" height="16"/>
+					</label>
+				</checkbox>
+				<checkbox id="ADVINVENTORY_TOGGLE">
+					<position x="40" y="376"/>
+					<size width="250" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Allow unloading clips and quick equip">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="250" height="16"/>
+					</label>
+				</checkbox>
+				<checkbox id="TEMPLATES_TOGGLE">
+					<position x="40" y="396"/>
+					<size width="250" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Enable agent equipment templates">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="250" height="16"/>
+					</label>
+				</checkbox>
+				<checkbox id="SEEDRNG_TOGGLE">
+					<position x="40" y="416"/>
+					<size width="250" height="16"/>
+					<image>BUTTON_CHECKBOX_FALSE</image>
+					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
+					<label text="Seed RNG on game start">
+						<position x="24" y="0"/>
+						<font>smalfont</font>
+						<size width="250" height="16"/>
+					</label>
+				</checkbox>
+				<label id="CITYLIST_NAME">
 					<position x="305" y="70"/>
 					<font>smalfont</font>
 					<size width="270" height="16"/>
 					<alignment horizontal="centre" vertical="centre"/>
 				</label>
-				<checkbox id="VANILLA_TOGGLE">
-					<position x="42" y="96"/>
-					<size width="120" height="16"/>
-					<image>BUTTON_CHECKBOX_FALSE</image>
-					<imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
-					<label text="Vanilla Toggle">
-						<position x="24" y="0"/>
-						<font>smalfont</font>
-						<size width="90" height="16"/>
-					</label>
-				</checkbox>
-				<scroll id="NOTIFICATIONS_SCROLL">
+				<graphic>
+					<image>city/menu-hr.png</image>
+					<position x="315" y="88"/>
+					<size width="245" height="1"/>
+				</graphic>
+				<scroll id="CITY_NOTIFICATIONS_SCROLL">
 					<position x="550" y="116"/>
-					<size width="16" height="290"/>
+					<size width="16" height="131"/>
 				</scroll>
-				<listbox id="NOTIFICATIONS_LIST" scrollbarid="NOTIFICATIONS_SCROLL">
+				<listbox id="CITY_NOTIFICATIONS_LIST" scrollbarid="CITY_NOTIFICATIONS_SCROLL">
 					<position x="311" y="96"/>
-					<size width="240" height="330"/>
+					<size width="240" height="170"/>
 					<item size="16" spacing="4"/>
 					<hovercolour r="255" g="255" b="255" a="0"/>
 					<selcolour r="255" g="255" b="255" a="0"/>
 				</listbox>
-				<graphicbutton id="NOTIFICATIONS_SCROLL_UP" scrollprev="NOTIFICATIONS_SCROLL">
+				<graphicbutton id="CITY_NOTIFICATIONS_SCROLL_UP" scrollprev="CITY_NOTIFICATIONS_SCROLL">
 					<tooltip text="Scroll Up" font="smallset"/>
 					<position x="550" y="96"/>
 					<size width="17" height="16"/>
 					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:13:ui/menuopt.pal</image>
 					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:14:ui/menuopt.pal</imagedepressed>
 				</graphicbutton>
-				<graphicbutton id="NOTIFICATIONS_SCROLL_DOWN" scrollnext="NOTIFICATIONS_SCROLL">
+				<graphicbutton id="CITY_NOTIFICATIONS_SCROLL_DOWN" scrollnext="CITY_NOTIFICATIONS_SCROLL">
 					<tooltip text="Scroll Down" font="smallset"/>
-					<position x="550" y="410"/>
+					<position x="550" y="250"/>
+					<size width="17" height="16"/>
+					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:15:ui/menuopt.pal</image>
+					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:16:ui/menuopt.pal</imagedepressed>
+				</graphicbutton>
+				<label id="BATTLELIST_NAME">
+					<position x="30" y="70"/>
+					<font>smalfont</font>
+					<size width="270" height="16"/>
+					<alignment horizontal="centre" vertical="centre"/>
+				</label>
+				<graphic>
+					<image>city/menu-hr.png</image>
+					<position x="46" y="88"/>
+					<size width="245" height="1"/>
+				</graphic>
+				<scroll id="BATTLE_NOTIFICATIONS_SCROLL">
+					<position x="280" y="116"/>
+					<size width="16" height="131"/>
+				</scroll>
+				<listbox id="BATTLE_NOTIFICATIONS_LIST" scrollbarid="BATTLE_NOTIFICATIONS_SCROLL">
+					<position x="40" y="96"/>
+					<size width="240" height="170"/>
+					<item size="16" spacing="4"/>
+					<hovercolour r="255" g="255" b="255" a="0"/>
+					<selcolour r="255" g="255" b="255" a="0"/>
+				</listbox>
+				<graphicbutton id="BATTLE_NOTIFICATIONS_SCROLL_UP" scrollprev="BATTLE_NOTIFICATIONS_SCROLL">
+					<tooltip text="Scroll Up" font="smallset"/>
+					<position x="280" y="96"/>
+					<size width="17" height="16"/>
+					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:13:ui/menuopt.pal</image>
+					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:14:ui/menuopt.pal</imagedepressed>
+				</graphicbutton>
+				<graphicbutton id="BATTLE_NOTIFICATIONS_SCROLL_DOWN" scrollnext="BATTLE_NOTIFICATIONS_SCROLL">
+					<tooltip text="Scroll Down" font="smallset"/>
+					<position x="280" y="250"/>
 					<size width="17" height="16"/>
 					<image>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:15:ui/menuopt.pal</image>
 					<imagedepressed>PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:16:ui/menuopt.pal</imagedepressed>

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -54,6 +54,7 @@ void dumpOptionsToLog()
 	dumpOption(actionMusicOption);
 	dumpOption(autoExecuteOption);
 	dumpOption(toolTipDelay);
+	dumpOption(vanillaToggle);
 
 	dumpOption(optionPauseOnUfoSpotted);
 	dumpOption(optionPauseOnVehicleLightDamage);
@@ -257,6 +258,7 @@ ConfigOptionBool autoExecuteOption("Options.Misc", "AutoExecute",
 ConfigOptionInt toolTipDelay("Options.Misc", "ToolTipDelay",
                              "Delay in milliseconds before showing tooltips (<= 0 to disable)",
                              500);
+ConfigOptionBool vanillaToggle("Options.Misc", "VanillaToggle", "Toggle vanilla mode", false);
 
 ConfigOptionBool optionPauseOnUfoSpotted("Notifications.City", "UfoSpotted", "UFO spotted", true);
 ConfigOptionBool optionPauseOnVehicleLightDamage("Notifications.City", "VehicleLightDamage",

--- a/framework/options.h
+++ b/framework/options.h
@@ -32,6 +32,7 @@ extern ConfigOptionBool autoScrollOption;
 extern ConfigOptionBool actionMusicOption;
 extern ConfigOptionBool autoExecuteOption;
 extern ConfigOptionInt toolTipDelay;
+extern ConfigOptionBool vanillaToggle;
 
 extern ConfigOptionBool optionPauseOnUfoSpotted;
 extern ConfigOptionBool optionPauseOnVehicleLightDamage;

--- a/game/ui/CMakeLists.txt
+++ b/game/ui/CMakeLists.txt
@@ -50,6 +50,7 @@ set (GAMEUI_SOURCE_FILES
 	general/agentsheet.cpp
 	general/difficultymenu.cpp
 	general/ingameoptions.cpp
+	general/moreoptions.cpp
 	general/cheatoptions.cpp
 	general/loadingscreen.cpp
 	general/mainmenu.cpp
@@ -121,6 +122,7 @@ set (GAMEUI_HEADER_FILES
 	general/agentsheet.h
 	general/difficultymenu.h
 	general/ingameoptions.h
+	general/moreoptions.h
 	general/cheatoptions.h
 	general/loadingscreen.h
 	general/mainmenu.h

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -94,7 +94,7 @@ void InGameOptions::saveList()
 void InGameOptions::loadList()
 {
 	saveList();
-	menuform->findControlTyped<Label>("LIST_NAME")->setText("Message Toggles");
+	menuform->findControlTyped<Label>("LIST_NAME")->setText(tr("Message Toggles"));
 	std::list<std::pair<UString, UString>> *notificationList = nullptr;
 
 	notificationList = state->current_battle ? &battleNotificationList : &cityNotificationList;

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -22,6 +22,7 @@
 #include "game/ui/skirmish/skirmish.h"
 #include "game/ui/tileview/cityview.h"
 #include <list>
+#include "moreoptions.h"
 
 namespace OpenApoc
 {
@@ -303,7 +304,8 @@ void InGameOptions::eventOccurred(Event *e)
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_NEXT_LIST")
 		{
-			loadNextList();
+			//loadNextList();
+			fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<MoreOptions>(state)});
 			return;
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_CHEATS")

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -21,8 +21,8 @@
 #include "game/ui/general/savemenu.h"
 #include "game/ui/skirmish/skirmish.h"
 #include "game/ui/tileview/cityview.h"
-#include <list>
 #include "moreoptions.h"
+#include <list>
 
 namespace OpenApoc
 {
@@ -304,7 +304,6 @@ void InGameOptions::eventOccurred(Event *e)
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_NEXT_LIST")
 		{
-			//loadNextList();
 			fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<MoreOptions>(state)});
 			return;
 		}

--- a/game/ui/general/ingameoptions.cpp
+++ b/game/ui/general/ingameoptions.cpp
@@ -72,57 +72,6 @@ std::list<std::pair<UString, UString>> cityNotificationList = {
     {"Notifications.City", "BaseDestroyed"},
 };
 
-std::list<std::pair<UString, UString>> openApocList = {
-    {"OpenApoc.NewFeature", "DebugCommandsVisible"},
-    {"OpenApoc.NewFeature", "UFODamageModel"},
-    {"OpenApoc.NewFeature", "InstantExplosionDamage"},
-    {"OpenApoc.NewFeature", "GravliftSounds"},
-    {"OpenApoc.NewFeature", "NoScrollSounds"},
-    {"OpenApoc.NewFeature", "NoInstantThrows"},
-    {"OpenApoc.NewFeature", "PayloadExplosion"},
-    {"OpenApoc.NewFeature", "DisplayUnitPaths"},
-    {"OpenApoc.NewFeature", "AdditionalUnitIcons"},
-    {"OpenApoc.NewFeature", "AllowForceFiringParallel"},
-    {"OpenApoc.NewFeature", "RequireLOSToMaintainPsi"},
-    {"OpenApoc.NewFeature", "AdvancedInventoryControls"},
-    {"OpenApoc.NewFeature", "EnableAgentTemplates"},
-    {"OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying"},
-    {"OpenApoc.NewFeature", "AllowManualCityTeleporters"},
-    {"OpenApoc.NewFeature", "AllowManualCargoFerry"},
-    {"OpenApoc.NewFeature", "AllowSoldierTaxiUse"},
-    {"OpenApoc.NewFeature", "AllowAttackingOwnedVehicles"},
-    {"OpenApoc.NewFeature", "CallExistingFerry"},
-    {"OpenApoc.NewFeature", "AlternateVehicleShieldSound"},
-    {"OpenApoc.NewFeature", "StoreDroppedEquipment"},
-    {"OpenApoc.NewFeature", "EnforceCargoLimits"},
-    {"OpenApoc.NewFeature", "AllowNearbyVehicleLootPickup"},
-    {"OpenApoc.NewFeature", "AllowBuildingLootDeposit"},
-    {"OpenApoc.NewFeature", "ArmoredRoads"},
-    {"OpenApoc.NewFeature", "CrashingGroundVehicles"},
-    {"OpenApoc.NewFeature", "OpenApocCityControls"},
-    {"OpenApoc.NewFeature", "CollapseRaidedBuilding"},
-    {"OpenApoc.NewFeature", "ScrambleOnUnintentionalHit"},
-    {"OpenApoc.NewFeature", "MarketOnRight"},
-    {"OpenApoc.NewFeature", "CrashingDimensionGate"},
-    {"OpenApoc.NewFeature", "SkipTurboMovement"},
-    {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
-    {"OpenApoc.NewFeature", "RunAndKneel"},
-    {"OpenApoc.NewFeature", "SeedRng"},
-    {"OpenApoc.NewFeature", "AutoReload"},
-    {"OpenApoc.NewFeature", "LeftClickIconEquip"},
-    {"OpenApoc.NewFeature", "BattlescapeVertScroll"},
-    {"OpenApoc.NewFeature", "SingleSquadSelect"},
-
-    {"OpenApoc.Mod", "StunHostileAction"},
-    {"OpenApoc.Mod", "RaidHostileAction"},
-    {"OpenApoc.Mod", "CrashingVehicles"},
-    {"OpenApoc.Mod", "InvulnerableRoads"},
-    {"OpenApoc.Mod", "ATVTank"},
-    {"OpenApoc.Mod", "ATVAPC"},
-    {"OpenApoc.Mod", "BSKLauncherSound"},
-};
-
-std::vector<UString> listNames = {tr("Message Toggles"), tr("OpenApoc Features")};
 } // namespace
 
 InGameOptions::InGameOptions(sp<GameState> state)
@@ -142,22 +91,14 @@ void InGameOptions::saveList()
 	}
 }
 
-void InGameOptions::loadList(int id)
+void InGameOptions::loadList()
 {
 	saveList();
-	curId = id;
-	menuform->findControlTyped<Label>("LIST_NAME")->setText(listNames[curId]);
+	menuform->findControlTyped<Label>("LIST_NAME")->setText("Message Toggles");
 	std::list<std::pair<UString, UString>> *notificationList = nullptr;
-	switch (curId)
-	{
-		case 0:
-			notificationList =
-			    state->current_battle ? &battleNotificationList : &cityNotificationList;
-			break;
-		case 1:
-			notificationList = &openApocList;
-			break;
-	}
+
+	notificationList = state->current_battle ? &battleNotificationList : &cityNotificationList;
+
 	auto listControl = menuform->findControlTyped<ListBox>("NOTIFICATIONS_LIST");
 	listControl->clear();
 	auto font = ui().getFont("smalfont");
@@ -176,16 +117,6 @@ void InGameOptions::loadList(int id)
 		label->ToolTipFont = font;
 		listControl->addItem(checkBox);
 	}
-}
-
-void InGameOptions::loadNextList()
-{
-	curId++;
-	if (curId > 1)
-	{
-		curId = 0;
-	}
-	loadList(curId);
 }
 
 void InGameOptions::begin()
@@ -223,7 +154,7 @@ void InGameOptions::begin()
 
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 
-	loadList(0);
+	loadList();
 }
 
 void InGameOptions::pause() {}

--- a/game/ui/general/ingameoptions.h
+++ b/game/ui/general/ingameoptions.h
@@ -21,9 +21,7 @@ class InGameOptions : public Stage
 	~InGameOptions() override;
 
 	void saveList();
-	void loadList(int id);
-	void loadNextList();
-	int curId = 0;
+	void loadList();
 
 	// Stage control
 	void begin() override;

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -1,3 +1,4 @@
+#include "game/ui/general/moreoptions.h"
 #include "forms/checkbox.h"
 #include "forms/form.h"
 #include "forms/label.h"
@@ -6,26 +7,120 @@
 #include "forms/textbutton.h"
 #include "forms/ui.h"
 #include "framework/configfile.h"
+#include "framework/data.h"
 #include "framework/event.h"
 #include "framework/framework.h"
 #include "framework/keycodes.h"
 #include "game/state/gamestate.h"
 #include "game/state/shared/organisation.h"
-#include "game/ui/general/moreoptions.h"
 #include <limits>
 
 namespace OpenApoc
 {
+namespace
+{
+std::list<std::pair<UString, UString>> openApocList = {
+    {"OpenApoc.NewFeature", "DebugCommandsVisible"},
+    {"OpenApoc.NewFeature", "UFODamageModel"},
+    {"OpenApoc.NewFeature", "InstantExplosionDamage"},
+    {"OpenApoc.NewFeature", "GravliftSounds"},
+    {"OpenApoc.NewFeature", "NoScrollSounds"},
+    {"OpenApoc.NewFeature", "NoInstantThrows"},
+    {"OpenApoc.NewFeature", "PayloadExplosion"},
+    {"OpenApoc.NewFeature", "DisplayUnitPaths"},
+    {"OpenApoc.NewFeature", "AdditionalUnitIcons"},
+    {"OpenApoc.NewFeature", "AllowForceFiringParallel"},
+    {"OpenApoc.NewFeature", "RequireLOSToMaintainPsi"},
+    {"OpenApoc.NewFeature", "AdvancedInventoryControls"},
+    {"OpenApoc.NewFeature", "EnableAgentTemplates"},
+    {"OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying"},
+    {"OpenApoc.NewFeature", "AllowManualCityTeleporters"},
+    {"OpenApoc.NewFeature", "AllowManualCargoFerry"},
+    {"OpenApoc.NewFeature", "AllowSoldierTaxiUse"},
+    {"OpenApoc.NewFeature", "AllowAttackingOwnedVehicles"},
+    {"OpenApoc.NewFeature", "CallExistingFerry"},
+    {"OpenApoc.NewFeature", "AlternateVehicleShieldSound"},
+    {"OpenApoc.NewFeature", "StoreDroppedEquipment"},
+    {"OpenApoc.NewFeature", "EnforceCargoLimits"},
+    {"OpenApoc.NewFeature", "AllowNearbyVehicleLootPickup"},
+    {"OpenApoc.NewFeature", "AllowBuildingLootDeposit"},
+    {"OpenApoc.NewFeature", "ArmoredRoads"},
+    {"OpenApoc.NewFeature", "CrashingGroundVehicles"},
+    {"OpenApoc.NewFeature", "OpenApocCityControls"},
+    {"OpenApoc.NewFeature", "CollapseRaidedBuilding"},
+    {"OpenApoc.NewFeature", "ScrambleOnUnintentionalHit"},
+    {"OpenApoc.NewFeature", "MarketOnRight"},
+    {"OpenApoc.NewFeature", "CrashingDimensionGate"},
+    {"OpenApoc.NewFeature", "SkipTurboMovement"},
+    {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
+    {"OpenApoc.NewFeature", "RunAndKneel"},
+    {"OpenApoc.NewFeature", "SeedRng"},
+    {"OpenApoc.NewFeature", "AutoReload"},
+    {"OpenApoc.NewFeature", "LeftClickIconEquip"},
+    {"OpenApoc.NewFeature", "BattlescapeVertScroll"},
+    {"OpenApoc.NewFeature", "SingleSquadSelect"},
 
+    {"OpenApoc.Mod", "StunHostileAction"},
+    {"OpenApoc.Mod", "RaidHostileAction"},
+    {"OpenApoc.Mod", "CrashingVehicles"},
+    {"OpenApoc.Mod", "InvulnerableRoads"},
+    {"OpenApoc.Mod", "ATVTank"},
+    {"OpenApoc.Mod", "ATVAPC"},
+    {"OpenApoc.Mod", "BSKLauncherSound"},
+};
+
+} // namespace
 MoreOptions::MoreOptions(sp<GameState> state)
     : Stage(), menuform(ui().getForm("moreoptions")), state(state)
 {
 }
 MoreOptions::~MoreOptions() {}
 
+void MoreOptions::saveList()
+{
+	auto listControl = menuform->findControlTyped<ListBox>("NOTIFICATIONS_LIST");
+	for (auto &c : listControl->Controls)
+	{
+		auto name = c->getData<UString>();
+		config().set(*name, std::dynamic_pointer_cast<CheckBox>(c)->isChecked());
+	}
+}
+
+void MoreOptions::loadList()
+{
+	saveList();
+	menuform->findControlTyped<Label>("LIST_NAME");
+	std::list<std::pair<UString, UString>> *notificationList = nullptr;
+
+	notificationList = &openApocList;
+
+	auto listControl = menuform->findControlTyped<ListBox>("NOTIFICATIONS_LIST");
+	listControl->clear();
+	auto font = ui().getFont("smalfont");
+	for (auto &p : *notificationList)
+	{
+		auto checkBox = mksp<CheckBox>(fw().data->loadImage("BUTTON_CHECKBOX_TRUE"),
+		                               fw().data->loadImage("BUTTON_CHECKBOX_FALSE"));
+		checkBox->Size = {240, listControl->ItemSize};
+		UString full_name = p.first + "." + p.second;
+		checkBox->setData(mksp<UString>(full_name));
+		checkBox->setChecked(config().getBool(full_name));
+		auto label = checkBox->createChild<Label>(tr(config().describe(p.first, p.second)), font);
+		label->Size = {216, listControl->ItemSize};
+		label->Location = {24, 0};
+		label->ToolTipText = tr(config().describe(p.first, p.second));
+		label->ToolTipFont = font;
+		listControl->addItem(checkBox);
+	}
+}
+
 bool MoreOptions::isTransition() { return false; }
 
-void MoreOptions::begin() {}
+void MoreOptions::begin()
+{
+	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
+	loadList();
+}
 
 void MoreOptions::pause() {}
 

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -120,13 +120,20 @@ void MoreOptions::begin()
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 	loadList();
+	menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")
+	    ->setChecked(config().getBool("Options.Misc.VanillaToggle"));
 }
 
 void MoreOptions::pause() {}
 
 void MoreOptions::resume() {}
 
-void MoreOptions::finish() {}
+void MoreOptions::finish()
+{
+		config().set("Options.Misc.VanillaToggle",
+	             menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")->isChecked());
+	saveList();
+}
 
 void MoreOptions::eventOccurred(Event *e)
 {

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -123,6 +123,7 @@ void MoreOptions::loadLists()
 	battlelistControl->clear();
 	auto font = ui().getFont("smalfont");
 
+	// FIXME: Can this be optimized?
 	for (auto &p : *citynotificationList)
 	{
 		auto checkBox = mksp<CheckBox>(fw().data->loadImage("BUTTON_CHECKBOX_TRUE"),
@@ -164,8 +165,8 @@ void MoreOptions::begin()
 	loadLists();
 
 	// TODO: Implement vanilla mode
-	menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")
-	    ->setChecked(config().getBool("Options.Misc.VanillaToggle"));
+	// menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")
+	//    ->setChecked(config().getBool("Options.Misc.VanillaToggle"));
 	menuform->findControlTyped<CheckBox>("DEBUGVIS_TOGGLE")
 	    ->setChecked(config().getBool("OpenApoc.NewFeature.DebugCommandsVisible"));
 	menuform->findControlTyped<CheckBox>("SCROLLSOUND_TOGGLE")
@@ -187,8 +188,8 @@ void MoreOptions::resume() {}
 void MoreOptions::finish()
 {
 	// TODO: Implement vanilla mode
-	config().set("Options.Misc.VanillaToggle",
-	             menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")->isChecked());
+	// config().set("Options.Misc.VanillaToggle",
+	//             menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")->isChecked());
 	config().set("OpenApoc.NewFeature.DebugCommandsVisible",
 	             menuform->findControlTyped<CheckBox>("DEBUGVIS_TOGGLE")->isChecked());
 	config().set("OpenApoc.NewFeature.NoScrollSounds",

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -1,0 +1,66 @@
+#include "forms/checkbox.h"
+#include "forms/form.h"
+#include "forms/label.h"
+#include "forms/listbox.h"
+#include "forms/scrollbar.h"
+#include "forms/textbutton.h"
+#include "forms/ui.h"
+#include "framework/configfile.h"
+#include "framework/event.h"
+#include "framework/framework.h"
+#include "framework/keycodes.h"
+#include "game/state/gamestate.h"
+#include "game/state/shared/organisation.h"
+#include "game/ui/general/moreoptions.h"
+#include <limits>
+
+namespace OpenApoc
+{
+
+MoreOptions::MoreOptions(sp<GameState> state)
+    : Stage(), menuform(ui().getForm("moreoptions")), state(state)
+{
+}
+MoreOptions::~MoreOptions() {}
+
+bool MoreOptions::isTransition() { return false; }
+
+void MoreOptions::begin() {}
+
+void MoreOptions::pause() {}
+
+void MoreOptions::resume() {}
+
+void MoreOptions::finish() {}
+
+void MoreOptions::eventOccurred(Event *e)
+{
+	menuform->eventOccured(e);
+
+	if (e->type() == EVENT_KEY_DOWN)
+	{
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
+		{
+			menuform->findControl("BUTTON_OK")->click();
+			return;
+		}
+	}
+	if (e->type() == EVENT_FORM_INTERACTION && e->forms().EventFlag == FormEventType::ButtonClick)
+	{
+		if (e->forms().RaisedBy->Name == "BUTTON_OK")
+		{
+			fw().stageQueueCommand({StageCmd::Command::POP});
+			return;
+		}
+	}
+}
+
+void MoreOptions::update() { menuform->update(); }
+
+void MoreOptions::render()
+{
+	fw().stageGetPrevious(this->shared_from_this())->render();
+	menuform->render();
+}
+} // namespace OpenApoc

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -13,33 +13,20 @@
 #include "framework/keycodes.h"
 #include "game/state/gamestate.h"
 #include "game/state/shared/organisation.h"
+#include <forms/graphic.h>
 #include <limits>
 
 namespace OpenApoc
 {
 namespace
 {
-std::list<std::pair<UString, UString>> openApocList = {
-    {"OpenApoc.NewFeature", "DebugCommandsVisible"},
-    {"OpenApoc.NewFeature", "UFODamageModel"},
-    {"OpenApoc.NewFeature", "InstantExplosionDamage"},
-    {"OpenApoc.NewFeature", "GravliftSounds"},
-    {"OpenApoc.NewFeature", "NoScrollSounds"},
-    {"OpenApoc.NewFeature", "NoInstantThrows"},
-    {"OpenApoc.NewFeature", "PayloadExplosion"},
-    {"OpenApoc.NewFeature", "DisplayUnitPaths"},
-    {"OpenApoc.NewFeature", "AdditionalUnitIcons"},
-    {"OpenApoc.NewFeature", "AllowForceFiringParallel"},
-    {"OpenApoc.NewFeature", "RequireLOSToMaintainPsi"},
-    {"OpenApoc.NewFeature", "AdvancedInventoryControls"},
-    {"OpenApoc.NewFeature", "EnableAgentTemplates"},
+std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying"},
     {"OpenApoc.NewFeature", "AllowManualCityTeleporters"},
     {"OpenApoc.NewFeature", "AllowManualCargoFerry"},
     {"OpenApoc.NewFeature", "AllowSoldierTaxiUse"},
     {"OpenApoc.NewFeature", "AllowAttackingOwnedVehicles"},
     {"OpenApoc.NewFeature", "CallExistingFerry"},
-    {"OpenApoc.NewFeature", "AlternateVehicleShieldSound"},
     {"OpenApoc.NewFeature", "StoreDroppedEquipment"},
     {"OpenApoc.NewFeature", "EnforceCargoLimits"},
     {"OpenApoc.NewFeature", "AllowNearbyVehicleLootPickup"},
@@ -50,23 +37,49 @@ std::list<std::pair<UString, UString>> openApocList = {
     {"OpenApoc.NewFeature", "CollapseRaidedBuilding"},
     {"OpenApoc.NewFeature", "ScrambleOnUnintentionalHit"},
     {"OpenApoc.NewFeature", "MarketOnRight"},
+    {"OpenApoc.NewFeature", "LeftClickIconEquip"},
     {"OpenApoc.NewFeature", "CrashingDimensionGate"},
     {"OpenApoc.NewFeature", "SkipTurboMovement"},
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
-    {"OpenApoc.NewFeature", "RunAndKneel"},
-    {"OpenApoc.NewFeature", "SeedRng"},
-    {"OpenApoc.NewFeature", "AutoReload"},
-    {"OpenApoc.NewFeature", "LeftClickIconEquip"},
-    {"OpenApoc.NewFeature", "BattlescapeVertScroll"},
-    {"OpenApoc.NewFeature", "SingleSquadSelect"},
-
-    {"OpenApoc.Mod", "StunHostileAction"},
     {"OpenApoc.Mod", "RaidHostileAction"},
     {"OpenApoc.Mod", "CrashingVehicles"},
     {"OpenApoc.Mod", "InvulnerableRoads"},
     {"OpenApoc.Mod", "ATVTank"},
     {"OpenApoc.Mod", "ATVAPC"},
+};
+
+std::list<std::pair<UString, UString>> battlescapeList = {
+    {"OpenApoc.NewFeature", "InstantExplosionDamage"},
+    {"OpenApoc.NewFeature", "UFODamageModel"},
+    {"OpenApoc.NewFeature", "GravliftSounds"},
+    {"OpenApoc.NewFeature", "NoInstantThrows"},
+    {"OpenApoc.NewFeature", "PayloadExplosion"},
+    {"OpenApoc.NewFeature", "DisplayUnitPaths"},
+    {"OpenApoc.NewFeature", "AllowForceFiringParallel"},
+    {"OpenApoc.NewFeature", "RequireLOSToMaintainPsi"},
+    {"OpenApoc.NewFeature", "AlternateVehicleShieldSound"},
+    {"OpenApoc.NewFeature", "RunAndKneel"},
+    {"OpenApoc.NewFeature", "AutoReload"},
+    {"OpenApoc.NewFeature", "BattlescapeVertScroll"},
+    {"OpenApoc.NewFeature", "SingleSquadSelect"},
+    {"OpenApoc.Mod", "StunHostileAction"},
     {"OpenApoc.Mod", "BSKLauncherSound"},
+};
+
+// TODO: Implement vanilla mode
+std::list<std::pair<UString, UString>> vanillaList = {
+    {"OpenApoc.NewFeature", "PayloadExplosion"},
+    {"OpenApoc.NewFeature", "DisplayUnitPaths"},
+    {"OpenApoc.NewFeature", "AdditionalUnitIcons"},
+    {"OpenApoc.NewFeature", "AllowForceFiringParallel"},
+    {"OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying"},
+    {"OpenApoc.NewFeature", "AllowSoldierTaxiUse"},
+    {"OpenApoc.NewFeature", "AllowAttackingOwnedVehicles"},
+    {"OpenApoc.NewFeature", "StoreDroppedEquipment"},
+    {"OpenApoc.NewFeature", "EnforceCargoLimits"},
+    {"OpenApoc.NewFeature", "SeedRng"},
+    {"OpenApoc.NewFeature", "AutoReload"},
+    {"OpenApoc.Mod", "RaidHostileAction"},
 };
 
 } // namespace
@@ -76,41 +89,70 @@ MoreOptions::MoreOptions(sp<GameState> state)
 }
 MoreOptions::~MoreOptions() {}
 
-void MoreOptions::saveList()
+void MoreOptions::saveLists()
 {
-	auto listControl = menuform->findControlTyped<ListBox>("NOTIFICATIONS_LIST");
-	for (auto &c : listControl->Controls)
+	auto citylistControl = menuform->findControlTyped<ListBox>("CITY_NOTIFICATIONS_LIST");
+	for (auto &c : citylistControl->Controls)
 	{
 		auto name = c->getData<UString>();
 		config().set(*name, std::dynamic_pointer_cast<CheckBox>(c)->isChecked());
 	}
+
+	auto battlelistControl = menuform->findControlTyped<ListBox>("BATTLE_NOTIFICATIONS_LIST");
+	for (auto &b : battlelistControl->Controls)
+	{
+		auto name = b->getData<UString>();
+		config().set(*name, std::dynamic_pointer_cast<CheckBox>(b)->isChecked());
+	}
 }
 
-void MoreOptions::loadList()
+void MoreOptions::loadLists()
 {
-	saveList();
-	menuform->findControlTyped<Label>("LIST_NAME");
-	std::list<std::pair<UString, UString>> *notificationList = nullptr;
+	saveLists();
+	menuform->findControlTyped<Label>("CITYLIST_NAME")->setText("Cityscape Options");
+	menuform->findControlTyped<Label>("BATTLELIST_NAME")->setText("Battlescape Options");
+	std::list<std::pair<UString, UString>> *citynotificationList = nullptr;
+	std::list<std::pair<UString, UString>> *battlenotificationList = nullptr;
 
-	notificationList = &openApocList;
+	citynotificationList = &cityscapeList;
+	battlenotificationList = &battlescapeList;
 
-	auto listControl = menuform->findControlTyped<ListBox>("NOTIFICATIONS_LIST");
-	listControl->clear();
+	auto citylistControl = menuform->findControlTyped<ListBox>("CITY_NOTIFICATIONS_LIST");
+	auto battlelistControl = menuform->findControlTyped<ListBox>("BATTLE_NOTIFICATIONS_LIST");
+	citylistControl->clear();
+	battlelistControl->clear();
 	auto font = ui().getFont("smalfont");
-	for (auto &p : *notificationList)
+
+	for (auto &p : *citynotificationList)
 	{
 		auto checkBox = mksp<CheckBox>(fw().data->loadImage("BUTTON_CHECKBOX_TRUE"),
 		                               fw().data->loadImage("BUTTON_CHECKBOX_FALSE"));
-		checkBox->Size = {240, listControl->ItemSize};
+		checkBox->Size = {240, citylistControl->ItemSize};
 		UString full_name = p.first + "." + p.second;
 		checkBox->setData(mksp<UString>(full_name));
 		checkBox->setChecked(config().getBool(full_name));
 		auto label = checkBox->createChild<Label>(tr(config().describe(p.first, p.second)), font);
-		label->Size = {216, listControl->ItemSize};
+		label->Size = {216, citylistControl->ItemSize};
 		label->Location = {24, 0};
 		label->ToolTipText = tr(config().describe(p.first, p.second));
 		label->ToolTipFont = font;
-		listControl->addItem(checkBox);
+		citylistControl->addItem(checkBox);
+	}
+
+	for (auto &p : *battlenotificationList)
+	{
+		auto checkBox = mksp<CheckBox>(fw().data->loadImage("BUTTON_CHECKBOX_TRUE"),
+		                               fw().data->loadImage("BUTTON_CHECKBOX_FALSE"));
+		checkBox->Size = {240, battlelistControl->ItemSize};
+		UString full_name = p.first + "." + p.second;
+		checkBox->setData(mksp<UString>(full_name));
+		checkBox->setChecked(config().getBool(full_name));
+		auto label = checkBox->createChild<Label>(tr(config().describe(p.first, p.second)), font);
+		label->Size = {216, battlelistControl->ItemSize};
+		label->Location = {24, 0};
+		label->ToolTipText = tr(config().describe(p.first, p.second));
+		label->ToolTipFont = font;
+		battlelistControl->addItem(checkBox);
 	}
 }
 
@@ -119,9 +161,23 @@ bool MoreOptions::isTransition() { return false; }
 void MoreOptions::begin()
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
-	loadList();
+	loadLists();
+
+	// TODO: Implement vanilla mode
 	menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")
 	    ->setChecked(config().getBool("Options.Misc.VanillaToggle"));
+	menuform->findControlTyped<CheckBox>("DEBUGVIS_TOGGLE")
+	    ->setChecked(config().getBool("OpenApoc.NewFeature.DebugCommandsVisible"));
+	menuform->findControlTyped<CheckBox>("SCROLLSOUND_TOGGLE")
+	    ->setChecked(config().getBool("OpenApoc.NewFeature.NoScrollSounds"));
+	menuform->findControlTyped<CheckBox>("MOREICONS_TOGGLE")
+	    ->setChecked(config().getBool("OpenApoc.NewFeature.AdditionalUnitIcons"));
+	menuform->findControlTyped<CheckBox>("ADVINVENTORY_TOGGLE")
+	    ->setChecked(config().getBool("OpenApoc.NewFeature.AdvancedInventoryControls"));
+	menuform->findControlTyped<CheckBox>("TEMPLATES_TOGGLE")
+	    ->setChecked(config().getBool("OpenApoc.NewFeature.EnableAgentTemplates"));
+	menuform->findControlTyped<CheckBox>("SEEDRNG_TOGGLE")
+	    ->setChecked(config().getBool("OpenApoc.NewFeature.SeedRng"));
 }
 
 void MoreOptions::pause() {}
@@ -130,9 +186,22 @@ void MoreOptions::resume() {}
 
 void MoreOptions::finish()
 {
-		config().set("Options.Misc.VanillaToggle",
+	// TODO: Implement vanilla mode
+	config().set("Options.Misc.VanillaToggle",
 	             menuform->findControlTyped<CheckBox>("VANILLA_TOGGLE")->isChecked());
-	saveList();
+	config().set("OpenApoc.NewFeature.DebugCommandsVisible",
+	             menuform->findControlTyped<CheckBox>("DEBUGVIS_TOGGLE")->isChecked());
+	config().set("OpenApoc.NewFeature.NoScrollSounds",
+	             menuform->findControlTyped<CheckBox>("SCROLLSOUND_TOGGLE")->isChecked());
+	config().set("OpenApoc.NewFeature.AdditionalUnitIcons",
+	             menuform->findControlTyped<CheckBox>("MOREICONS_TOGGLE")->isChecked());
+	config().set("OpenApoc.NewFeature.AdvancedInventoryControls",
+	             menuform->findControlTyped<CheckBox>("ADVINVENTORY_TOGGLE")->isChecked());
+	config().set("OpenApoc.NewFeature.EnableAgentTemplates",
+	             menuform->findControlTyped<CheckBox>("TEMPLATES_TOGGLE")->isChecked());
+	config().set("OpenApoc.NewFeature.SeedRng",
+	             menuform->findControlTyped<CheckBox>("SEEDRNG_TOGGLE")->isChecked());
+	saveLists();
 }
 
 void MoreOptions::eventOccurred(Event *e)

--- a/game/ui/general/moreoptions.h
+++ b/game/ui/general/moreoptions.h
@@ -19,6 +19,9 @@ class MoreOptions : public Stage
 	MoreOptions(sp<GameState> state);
 	~MoreOptions() override;
 
+	void saveList();
+	void loadList();
+
 	// Stage control
 	void begin() override;
 	void pause() override;

--- a/game/ui/general/moreoptions.h
+++ b/game/ui/general/moreoptions.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "framework/stage.h"
+#include "library/sp.h"
+
+namespace OpenApoc
+{
+
+class GameState;
+class Form;
+
+class MoreOptions : public Stage
+{
+  private:
+	sp<Form> menuform;
+	sp<GameState> state;
+
+  public:
+	MoreOptions(sp<GameState> state);
+	~MoreOptions() override;
+
+	// Stage control
+	void begin() override;
+	void pause() override;
+	void resume() override;
+	void finish() override;
+	void eventOccurred(Event *e) override;
+	void update() override;
+	void render() override;
+	bool isTransition() override;
+};
+} // namespace OpenApoc

--- a/game/ui/general/moreoptions.h
+++ b/game/ui/general/moreoptions.h
@@ -19,8 +19,8 @@ class MoreOptions : public Stage
 	MoreOptions(sp<GameState> state);
 	~MoreOptions() override;
 
-	void saveList();
-	void loadList();
+	void saveLists();
+	void loadLists();
 
 	// Stage control
 	void begin() override;


### PR DESCRIPTION
Would like some feedback on something I've been working on. I think it is time to ditch the more options list and move to a different options menu. When trying to add features such as a map scroll speed scrollbar, there is no room left on the original options menu. 

Here is the rough example I'm working with:
![menu](https://github.com/OpenApoc/OpenApoc/assets/73447098/f31826a1-7d33-47bd-b2df-fe40f93b75ce)

So far the options list has moved to this new menu, but you can see there is now room to add different options besides a checkbox in a list.

If a consensus agrees this would be a good idea moving forward, the menu could be spruced up with a frame around the list. I'm also thinking of moving some of the more important options out of the list and adding a vanilla mode toggle that would toggle all options to simulate a vanilla experience.

Let me know what you think.

TODO:

- [x] Menu design done
- [x] Menu functionality done
- [x] Clean up old menu