### PR TITLE
WORK IN PROGRESS - Decouple update and render loop

### DIFF
--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -30,7 +30,7 @@ set (FRAMEWORK_SOURCE_FILES
 	logger_sdldialog.cpp
 	logger_file.cpp
 	options.cpp
-	modinfo.cpp)
+	modinfo.cpp "timer.cpp")
 
 source_group(framework\\sources FILES ${FRAMEWORK_SOURCE_FILES})
 list(APPEND ALL_SOURCE_FILES ${FRAMEWORK_SOURCE_FILES})
@@ -68,7 +68,8 @@ set (FRAMEWORK_HEADER_FILES
 	logger_sdldialog.h
 	logger_file.h
 	options.h
-	modinfo.h translation.h)
+	modinfo.h translation.h
+	locked_queue.h "timer.h")
 
 source_group(framework\\headers FILES ${FRAMEWORK_HEADER_FILES})
 list(APPEND ALL_HEADER_FILES ${FRAMEWORK_HEADER_FILES})
@@ -196,7 +197,7 @@ add_library(OpenApoc_Framework STATIC
 	${MUSICLOADER_SOURCE_FILES} ${MUSICLOADER_HEADER_FILES}
 	${SOUND_SOURCE_FILES} ${SOUND_HEADER_FILES}
 	${RENDERER_SOURCE_FILES} ${RENDERER_HEADER_FILES}
-	${FILESYSTEM_SOURCE_FILES} ${FILESYSTEM_HEADER_FILES})
+	${FILESYSTEM_SOURCE_FILES} ${FILESYSTEM_HEADER_FILES} "timer.cpp")
 
 target_compile_definitions(OpenApoc_Framework PUBLIC
 		"-DRENDERERS=\"GLES_3_0:GL_2_0\"")

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -1,11 +1,13 @@
 #pragma once
 
 #include "framework/modinfo.h"
+#include "framework/timer.h"
 #include "library/sp.h"
 #include "library/strings.h"
 #include "library/vec.h"
 #include <functional>
 #include <future>
+#include <map>
 
 namespace OpenApoc
 {
@@ -23,7 +25,6 @@ class JukeBox;
 class StageCmd;
 class Stage;
 class RGBImage;
-
 #define FRAMES_PER_SECOND 100
 
 class Framework
@@ -46,6 +47,11 @@ class Framework
 	std::unique_ptr<Renderer> renderer;
 	std::unique_ptr<SoundBackend> soundBackend;
 	std::unique_ptr<JukeBox> jukebox;
+	struct sdl_callback_info
+	{
+		std::function<void()> callback;
+	};
+	std::map<TimerID, up<sdl_callback_info>> timer_data;
 
 	Framework(const UString programName, bool createWindow = true);
 	~Framework();

--- a/framework/locked_queue.h
+++ b/framework/locked_queue.h
@@ -1,0 +1,85 @@
+#pragma once
+
+#include "framework/framework.h"
+#include <mutex>
+#include <optional>
+#include <queue>
+
+namespace OpenApoc
+{
+
+template <typename T, size_t max_size = 0, bool blocks = false> class locked_queue
+{
+  private:
+	std::queue<T> queue;
+	std::mutex mutex;
+	std::condition_variable cv;
+	bool quit = false;
+
+  public:
+	locked_queue() = default;
+	~locked_queue()
+	{
+		{
+			{
+				std::unique_lock lk(mutex);
+				quit = true;
+			}
+			cv.notify_all();
+			{
+				std::unique_lock lk(mutex);
+			}
+		}
+
+		cv.notify_all();
+	}
+
+	std::optional<T> pop()
+	{
+		std::optional<T> result;
+		{
+			std::unique_lock lock(mutex);
+			cv.wait(lock, [&] { return !queue.empty() || quit; });
+			if (!quit)
+
+			{
+				result = queue.front();
+				queue.pop();
+			}
+		}
+		cv.notify_all();
+		return result;
+	}
+
+	bool push(const T &obj)
+	{
+		{
+			std::unique_lock lock(mutex);
+			if (max_size != 0)
+			{
+				if (blocks)
+				{
+					cv.wait(lock, [&] { return queue.size() < max_size || quit; });
+				}
+				else
+				{
+					if (queue.size() >= max_size)
+					{
+						LogWarning("Dropping object");
+						return false;
+					}
+				}
+			}
+			if (quit)
+			{
+				return false;
+			}
+			queue.push(obj);
+		}
+
+		cv.notify_all();
+		return true;
+	}
+};
+
+} // namespace OpenApoc

--- a/framework/timer.cpp
+++ b/framework/timer.cpp
@@ -1,0 +1,39 @@
+#include "framework/timer.h"
+#include "framework/framework.h"
+#include "framework/logger.h"
+#include "library/strings_format.h"
+
+namespace OpenApoc
+{
+
+static Uint32 sdl_timer_callback(const Uint32 interval, void *param)
+{
+	auto info = static_cast<Framework::sdl_callback_info *>(param);
+	info->callback();
+	return interval;
+}
+
+TimerID start_timer(Framework &fw, std::chrono::duration<uint32_t, std::milli> interval,
+                    std::function<void()> callback)
+{
+	auto callback_info = mkup<Framework::sdl_callback_info>();
+	LogInfo("Start timer, interval %d", interval.count());
+	callback_info->callback = callback;
+	const TimerID id{SDL_AddTimer(interval.count(), sdl_timer_callback, callback_info.get())};
+	if (id == 0)
+	{
+		LogError("Failed to start timer: %s", SDL_GetError());
+	}
+	fw.timer_data[id] = std::move(callback_info);
+	LogInfo("Started timer, ID %d", (int)id);
+	return id;
+}
+
+void destroy_timer(Framework &fw, TimerID id)
+{
+	LogInfo("End timer");
+	SDL_RemoveTimer(id);
+	fw.timer_data.erase(id);
+}
+
+} // namespace OpenApoc

--- a/framework/timer.h
+++ b/framework/timer.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include <SDL.h>
+#include <chrono>
+#include <functional>
+
+namespace OpenApoc
+{
+class Framework;
+using TimerID = SDL_TimerID;
+
+TimerID start_timer(Framework &fw, std::chrono::duration<uint32_t, std::milli> interval,
+                    std::function<void()> callback);
+
+void destroy_timer(Framework &fw, TimerID id);
+
+} // namespace OpenApoc


### PR DESCRIPTION
Proof-of-concept decoupling render and update loops

Uses timers to trigger events rather than a loop - should allow (pretty much) arbitrary intervals between render and update steps.

TODO before we can even *consider* merging this:
 - Drag the GameState update out of the "owning" UI element
 - Fixup the hardcoded timings for each time
 - Find a decent way of aligning frame rate to running screens?
 - Should UI update and render be a single event anyway?
 - Use existing TICKS_PER_SECOND etc. constants rather than hardcoded test values
 - Are SDL timers accurate enough? The documentation doesn't really guarantee much, but is this fine for a game?
 - locked_queue is a quick dirty untested wrapper around std::queue to add a mutex, doesn't instantly crash at least...
 - What happens on exit? Race conditions with locked_queue?
 - What happens if we can't keep up? I think the locked_queue will just drop events over it's arbitrary limit if non blocking. Would this happen to starve one event?
 - Everything running in a single thread could cause issues, especially if ahead in the render queue so the swap blocks