### PR TITLE
Bug Fix : Form debugger selection labels

### DIFF
--- a/game/ui/debugtools/formpreview.cpp
+++ b/game/ui/debugtools/formpreview.cpp
@@ -82,7 +82,8 @@ FormPreview::FormPreview() : Stage()
 		l = lb->createChild<Label>(*idx, ui().getFont("smalfont"));
 		l->Name = l->getText();
 		l->BackgroundColour = {192, 80, 80, 0};
-		// lb->addItem( l );
+		l->Size.x = lb->Size.x;
+		l->Size.y = ui().getFont("smalfont")->getFontHeight();
 	}
 
 	propertyeditor = mksp<Form>();


### PR DESCRIPTION
Currently, the labels in the debug tools form preview are not visible. This change sets a height and width of the labels so they can now be seen.

Before: 

![image](https://github.com/OpenApoc/OpenApoc/assets/31781/eb3db92f-a18a-44d3-839d-fdeee5c8564e)

After:

![image](https://github.com/OpenApoc/OpenApoc/assets/31781/72289e11-d501-4e57-bd88-fbbd231c7bd8)

