### PR TITLE
Add vehicle target debug view plus fix debug overlay cutoff.

### DIFF
--- a/data/forms/city/debugoverlay_city.form
+++ b/data/forms/city/debugoverlay_city.form
@@ -151,7 +151,13 @@
 			</label>
 			<label id="ShiftLeft" text="Shift+LeftClick = Fix Stuck Vehicle in CityScape">
 				<position x="left" y="336"/>
-				<size width="250" height="14"/>
+				<size width="350" height="14"/>
+				<alignment horizontal="left" vertical="top"/>
+				<font>smalfont</font>
+			</label>
+			<label id="P" text="P = Show Vehicle Targets">
+				<position x="left" y="350"/>
+				<size width="350" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -126,6 +126,11 @@ void CityTileView::eventOccurred(Event *e)
 					DEBUG_SHOW_ALIEN = !DEBUG_SHOW_ALIEN;
 					return;
 				}
+				case SDLK_p:
+				{
+					DEBUG_SHOW_VEHICLE_TARGETS = !DEBUG_SHOW_VEHICLE_TARGETS;
+					return;
+				}
 				case SDLK_F2:
 				{
 					DEBUG_SHOW_ROAD_PATHFINDING = !DEBUG_SHOW_ROAD_PATHFINDING;

--- a/game/ui/tileview/citytileview.h
+++ b/game/ui/tileview/citytileview.h
@@ -64,6 +64,7 @@ class CityTileView : public TileView
 	int DEBUG_DIRECTION = -1;
 	int DEBUG_LAYER = -1;
 	bool DEBUG_SHOW_ALIEN = false;
+	bool DEBUG_SHOW_VEHICLE_TARGETS = false;
 
   private:
 	GameState &state;


### PR DESCRIPTION
This adds a debug option to view what each vehicle is currently targeting. I used this while trying to fix the stuck vehicle problem. It turned out that targeting wasn't the problem, but this is pretty useful. The last addition to the debug overlay was being cut off so that was fixed as well.

Green line = XCOM vehicle is targeting an enemy.
Red line = Enemy is targeting an XCOM craft.
Yellow line = The two are targeting each other!
![2023-11-25 14_59_52-Greenshot](https://github.com/OpenApoc/OpenApoc/assets/73447098/e2481f25-d650-4d3f-b79b-31e8f89b7b98)
