### PR TITLE
Issue 1212: Added agent history screen

### DIFF
--- a/data/forms/aequipscreen.form
+++ b/data/forms/aequipscreen.form
@@ -104,7 +104,7 @@
         <image/>
         <imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <checkbox ID="BUTTON_TOGGLE_STATS">
+      <checkbox id="BUTTON_TOGGLE_STATS">
         <position x="167" y="56"/>
         <size width="22" height="21"/>
         <image/>
@@ -118,6 +118,12 @@
       </graphic>
 
       <subform id="AGENT_STATS_VIEW" src="sheet_agent_stats">
+        <position x="17" y="62"/>
+      </subform>
+      <subform id="AGENT_PROFILE_VIEW" src="sheet_agent_profile">
+        <position x="17" y="62"/>
+      </subform>
+      <subform id="AGENT_HISTORY_VIEW" src="sheet_agent_history">
         <position x="17" y="62"/>
       </subform>
       <subform id="AGENT_ITEM_VIEW" src="sheet_agent_item">

--- a/data/forms/battle/prestart.form
+++ b/data/forms/battle/prestart.form
@@ -31,6 +31,9 @@
       <subform id="AGENT_STATS_VIEW" src="sheet_agent_stats">
         <position x="17" y="64"/>
       </subform>
+      <subform id="AGENT_PROFILE_VIEW" src="sheet_agent_profile">
+        <position x="17" y="64"/>
+      </subform>
 
       <!-- Items -->
       <graphic id="RIGHT_HAND">

--- a/data/forms/sheet_agent_history.form
+++ b/data/forms/sheet_agent_history.form
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openapoc>
+  <form id="FORM_AEQUIPSCREEN_AGENT_HISTORY">
+    <style minwidth="160" minheight="280">
+      <position x="centre" y="centre"/>
+      <size width="160" height="280"/>
+
+      <label id="VALUE_DAYS_IN_SERVICE" text="">
+		<position x="15" y="105"/>
+        <size width="25" height="15"/>
+        <alignment horizontal="right" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+
+      <label id="LABEL_DAYS_IN_SERVICE" text="">
+        <position x="50" y="105"/>
+        <size width="142" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+
+      <label id="VALUE_MISSION_COUNT" text="">
+        <position x="15" y="121"/>
+        <size width="25" height="15"/>
+        <alignment horizontal="right" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+
+      <label id="LABEL_MISSION_COUNT" text="">
+        <position x="50" y="121"/>
+        <size width="142" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+
+      <label id="VALUE_KILL_COUNT" text="">
+        <position x="15" y="137"/>
+        <size width="25" height="15"/>
+        <alignment horizontal="right" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+
+      <label id="LABEL_KILL_COUNT" text="">
+        <position x="50" y="137"/>
+        <size width="142" height="15"/>
+        <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+      </label>
+
+    </style>
+  </form>
+</openapoc>

--- a/data/forms/sheet_agent_profile.form
+++ b/data/forms/sheet_agent_profile.form
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openapoc>
+  <form id="FORM_AEQUIPSCREEN_AGENT_PROFILE">
+    <style minwidth="160" minheight="280">
+      <position x="centre" y="centre"/>
+      <size width="160" height="280"/>
+      <textedit id="AGENT_NAME" text="AGENT NAME GOES HERE">
+        <position x="0" y="86"/>
+        <size width="160" height="15"/>
+        <alignment horizontal="centre" vertical="centre"/>
+        <font>smalfont</font>
+      </textedit>
+      <graphic id="SELECTED_PORTRAIT">
+        <position x="11" y="7"/>
+        <size width="65" height="64"/>
+        <image>placeholder.png</image>
+        <imageposition>fit</imageposition>
+      </graphic>
+      <graphic id="SELECTED_RANK">
+        <position x="122" y="41"/>
+        <size width="33" height="32"/>
+        <image>placeholder.png</image>
+        <imageposition>fit</imageposition>
+      </graphic>
+    </style>
+  </form>
+</openapoc>

--- a/data/forms/sheet_agent_stats.form
+++ b/data/forms/sheet_agent_stats.form
@@ -4,24 +4,6 @@
     <style minwidth="160" minheight="280">
       <position x="centre" y="centre"/>
       <size width="160" height="280"/>
-      <textedit id="AGENT_NAME" text="AGENT NAME GOES HERE">
-        <position x="0" y="86"/>
-        <size width="160" height="15"/>
-        <alignment horizontal="centre" vertical="centre"/>
-        <font>smalfont</font>
-      </textedit>
-      <graphic id="SELECTED_PORTRAIT">
-        <position x="11" y="7"/>
-        <size width="65" height="64"/>
-        <image>placeholder.png</image>
-        <imageposition>fit</imageposition>
-      </graphic>
-      <graphic id="SELECTED_RANK">
-        <position x="122" y="41"/>
-        <size width="33" height="32"/>
-        <image>placeholder.png</image>
-        <imageposition>fit</imageposition>
-      </graphic>
 
       <label id="LABEL_1" text="Health">
         <position x="0" y="105"/>

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -131,6 +131,7 @@ void Battle::initBattle(GameState &state, bool first)
 		o.second->genericHitSounds = state.battle_common_sample_list->genericHitSounds;
 		o.second->psiSuccessSounds = state.battle_common_sample_list->psiSuccessSounds;
 		o.second->psiFailSounds = state.battle_common_sample_list->psiFailSounds;
+		o.second->activatedInSquad();
 	}
 	if (forces.empty())
 	{

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -4675,6 +4675,7 @@ bool BattleUnit::useSpawner(GameState &state, const AEquipmentType &item)
 void BattleUnit::die(GameState &state, StateRef<BattleUnit> attacker, bool violently)
 {
 	auto attackerOrg = attacker ? attacker->agent->owner : nullptr;
+	attacker->recordKill();
 	auto ourOrg = agent->owner;
 	bool destroy = false;
 	// Violent deaths (spawn stuff, blow up)
@@ -5946,4 +5947,13 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool t
 	}
 	return !mission->cancelled;
 }
+
+void BattleUnit::activatedInSquad() {
+	agent->incrementMissionCount();
+}
+
+void BattleUnit::recordKill() {
+	agent->incrementKillCount();
+}
+
 } // namespace OpenApoc

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -5948,12 +5948,8 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool t
 	return !mission->cancelled;
 }
 
-void BattleUnit::activatedInSquad() {
-	agent->incrementMissionCount();
-}
+void BattleUnit::activatedInSquad() { agent->incrementMissionCount(); }
 
-void BattleUnit::recordKill() {
-	agent->incrementKillCount();
-}
+void BattleUnit::recordKill() { agent->incrementKillCount(); }
 
 } // namespace OpenApoc

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -839,5 +839,8 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	                       StateRef<BattleUnit> targetUnit = StateRef<BattleUnit>());
 	// Update both this unit's vision and other unit's vision of this unit
 	void refreshUnitVisibilityAndVision(GameState &state);
+
+	void activatedInSquad();
+	void recordKill();
 };
 } // namespace OpenApoc

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -402,6 +402,7 @@ void Agent::hire(GameState &state, StateRef<Building> newHome)
 	owner = newHome->owner;
 	homeBuilding = newHome;
 	recentlyHired = true;
+	hiredOn = state.gameTime;
 	setMission(state, AgentMission::gotoBuilding(state, *this, newHome, false, true));
 }
 
@@ -1464,4 +1465,25 @@ void Agent::destroy()
 	}
 }
 
-} // namespace OpenApoc
+unsigned int Agent::getDaysInService(const GameState &state) const {
+	return state.gameTime.getDay() - hiredOn.getDay();
+}
+
+unsigned int Agent::getKills() const {
+	return killCount;
+}
+
+unsigned int Agent::getMissions() const {
+	return missionCount;
+}
+
+void Agent::incrementMissionCount() {
+	missionCount++;
+}
+
+void Agent::incrementKillCount() {
+	killCount++;
+}
+
+
+} // namespace OpggApoc

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -1465,25 +1465,17 @@ void Agent::destroy()
 	}
 }
 
-unsigned int Agent::getDaysInService(const GameState &state) const {
+unsigned int Agent::getDaysInService(const GameState &state) const
+{
 	return state.gameTime.getDay() - hiredOn.getDay();
 }
 
-unsigned int Agent::getKills() const {
-	return killCount;
-}
+unsigned int Agent::getKills() const { return killCount; }
 
-unsigned int Agent::getMissions() const {
-	return missionCount;
-}
+unsigned int Agent::getMissions() const { return missionCount; }
 
-void Agent::incrementMissionCount() {
-	missionCount++;
-}
+void Agent::incrementMissionCount() { missionCount++; }
 
-void Agent::incrementKillCount() {
-	killCount++;
-}
+void Agent::incrementKillCount() { killCount++; }
 
-
-} // namespace OpggApoc
+} // namespace OpenApoc

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -85,6 +85,9 @@ class Agent : public StateObject<Agent>,
 	bool overEncumbred = false;
 	Rank rank = Rank::Rookie;
 	AgentStatus status = AgentStatus::Alive;
+	GameTime hiredOn;
+	unsigned int missionCount = 0;
+	unsigned int killCount = 0;
 
 	unsigned int teleportTicksAccumulated = 0;
 	bool canTeleport() const;
@@ -232,8 +235,16 @@ class Agent : public StateObject<Agent>,
 
 	sp<AEquipment> leftHandItem;  // Left hand item, frequently accessed so will be stored here
 	sp<AEquipment> rightHandItem; // Right hand item, frequently accessed so will be stored here
+	
+	unsigned int getDaysInService(const GameState &state) const;
+	unsigned int getKills() const;
+	unsigned int getMissions() const;
+
+	void incrementMissionCount();
+	void incrementKillCount();
 
 	void destroy() override;
+	
 };
 
 class AgentGenerator

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -235,7 +235,7 @@ class Agent : public StateObject<Agent>,
 
 	sp<AEquipment> leftHandItem;  // Left hand item, frequently accessed so will be stored here
 	sp<AEquipment> rightHandItem; // Right hand item, frequently accessed so will be stored here
-	
+
 	unsigned int getDaysInService(const GameState &state) const;
 	unsigned int getKills() const;
 	unsigned int getMissions() const;
@@ -244,7 +244,6 @@ class Agent : public StateObject<Agent>,
 	void incrementKillCount();
 
 	void destroy() override;
-	
 };
 
 class AgentGenerator

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -37,6 +37,7 @@ RecruitScreen::RecruitScreen(sp<GameState> state)
 	// Load resources
 	form = ui().getForm("recruitscreen");
 	formAgentStats = form->findControlTyped<Form>("AGENT_STATS_VIEW");
+	formAgentProfile = form->findControlTyped<Form>("AGENT_PROFILE_VIEW");
 	formPersonnelStats = form->findControlTyped<Form>("PERSONNEL_STATS_VIEW");
 	formAgentStats->setVisible(false);
 	formPersonnelStats->setVisible(false);
@@ -381,7 +382,7 @@ void RecruitScreen::displayAgentStats(const Agent &agent)
 	switch (agent.type->role)
 	{
 		case AgentType::Role::Soldier:
-			AgentSheet(formAgentStats).display(agent, bigUnitRanks, false);
+			AgentSheet(formAgentProfile, formAgentStats).display(agent, bigUnitRanks, false);
 			formAgentStats->setVisible(true);
 			formPersonnelStats->setVisible(false);
 			break;

--- a/game/ui/base/recruitscreen.h
+++ b/game/ui/base/recruitscreen.h
@@ -38,6 +38,7 @@ class RecruitScreen : public BaseStage
 	std::vector<sp<Image>> bigUnitRanks;
 
 	sp<Form> formAgentStats;
+	sp<Form> formAgentProfile;
 	sp<Form> formPersonnelStats;
 
 	AgentType::Role type;

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -48,7 +48,8 @@ TransactionScreen::TransactionScreen(sp<GameState> state, bool forceLimits)
 
 	// Assign event handlers
 	onScrollChange = [this](FormsEvent *) { this->updateFormValues(); };
-	onHover = [this](FormsEvent *e) {
+	onHover = [this](FormsEvent *e)
+	{
 		auto tctrl = std::dynamic_pointer_cast<TransactionControl>(e->forms().RaisedBy);
 		if (!tctrl)
 		{
@@ -751,9 +752,9 @@ sp<TransactionControl> TransactionScreen::findControlById(const UString &itemId)
 		auto it = transactionControls.find(type);
 		if (it != transactionControls.end())
 		{
-			auto it2 = std::find_if(
-			    it->second.begin(), it->second.end(),
-			    [itemId](const sp<TransactionControl> &c) { return c->itemId == itemId; });
+			auto it2 = std::find_if(it->second.begin(), it->second.end(),
+			                        [itemId](const sp<TransactionControl> &c)
+			                        { return c->itemId == itemId; });
 			if (it2 != it->second.end())
 			{
 				return *it2;

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -38,6 +38,7 @@ TransactionScreen::TransactionScreen(sp<GameState> state, bool forceLimits)
 	formItemAgent = form->findControlTyped<Form>("AGENT_ITEM_VIEW");
 	formItemVehicle = form->findControlTyped<Form>("VEHICLE_ITEM_VIEW");
 	formAgentStats = form->findControlTyped<Form>("AGENT_STATS_VIEW");
+	formAgentProfile = form->findControlTyped<Form>("AGENT_PROFILE_VIEW");
 	formPersonnelStats = form->findControlTyped<Form>("PERSONNEL_STATS_VIEW");
 
 	formItemAgent->setVisible(false);

--- a/game/ui/base/transactionscreen.h
+++ b/game/ui/base/transactionscreen.h
@@ -62,6 +62,7 @@ class TransactionScreen : public BaseStage
 	sp<Form> formItemAgent;
 	sp<Form> formItemVehicle;
 	sp<Form> formAgentStats;
+	sp<Form> formAgentProfile;
 	sp<Form> formPersonnelStats;
 
 	sp<Label> textViewBaseStatic;

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -226,7 +226,7 @@ void TransferScreen::displayItem(sp<TransactionControl> control)
 		}
 		case TransactionControl::Type::Soldier:
 		{
-			AgentSheet(formAgentStats)
+			AgentSheet(formAgentProfile, formAgentStats)
 			    .display(*state->agents[control->itemId], bigUnitRanks, false);
 			formAgentStats->setVisible(true);
 			break;

--- a/game/ui/battle/battleprestart.cpp
+++ b/game/ui/battle/battleprestart.cpp
@@ -39,9 +39,10 @@ void BattlePreStart::displayAgent(sp<Agent> agent)
 		return;
 	}
 
-	AgentSheet(formAgentStats)
+	AgentSheet(formAgentProfile, formAgentStats)
 	    .display(*agent, bigUnitRanks, state->current_battle->mode == Battle::Mode::TurnBased);
 	formAgentStats->setVisible(true);
+	formAgentProfile->setVisible(true);
 
 	auto rHand = agent->getFirstItemInSlot(EquipmentSlotType::RightHand);
 	auto lHand = agent->getFirstItemInSlot(EquipmentSlotType::LeftHand);
@@ -59,7 +60,9 @@ BattlePreStart::BattlePreStart(sp<GameState> state)
 		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
 	    });
 	formAgentStats = menuform->findControlTyped<Form>("AGENT_STATS_VIEW");
+	formAgentProfile = menuform->findControlTyped<Form>("AGENT_PROFILE_VIEW");
 	formAgentStats->setVisible(false);
+	formAgentProfile->setVisible(false);
 	menuform->findControlTyped<GraphicButton>("BUTTON_OK")
 	    ->addCallback(FormEventType::ButtonClick, [this, state](Event *) {
 		    auto gameState = this->state;

--- a/game/ui/battle/battleprestart.cpp
+++ b/game/ui/battle/battleprestart.cpp
@@ -56,23 +56,28 @@ BattlePreStart::BattlePreStart(sp<GameState> state)
 {
 
 	menuform->findControlTyped<GraphicButton>("BUTTON_EQUIP")
-	    ->addCallback(FormEventType::ButtonClick, [state](Event *) {
-		    fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
-	    });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [state](Event *) {
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
+	        });
 	formAgentStats = menuform->findControlTyped<Form>("AGENT_STATS_VIEW");
 	formAgentProfile = menuform->findControlTyped<Form>("AGENT_PROFILE_VIEW");
 	formAgentStats->setVisible(false);
 	formAgentProfile->setVisible(false);
 	menuform->findControlTyped<GraphicButton>("BUTTON_OK")
-	    ->addCallback(FormEventType::ButtonClick, [this, state](Event *) {
-		    auto gameState = this->state;
+	    ->addCallback(FormEventType::ButtonClick,
+	                  [this, state](Event *)
+	                  {
+		                  auto gameState = this->state;
 
-		    fw().stageQueueCommand({StageCmd::Command::PUSH,
-		                            mksp<LoadingScreen>(
-		                                gameState, enterBattle(gameState),
-		                                [gameState]() { return mksp<BattleView>(gameState); },
-		                                this->state->battle_common_image_list->loadingImage, 1)});
-	    });
+		                  fw().stageQueueCommand(
+		                      {StageCmd::Command::PUSH,
+		                       mksp<LoadingScreen>(
+		                           gameState, enterBattle(gameState),
+		                           [gameState]() { return mksp<BattleView>(gameState); },
+		                           this->state->battle_common_image_list->loadingImage, 1)});
+	                  });
 
 	for (int i = 12; i <= 18; i++)
 	{

--- a/game/ui/battle/battleprestart.h
+++ b/game/ui/battle/battleprestart.h
@@ -41,6 +41,7 @@ class BattlePreStart : public Stage
 
 	sp<Form> menuform;
 	sp<Form> formAgentStats;
+	sp<Form> formAgentProfile;
 
 	sp<GameState> state;
 

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -116,24 +116,26 @@ AEquipScreen::AEquipScreen(sp<GameState> state, sp<Agent> firstAgent)
 	                  });
 
 	formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")
-		->addCallback(FormEventType::CheckBoxChange,
-				[this](FormsEvent *e)
-				{
-					auto shouldDisplayHistory = formMain
-						->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")
-						->isChecked();
+	    ->addCallback(
+	        FormEventType::CheckBoxChange,
+	        [this](FormsEvent *e)
+	        {
+		        auto shouldDisplayHistory =
+		            formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 
-					if (shouldDisplayHistory) {
-						formAgentHistory->setVisible(true);
-						formAgentStats->setVisible(false);
-					} else {
-						formAgentStats->setVisible(true);
-						formAgentHistory->setVisible(false);
-					}
+		        if (shouldDisplayHistory)
+		        {
+			        formAgentHistory->setVisible(true);
+			        formAgentStats->setVisible(false);
+		        }
+		        else
+		        {
+			        formAgentStats->setVisible(true);
+			        formAgentHistory->setVisible(false);
+		        }
 
-					formAgentProfile->setVisible(true);
-
-				});
+		        formAgentProfile->setVisible(true);
+	        });
 
 	woundImage = fw().data->loadImage(format("PCK:xcom3/tacdata/icons.pck:xcom3/tacdata/"
 	                                         "icons.tab:%d:xcom3/tacdata/tactical.pal",
@@ -420,14 +422,16 @@ void AEquipScreen::eventOccurred(Event *e)
 		}
 		else
 		{
-			auto shouldDisplayHistory = formMain
-				->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")
-				->isChecked();
+			auto shouldDisplayHistory =
+			    formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 
-			if (shouldDisplayHistory) {
+			if (shouldDisplayHistory)
+			{
 				formAgentHistory->setVisible(true);
 				formAgentStats->setVisible(false);
-			} else {
+			}
+			else
+			{
 				formAgentStats->setVisible(true);
 				formAgentHistory->setVisible(false);
 			}
@@ -1949,16 +1953,18 @@ void AEquipScreen::displayAgent(sp<Agent> agent)
 	formMain->findControlTyped<Graphic>("BACKGROUND")->setImage(agent->type->inventoryBackground);
 
 	AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
-		.display(*agent, bigUnitRanks, isTurnBased());
+	    .display(*agent, bigUnitRanks, isTurnBased());
 
-	auto shouldDisplayHistory = formMain
-		->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")
-		->isChecked();
+	auto shouldDisplayHistory =
+	    formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 
-	if (shouldDisplayHistory) {
+	if (shouldDisplayHistory)
+	{
 		formAgentHistory->setVisible(true);
 		formAgentStats->setVisible(false);
-	} else {
+	}
+	else
+	{
 		formAgentStats->setVisible(true);
 		formAgentHistory->setVisible(false);
 	}
@@ -2042,49 +2048,55 @@ void AEquipScreen::updateAgentControl(sp<Agent> agent)
 	auto control = ControlGenerator::createLargeAgentControl(
 	    *state, agent, agentList->Size.x, UnitSkillState::Hidden, selstate, !isInVicinity(agent));
 
-	control->addCallback(FormEventType::MouseEnter,
+	control->addCallback(
+	    FormEventType::MouseEnter,
 	    [this, agent](FormsEvent *e [[maybe_unused]])
 	    {
 		    AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
-				.display(*agent, bigUnitRanks, isTurnBased());
+		        .display(*agent, bigUnitRanks, isTurnBased());
 
-			auto shouldDisplayHistory = formMain
-				->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")
-				->isChecked();
+		    auto shouldDisplayHistory =
+		        formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 
-			if (shouldDisplayHistory) {
-				formAgentHistory->setVisible(true);
-				formAgentStats->setVisible(false);
-			} else {
-				formAgentStats->setVisible(true);
-				formAgentHistory->setVisible(false);
-			}
+		    if (shouldDisplayHistory)
+		    {
+			    formAgentHistory->setVisible(true);
+			    formAgentStats->setVisible(false);
+		    }
+		    else
+		    {
+			    formAgentStats->setVisible(true);
+			    formAgentHistory->setVisible(false);
+		    }
 
 		    formAgentProfile->setVisible(true);
 		    formAgentItem->setVisible(false);
 	    });
 
-	control->addCallback(FormEventType::MouseLeave,
-		[this](FormsEvent *e [[maybe_unused]])
-		{
-			AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
-				.display(*selectedAgents.front(), bigUnitRanks, isTurnBased());
+	control->addCallback(
+	    FormEventType::MouseLeave,
+	    [this](FormsEvent *e [[maybe_unused]])
+	    {
+		    AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
+		        .display(*selectedAgents.front(), bigUnitRanks, isTurnBased());
 
-			auto shouldDisplayHistory = formMain
-				->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")
-				->isChecked();
+		    auto shouldDisplayHistory =
+		        formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 
-			if (shouldDisplayHistory) {
-				formAgentHistory->setVisible(true);
-				formAgentStats->setVisible(false);
-			} else {
-				formAgentStats->setVisible(true);
-				formAgentHistory->setVisible(false);
-			}
+		    if (shouldDisplayHistory)
+		    {
+			    formAgentHistory->setVisible(true);
+			    formAgentStats->setVisible(false);
+		    }
+		    else
+		    {
+			    formAgentStats->setVisible(true);
+			    formAgentHistory->setVisible(false);
+		    }
 
 		    formAgentProfile->setVisible(true);
-			formAgentItem->setVisible(false);
-		});
+		    formAgentItem->setVisible(false);
+	    });
 
 	agentList->replaceItem(control);
 }

--- a/game/ui/general/aequipscreen.h
+++ b/game/ui/general/aequipscreen.h
@@ -47,6 +47,8 @@ class AEquipScreen : public Stage
 	sp<Form> formMain;
 	sp<Form> formAgentStats;
 	sp<Form> formAgentItem;
+	sp<Form> formAgentProfile;
+	sp<Form> formAgentHistory;
 
 	sp<Palette> pal;
 	sp<GameState> state;

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -28,21 +28,28 @@ const std::pair<Colour, Colour> psiAttackColour{{192, 56, 144}, {255, 120, 208}}
 const std::pair<Colour, Colour> psiDefenceColour{{192, 56, 144}, {255, 120, 208}};
 const Colour bkgColour{36, 36, 36};
 
-AgentSheet::AgentSheet(sp<Form> profileForm, sp<Form> statsForm) : 
-	profileForm(profileForm), statsForm(statsForm) {}
+AgentSheet::AgentSheet(sp<Form> profileForm, sp<Form> statsForm)
+    : profileForm(profileForm), statsForm(statsForm)
+{
+}
 
-AgentSheet::AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm, sp<Form> historyForm) : 
-	profileForm(profileForm), statsForm(statsForm), historyForm(historyForm), state(state) {}
+AgentSheet::AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm,
+                       sp<Form> historyForm)
+    : profileForm(profileForm), statsForm(statsForm), historyForm(historyForm), state(state)
+{
+}
 
-void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased) {
+void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased)
+{
 	clear();
 	displayProfile(item, ranks);
 	displayStats(item, ranks, turnBased);
 	if (historyForm)
-		displayHistory (item);
+		displayHistory(item);
 }
 
-void AgentSheet::displayProfile(const Agent &item, std::vector<sp<Image>> &ranks) {
+void AgentSheet::displayProfile(const Agent &item, std::vector<sp<Image>> &ranks)
+{
 	profileForm->findControlTyped<TextEdit>("AGENT_NAME")->setText(item.name);
 	profileForm->findControlTyped<Graphic>("SELECTED_PORTRAIT")->setImage(item.getPortrait().photo);
 
@@ -50,7 +57,8 @@ void AgentSheet::displayProfile(const Agent &item, std::vector<sp<Image>> &ranks
 	    ->setImage(item.type->displayRank ? ranks[(int)item.rank] : nullptr);
 }
 
-void AgentSheet::displayHistory(const Agent &item) {
+void AgentSheet::displayHistory(const Agent &item)
+{
 
 	historyForm->findControlTyped<Label>("LABEL_DAYS_IN_SERVICE")->setText(tr("Days In Service"));
 	std::stringstream daysInService;
@@ -95,7 +103,8 @@ void AgentSheet::displayStats(const Agent &item, std::vector<sp<Image>> &ranks, 
 	    statsForm->findControlTyped<Label>("LABEL_3")->getText() +
 	    format(": %d/%d", item.modified_stats.reactions, item.current_stats.reactions);
 
-	statsForm->findControlTyped<Label>("LABEL_4")->setText(turnBased ? tr("Time Units") : tr("Speed"));
+	statsForm->findControlTyped<Label>("LABEL_4")->setText(turnBased ? tr("Time Units")
+	                                                                 : tr("Speed"));
 	statsForm->findControlTyped<Graphic>("VALUE_4")->ToolTipText =
 	    statsForm->findControlTyped<Label>("LABEL_4")->getText();
 	if (turnBased)
@@ -165,7 +174,6 @@ void AgentSheet::displayStats(const Agent &item, std::vector<sp<Image>> &ranks, 
 	    statsForm->findControlTyped<Label>("LABEL_10")->getText() +
 	    format(": %d/%d", item.modified_stats.psi_defence, item.current_stats.psi_defence);
 }
-
 
 void AgentSheet::clear()
 {

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -9,6 +9,7 @@
 #include "framework/renderer.h"
 #include "game/state/gamestate.h"
 #include "game/state/rules/battle/damage.h"
+#include <sstream>
 
 namespace OpenApoc
 {
@@ -27,118 +28,151 @@ const std::pair<Colour, Colour> psiAttackColour{{192, 56, 144}, {255, 120, 208}}
 const std::pair<Colour, Colour> psiDefenceColour{{192, 56, 144}, {255, 120, 208}};
 const Colour bkgColour{36, 36, 36};
 
-AgentSheet::AgentSheet(sp<Form> dstForm) : form(dstForm) {}
+AgentSheet::AgentSheet(sp<Form> profileForm, sp<Form> statsForm) : 
+	profileForm(profileForm), statsForm(statsForm) {}
 
-void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased)
-{
+AgentSheet::AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm, sp<Form> historyForm) : 
+	profileForm(profileForm), statsForm(statsForm), historyForm(historyForm), state(state) {}
+
+void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased) {
 	clear();
-	form->findControlTyped<TextEdit>("AGENT_NAME")->setText(item.name);
-	form->findControlTyped<Graphic>("SELECTED_PORTRAIT")->setImage(item.getPortrait().photo);
+	displayProfile(item, ranks);
+	displayStats(item, ranks, turnBased);
+	if (historyForm)
+		displayHistory (item);
+}
 
-	form->findControlTyped<Graphic>("SELECTED_RANK")
+void AgentSheet::displayProfile(const Agent &item, std::vector<sp<Image>> &ranks) {
+	profileForm->findControlTyped<TextEdit>("AGENT_NAME")->setText(item.name);
+	profileForm->findControlTyped<Graphic>("SELECTED_PORTRAIT")->setImage(item.getPortrait().photo);
+
+	profileForm->findControlTyped<Graphic>("SELECTED_RANK")
 	    ->setImage(item.type->displayRank ? ranks[(int)item.rank] : nullptr);
+}
 
-	form->findControlTyped<Label>("LABEL_1")->setText(tr("Health"));
-	form->findControlTyped<Graphic>("VALUE_1")->setImage(
+void AgentSheet::displayHistory(const Agent &item) {
+
+	historyForm->findControlTyped<Label>("LABEL_DAYS_IN_SERVICE")->setText(tr("Days In Service"));
+	std::stringstream daysInService;
+	daysInService << item.getDaysInService(*state);
+	historyForm->findControlTyped<Label>("VALUE_DAYS_IN_SERVICE")->setText(daysInService.str());
+
+	historyForm->findControlTyped<Label>("LABEL_MISSION_COUNT")->setText(tr("Missions"));
+	std::stringstream missionsCount;
+	missionsCount << item.getMissions();
+	historyForm->findControlTyped<Label>("VALUE_MISSION_COUNT")->setText(missionsCount.str());
+
+	historyForm->findControlTyped<Label>("LABEL_KILL_COUNT")->setText(tr("Kills"));
+	std::stringstream killCount;
+	killCount << item.getKills();
+	historyForm->findControlTyped<Label>("VALUE_KILL_COUNT")->setText(killCount.str());
+}
+
+void AgentSheet::displayStats(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased)
+{
+
+	statsForm->findControlTyped<Label>("LABEL_1")->setText(tr("Health"));
+	statsForm->findControlTyped<Graphic>("VALUE_1")->setImage(
 	    createStatsBar(item.initial_stats.health, item.current_stats.health,
 	                   item.modified_stats.health, 100, healthColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_1")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_1")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_1")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_1")->getText() +
 	    format(": %d/%d", item.modified_stats.health, item.current_stats.health);
 
-	form->findControlTyped<Label>("LABEL_2")->setText(tr("Accuracy"));
-	form->findControlTyped<Graphic>("VALUE_2")->setImage(
+	statsForm->findControlTyped<Label>("LABEL_2")->setText(tr("Accuracy"));
+	statsForm->findControlTyped<Graphic>("VALUE_2")->setImage(
 	    createStatsBar(item.initial_stats.accuracy, item.current_stats.accuracy,
 	                   item.modified_stats.accuracy, 100, accuracyColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_2")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_2")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_2")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_2")->getText() +
 	    format(": %d/%d", item.modified_stats.accuracy, item.current_stats.accuracy);
 
-	form->findControlTyped<Label>("LABEL_3")->setText(tr("Reactions"));
-	form->findControlTyped<Graphic>("VALUE_3")->setImage(
+	statsForm->findControlTyped<Label>("LABEL_3")->setText(tr("Reactions"));
+	statsForm->findControlTyped<Graphic>("VALUE_3")->setImage(
 	    createStatsBar(item.initial_stats.reactions, item.current_stats.reactions,
 	                   item.modified_stats.reactions, 100, reactionsColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_3")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_3")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_3")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_3")->getText() +
 	    format(": %d/%d", item.modified_stats.reactions, item.current_stats.reactions);
 
-	form->findControlTyped<Label>("LABEL_4")->setText(turnBased ? tr("Time Units") : tr("Speed"));
-	form->findControlTyped<Graphic>("VALUE_4")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_4")->getText();
+	statsForm->findControlTyped<Label>("LABEL_4")->setText(turnBased ? tr("Time Units") : tr("Speed"));
+	statsForm->findControlTyped<Graphic>("VALUE_4")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_4")->getText();
 	if (turnBased)
 	{
-		form->findControlTyped<Graphic>("VALUE_4")->setImage(
+		statsForm->findControlTyped<Graphic>("VALUE_4")->setImage(
 		    createStatsBar(item.initial_stats.time_units, item.current_stats.time_units,
 		                   item.modified_stats.time_units, 100, speedColour, {88, 7}));
-		form->findControlTyped<Graphic>("VALUE_4")->ToolTipText +=
+		statsForm->findControlTyped<Graphic>("VALUE_4")->ToolTipText +=
 		    format(": %d/%d", item.modified_stats.time_units, item.current_stats.time_units);
 	}
 	else
 	{
-		form->findControlTyped<Graphic>("VALUE_4")->setImage(createStatsBar(
+		statsForm->findControlTyped<Graphic>("VALUE_4")->setImage(createStatsBar(
 		    item.initial_stats.getDisplaySpeedValue(), item.current_stats.getDisplaySpeedValue(),
 		    item.modified_stats.getDisplaySpeedValue(), 100, speedColour, {88, 7}));
-		form->findControlTyped<Graphic>("VALUE_4")->ToolTipText +=
+		statsForm->findControlTyped<Graphic>("VALUE_4")->ToolTipText +=
 		    format("^ %d/%d", item.modified_stats.getDisplaySpeedValue(),
 		           item.current_stats.getDisplaySpeedValue());
 	}
 
-	form->findControlTyped<Label>("LABEL_5")->setText(tr("Stamina"));
-	form->findControlTyped<Graphic>("VALUE_5")->setImage(createStatsBar(
+	statsForm->findControlTyped<Label>("LABEL_5")->setText(tr("Stamina"));
+	statsForm->findControlTyped<Graphic>("VALUE_5")->setImage(createStatsBar(
 	    item.initial_stats.getDisplayStaminaValue(), item.current_stats.getDisplayStaminaValue(),
 	    item.modified_stats.getDisplayStaminaValue(), 100, staminaColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_5")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_5")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_5")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_5")->getText() +
 	    format(": %d/%d", item.modified_stats.getDisplayStaminaValue(),
 	           item.current_stats.getDisplayStaminaValue());
 
-	form->findControlTyped<Label>("LABEL_6")->setText(tr("Bravery"));
-	form->findControlTyped<Graphic>("VALUE_6")->setImage(
+	statsForm->findControlTyped<Label>("LABEL_6")->setText(tr("Bravery"));
+	statsForm->findControlTyped<Graphic>("VALUE_6")->setImage(
 	    createStatsBar(item.initial_stats.bravery, item.current_stats.bravery,
 	                   item.modified_stats.bravery, 100, braveryColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_6")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_6")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_6")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_6")->getText() +
 	    format(": %d/%d", item.modified_stats.bravery, item.current_stats.bravery);
 
-	form->findControlTyped<Label>("LABEL_7")->setText(tr("Strength"));
-	form->findControlTyped<Graphic>("VALUE_7")->setImage(
+	statsForm->findControlTyped<Label>("LABEL_7")->setText(tr("Strength"));
+	statsForm->findControlTyped<Graphic>("VALUE_7")->setImage(
 	    createStatsBar(item.initial_stats.strength, item.current_stats.strength,
 	                   item.modified_stats.strength, 100, strengthColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_7")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_7")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_7")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_7")->getText() +
 	    format(": %d/%d", item.modified_stats.strength, item.current_stats.strength);
 
-	form->findControlTyped<Label>("LABEL_8")->setText(tr("Psi-energy"));
-	form->findControlTyped<Graphic>("VALUE_8")->setImage(
+	statsForm->findControlTyped<Label>("LABEL_8")->setText(tr("Psi-energy"));
+	statsForm->findControlTyped<Graphic>("VALUE_8")->setImage(
 	    createStatsBar(item.initial_stats.psi_energy, item.current_stats.psi_energy,
 	                   item.modified_stats.psi_energy, 100, psiEnergyColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_8")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_8")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_8")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_8")->getText() +
 	    format(": %d/%d", item.modified_stats.psi_energy, item.current_stats.psi_energy);
 
-	form->findControlTyped<Label>("LABEL_9")->setText(tr("Psi-attack"));
-	form->findControlTyped<Graphic>("VALUE_9")->setImage(
+	statsForm->findControlTyped<Label>("LABEL_9")->setText(tr("Psi-attack"));
+	statsForm->findControlTyped<Graphic>("VALUE_9")->setImage(
 	    createStatsBar(item.initial_stats.psi_attack, item.current_stats.psi_attack,
 	                   item.modified_stats.psi_attack, 100, psiAttackColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_9")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_9")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_9")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_9")->getText() +
 	    format(": %d/%d", item.modified_stats.psi_attack, item.current_stats.psi_attack);
 
-	form->findControlTyped<Label>("LABEL_10")->setText(tr("Psi-defence"));
-	form->findControlTyped<Graphic>("VALUE_10")
+	statsForm->findControlTyped<Label>("LABEL_10")->setText(tr("Psi-defence"));
+	statsForm->findControlTyped<Graphic>("VALUE_10")
 	    ->setImage(createStatsBar(item.initial_stats.psi_defence, item.current_stats.psi_defence,
 	                              item.modified_stats.psi_defence, 100, psiDefenceColour, {88, 7}));
-	form->findControlTyped<Graphic>("VALUE_10")->ToolTipText =
-	    form->findControlTyped<Label>("LABEL_10")->getText() +
+	statsForm->findControlTyped<Graphic>("VALUE_10")->ToolTipText =
+	    statsForm->findControlTyped<Label>("LABEL_10")->getText() +
 	    format(": %d/%d", item.modified_stats.psi_defence, item.current_stats.psi_defence);
 }
+
 
 void AgentSheet::clear()
 {
 	for (int i = 0; i < 10; i++)
 	{
 		auto labelName = format("LABEL_%d", i + 1);
-		auto label = form->findControlTyped<Label>(labelName);
+		auto label = statsForm->findControlTyped<Label>(labelName);
 		if (!label)
 		{
 			LogError("Failed to find UI control matching \"%s\"", labelName);

--- a/game/ui/general/agentsheet.h
+++ b/game/ui/general/agentsheet.h
@@ -13,7 +13,7 @@ class AgentSheet
 {
   public:
 	AgentSheet(sp<Form> profileForm, sp<Form> statsForm);
-	AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm,  sp<Form> historyFrom);
+	AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm, sp<Form> historyFrom);
 	void display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased = true);
 	void clear();
 

--- a/game/ui/general/agentsheet.h
+++ b/game/ui/general/agentsheet.h
@@ -12,14 +12,22 @@ namespace OpenApoc
 class AgentSheet
 {
   public:
-	AgentSheet(sp<Form> form);
+	AgentSheet(sp<Form> profileForm, sp<Form> statsForm);
+	AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm,  sp<Form> historyFrom);
 	void display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased = true);
 	void clear();
 
   private:
-	sp<Form> form;
+	sp<Form> profileForm;
+	sp<Form> historyForm;
+	sp<Form> statsForm;
+	sp<GameState> state;
 	sp<Image> createStatsBar(int initialValue, int currentValue, int modifiedValue, int maxValue,
 	                         const std::pair<Colour, Colour> &colour, Vec2<int> imageSize);
+
+	void displayProfile(const Agent &item, std::vector<sp<Image>> &ranks);
+	void displayHistory(const Agent &item);
+	void displayStats(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased = true);
 };
 
 }; // namespace OpenApoc


### PR DESCRIPTION
Hi OpenApoc Team,

First up  I apologise in advance for my dyslexia.

Thanks for the awesome work you guys are doing with this project, it's amazing. I started hacking a couple of weeks ago and I was able to get something working for #1212 the agent history screen.  I'm not a C++ dev so I'm sure there are many issues here but I figured I'd throw up a PR just for shits and gigs.  I have had a lot of fun working on this.  Throw the book or ignore it altogether. I won't be offended.

---

A breakdown of the changes I have made:

 * Fixed a id attribute in `aequipscreen` form
 * Created a new agent history form
 * Broke a profile form out from agent stats so it can be shared between the new history form and the existing stats form
 * Added an activatedInSquad member function to battle unit in order to count missions
 * Added a `recordKill` member function called each time a unit is attacked and dies.
 * The agent class now has a `hiredOn` memeber that should record the date they are hired.
 * Agent how has `getKills`, `getMissions` and getDaysInService in order to populate the values in the new history form
 * AgentSheet now has two different constructors depending on where it is called from and what data is required. Not all screens allow for displaying history.
 * A handler has been added to the toggle stats checkbox in order to toggle history hiding and showing.
 * Event handlers have been updated to now handle both forms.
 * AgentSheet display logic has been broken up into multiple methods to support the two different modes the screen can now display.

![image](https://github.com/OpenApoc/OpenApoc/assets/31781/2492409b-0385-4e6b-9893-7e754b3fa1c5)
