### PR TITLE
Added medal rendering

### DIFF
--- a/data/forms/sheet_agent_history.form
+++ b/data/forms/sheet_agent_history.form
@@ -47,6 +47,45 @@
         <font>smalfont</font>
       </label>
 
+      <graphic id="MEDAL_1">
+        <position x="11" y="155"/>
+        <size width="33" height="47"/>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:7:xcom3/tacdata/tactical.pal</image>
+      </graphic>
+
+      <graphic id="MEDAL_2">
+        <position x="38" y="155"/>
+        <size width="32" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:8:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
+
+      <graphic id="MEDAL_3">
+        <position x="65" y="155"/>
+        <size width="31" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:9:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
+
+      <graphic id="MEDAL_4">
+        <position x="92" y="155"/>
+        <size width="33" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:10:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
+
+      <graphic id="MEDAL_5">
+        <position x="119" y="155"/>
+        <size width="33" height="48"/>
+        <image>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:11:xcom3/tacdata/tactical.pal</image>
+        <imageposition>fit</imageposition>
+        <alignment horizontal="center" vertical="centre"/>
+      </graphic>
     </style>
   </form>
 </openapoc>

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -1474,6 +1474,8 @@ unsigned int Agent::getKills() const { return killCount; }
 
 unsigned int Agent::getMissions() const { return missionCount; }
 
+unsigned int Agent::getMedalTier() const { return 0; }
+
 void Agent::incrementMissionCount() { missionCount++; }
 
 void Agent::incrementKillCount() { killCount++; }

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -239,6 +239,7 @@ class Agent : public StateObject<Agent>,
 	unsigned int getDaysInService(const GameState &state) const;
 	unsigned int getKills() const;
 	unsigned int getMissions() const;
+	unsigned int getMedalTier() const;
 
 	void incrementMissionCount();
 	void incrementKillCount();

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -74,6 +74,13 @@ void AgentSheet::displayHistory(const Agent &item)
 	std::stringstream killCount;
 	killCount << item.getKills();
 	historyForm->findControlTyped<Label>("VALUE_KILL_COUNT")->setText(killCount.str());
+
+	for (unsigned int i = 5; i > item.getMedalTier(); i--)
+	{
+		auto formLabel = format("MEDAL_%d", i);
+		auto medalFormElement = historyForm->findControlTyped<Graphic>(formLabel);
+		medalFormElement->setVisible(false);
+	}
 }
 
 void AgentSheet::displayStats(const Agent &item, std::vector<sp<Image>> &ranks, bool turnBased)


### PR DESCRIPTION
 * Added medals to the agent history form
 * Added code that will hide the medals according to agents current medal tier
 * Added stub method to agent that will always return a tier of zero.

![A screen shot with medal tier hard coded to 5](https://github.com/OpenApoc/OpenApoc/assets/31781/a43f320d-c481-47b1-82ad-717763778bf4)

Note: This PR should not change anything that the player can see as the medal tier will always be set to zero. In the above screenshot, the medal tier has been hardcoded to 5 for illustrative reasons. This is intended as a precursor for a bigger set of changes around agent experience.



