### PR TITLE
Delay the switch from alien dimension to clear projectiles

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -1921,6 +1921,17 @@ void CityView::update()
 				switchDimension = false;
 				break;
 			}
+			// Don't switch if UFOs crashing
+			if (v.second->owner == state->getAliens() && v.second->falling)
+			{
+				switchDimension = false;
+				break;
+			}
+		}
+		// Don't switch if any projectiles exist
+		if (!state->current_city->projectiles.empty())
+		{
+			switchDimension = false;
 		}
 	}
 	if (DEBUG_SHOW_ALIEN ? state->current_city.id != "CITYMAP_ALIEN" : switchDimension)


### PR DESCRIPTION
Addresses #991 among others.

This delays the switch from the alien dimension until all projectiles have died and all UFOs have crashed. Has been lightly tested and seems to function.

Should this rule apply to anything else? XCOM craft too?