### PR TITLE
Add simple credits menu

### DIFF
--- a/data/forms/creditsmenu.form
+++ b/data/forms/creditsmenu.form
@@ -17,31 +17,31 @@
         <font>bigfont</font>
       </label>
       <!-- List of contributors -->
-      <scroll id="LISTBOX_SCROLL">
-        <position x="553" y="82"/>
+      <scroll id="LISTBOX_SCROLL" scrollpercent = "5">
+        <position x="555" y="84"/>
         <size width="26" height="356"/>
       </scroll>
       <listbox id="LISTBOX_CREDITS" scrollbarid="LISTBOX_SCROLL">
-        <position x="centre" y="74"/>
-        <size width="510" height="375"/>
+        <position x="32" y="65"/>
+        <size width="510" height="392"/>
         <item size="16" spacing="4"/>
       </listbox>
       <graphicbutton id="LISTBOX_SCROLL_UP" scrollprev="LISTBOX_SCROLL">
         <tooltip text="Scroll Up" font="smallset"/>
-        <position x="555" y="58"/>
+        <position x="557" y="60"/>
         <size width="22" height="21"/>
         <image/>
         <imagedepressed>BUTTON_SCROLL_UP_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton id="LISTBOX_SCROLL_DOWN" scrollnext="LISTBOX_SCROLL">
         <tooltip text="Scroll Down" font="smallset"/>
-        <position x="555" y="441"/>
+        <position x="557" y="443"/>
         <size width="22" height="21"/>
         <image/>
         <imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton id="BUTTON_OK">
-        <position x="602" y="443"/>
+        <position x="604" y="445"/>
         <size width="40" height="40"/>
         <image/>
         <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>

--- a/data/forms/creditsmenu.form
+++ b/data/forms/creditsmenu.form
@@ -1,51 +1,51 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openapoc>
-  <form id="FORM_CREDITSMENU">
-    <style minwidth="640" minheight="480">
-      <position x="centre" y="centre"/>
-      <size width="644" height="484"/>
-      <backcolour r="80" g="80" b="80"/>
-      <graphic>
-        <image>xcom3/ufodata/message.pcx</image>
-        <position x="2" y="2"/>
-        <size width="640" height="480"/>
-      </graphic>
-       <label text="CREDITS">
-        <position x="113" y="0"/>
-        <size width="420" height="32"/>
-        <alignment horizontal="centre" vertical="centre"/>
-        <font>bigfont</font>
-      </label>
-      <!-- List of contributors -->
-      <scroll id="LISTBOX_SCROLL" scrollpercent = "5">
-        <position x="555" y="84"/>
-        <size width="26" height="356"/>
-      </scroll>
-      <listbox id="LISTBOX_CREDITS" scrollbarid="LISTBOX_SCROLL">
-        <position x="32" y="65"/>
-        <size width="510" height="392"/>
-        <item size="16" spacing="4"/>
-      </listbox>
-      <graphicbutton id="LISTBOX_SCROLL_UP" scrollprev="LISTBOX_SCROLL">
-        <tooltip text="Scroll Up" font="smallset"/>
-        <position x="557" y="60"/>
-        <size width="22" height="21"/>
-        <image/>
-        <imagedepressed>BUTTON_SCROLL_UP_DEPRESSED</imagedepressed>
-      </graphicbutton>
-      <graphicbutton id="LISTBOX_SCROLL_DOWN" scrollnext="LISTBOX_SCROLL">
-        <tooltip text="Scroll Down" font="smallset"/>
-        <position x="557" y="443"/>
-        <size width="22" height="21"/>
-        <image/>
-        <imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
-      </graphicbutton>
-      <graphicbutton id="BUTTON_OK">
-        <position x="604" y="445"/>
-        <size width="40" height="40"/>
-        <image/>
-        <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
-      </graphicbutton>
-    </style>
-  </form>
+	<form id="FORM_CREDITSMENU">
+		<style minwidth="640" minheight="480">
+			<position x="centre" y="centre"/>
+			<size width="644" height="484"/>
+			<backcolour r="80" g="80" b="80"/>
+			<graphic>
+				<image>xcom3/ufodata/message.pcx</image>
+				<position x="2" y="2"/>
+				<size width="640" height="480"/>
+			</graphic>
+			<label text="CREDITS">
+				<position x="113" y="0"/>
+				<size width="420" height="32"/>
+				<alignment horizontal="centre" vertical="centre"/>
+				<font>bigfont</font>
+			</label>
+			<!-- List of contributors -->
+			<scroll id="LISTBOX_SCROLL" scrollpercent = "5">
+				<position x="555" y="84"/>
+				<size width="26" height="356"/>
+			</scroll>
+			<listbox id="LISTBOX_CREDITS" scrollbarid="LISTBOX_SCROLL">
+				<position x="32" y="65"/>
+				<size width="510" height="392"/>
+				<item size="16" spacing="4"/>
+			</listbox>
+			<graphicbutton id="LISTBOX_SCROLL_UP" scrollprev="LISTBOX_SCROLL">
+				<tooltip text="Scroll Up" font="smallset"/>
+				<position x="557" y="60"/>
+				<size width="22" height="21"/>
+				<image/>
+				<imagedepressed>BUTTON_SCROLL_UP_DEPRESSED</imagedepressed>
+			</graphicbutton>
+			<graphicbutton id="LISTBOX_SCROLL_DOWN" scrollnext="LISTBOX_SCROLL">
+				<tooltip text="Scroll Down" font="smallset"/>
+				<position x="557" y="443"/>
+				<size width="22" height="21"/>
+				<image/>
+				<imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
+			</graphicbutton>
+			<graphicbutton id="BUTTON_OK">
+				<position x="604" y="445"/>
+				<size width="40" height="40"/>
+				<image/>
+				<imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
+			</graphicbutton>
+		</style>
+	</form>
 </openapoc>

--- a/data/forms/creditsmenu.form
+++ b/data/forms/creditsmenu.form
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openapoc>
+  <form id="FORM_CREDITSMENU">
+    <style minwidth="640" minheight="480">
+      <position x="centre" y="centre"/>
+      <size width="644" height="484"/>
+      <backcolour r="80" g="80" b="80"/>
+      <graphic>
+        <image>xcom3/ufodata/message.pcx</image>
+        <position x="2" y="2"/>
+        <size width="640" height="480"/>
+      </graphic>
+       <label text="CREDITS">
+        <position x="113" y="0"/>
+        <size width="420" height="32"/>
+        <alignment horizontal="centre" vertical="centre"/>
+        <font>bigfont</font>
+      </label>
+      <!-- List of contributors -->
+      <scroll id="LISTBOX_SCROLL">
+        <position x="553" y="82"/>
+        <size width="26" height="356"/>
+      </scroll>
+      <listbox id="LISTBOX_CREDITS" scrollbarid="LISTBOX_SCROLL">
+        <position x="centre" y="74"/>
+        <size width="510" height="375"/>
+        <item size="16" spacing="4"/>
+      </listbox>
+      <graphicbutton id="LISTBOX_SCROLL_UP" scrollprev="LISTBOX_SCROLL">
+        <tooltip text="Scroll Up" font="smallset"/>
+        <position x="555" y="58"/>
+        <size width="22" height="21"/>
+        <image/>
+        <imagedepressed>BUTTON_SCROLL_UP_DEPRESSED</imagedepressed>
+      </graphicbutton>
+      <graphicbutton id="LISTBOX_SCROLL_DOWN" scrollnext="LISTBOX_SCROLL">
+        <tooltip text="Scroll Down" font="smallset"/>
+        <position x="555" y="441"/>
+        <size width="22" height="21"/>
+        <image/>
+        <imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
+      </graphicbutton>
+      <graphicbutton id="BUTTON_OK">
+        <position x="602" y="443"/>
+        <size width="40" height="40"/>
+        <image/>
+        <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
+      </graphicbutton>
+    </style>
+  </form>
+</openapoc>

--- a/data/forms/mainmenu.form
+++ b/data/forms/mainmenu.form
@@ -1,54 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <openapoc>
-  <form id="FORM_MAINMENU">
-    <style minwidth="640" minheight="480">
-      <position x="centre" y="centre"/>
-      <size width="644" height="484"/>
-      <backcolour r="128" g="80" b="80"/>
-      <graphic>
-        <image>xcom3/ufodata/titles.pcx</image>
-        <position x="2" y="2"/>
-        <size width="640" height="480"/>
-        <label text="OpenApocalypse">
-          <backcolour r="255" g="255" b="255" a="192"/>
-          <position x="0" y="0"/>
-          <size width="640" height="32"/>
-          <alignment horizontal="centre" vertical="centre"/>
-          <font>bigfont</font>
-        </label>
-        <label text="Version" id="VERSION_LABEL">
-          <position x="0" y="0"/>
-          <size width="640" height="16"/>
-          <alignment horizontal="left" vertical="centre"/>
-          <font>smallset</font>
-        </label>
-      </graphic>
-      <textbutton id="BUTTON_NEWGAME" text="Start Campaign Game">
-        <position x="centre" y="190"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton>
-      <textbutton id="BUTTON_LOADGAME" text="Load Saved Game">
-        <position x="centre" y="240"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton>
-  <!-- Options menu commented out until useful -->
-	<!-- <textbutton id="BUTTON_OPTIONS" text="Options">
-        <position x="centre" y="290"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton> -->
-      <textbutton id="BUTTON_QUIT" text="Quit">
-        <position x="centre" y="290"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton>
-      <textbutton id="BUTTON_DEBUG" text="Debug Menu" visible="N">
-        <position x="centre" y="340"/>
-        <size width="300" height="32"/>
-        <font>smalfont</font>
-      </textbutton>
-    </style>
-  </form>
+	<form id="FORM_MAINMENU">
+		<style minwidth="640" minheight="480">
+			<position x="centre" y="centre"/>
+			<size width="644" height="484"/>
+			<backcolour r="128" g="80" b="80"/>
+			<graphic>
+				<image>xcom3/ufodata/titles.pcx</image>
+				<position x="2" y="2"/>
+				<size width="640" height="480"/>
+				<label text="OpenApocalypse">
+					<backcolour r="255" g="255" b="255" a="192"/>
+					<position x="0" y="0"/>
+					<size width="640" height="32"/>
+					<alignment horizontal="centre" vertical="centre"/>
+					<font>bigfont</font>
+				</label>
+				<label text="Version" id="VERSION_LABEL">
+					<position x="0" y="0"/>
+					<size width="640" height="16"/>
+					<alignment horizontal="left" vertical="centre"/>
+					<font>smallset</font>
+				</label>
+			</graphic>
+			<textbutton id="BUTTON_NEWGAME" text="Start Campaign Game">
+				<position x="centre" y="190"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton>
+			<textbutton id="BUTTON_LOADGAME" text="Load Saved Game">
+				<position x="centre" y="240"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton>
+			<!-- Options menu commented out until useful -->
+			<!-- <textbutton id="BUTTON_OPTIONS" text="Options">
+				<position x="centre" y="290"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton> -->
+			<textbutton id="BUTTON_CREDITS" text="Credits">
+				<position x="centre" y="290"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton>
+			<textbutton id="BUTTON_QUIT" text="Quit">
+				<position x="centre" y="340"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton>
+			<textbutton id="BUTTON_DEBUG" text="Debug Menu" visible="N">
+				<position x="centre" y="390"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton>
+		</style>
+	</form>
 </openapoc>

--- a/game/ui/CMakeLists.txt
+++ b/game/ui/CMakeLists.txt
@@ -62,6 +62,7 @@ set (GAMEUI_SOURCE_FILES
 	general/notificationscreen.cpp
 	general/vehiclesheet.cpp
 	general/transactioncontrol.cpp
+	general/creditsmenu.cpp
 
 	skirmish/skirmish.cpp
 	skirmish/selectforces.cpp
@@ -134,6 +135,7 @@ set (GAMEUI_HEADER_FILES
 	general/notificationscreen.h
 	general/vehiclesheet.h
 	general/transactioncontrol.h
+	general/creditsmenu.h
 
 	skirmish/skirmish.h
 	skirmish/selectforces.h

--- a/game/ui/general/creditsmenu.cpp
+++ b/game/ui/general/creditsmenu.cpp
@@ -20,76 +20,80 @@ namespace
 {
 // Contributor lists, if adding to these keep the blank entry at the end!
 std::list<UString> developerList = {
-    "pmprog",         "Andrey",     "redv",   "empty'void", "Flacko",
-    "Flacko the 2nd", "Istrebitel", "JonnyH", "shellstorm", "skin36",
-    "SupSuper",       "Warboy",     "",
-};
-std::list<UString> traineeList = {
-    "FilmBoy84",
-    "Jari",
+    "PmProg - Marq Watkin",
+    "redv",
+    "SupSuper - Daniel Albano",
+    "JonnyH - Jonathan Hamilton",
+    "Istrebitel",
+    "Skin36",
+    "FilmBoy84 - Jacob Deuchar",
+    "Makus / Makus82 Shellstorm - Ivan Shibanov",
+    "FranciscoDA / Flacko empty`void / Empty Void Jarskih - Jari Hanski",
+    "Kurtsley - Brian Beard",
+    "Atrosha - Panasenko Vasiliy Sergeevich",
     "",
 };
-std::list<UString> programmerList = {
-    "Andy51",  "Atrosha",  "Bluddy",         "clowds",            /*"Cristi Popa",*/
-    "Drosan",  "gnegno",   "Kurtsley",       "Leon",   "letwolf", /*"luiscamara",*/
-    "Stewart", "TheSnide", "TreacherousOne", "Zigmar", "",
-};
-std::list<UString> testerList = {
-    "Filmboy84",
-    "Atrosha",
-    "Beorn",
-    "CidDaBird",
-    "empty'void",
-    "Flacko the 2nd",
-    "Hyton",
-    "Jigoku-Panzer",
-    "laurieblakesdr",
-    "MadHaTr",
-    "makus",
-    "Quickmind",
-    "RoadhogsButt",
-    "Sergi4UA",
-    "TimboF5",
-    /*"Yataka Shimaoka",*/ "",
-};
-std::list<UString> translatorList = {
-    "Filmboy84", "Confederate Ghost", "IFoldlyGo", "Kammerer",       "makus",
-    "PlayMann",  "PPeti66x",          "SAlex_UT",  "Sergi4UA",       "skin36",
-    "Slitchy",   "TaoQiBao",          "TimboF5",   "Xcom commander", /*"Yataka Shimaoka",*/ "",
-};
-std::list<UString> githubContribList = {
-    "FranciscoDA",
-    "idshibanov",
-    "superusercode",
-    "kgd192",
-    "sfalexrog",
+std::list<UString> otherGitList = {
+    "Luis Camara",
+    "SuperUserCode",
+    "KGD192",
+    "sfalexrog - Alexey Rogachevskiy",
+    "zigmar / zigmar - ems - Pavel Antokolsky",
     "ShadowDancer",
-    "Xracer",
-    /*"steveschnepp",*/
-    /*"stewartmatheson",*/
-    "RedRobin84",
+    "TreacherousOne - Kirill Mishustin",
+    "steveschnepp - Steve Schnepp",
+    "StewartM",
+    "RedRobin84 - Martin Cervenka",
     "SiemensSchuckert",
     "sparkstar",
     "dl471",
     "5thAvenue",
-    "killermosi",
-    "BabyWolf",
-    "AMDmi3",
-    "AndyCreator",
-    "BlackWolf-Kuzoku",
+    "gnegno84 - Marcello Santambrogio",
+    "killermosi - Silviu Ghita",
+    "BabyWolf - Volkov Semjon",
+    "AMDmi3 - Dmitry Marakasov",
+    "AndreyCreator",
+    "Blackwolf - Kuzoku",
     "andersand",
-    "Andy51",
+    "Andy51 - Andrey Isakov",
     "Hambones82",
-    /*"MartinCervenka",*/
-    "h3xx",
+    "h3xx - Dan Church",
     "ashenomo",
     "kaja47",
-    "solbu",
+    "solbu - Johnny Solbu",
     "pkubaj",
-    "DoxaLogosGit",
-    "Sonicelo",
-    "SolariusScorch",
+    "DoxaLogosGit - Jay Atkinson",
+    "Sonicelo - Gregor Sušanj",
+    "kkmic",
+    "Przemyslaw",
+    "Onak",
+    "Roger",
     "",
+};
+std::list<UString> testingList = {
+    "FilmBoy84 - Jacob Deuchar",
+    "Quickmind / Quickmind01",
+    "HeadGrowsBack",
+    "RoadHogsButt",
+    "Yataka Shimaoka",
+    "EmperorLol - Laurie Blake",
+    "Jigoku - Panzer - Dean Martin",
+    "",
+};
+std::list<UString> moddingList = {
+    "JonnyH - Jonathan Hamilton",
+    "FilmBoy84 - Jacob Deuchar",
+    "Istrebitel",
+    "Voiddweller",
+    "Skin36",
+    "",
+};
+std::list<UString> reversingList = {
+    "Skin36",
+    "",
+};
+std::list<UString> translationList = {
+    "5thAvenue", "Blackwolf - Kuzoku", "Skin36", "SolariusScorch", "Xracer", "",
 };
 } // namespace
 
@@ -108,8 +112,8 @@ void CreditsMenu::loadlist()
 	spacer->Size = {100, contributorListControl->ItemSize};
 	contributorListControl->addItem(spacer);
 
-	// Developers
-	auto devLabel = mksp<Label>("- Developers -\n__________", font);
+	// Lead Team, Developers and Programming
+	auto devLabel = mksp<Label>("- Lead Team, Developers and Programming -\n--==--", font);
 	devLabel->Size = {100, contributorListControl->ItemSize * 2};
 	devLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(devLabel);
@@ -123,13 +127,13 @@ void CreditsMenu::loadlist()
 		contributorListControl->addItem(label);
 	}
 
-	// Trainee developers
-	auto trainLabel = mksp<Label>("- Trainee Developers -\n__________", font);
+	// Other GitHub contributors
+	auto trainLabel = mksp<Label>("- Other GitHub Contributors -\n--==--", font);
 	trainLabel->Size = {140, contributorListControl->ItemSize * 2};
 	trainLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(trainLabel);
 
-	for (auto &l : traineeList)
+	for (auto &l : otherGitList)
 	{
 		auto label = mksp<Label>(l, font);
 
@@ -138,13 +142,13 @@ void CreditsMenu::loadlist()
 		contributorListControl->addItem(label);
 	}
 
-	// Programmers
-	auto progLabel = mksp<Label>("- Programmers -\n__________", font);
+	// Testers
+	auto progLabel = mksp<Label>("- Testing -\n--==--", font);
 	progLabel->Size = {140, contributorListControl->ItemSize * 2};
 	progLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(progLabel);
 
-	for (auto &l : programmerList)
+	for (auto &l : testingList)
 	{
 		auto label = mksp<Label>(l, font);
 
@@ -153,13 +157,13 @@ void CreditsMenu::loadlist()
 		contributorListControl->addItem(label);
 	}
 
-	// Testers
-	auto testLabel = mksp<Label>("- Testers -\n__________", font);
+	// Modding Structure
+	auto testLabel = mksp<Label>("- Modding Structure -\n--==--", font);
 	testLabel->Size = {140, contributorListControl->ItemSize * 2};
 	testLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(testLabel);
 
-	for (auto &l : testerList)
+	for (auto &l : moddingList)
 	{
 		auto label = mksp<Label>(l, font);
 
@@ -168,13 +172,13 @@ void CreditsMenu::loadlist()
 		contributorListControl->addItem(label);
 	}
 
-	// Translators
-	auto translateLabel = mksp<Label>("- Translators -\n__________", font);
+	// Reversing and Research
+	auto translateLabel = mksp<Label>("- Reversing and Research -\n--==--", font);
 	translateLabel->Size = {140, contributorListControl->ItemSize * 2};
 	translateLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(translateLabel);
 
-	for (auto &l : translatorList)
+	for (auto &l : reversingList)
 	{
 		auto label = mksp<Label>(l, font);
 
@@ -183,13 +187,13 @@ void CreditsMenu::loadlist()
 		contributorListControl->addItem(label);
 	}
 
-	// Github contributors if not already in list
-	auto githubLabel = mksp<Label>("- GitHub Contributors -\n__________", font);
+	// Translation
+	auto githubLabel = mksp<Label>("- Translation -\n--==--", font);
 	githubLabel->Size = {140, contributorListControl->ItemSize * 2};
 	githubLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(githubLabel);
 
-	for (auto &l : githubContribList)
+	for (auto &l : translationList)
 	{
 		auto label = mksp<Label>(l, font);
 
@@ -199,8 +203,9 @@ void CreditsMenu::loadlist()
 	}
 
 	// Memorial
-	auto memLabel =
-	    mksp<Label>("- In Memory of -\nPanasenko Vasiliy Sergeevich / 'Atrosha' 1980-2021\n", font);
+	auto memLabel = mksp<Label>(
+	    "--==--\nIn Memory of Panasenko Vasiliy Sergeevich / \"Atrosha\" (1980-2021)\n--==--",
+	    font);
 	memLabel->Size = {140, contributorListControl->ItemSize * 3};
 	memLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(memLabel);

--- a/game/ui/general/creditsmenu.cpp
+++ b/game/ui/general/creditsmenu.cpp
@@ -18,36 +18,77 @@ namespace OpenApoc
 {
 namespace
 {
-// If adding to these lists, don't remove the space at the end...
+// Contributor lists, if adding to these keep the blank entry at the end!
 std::list<UString> developerList = {
-    "__________", "pmprog", "redv",       "Andrey", "empty'void", "Flacko", "Flacko the 2nd",
-    "istrebitel", "JonnyH", "shellstorm", "skin36", "SupSuper",   "Warboy", "",
+    "pmprog",         "Andrey",     "redv",   "empty'void", "Flacko",
+    "Flacko the 2nd", "Istrebitel", "JonnyH", "shellstorm", "skin36",
+    "SupSuper",       "Warboy",     "",
 };
 std::list<UString> traineeList = {
-    "__________",
     "FilmBoy84",
     "Jari",
     "",
 };
 std::list<UString> programmerList = {
-    "__________", "Andy51",   "Atrosha",        "Bluddy", "clowds",  "Cristi Popa",
-    "Drosan",     "gnegno",   "Kurtsley",       "Leon",   "letwolf", "luiscamara",
-    "Stewart",    "TheSnide", "TreacherousOne", "Zigmar", "",
+    "Andy51",  "Atrosha",  "Bluddy",         "clowds",            /*"Cristi Popa",*/
+    "Drosan",  "gnegno",   "Kurtsley",       "Leon",   "letwolf", /*"luiscamara",*/
+    "Stewart", "TheSnide", "TreacherousOne", "Zigmar", "",
 };
 std::list<UString> testerList = {
-    "__________", "Filmboy84",       "Atrosha",   "Beorn",         "CidDaBird",
-    "empty'void", "Flacko the 2nd",  "Hyton",     "Jigoku-Panzer", "laurieblakesdr",
-    "MadHaTr",    "makus",           "Quickmind", "RoadhogsButt",  "Sergi4UA",
-    "TimboF5",    "Yataka Shimaoka", "",
+    "Filmboy84",
+    "Atrosha",
+    "Beorn",
+    "CidDaBird",
+    "empty'void",
+    "Flacko the 2nd",
+    "Hyton",
+    "Jigoku-Panzer",
+    "laurieblakesdr",
+    "MadHaTr",
+    "makus",
+    "Quickmind",
+    "RoadhogsButt",
+    "Sergi4UA",
+    "TimboF5",
+    /*"Yataka Shimaoka",*/ "",
 };
 std::list<UString> translatorList = {
-    "__________", "Filmboy84", "Confederate Ghost", "IFoldlyGo",       "Kammerer", "makus",
-    "PlayMann",   "PPeti66x",  "SAlex_UT",          "Sergi4UA",        "skin36",   "Slitchy",
-    "TaoQiBao",   "TimboF5",   "Xcom commander",    "Yataka Shimaoka", "",
+    "Filmboy84", "Confederate Ghost", "IFoldlyGo", "Kammerer",       "makus",
+    "PlayMann",  "PPeti66x",          "SAlex_UT",  "Sergi4UA",       "skin36",
+    "Slitchy",   "TaoQiBao",          "TimboF5",   "Xcom commander", /*"Yataka Shimaoka",*/ "",
 };
 std::list<UString> githubContribList = {
-    "__________",
-    "etc...",
+    "FranciscoDA",
+    "idshibanov",
+    "superusercode",
+    "kgd192",
+    "sfalexrog",
+    "ShadowDancer",
+    "Xracer",
+    /*"steveschnepp",*/
+    /*"stewartmatheson",*/
+    "RedRobin84",
+    "SiemensSchuckert",
+    "sparkstar",
+    "dl471",
+    "5thAvenue",
+    "killermosi",
+    "BabyWolf",
+    "AMDmi3",
+    "AndyCreator",
+    "BlackWolf-Kuzoku",
+    "andersand",
+    "Andy51",
+    "Hambones82",
+    /*"MartinCervenka",*/
+    "h3xx",
+    "ashenomo",
+    "kaja47",
+    "solbu",
+    "pkubaj",
+    "DoxaLogosGit",
+    "Sonicelo",
+    "SolariusScorch",
     "",
 };
 } // namespace
@@ -62,9 +103,14 @@ void CreditsMenu::loadlist()
 	contributorListControl->clear();
 	auto font = ui().getFont("smalfont");
 
+	// Need this because new line doesn't work at the beginning of a label
+	auto spacer = mksp<Label>("", font);
+	spacer->Size = {100, contributorListControl->ItemSize};
+	contributorListControl->addItem(spacer);
+
 	// Developers
-	auto devLabel = mksp<Label>("- Developers -", font);
-	devLabel->Size = {100, contributorListControl->ItemSize};
+	auto devLabel = mksp<Label>("- Developers -\n__________", font);
+	devLabel->Size = {100, contributorListControl->ItemSize * 2};
 	devLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(devLabel);
 
@@ -78,8 +124,8 @@ void CreditsMenu::loadlist()
 	}
 
 	// Trainee developers
-	auto trainLabel = mksp<Label>("- Trainee Developers -", font);
-	trainLabel->Size = {140, contributorListControl->ItemSize};
+	auto trainLabel = mksp<Label>("- Trainee Developers -\n__________", font);
+	trainLabel->Size = {140, contributorListControl->ItemSize * 2};
 	trainLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(trainLabel);
 
@@ -93,8 +139,8 @@ void CreditsMenu::loadlist()
 	}
 
 	// Programmers
-	auto progLabel = mksp<Label>("- Programmers -", font);
-	progLabel->Size = {140, contributorListControl->ItemSize};
+	auto progLabel = mksp<Label>("- Programmers -\n__________", font);
+	progLabel->Size = {140, contributorListControl->ItemSize * 2};
 	progLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(progLabel);
 
@@ -108,8 +154,8 @@ void CreditsMenu::loadlist()
 	}
 
 	// Testers
-	auto testLabel = mksp<Label>("- Testers -", font);
-	testLabel->Size = {140, contributorListControl->ItemSize};
+	auto testLabel = mksp<Label>("- Testers -\n__________", font);
+	testLabel->Size = {140, contributorListControl->ItemSize * 2};
 	testLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(testLabel);
 
@@ -123,8 +169,8 @@ void CreditsMenu::loadlist()
 	}
 
 	// Translators
-	auto translateLabel = mksp<Label>("- Translators -", font);
-	translateLabel->Size = {140, contributorListControl->ItemSize};
+	auto translateLabel = mksp<Label>("- Translators -\n__________", font);
+	translateLabel->Size = {140, contributorListControl->ItemSize * 2};
 	translateLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(translateLabel);
 
@@ -138,8 +184,8 @@ void CreditsMenu::loadlist()
 	}
 
 	// Github contributors if not already in list
-	auto githubLabel = mksp<Label>("- GitHub Contributors -", font);
-	githubLabel->Size = {140, contributorListControl->ItemSize};
+	auto githubLabel = mksp<Label>("- GitHub Contributors -\n__________", font);
+	githubLabel->Size = {140, contributorListControl->ItemSize * 2};
 	githubLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(githubLabel);
 
@@ -153,8 +199,9 @@ void CreditsMenu::loadlist()
 	}
 
 	// Memorial
-	auto memLabel = mksp<Label>("- In Memory of Atrosha -", font);
-	memLabel->Size = {140, contributorListControl->ItemSize};
+	auto memLabel =
+	    mksp<Label>("- In Memory of -\nPanasenko Vasiliy Sergeevich / 'Atrosha' 1980-2021\n", font);
+	memLabel->Size = {140, contributorListControl->ItemSize * 3};
 	memLabel->TextHAlign = HorizontalAlignment::Centre;
 	contributorListControl->addItem(memLabel);
 }

--- a/game/ui/general/creditsmenu.cpp
+++ b/game/ui/general/creditsmenu.cpp
@@ -1,0 +1,202 @@
+#include "game/ui/general/creditsmenu.h"
+#include "forms/checkbox.h"
+#include "forms/form.h"
+#include "forms/label.h"
+#include "forms/listbox.h"
+#include "forms/scrollbar.h"
+#include "forms/ui.h"
+#include "framework/configfile.h"
+#include "framework/data.h"
+#include "framework/event.h"
+#include "framework/framework.h"
+#include "framework/image.h"
+#include "framework/keycodes.h"
+#include "game/ui/components/controlgenerator.h"
+#include "stdio.h"
+
+namespace OpenApoc
+{
+namespace
+{
+// If adding to these lists, don't remove the space at the end...
+std::list<UString> developerList = {
+    "__________", "pmprog", "redv",       "Andrey", "empty'void", "Flacko", "Flacko the 2nd",
+    "istrebitel", "JonnyH", "shellstorm", "skin36", "SupSuper",   "Warboy", "",
+};
+std::list<UString> traineeList = {
+    "__________",
+    "FilmBoy84",
+    "Jari",
+    "",
+};
+std::list<UString> programmerList = {
+    "__________", "Andy51",   "Atrosha",        "Bluddy", "clowds",  "Cristi Popa",
+    "Drosan",     "gnegno",   "Kurtsley",       "Leon",   "letwolf", "luiscamara",
+    "Stewart",    "TheSnide", "TreacherousOne", "Zigmar", "",
+};
+std::list<UString> testerList = {
+    "__________", "Filmboy84",       "Atrosha",   "Beorn",         "CidDaBird",
+    "empty'void", "Flacko the 2nd",  "Hyton",     "Jigoku-Panzer", "laurieblakesdr",
+    "MadHaTr",    "makus",           "Quickmind", "RoadhogsButt",  "Sergi4UA",
+    "TimboF5",    "Yataka Shimaoka", "",
+};
+std::list<UString> translatorList = {
+    "__________", "Filmboy84", "Confederate Ghost", "IFoldlyGo",       "Kammerer", "makus",
+    "PlayMann",   "PPeti66x",  "SAlex_UT",          "Sergi4UA",        "skin36",   "Slitchy",
+    "TaoQiBao",   "TimboF5",   "Xcom commander",    "Yataka Shimaoka", "",
+};
+std::list<UString> githubContribList = {
+    "__________",
+    "etc...",
+    "",
+};
+} // namespace
+
+CreditsMenu::CreditsMenu() : Stage(), menuform(ui().getForm("creditsmenu")) {}
+
+CreditsMenu::~CreditsMenu() = default;
+
+void CreditsMenu::loadlist()
+{
+	auto contributorListControl = menuform->findControlTyped<ListBox>("LISTBOX_CREDITS");
+	contributorListControl->clear();
+	auto font = ui().getFont("smalfont");
+
+	// Developers
+	auto devLabel = mksp<Label>("- Developers -", font);
+	devLabel->Size = {100, contributorListControl->ItemSize};
+	devLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(devLabel);
+
+	for (auto &l : developerList)
+	{
+		auto label = mksp<Label>(l, font);
+
+		label->Size = {216, contributorListControl->ItemSize};
+		label->TextHAlign = HorizontalAlignment::Centre;
+		contributorListControl->addItem(label);
+	}
+
+	// Trainee developers
+	auto trainLabel = mksp<Label>("- Trainee Developers -", font);
+	trainLabel->Size = {140, contributorListControl->ItemSize};
+	trainLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(trainLabel);
+
+	for (auto &l : traineeList)
+	{
+		auto label = mksp<Label>(l, font);
+
+		label->Size = {216, contributorListControl->ItemSize};
+		label->TextHAlign = HorizontalAlignment::Centre;
+		contributorListControl->addItem(label);
+	}
+
+	// Programmers
+	auto progLabel = mksp<Label>("- Programmers -", font);
+	progLabel->Size = {140, contributorListControl->ItemSize};
+	progLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(progLabel);
+
+	for (auto &l : programmerList)
+	{
+		auto label = mksp<Label>(l, font);
+
+		label->Size = {116, contributorListControl->ItemSize};
+		label->TextHAlign = HorizontalAlignment::Centre;
+		contributorListControl->addItem(label);
+	}
+
+	// Testers
+	auto testLabel = mksp<Label>("- Testers -", font);
+	testLabel->Size = {140, contributorListControl->ItemSize};
+	testLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(testLabel);
+
+	for (auto &l : testerList)
+	{
+		auto label = mksp<Label>(l, font);
+
+		label->Size = {216, contributorListControl->ItemSize};
+		label->TextHAlign = HorizontalAlignment::Centre;
+		contributorListControl->addItem(label);
+	}
+
+	// Translators
+	auto translateLabel = mksp<Label>("- Translators -", font);
+	translateLabel->Size = {140, contributorListControl->ItemSize};
+	translateLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(translateLabel);
+
+	for (auto &l : translatorList)
+	{
+		auto label = mksp<Label>(l, font);
+
+		label->Size = {216, contributorListControl->ItemSize};
+		label->TextHAlign = HorizontalAlignment::Centre;
+		contributorListControl->addItem(label);
+	}
+
+	// Github contributors if not already in list
+	auto githubLabel = mksp<Label>("- GitHub Contributors -", font);
+	githubLabel->Size = {140, contributorListControl->ItemSize};
+	githubLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(githubLabel);
+
+	for (auto &l : githubContribList)
+	{
+		auto label = mksp<Label>(l, font);
+
+		label->Size = {216, contributorListControl->ItemSize};
+		label->TextHAlign = HorizontalAlignment::Centre;
+		contributorListControl->addItem(label);
+	}
+
+	// Memorial
+	auto memLabel = mksp<Label>("- In Memory of Atrosha -", font);
+	memLabel->Size = {140, contributorListControl->ItemSize};
+	memLabel->TextHAlign = HorizontalAlignment::Centre;
+	contributorListControl->addItem(memLabel);
+}
+
+bool CreditsMenu::isTransition() { return false; }
+
+void CreditsMenu::begin() { loadlist(); }
+
+void CreditsMenu::pause() {}
+
+void CreditsMenu::resume() {}
+
+void CreditsMenu::finish() {}
+
+void CreditsMenu::eventOccurred(Event *e)
+{
+	menuform->eventOccured(e);
+
+	if (e->type() == EVENT_KEY_DOWN)
+	{
+		if (e->keyboard().KeyCode == SDLK_ESCAPE || e->keyboard().KeyCode == SDLK_RETURN ||
+		    e->keyboard().KeyCode == SDLK_KP_ENTER)
+		{
+			menuform->findControl("BUTTON_OK")->click();
+			return;
+		}
+	}
+	if (e->type() == EVENT_FORM_INTERACTION && e->forms().EventFlag == FormEventType::ButtonClick)
+	{
+		if (e->forms().RaisedBy->Name == "BUTTON_OK")
+		{
+			fw().stageQueueCommand({StageCmd::Command::POP});
+			return;
+		}
+	}
+}
+
+void CreditsMenu::update() { menuform->update(); }
+
+void CreditsMenu::render()
+{
+	fw().stageGetPrevious(this->shared_from_this())->render();
+	menuform->render();
+}
+} // namespace OpenApoc

--- a/game/ui/general/creditsmenu.h
+++ b/game/ui/general/creditsmenu.h
@@ -1,0 +1,32 @@
+#pragma once
+
+#include "framework/stage.h"
+#include "library/sp.h"
+
+namespace OpenApoc
+{
+
+class Form;
+
+class CreditsMenu : public Stage
+{
+  private:
+	sp<Form> menuform;
+
+  public:
+	CreditsMenu();
+	~CreditsMenu() override;
+
+	void loadlist();
+
+	// Stage control
+	void begin() override;
+	void pause() override;
+	void resume() override;
+	void finish() override;
+	void eventOccurred(Event *e) override;
+	void update() override;
+	void render() override;
+	bool isTransition() override;
+};
+} // namespace OpenApoc

--- a/game/ui/general/mainmenu.cpp
+++ b/game/ui/general/mainmenu.cpp
@@ -1,4 +1,5 @@
 #include "game/ui/general/mainmenu.h"
+#include "creditsmenu.h"
 #include "forms/form.h"
 #include "forms/label.h"
 #include "forms/ui.h"
@@ -63,6 +64,11 @@ void MainMenu::eventOccurred(Event *e)
 		*	fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<OptionsMenu>()});
 		*	return;
 		} */
+		if (e->forms().RaisedBy->Name == "BUTTON_CREDITS")
+		{
+			fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<CreditsMenu>()});
+			return;
+		}
 		if (e->forms().RaisedBy->Name == "BUTTON_QUIT")
 		{
 			fw().stageQueueCommand({StageCmd::Command::QUIT});


### PR DESCRIPTION
Here is the first draft. Some thoughts:
I have not figured out how to do two columns and still have text alignment on both. I can do a split list, but the names are all over the place. That is why it is a single column down the middle. The github contributors will probably add some length to the menu. I noticed that a couple people on the discord list seem to be using their real names, I left them in for now but I don't know the rules. The separators between sections are crude underlines because I can't figure out how to get an image to show in the listbox yet. If someone appears on the developer and programmer list, I left them off the programmer list. I kept duplicates on the testers and translators list because that seems to be a seperate job.