### PR TITLE
Fix vehicles getting stuck in cityscape

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -1149,7 +1149,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 							// Bring angle to one of directional alignments
 							int angleToTargetInt = angleToTarget / (float)M_PI * 4.0f + 0.5f;
 							angleToTarget = (float)angleToTargetInt * (float)M_PI / 4.0f;
-							if (destFacing != angleToTarget)
+							if (destFacing != angleToTarget && v.ticksToTurn > 0)
 							{
 								LogWarning("Vehicle %s facing target", v.name);
 								destFacing = angleToTarget;
@@ -1239,7 +1239,7 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 								// Bring angle to one of directional alignments
 								int angleToTargetInt = angleToTarget / (float)M_PI * 4.0f + 0.5f;
 								angleToTarget = (float)angleToTargetInt * (float)M_PI / 4.0f;
-								if (destFacing != angleToTarget)
+								if (destFacing != angleToTarget && v.ticksToTurn > 0)
 								{
 									LogWarning("Vehicle %s facing target", v.name);
 									destFacing = angleToTarget;


### PR DESCRIPTION
I think I finally narrowed this problem down. The vehicle was attempting to sidestep to another location when it had 0 tickstoturn. Since it was trying to turn but couldn't, this froze the vehicle in place. This checks if tickstoturn is over 0 before sidestepping. I will admit that I can't test every situation that could happen so this could have unforeseen consequences. I have included the save I was using to test, it is a gigantic firefight. One or more vehicles would get stuck every other time I played on average before the fix. So far the fix has stopped any vehicles from getting stuck for 30 plus playthroughs of the fight.


[save_stucktest.zip](https://github.com/OpenApoc/OpenApoc/files/13465294/save_stucktest.zip)
