### PR TITLE
Remove boost::filesytem support

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ OpenApocalypse is built leveraging a number of libraries - to provide needed fun
 Note: The following libraries will be fetched and built with vcpkg in a later step, ensuring you get the correct version.
 
 * [SDL2](https://www.libsdl.org)
-* [Boost](https://boost.org) - We specifially use the 'locale' library, used for localisation, 'program-options' for settings management, and 'filesystem'.
+* [Boost](https://boost.org) - We specifially use the 'locale' library, used for localisation, 'algorithm' for some small stuff in string handling, 'program-options' for settings management, 'date-time' for some formatting, and parts of 'UUID' and 'CRC' for their hash functions and some temporary filename stuff.
 * [Qt](https://www.qt.io/) - needed for the launcher, can be disabled with 'BUILD_LAUNCHER'.
 * [Libunwind](https://nongnu.org/libunwind/download.html) - debug backtracing on linux - not needed on windows.
 * [LibVorbis](https://xiph.org/vorbis/) - Ogg vorbis music decoder library.
@@ -146,12 +146,12 @@ vcpkg --triplet x86-windows install sdl2 boost-locale boost-program-options boos
 
 ### Building on Linux
 
-(Tested on Ubuntu 16.04, Mageia 6 and Fedora 31)
+(Tested on Ubuntu 22.04)
 
 * On Ubuntu, install the following packages:
 
 ```sh
-sudo apt-get install libsdl2-dev cmake build-essential git libunwind8-dev libboost-locale-dev libboost-filesystem-dev libboost-program-options-dev qtbase5-dev libvorbis-dev
+sudo apt-get install sdl2-dev cmake build-essential git libunwind8-dev libboost-locale-dev libboost-program-options-dev qtbase5-dev libvorbis-dev
 ```
 
 * On Mageia, install the following packages as root:

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -220,29 +220,7 @@ set(BOOST_PACKAGES locale system program_options)
 # Arbitrary version that I remember testing previously
 set(BOOST_VERSION 1.50)
 
-set(USE_STD_FILESYSTEM FALSE)
-
-if(CMAKE_COMPILER_IS_GNUCC)
-    if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER 8.0)
-			set(USE_STD_FILESYSTEM TRUE)
-	endif()
-endif()
-if(MSVC)
-	if (MSVC_VERSION GREATER_EQUAL 1910)
-		set(USE_STD_FILESYSTEM TRUE)
-	endif()
-endif()
-
-if(USE_STD_FILESYSTEM)
-    message(STATUS "Using <filesystem>")
-	target_compile_definitions(OpenApoc_Framework PUBLIC "-DUSE_STD_FILESYSTEM")
-else()
-	message(STATUS "Using <boost/filesystem>")
-	set(BOOST_PACKAGES ${BOOST_PACKAGES} filesystem)
-	# filesystem::relative() didn't exist until 1.60 from what I can see in the docs
-	set(BOOST_VERSION 1.60)
-	target_compile_definitions(OpenApoc_Framework PUBLIC "-DUSE_BOOST_FILESYSTEM")
-endif()
+target_compile_definitions(OpenApoc_Framework PUBLIC "-DUSE_STD_FILESYSTEM")
 
 find_package(Boost ${BOOST_VERSION} REQUIRED COMPONENTS ${BOOST_PACKAGES})
 target_link_libraries(OpenApoc_Framework PUBLIC ${Boost_LIBRARIES})

--- a/framework/filesystem.h
+++ b/framework/filesystem.h
@@ -2,4 +2,3 @@
 
 #include <filesystem>
 namespace fs = std::filesystem;
-

--- a/framework/filesystem.h
+++ b/framework/filesystem.h
@@ -1,15 +1,5 @@
 #pragma once
 
-#if defined(USE_STD_FILESYSTEM)
-
 #include <filesystem>
 namespace fs = std::filesystem;
 
-#elif defined(USE_BOOST_FILESYSTEM)
-
-#include <boost/filesystem.hpp>
-namespace fs = boost::filesystem;
-
-#else
-#error No filesystem implementation
-#endif


### PR DESCRIPTION
We don't support pre-c++17 compilers anyway, so we only need std::filesystem.