### PR TITLE
Fix agent shields now show current health

### DIFF
--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -459,15 +459,16 @@ AgentInfo ControlGenerator::createAgentInfo(GameState &state, sp<Agent> a,
 	i.shield = a->getMaxShield(state) > 0;
 	float maxHealth;
 	float currentHealth;
+
+	currentHealth = a->getHealth();
+	maxHealth = a->getMaxHealth();
 	if (i.shield)
 	{
-		currentHealth = a->getShield(state);
-		maxHealth = a->getMaxShield(state);
-	}
-	else
-	{
-		currentHealth = a->getHealth();
-		maxHealth = a->getMaxHealth();
+		if (currentHealth == maxHealth || state.current_battle)
+		{
+			currentHealth = a->getShield(state);
+			maxHealth = a->getMaxShield(state);
+		}
 	}
 	i.healthProportion = maxHealth == 0.0f ? 0.0f : currentHealth / maxHealth;
 	// Set state that is used in battle


### PR DESCRIPTION
Per the stream, agent shields now show current health until the shield is gone. I messed around with vehicles but they work differently because of the recharge. Should they be included?