### PR TITLE
Fix selected agent dying in battle causes error

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2535,6 +2535,9 @@ void Battle::enterBattle(GameState &state)
 
 	// Remember time
 	state.updateBeforeBattle();
+
+	// Clear selected units in case they die
+	state.current_city->cityViewSelectedAgents.clear();
 }
 
 // To be called when battle must be finished and before showing score screen


### PR DESCRIPTION
Fixes this annoying issue that crops up sometimes after an agent dies in battle:

![noagent](https://github.com/OpenApoc/OpenApoc/assets/73447098/56e026eb-6494-419c-ab13-1f23485e83b8)

This was happening if a selected agent in the cityscape died in battle. The gamestate was updating the agents and expecting this selected agent to still exist. This clears the selected agents before a battle to make sure this can't happen.
