### PR TITLE
Split messages between city and battle

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -110,6 +110,7 @@ void Battle::initBattle(GameState &state, bool first)
 	common_image_list = state.battle_common_image_list;
 	common_sample_list = state.battle_common_sample_list;
 	loadResources(state);
+	saveMessages(state);
 	auto stt = shared_from_this();
 	for (auto &s : this->map_parts)
 	{
@@ -2957,6 +2958,8 @@ void Battle::exitBattle(GameState &state)
 		LogError("Battle::ExitBattle called with no battle!");
 		return;
 	}
+	// Load cityscape messages
+	state.current_battle->loadMessages(state);
 
 	// Fake battle, remove fake stuff, restore relationships
 	if (state.current_battle->skirmish)
@@ -3734,6 +3737,32 @@ void Battle::unloadAnimationPacks(GameState &state)
 {
 	state.battle_unit_animation_packs.clear();
 	LogInfo("Unloaded all animation packs.");
+}
+
+void Battle::saveMessages(GameState &state)
+{
+	if (!state.messages.empty())
+	{
+		state.cityMessages.clear();
+		for (auto &m : state.messages)
+		{
+			state.cityMessages.push_back(m);
+		}
+		state.messages.clear();
+	}
+}
+
+void Battle::loadMessages(GameState &state)
+{
+	state.messages.clear();
+	if (!state.cityMessages.empty())
+	{
+		for (auto &m : state.cityMessages)
+		{
+			state.messages.push_back(m);
+		}
+		state.cityMessages.clear();
+	}
 }
 
 int BattleScore::getLeadershipBonus()

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -212,6 +212,10 @@ class Battle : public std::enable_shared_from_this<Battle>
 	void initialMapPartRemoval(GameState &state);
 	void initialMapPartLinkUp();
 
+	// Save and load messages from cityscape
+	void saveMessages(GameState &state);
+	void loadMessages(GameState &state);
+
 	void initialUnitSpawn(GameState &state);
 
 	void setMode(Mode mode);

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -107,6 +107,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 	StateRefMap<BattleMapPartType> battleMapTiles;
 
 	std::list<EventMessage> messages;
+	std::list<EventMessage> cityMessages;
 
 	int baseIndex = 1;
 	int difficulty = 0;


### PR DESCRIPTION
#1264.

I just went ahead with this. The messages from the city get saved to a separate list when a battle begins. The battle starts with a blank message log. The city messages get loaded back to the messages list after the battle. It works in my limited testing, but I could see this causing an unforeseen issue. I would run this through a few different saves.