### PR TITLE
Change to 180 TPS

### DIFF
--- a/game/state/battle/battleexplosion.cpp
+++ b/game/state/battle/battleexplosion.cpp
@@ -83,6 +83,14 @@ void BattleExplosion::update(GameState &state, unsigned int ticks)
 void BattleExplosion::damage(GameState &state, const TileMap &map, Vec3<int> pos, int damage)
 {
 	auto tile = map.getTile(pos);
+	// Explosions with no hazard spawn smoke with half ttl
+	if (!damageType->hazardType)
+	{
+		StateRef<DamageType> dtSmoke = {&state, "DAMAGETYPE_SMOKE"};
+		state.current_battle->placeHazard(state, ownerOrganisation, ownerUnit, dtSmoke, pos,
+		                                  dtSmoke->hazardType->getLifetime(state), damage, 30,
+		                                  false);
+	}
 	// Explosions with no custom explosion doodad spawn hazards when dealing damage
 	if (damageType->hazardType && !damageType->explosionDoodad)
 	{
@@ -170,7 +178,7 @@ void BattleExplosion::damage(GameState &state, const TileMap &map, Vec3<int> pos
 }
 
 void BattleExplosion::expand(GameState &state, const TileMap &map, const Vec3<int> &from,
-                             const Vec3<int> &to, float nextPower)
+                             const Vec3<int> &to, int nextPower)
 {
 	// list of coordinates to check
 	static const std::map<Vec3<int>, std::list<std::pair<Vec3<int>, std::set<TileObject::Type>>>>
@@ -272,7 +280,7 @@ void BattleExplosion::expand(GameState &state, const TileMap &map, const Vec3<in
 	}
 	// FIXME: Actually read this option
 	int distance = (1 + (dir.x != 0 ? 1 : 0) + (dir.y != 0 ? 1 : 0) + (dir.z != 0 ? 2 : 0));
-	nextPower -= (float)depletionRate * (float)distance / 1.5f;
+	nextPower -= depletionRate * distance / 1.5;
 
 	// If we reach the tile, and our type has no range dissipation, just apply power
 	int thisPower = nextPower - depletionThis;

--- a/game/state/battle/battleexplosion.h
+++ b/game/state/battle/battleexplosion.h
@@ -46,7 +46,7 @@ class BattleExplosion : public std::enable_shared_from_this<BattleExplosion>
 	void grow(GameState &state);
 	void damage(GameState &state, const TileMap &map, Vec3<int> pos, int power);
 	void expand(GameState &state, const TileMap &map, const Vec3<int> &from, const Vec3<int> &to,
-	            int power);
+	            float power);
 	void die(GameState &state);
 
 	void update(GameState &state, unsigned int ticks);

--- a/game/state/battle/battleexplosion.h
+++ b/game/state/battle/battleexplosion.h
@@ -46,7 +46,7 @@ class BattleExplosion : public std::enable_shared_from_this<BattleExplosion>
 	void grow(GameState &state);
 	void damage(GameState &state, const TileMap &map, Vec3<int> pos, int power);
 	void expand(GameState &state, const TileMap &map, const Vec3<int> &from, const Vec3<int> &to,
-	            float power);
+	            int power);
 	void die(GameState &state);
 
 	void update(GameState &state, unsigned int ticks);

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -53,7 +53,7 @@ static const int FV_CHANCE_TO_RECOVER_EQUIPMENT = 90;
 // How much percent is "scrapped" sold for
 static const int FV_SCRAPPED_COST_PERCENT = 25;
 // How much ticks is accumulated per second of engine usage
-static const int FUEL_TICKS_PER_SECOND = 144;
+static const int FUEL_TICKS_PER_SECOND = 180;
 // How much ticks is required to spend one unit of fuel
 static const int FUEL_TICKS_PER_UNIT = 40000;
 // Correction factor for turning slowdown mechanic, purely found by data analysis, could not

--- a/game/state/gametime.h
+++ b/game/state/gametime.h
@@ -7,7 +7,7 @@ namespace OpenApoc
 {
 
 static constexpr unsigned VANILLA_TICKS_PER_SECOND = 36;
-static constexpr unsigned TICKS_MULTIPLIER = 4;
+static constexpr unsigned TICKS_MULTIPLIER = 5;
 static constexpr unsigned TICKS_PER_SECOND = VANILLA_TICKS_PER_SECOND * TICKS_MULTIPLIER;
 static constexpr unsigned TICKS_PER_MINUTE = TICKS_PER_SECOND * 60;
 static constexpr unsigned TICKS_PER_HOUR = TICKS_PER_MINUTE * 60;

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -28,7 +28,7 @@ namespace OpenApoc
 {
 
 // FIXME: Alexey Andronov: Does anyone know why we divide by 4 here?
-static const unsigned TICK_SCALE = TICKS_PER_SECOND / 10;
+static const unsigned TICK_SCALE = TICKS_PER_SECOND / 5;
 
 class Image;
 class TileMap;

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -28,7 +28,7 @@ namespace OpenApoc
 {
 
 // FIXME: Alexey Andronov: Does anyone know why we divide by 4 here?
-static const unsigned TICK_SCALE = TICKS_PER_SECOND / 4;
+static const unsigned TICK_SCALE = TICKS_PER_SECOND / 10;
 
 class Image;
 class TileMap;


### PR DESCRIPTION
Addresses #997, #1216 so far.

The following is a list of what appears to have been fixed, many are very lightly tested and the changes could very easily have affected things in other parts of the game that I don't yet know about. This is just a running list to help me keep track of what has been done.

### Battlescape

- Walking speed seems to be a bit faster, closer to the original.
- Explosive hazard type doesn't leave smoke behind anymore, it stayed around way too long. Was this a feature?
- Explosions now expand faster to more closely match the OG game.
- Explosions seem to be the correct radius now, although this needs more testing. I have only tried a couple items.

### Cityscape
NA

### Both

- Projectile speed has been increased, it seems much closer to the OG game. TICK_SCALE was set to 18 instead of 36 in this case. This has not been tested in cityscape, likely will cause issues somewhere.

### Problems

- [ ] Rate of fire is now too fast. Should seperate speed from ROF if that is what is happening.