### PR TITLE
Added medals to agent sheet.

### DIFF
--- a/data/forms/sheet_agent_history.form
+++ b/data/forms/sheet_agent_history.form
@@ -6,7 +6,7 @@
       <size width="160" height="280"/>
 
       <label id="VALUE_DAYS_IN_SERVICE" text="">
-		<position x="15" y="105"/>
+		    <position x="15" y="105"/>
         <size width="25" height="15"/>
         <alignment horizontal="right" vertical="centre"/>
         <font>smalfont</font>
@@ -46,6 +46,46 @@
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>
+
+      <graphic id="MEDAL_1">
+        <position x="11" y="155"/>
+        <size width="33" height="47"/>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:7:xcom3/tacdata/tactical.pal</image>
+      </graphic>
+      
+      <graphic id="MEDAL_2">
+        <position x="38" y="155"/>
+        <size width="32" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:8:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
+
+      <graphic id="MEDAL_3">
+        <position x="65" y="155"/>
+        <size width="31" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:9:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
+
+      <graphic id="MEDAL_4">
+        <position x="92" y="155"/>
+        <size width="33" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:10:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
+      
+      <graphic id="MEDAL_5">
+        <position x="119" y="155"/>
+        <size width="33" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:11:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
 
     </style>
   </form>

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -1474,6 +1474,8 @@ unsigned int Agent::getKills() const { return killCount; }
 
 unsigned int Agent::getMissions() const { return missionCount; }
 
+unsigned int Agent::getMedalTier() const { return 0; }
+
 void Agent::incrementMissionCount() { missionCount++; }
 
 void Agent::incrementKillCount() { killCount++; }

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -239,6 +239,7 @@ class Agent : public StateObject<Agent>,
 	unsigned int getDaysInService(const GameState &state) const;
 	unsigned int getKills() const;
 	unsigned int getMissions() const;
+	unsigned int getMedalTier() const;
 
 	void incrementMissionCount();
 	void incrementKillCount();

--- a/game/ui/CMakeLists.txt
+++ b/game/ui/CMakeLists.txt
@@ -48,6 +48,7 @@ set (GAMEUI_SOURCE_FILES
 	general/aequipscreen.cpp
 	general/aequipmentsheet.cpp
 	general/agentsheet.cpp
+	general/agenthistorysheet.cpp
 	general/difficultymenu.cpp
 	general/ingameoptions.cpp
 	general/moreoptions.cpp
@@ -120,6 +121,7 @@ set (GAMEUI_HEADER_FILES
 	general/aequipscreen.h
 	general/aequipmentsheet.h
 	general/agentsheet.h
+	general/agenthistorysheet.h
 	general/difficultymenu.h
 	general/ingameoptions.h
 	general/moreoptions.h

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -30,6 +30,7 @@
 #include "game/ui/components/controlgenerator.h"
 #include "game/ui/components/equipscreen.h"
 #include "game/ui/general/aequipmentsheet.h"
+#include "game/ui/general/agenthistorysheet.h"
 #include "game/ui/general/agentsheet.h"
 #include "game/ui/general/messagebox.h"
 
@@ -1952,8 +1953,8 @@ void AEquipScreen::displayAgent(sp<Agent> agent)
 {
 	formMain->findControlTyped<Graphic>("BACKGROUND")->setImage(agent->type->inventoryBackground);
 
-	AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
-	    .display(*agent, bigUnitRanks, isTurnBased());
+	AgentHistorySheet(formAgentHistory, state).display(*agent);
+	AgentSheet(formAgentProfile, formAgentStats).display(*agent, bigUnitRanks, isTurnBased());
 
 	auto shouldDisplayHistory =
 	    formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
@@ -2052,9 +2053,9 @@ void AEquipScreen::updateAgentControl(sp<Agent> agent)
 	    FormEventType::MouseEnter,
 	    [this, agent](FormsEvent *e [[maybe_unused]])
 	    {
-		    AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
+		    AgentHistorySheet(formAgentHistory, state).display(*agent);
+		    AgentSheet(formAgentProfile, formAgentStats)
 		        .display(*agent, bigUnitRanks, isTurnBased());
-
 		    auto shouldDisplayHistory =
 		        formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 
@@ -2077,9 +2078,9 @@ void AEquipScreen::updateAgentControl(sp<Agent> agent)
 	    FormEventType::MouseLeave,
 	    [this](FormsEvent *e [[maybe_unused]])
 	    {
-		    AgentSheet(state, formAgentProfile, formAgentStats, formAgentHistory)
+		    AgentHistorySheet(formAgentHistory, state).display(*selectedAgents.front());
+		    AgentSheet(formAgentProfile, formAgentStats)
 		        .display(*selectedAgents.front(), bigUnitRanks, isTurnBased());
-
 		    auto shouldDisplayHistory =
 		        formMain->findControlTyped<CheckBox>("BUTTON_TOGGLE_STATS")->isChecked();
 

--- a/game/ui/general/agenthistorysheet.cpp
+++ b/game/ui/general/agenthistorysheet.cpp
@@ -1,0 +1,39 @@
+#include "game/ui/general/agenthistorysheet.h"
+#include "forms/graphic.h"
+#include "forms/label.h"
+#include <sstream>
+
+namespace OpenApoc
+{
+
+AgentHistorySheet::AgentHistorySheet(sp<Form> historyForm, sp<GameState> state)
+    : historyForm(historyForm), state(state)
+{
+}
+
+void AgentHistorySheet::display(const Agent &item)
+{
+	historyForm->findControlTyped<Label>("LABEL_DAYS_IN_SERVICE")->setText(tr("Days service"));
+	std::stringstream daysInService;
+	daysInService << item.getDaysInService(*state);
+	historyForm->findControlTyped<Label>("VALUE_DAYS_IN_SERVICE")->setText(daysInService.str());
+
+	historyForm->findControlTyped<Label>("LABEL_MISSION_COUNT")->setText(tr("Missions"));
+	std::stringstream missionsCount;
+	missionsCount << item.getMissions();
+	historyForm->findControlTyped<Label>("VALUE_MISSION_COUNT")->setText(missionsCount.str());
+
+	historyForm->findControlTyped<Label>("LABEL_KILL_COUNT")->setText(tr("Kills"));
+	std::stringstream killCount;
+	killCount << item.getKills();
+	historyForm->findControlTyped<Label>("VALUE_KILL_COUNT")->setText(killCount.str());
+
+	for (int i = 5; i > (int)item.getMedalTier(); i--)
+	{
+		auto formLabel = format("MEDAL_%d", i);
+		auto medalFromElement = historyForm->findControlTyped<Graphic>(formLabel);
+		medalFromElement->setVisible(false);
+	}
+}
+
+} // namespace OpenApoc

--- a/game/ui/general/agenthistorysheet.h
+++ b/game/ui/general/agenthistorysheet.h
@@ -1,0 +1,17 @@
+#include "forms/form.h"
+#include "game/state/shared/agent.h"
+
+namespace OpenApoc
+{
+
+class AgentHistorySheet
+{
+	sp<Form> historyForm;
+	sp<GameState> state;
+
+  public:
+	AgentHistorySheet(sp<Form> historyForm, sp<GameState> gameState);
+	void display(const Agent &item);
+};
+
+}; // namespace OpenApoc

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -7,9 +7,8 @@
 #include "framework/framework.h"
 #include "framework/keycodes.h"
 #include "framework/renderer.h"
-#include "game/state/gamestate.h"
 #include "game/state/rules/battle/damage.h"
-#include <sstream>
+#include "game/ui/general/agenthistorysheet.h"
 
 namespace OpenApoc
 {
@@ -33,19 +32,11 @@ AgentSheet::AgentSheet(sp<Form> profileForm, sp<Form> statsForm)
 {
 }
 
-AgentSheet::AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm,
-                       sp<Form> historyForm)
-    : profileForm(profileForm), statsForm(statsForm), historyForm(historyForm), state(state)
-{
-}
-
 void AgentSheet::display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased)
 {
 	clear();
 	displayProfile(item, ranks);
-	displayStats(item, ranks, turnBased);
-	if (historyForm)
-		displayHistory(item);
+	displayStats(item, turnBased);
 }
 
 void AgentSheet::displayProfile(const Agent &item, std::vector<sp<Image>> &ranks)
@@ -57,28 +48,8 @@ void AgentSheet::displayProfile(const Agent &item, std::vector<sp<Image>> &ranks
 	    ->setImage(item.type->displayRank ? ranks[(int)item.rank] : nullptr);
 }
 
-void AgentSheet::displayHistory(const Agent &item)
+void AgentSheet::displayStats(const Agent &item, bool turnBased)
 {
-
-	historyForm->findControlTyped<Label>("LABEL_DAYS_IN_SERVICE")->setText(tr("Days In Service"));
-	std::stringstream daysInService;
-	daysInService << item.getDaysInService(*state);
-	historyForm->findControlTyped<Label>("VALUE_DAYS_IN_SERVICE")->setText(daysInService.str());
-
-	historyForm->findControlTyped<Label>("LABEL_MISSION_COUNT")->setText(tr("Missions"));
-	std::stringstream missionsCount;
-	missionsCount << item.getMissions();
-	historyForm->findControlTyped<Label>("VALUE_MISSION_COUNT")->setText(missionsCount.str());
-
-	historyForm->findControlTyped<Label>("LABEL_KILL_COUNT")->setText(tr("Kills"));
-	std::stringstream killCount;
-	killCount << item.getKills();
-	historyForm->findControlTyped<Label>("VALUE_KILL_COUNT")->setText(killCount.str());
-}
-
-void AgentSheet::displayStats(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased)
-{
-
 	statsForm->findControlTyped<Label>("LABEL_1")->setText(tr("Health"));
 	statsForm->findControlTyped<Graphic>("VALUE_1")->setImage(
 	    createStatsBar(item.initial_stats.health, item.current_stats.health,

--- a/game/ui/general/agentsheet.h
+++ b/game/ui/general/agentsheet.h
@@ -13,21 +13,17 @@ class AgentSheet
 {
   public:
 	AgentSheet(sp<Form> profileForm, sp<Form> statsForm);
-	AgentSheet(sp<GameState> state, sp<Form> profileForm, sp<Form> statsForm, sp<Form> historyFrom);
 	void display(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased = true);
 	void clear();
 
   private:
 	sp<Form> profileForm;
-	sp<Form> historyForm;
 	sp<Form> statsForm;
-	sp<GameState> state;
 	sp<Image> createStatsBar(int initialValue, int currentValue, int modifiedValue, int maxValue,
 	                         const std::pair<Colour, Colour> &colour, Vec2<int> imageSize);
 
 	void displayProfile(const Agent &item, std::vector<sp<Image>> &ranks);
-	void displayHistory(const Agent &item);
-	void displayStats(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased = true);
+	void displayStats(const Agent &item, bool turnBased = true);
 };
 
 }; // namespace OpenApoc


### PR DESCRIPTION
 * Broke out the agent history sheet into its own class.
 * Created a new agent history form that displays the medals.
 * Added a medal tier to agent which allows for the agent to report its current medal tier. Note this is currently hard coded to zero as we don't have a system to track XP as yet.
 * Added display logic to render the medals based on the agents current tier.

![image](https://github.com/OpenApoc/OpenApoc/assets/31781/620c9f46-aa76-465b-bf7a-bd64027a5753)
