### PR TITLE
Load lua scripts using virtual FileSystem

### DIFF
--- a/data/scripts/openapoc_base.lua
+++ b/data/scripts/openapoc_base.lua
@@ -34,8 +34,8 @@ end
 --table.dump(OpenApoc, 1)
 --print("}")
 
-dofile('data/scripts/update_economy.lua')
-dofile('data/scripts/update_ufo_growth.lua')
+dofile('scripts/update_economy.lua')
+dofile('scripts/update_ufo_growth.lua')
 
 local oldNewGameHook = OpenApoc.hook.newGame
 OA.hook.newGame = function()

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -448,7 +448,7 @@ ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
 
 ConfigOptionString optionScriptsList("OpenApoc.Mod", "ScriptsList",
                                      "Semicolon-separated list of scripts to load",
-                                     "data/scripts/openapoc_base.lua;");
+                                     "scripts/openapoc_base.lua;");
 
 ConfigOptionBool optionInfiniteAmmoCheat("OpenApoc.Cheat", "InfiniteAmmo",
                                          "Infinite ammo for X-Com agents and vehicles", false);


### PR DESCRIPTION
The mod ScriptsList (scripts ran at mod init) didn't use the virtual FS, so would not load if the $(CWD) didn't match the data directory.

This caused warning as scripts failed to load in the tests, as well as if any mod overrides the file.

Note that this means that scripts loaded through dofile() in lua are now relative to the data/ directory and can be replaced by mods overwriting the name in their own data.