### PR TITLE
Add vehicles don't dodge when returning home

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -179,6 +179,13 @@ class FlyingVehicleMover : public VehicleMover
 				dodge = 100;
 				break;
 		}
+		// Don't dodge if running away
+		if (vehicle.attackMode == Vehicle::AttackMode::Defensive ||
+		    vehicle.attackMode == Vehicle::AttackMode::Evasive &&
+		        vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
+		{
+			return;
+		}
 		if (vehicle.type->aggressiveness > 0 && randBoundsExclusive(state.rng, 0, 100) < dodge)
 		{
 			for (auto &p : state.current_city->projectiles)

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -180,9 +180,7 @@ class FlyingVehicleMover : public VehicleMover
 				dodge = 100;
 				break;
 		}
-		// Don't dodge if running away
-		if (vehicle.attackMode == Vehicle::AttackMode::Aggressive &&
-		    vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
+		if (vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
 		{
 			return;
 		}

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -180,9 +180,8 @@ class FlyingVehicleMover : public VehicleMover
 				break;
 		}
 		// Don't dodge if running away
-		if (vehicle.attackMode == Vehicle::AttackMode::Defensive ||
-		    vehicle.attackMode == Vehicle::AttackMode::Evasive &&
-		        vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
+		if (vehicle.attackMode == Vehicle::AttackMode::Aggressive &&
+		    vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
 		{
 			return;
 		}


### PR DESCRIPTION
This has bothered me for a while and I'm not sure it's an OG function. When I'm trying to return a vehicle back to the base and it's in a firefight, it keeps dodging which prevents it from getting home as fast as possible. I think there should be some option that a vehicle can simply run away from a fight without dodging. 
In this PR, vehicles will run straight home if:
- The vehicle is returning to base
- The attack mode is set to either defensive or evasive

I would like some feedback on this, maybe they should run home if aggressive? Maybe this should just stay the way it is?