### PR TITLE
Auto detect number of displays in the launcher

### DIFF
--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -205,17 +205,17 @@ void LauncherWindow::setupScreenModes()
 
 void LauncherWindow::setupDisplayNum()
 {
-	constexpr int MAX_DISPLAYS = 4;
+	const auto displays = QGuiApplication::screens();
 	auto &comboBox = *ui->displayNumBox;
 	comboBox.clear();
 
-	for (int i = 0; i < MAX_DISPLAYS; ++i)
+	for (int i = 0; i < displays.count(); ++i)
 	{
 		comboBox.addItem(QString("Display #%1").arg(i));
 	}
 
 	int curDisplayValue = Options::screenDisplayNumberOption.get();
-	if (curDisplayValue < MAX_DISPLAYS)
+	if (curDisplayValue < displays.count())
 	{
 		comboBox.setCurrentIndex(curDisplayValue);
 	}


### PR DESCRIPTION
This removes the MAX_DISPLAYS variable and instead checks the number of attached displays when the launcher starts.

Two questions:

- Was the MAX_DISPLAYS variable chosen for a reason?

- Should this be kept but replaced with the displays.count() variable?
https://github.com/OpenApoc/OpenApoc/blob/e3a41f96078237cf31aee3337afa6dfcd52674c8/tools/launcher/launcherwindow.cpp#L218-L221

I figured no for both so I removed them.