### PR TITLE
Rebind fix stuck vehicle debug

### DIFF
--- a/data/forms/city/debugoverlay_city.form
+++ b/data/forms/city/debugoverlay_city.form
@@ -11,15 +11,15 @@
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="CtrlAltShiftLeft" text="Ctrl+Alt+Shift+LeftClick = Destroy Scenery">
+			<label id="CtrlAltShiftLeft" text="Ctrl+Alt+Shift+LeftClick = Destroy Scenery or Crash Vehicle">
 				<position x="left" y="14"/>
-				<size width="250" height="14"/>
+				<size width="450" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="CtrlAltShiftRight" text="Ctrl+Alt+Shift+RightClick = Collapse Building">
+			<label id="CtrlAltShiftRight" text="Ctrl+Alt+Shift+RightClick = Collapse Building or Destroy Vehicle">
 				<position x="left" y="28"/>
-				<size width="250" height="14"/>
+				<size width="450" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
@@ -137,27 +137,27 @@
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="Base" text="Base Screen - F10 = Finish All Facilities">
+			<label id="VClick" text="V+LeftClick = Fix Stuck Vehicle in CityScape (Deprecated)">
 				<position x="left" y="308"/>
-				<size width="250" height="14"/>
-				<alignment horizontal="left" vertical="top"/>
-				<font>smalfont</font>
-			</label>
-			<label id="Research" text="Research Screen - F10 = Complete Project at Next Update (With at least two Scientists Assigned)">
-				<position x="left" y="322"/>
-				<size width="640" height="14"/>
-				<alignment horizontal="left" vertical="top"/>
-				<font>smalfont</font>
-			</label>
-			<label id="ShiftLeft" text="Shift+LeftClick = Fix Stuck Vehicle in CityScape">
-				<position x="left" y="336"/>
 				<size width="350" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
 			<label id="P" text="P = Show Vehicle Targets">
-				<position x="left" y="350"/>
+				<position x="left" y="322"/>
 				<size width="350" height="14"/>
+				<alignment horizontal="left" vertical="top"/>
+				<font>smalfont</font>
+			</label>
+			<label id="Base" text="Base Screen - F10 = Finish All Facilities">
+				<position x="left" y="336"/>
+				<size width="250" height="14"/>
+				<alignment horizontal="left" vertical="top"/>
+				<font>smalfont</font>
+			</label>
+			<label id="Research" text="Research Screen - F10 = Complete Project at Next Update (With at least two Scientists Assigned)">
+				<position x="left" y="350"/>
+				<size width="640" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3164,6 +3164,9 @@ bool CityView::handleKeyDown(Event *e)
 		case SDLK_LCTRL:
 			modifierLCtrl = true;
 			return true;
+		case SDLK_v:
+			modifierV = true;
+			return true;
 		case SDLK_F1:
 			if (config().getBool("OpenApoc.NewFeature.DebugCommandsVisible"))
 			{
@@ -3379,6 +3382,9 @@ bool CityView::handleKeyUp(Event *e)
 		case SDLK_LCTRL:
 			modifierLCtrl = false;
 			return true;
+		case SDLK_v:
+			modifierV = false;
+			return true;
 	}
 	return false;
 }
@@ -3548,8 +3554,9 @@ bool CityView::handleMouseDown(Event *e)
 					{
 						LogInfo("Cargo %sx%d", c.id, c.count);
 					}
-					if (debugHotkeyMode && (modifierLShift || modifierRShift))
+					if (modifierV)
 					{
+						// Unfreeze vehicles (hopefully useless except old saves)
 						vehicle->ticksToTurn += 1;
 					}
 					if (modifierLAlt && modifierLCtrl && modifierLShift)

--- a/game/ui/tileview/cityview.h
+++ b/game/ui/tileview/cityview.h
@@ -82,6 +82,7 @@ class CityView : public CityTileView
 	bool modifierRAlt = false;
 	bool modifierLCtrl = false;
 	bool modifierRCtrl = false;
+	bool modifierV = false;
 
 	bool vanillaControls = false;
 


### PR DESCRIPTION
Holding V plus left click will now unfreeze a stuck vehicle. Added the deprecated comment because this should only work on vehicles that are stuck in old saves, the problem is hopefully resolved moving forward. I also noticed that quickmind was wondering about the crash and destroy vehicle commands. They don't seem to be documented, but they exist in the code. I relabled the debug overlay to fix this. 