### PR TITLE
Allow ATV type vehicles to initiate UFO missions.

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -135,6 +135,7 @@ void dumpOptionsToLog()
 	dumpOption(optionLeftClickIcon);
 	dumpOption(optionBattlescapeVertScroll);
 	dumpOption(optionSingleSquadSelect);
+	dumpOption(optionATVUFOMission);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -423,6 +424,8 @@ ConfigOptionBool optionBattlescapeVertScroll("OpenApoc.NewFeature", "Battlescape
                                              true);
 ConfigOptionBool optionSingleSquadSelect("OpenApoc.NewFeature", "SingleSquadSelect",
                                          "Select squad with single click", false);
+ConfigOptionBool optionATVUFOMission("OpenApoc.NewFeature", "ATVUFOMission",
+                                     "Allow ATV vehicles to initiate UFO missions", false);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -424,8 +424,10 @@ ConfigOptionBool optionBattlescapeVertScroll("OpenApoc.NewFeature", "Battlescape
                                              true);
 ConfigOptionBool optionSingleSquadSelect("OpenApoc.NewFeature", "SingleSquadSelect",
                                          "Select squad with single click", false);
-ConfigOptionBool optionATVUFOMission("OpenApoc.NewFeature", "ATVUFOMission",
-                                     "Allow ATV vehicles to initiate UFO missions", false);
+ConfigOptionBool
+    optionATVUFOMission("OpenApoc.NewFeature", "ATVUFOMission",
+                        "Allow ATV vehicles to initiate UFO missions (and recover vehicles)",
+                        false);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -113,6 +113,7 @@ extern ConfigOptionBool optionAutoReload;
 extern ConfigOptionBool optionLeftClickIcon;
 extern ConfigOptionBool optionBattlescapeVertScroll;
 extern ConfigOptionBool optionSingleSquadSelect;
+extern ConfigOptionBool optionATVUFOMission;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -3060,8 +3060,14 @@ void VehicleMission::takePositionNearPortal(GameState &state, Vehicle &v)
 bool VehicleMission::canRecoverVehicle(const GameState &state, const Vehicle &v,
                                        const Vehicle &target)
 {
-	// Ground can't recover
-	if (v.type->isGround())
+	// Non ATV vehicles can't initiate UFO missions
+	if (v.type->type == VehicleType::Type::Road)
+	{
+		return false;
+	}
+	// ATV vehicles can initiate UFO missions (if enabled)
+	if (v.type->type == VehicleType::Type::ATV &&
+	    !config().getBool("OpenApoc.NewFeature.ATVUFOMission"))
 	{
 		return false;
 	}

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -41,6 +41,7 @@ std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "CrashingDimensionGate"},
     {"OpenApoc.NewFeature", "SkipTurboMovement"},
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
+    {"OpenApoc.NewFeature", "ATVUFOMission"},
     {"OpenApoc.Mod", "RaidHostileAction"},
     {"OpenApoc.Mod", "CrashingVehicles"},
     {"OpenApoc.Mod", "InvulnerableRoads"},

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3716,12 +3716,21 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 			else
 			{
-				fw().pushEvent(new GameVehicleEvent(GameEventType::UfoRecoveryUnmanned,
-				                                    gameRecoveryEvent->vehicle,
-				                                    gameRecoveryEvent->actor));
-				for (auto &u : gameRecoveryEvent->vehicle->type->researchUnlock)
+				// Ground vehicles can't recover UFOs
+				if (!gameRecoveryEvent->actor->type->isGround())
 				{
-					u->forceComplete();
+					fw().pushEvent(new GameVehicleEvent(GameEventType::UfoRecoveryUnmanned,
+					                                    gameRecoveryEvent->vehicle,
+					                                    gameRecoveryEvent->actor));
+					for (auto &u : gameRecoveryEvent->vehicle->type->researchUnlock)
+					{
+						u->forceComplete();
+					}
+				}
+				else
+				{
+					gameRecoveryEvent->actor->setMission(
+					    *state, VehicleMission::gotoBuilding(*state, *gameRecoveryEvent->actor));
 				}
 			}
 			break;

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3716,21 +3716,12 @@ bool CityView::handleGameStateEvent(Event *e)
 			}
 			else
 			{
-				// Ground vehicles can't recover UFOs
-				if (!gameRecoveryEvent->actor->type->isGround())
+				fw().pushEvent(new GameVehicleEvent(GameEventType::UfoRecoveryUnmanned,
+				                                    gameRecoveryEvent->vehicle,
+				                                    gameRecoveryEvent->actor));
+				for (auto &u : gameRecoveryEvent->vehicle->type->researchUnlock)
 				{
-					fw().pushEvent(new GameVehicleEvent(GameEventType::UfoRecoveryUnmanned,
-					                                    gameRecoveryEvent->vehicle,
-					                                    gameRecoveryEvent->actor));
-					for (auto &u : gameRecoveryEvent->vehicle->type->researchUnlock)
-					{
-						u->forceComplete();
-					}
-				}
-				else
-				{
-					gameRecoveryEvent->actor->setMission(
-					    *state, VehicleMission::gotoBuilding(*state, *gameRecoveryEvent->actor));
+					u->forceComplete();
 				}
 			}
 			break;


### PR DESCRIPTION
Addresses #696. 

This allows ATV type vehicles to initiate UFO missions, but not recover UFOs. If an ATV type vehicle approaches an unmanned UFO, it just returns to base. This could be done better, maybe not even try in the first place. Should they also be able to recover the UFOs?