### PR TITLE
Add multi select for agents and vehicles

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2539,7 +2539,7 @@ void Battle::enterBattle(GameState &state)
 	state.updateBeforeBattle();
 
 	// Clear selected units in case they die
-	state.current_city->cityViewSelectedAgents.clear();
+	state.current_city->cityViewSelectedSoldiers.clear();
 }
 
 // To be called when battle must be finished and before showing score screen

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -115,8 +115,12 @@ class City : public StateObject<City>, public std::enable_shared_from_this<City>
 
 	Vec3<float> cityViewScreenCenter = {0.0f, 0.0f, 0.0f};
 	int cityViewPageIndex = 0;
-	std::list<StateRef<Vehicle>> cityViewSelectedVehicles;
-	std::list<StateRef<Agent>> cityViewSelectedAgents;
+	std::list<StateRef<Vehicle>> cityViewSelectedOwnedVehicles;
+	std::list<StateRef<Vehicle>> cityViewSelectedOtherVehicles;
+	std::list<StateRef<Agent>> cityViewSelectedSoldiers;
+	std::list<StateRef<Agent>> cityViewSelectedBios;
+	std::list<StateRef<Agent>> cityViewSelectedPhysics;
+	std::list<StateRef<Agent>> cityViewSelectedEngineers;
 	StateRef<Organisation> cityViewSelectedOrganisation;
 	int cityViewOrgButtonIndex = 0;
 

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -118,6 +118,7 @@ class City : public StateObject<City>, public std::enable_shared_from_this<City>
 	std::list<StateRef<Vehicle>> cityViewSelectedOwnedVehicles;
 	std::list<StateRef<Vehicle>> cityViewSelectedOtherVehicles;
 	std::list<StateRef<Agent>> cityViewSelectedSoldiers;
+	std::list<StateRef<Agent>> cityViewSelectedCivilians;
 	std::list<StateRef<Agent>> cityViewSelectedBios;
 	std::list<StateRef<Agent>> cityViewSelectedPhysics;
 	std::list<StateRef<Agent>> cityViewSelectedEngineers;

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -982,12 +982,24 @@ void OpenApoc::GameState::cleanUpDeathNote()
 			// Remove vehicle from selection
 			for (const auto &[cityId, city] : cities)
 			{
-				for (auto it = city->cityViewSelectedVehicles.begin();
-				     it != city->cityViewSelectedVehicles.end();)
+				for (auto it = city->cityViewSelectedOwnedVehicles.begin();
+				     it != city->cityViewSelectedOwnedVehicles.end();)
+				{
+				    if (it->id == name)
+				    {
+				        it = city->cityViewSelectedOwnedVehicles.erase(it);
+				    }
+				    else
+				    {
+				        ++it;
+				    }
+				}
+				for (auto it = city->cityViewSelectedOtherVehicles.begin();
+				     it != city->cityViewSelectedOtherVehicles.end();)
 				{
 					if (it->id == name)
 					{
-						it = city->cityViewSelectedVehicles.erase(it);
+						it = city->cityViewSelectedOtherVehicles.erase(it);
 					}
 					else
 					{

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -985,14 +985,14 @@ void OpenApoc::GameState::cleanUpDeathNote()
 				for (auto it = city->cityViewSelectedOwnedVehicles.begin();
 				     it != city->cityViewSelectedOwnedVehicles.end();)
 				{
-				    if (it->id == name)
-				    {
-				        it = city->cityViewSelectedOwnedVehicles.erase(it);
-				    }
-				    else
-				    {
-				        ++it;
-				    }
+					if (it->id == name)
+					{
+						it = city->cityViewSelectedOwnedVehicles.erase(it);
+					}
+					else
+					{
+						++it;
+					}
 				}
 				for (auto it = city->cityViewSelectedOtherVehicles.begin();
 				     it != city->cityViewSelectedOtherVehicles.end();)

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -976,8 +976,12 @@
 		<member>researchUnlock</member>
 		<member>cityViewScreenCenter</member>
 		<member>cityViewPageIndex</member>
-		<member>cityViewSelectedVehicles</member>
-		<member>cityViewSelectedAgents</member>
+		<member>cityViewSelectedOwnedVehicles</member>
+		<member>cityViewSelectedOtherVehicles</member>
+		<member>cityViewSelectedSoldiers</member>
+		<member>cityViewSelectedBios</member>
+		<member>cityViewSelectedPhysics</member>
+		<member>cityViewSelectedEngineers</member>
 		<member>cityViewSelectedOrganisation</member>
 		<member>cityViewOrgButtonIndex</member>
 	</object>

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -118,11 +118,11 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 	t.vehicle = v;
 	t.selected = UnitSelectionState::Unselected;
 
-	for (auto &veh : state.current_city->cityViewSelectedVehicles)
+	for (auto &veh : state.current_city->cityViewSelectedOwnedVehicles)
 	{
 		if (veh == v)
 		{
-			t.selected = (veh == state.current_city->cityViewSelectedVehicles.front())
+			t.selected = (veh == state.current_city->cityViewSelectedOwnedVehicles.front())
 			                 ? UnitSelectionState::FirstSelected
 			                 : UnitSelectionState::Selected;
 			break;
@@ -435,11 +435,41 @@ AgentInfo ControlGenerator::createAgentInfo(GameState &state, sp<Agent> a,
 		// Select according to city state
 		else
 		{
-			for (auto &ag : state.current_city->cityViewSelectedAgents)
+			for (auto &ag : state.current_city->cityViewSelectedSoldiers)
 			{
 				if (ag == a)
 				{
-					i.selected = (ag == state.current_city->cityViewSelectedAgents.front())
+					i.selected = (ag == state.current_city->cityViewSelectedSoldiers.front())
+					                 ? UnitSelectionState::FirstSelected
+					                 : UnitSelectionState::Selected;
+					break;
+				}
+			}
+			for (auto &ag : state.current_city->cityViewSelectedBios)
+			{
+				if (ag == a)
+				{
+					i.selected = (ag == state.current_city->cityViewSelectedBios.front())
+					                 ? UnitSelectionState::FirstSelected
+					                 : UnitSelectionState::Selected;
+					break;
+				}
+			}
+			for (auto &ag : state.current_city->cityViewSelectedPhysics)
+			{
+				if (ag == a)
+				{
+					i.selected = (ag == state.current_city->cityViewSelectedPhysics.front())
+					                 ? UnitSelectionState::FirstSelected
+					                 : UnitSelectionState::Selected;
+					break;
+				}
+			}
+			for (auto &ag : state.current_city->cityViewSelectedEngineers)
+			{
+				if (ag == a)
+				{
+					i.selected = (ag == state.current_city->cityViewSelectedEngineers.front())
 					                 ? UnitSelectionState::FirstSelected
 					                 : UnitSelectionState::Selected;
 					break;

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -128,6 +128,16 @@ VehicleTileInfo ControlGenerator::createVehicleInfo(GameState &state, sp<Vehicle
 			break;
 		}
 	}
+	for (auto &veh : state.current_city->cityViewSelectedOtherVehicles)
+	{
+		if (veh == v)
+		{
+			t.selected = (veh == state.current_city->cityViewSelectedOtherVehicles.front())
+			                 ? UnitSelectionState::FirstSelected
+			                 : UnitSelectionState::Selected;
+			break;
+		}
+	}
 
 	float maxHealth;
 	float currentHealth;

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -334,9 +334,10 @@ void CityTileView::render()
 			// List of vehicles that require drawing of brackets
 			std::set<sp<Vehicle>> vehiclesToDrawBrackets;
 			std::map<sp<Vehicle>, int> vehiclesBracketsIndex;
-
+			state.current_city->cityViewSelectedOwnedVehicles.merge(
+			    state.current_city->cityViewSelectedOtherVehicles);
 			// Go through every selected vehicle and add target to list of bracket draws
-			for (auto &vehicle : state.current_city->cityViewSelectedVehicles)
+			for (auto &vehicle : state.current_city->cityViewSelectedOwnedVehicles)
 			{
 				if (vehicle->owner != state.getPlayer())
 				{
@@ -387,16 +388,16 @@ void CityTileView::render()
 										auto v = std::static_pointer_cast<TileObjectVehicle>(obj)
 										             ->getVehicle();
 
-										if (!state.current_city->cityViewSelectedVehicles.empty())
+										if (!state.current_city->cityViewSelectedOwnedVehicles.empty())
 										{
 											auto selectedPos = std::find(
-											    state.current_city->cityViewSelectedVehicles
+											    state.current_city->cityViewSelectedOwnedVehicles
 											        .begin(),
-											    state.current_city->cityViewSelectedVehicles.end(),
+											    state.current_city->cityViewSelectedOwnedVehicles.end(),
 											    v);
 
 											if (selectedPos ==
-											    state.current_city->cityViewSelectedVehicles
+											    state.current_city->cityViewSelectedOwnedVehicles
 											        .begin())
 											{
 												if (v->owner == state.getPlayer())
@@ -406,7 +407,7 @@ void CityTileView::render()
 												}
 											}
 											else if (selectedPos !=
-											         state.current_city->cityViewSelectedVehicles
+											         state.current_city->cityViewSelectedOwnedVehicles
 											             .end())
 											{
 												vehiclesToDrawBrackets.insert(v);
@@ -585,11 +586,11 @@ void CityTileView::render()
 										          Organisation::Relation::Hostile;
 										bool selected =
 										    std::find(
-										        state.current_city->cityViewSelectedVehicles
+										        state.current_city->cityViewSelectedOwnedVehicles
 										            .begin(),
-										        state.current_city->cityViewSelectedVehicles.end(),
+										        state.current_city->cityViewSelectedOwnedVehicles.end(),
 										        v) !=
-										    state.current_city->cityViewSelectedVehicles.end();
+										    state.current_city->cityViewSelectedOwnedVehicles.end();
 
 										if (friendly)
 										{
@@ -715,9 +716,9 @@ void CityTileView::render()
 					continue;
 				}
 				bool selected =
-				    std::find(state.current_city->cityViewSelectedVehicles.begin(),
-				              state.current_city->cityViewSelectedVehicles.end(),
-				              v.second) != state.current_city->cityViewSelectedVehicles.end();
+				    std::find(state.current_city->cityViewSelectedOwnedVehicles.begin(),
+				              state.current_city->cityViewSelectedOwnedVehicles.end(),
+				              v.second) != state.current_city->cityViewSelectedOwnedVehicles.end();
 
 				// Draw those in buildings
 				if (v.second->currentBuilding)
@@ -834,10 +835,10 @@ void CityTileView::render()
 				if (selectionFrameTicksAccumulated / SELECTION_FRAME_ANIMATION_DELAY)
 				{
 					bool selected =
-					    !state.current_city->cityViewSelectedAgents.empty() &&
-					    std::find(state.current_city->cityViewSelectedAgents.begin(),
-					              state.current_city->cityViewSelectedAgents.end(),
-					              a.second) != state.current_city->cityViewSelectedAgents.end();
+					    !state.current_city->cityViewSelectedSoldiers.empty() &&
+					    std::find(state.current_city->cityViewSelectedSoldiers.begin(),
+					              state.current_city->cityViewSelectedSoldiers.end(),
+					              a.second) != state.current_city->cityViewSelectedSoldiers.end();
 					if (selected)
 					{
 						r.draw(selectionImageFriendlySmall,

--- a/game/ui/tileview/citytileview.cpp
+++ b/game/ui/tileview/citytileview.cpp
@@ -334,8 +334,6 @@ void CityTileView::render()
 			// List of vehicles that require drawing of brackets
 			std::set<sp<Vehicle>> vehiclesToDrawBrackets;
 			std::map<sp<Vehicle>, int> vehiclesBracketsIndex;
-			state.current_city->cityViewSelectedOwnedVehicles.merge(
-			    state.current_city->cityViewSelectedOtherVehicles);
 			// Go through every selected vehicle and add target to list of bracket draws
 			for (auto &vehicle : state.current_city->cityViewSelectedOwnedVehicles)
 			{
@@ -388,12 +386,14 @@ void CityTileView::render()
 										auto v = std::static_pointer_cast<TileObjectVehicle>(obj)
 										             ->getVehicle();
 
-										if (!state.current_city->cityViewSelectedOwnedVehicles.empty())
+										if (!state.current_city->cityViewSelectedOwnedVehicles
+										         .empty())
 										{
 											auto selectedPos = std::find(
 											    state.current_city->cityViewSelectedOwnedVehicles
 											        .begin(),
-											    state.current_city->cityViewSelectedOwnedVehicles.end(),
+											    state.current_city->cityViewSelectedOwnedVehicles
+											        .end(),
 											    v);
 
 											if (selectedPos ==
@@ -407,8 +407,8 @@ void CityTileView::render()
 												}
 											}
 											else if (selectedPos !=
-											         state.current_city->cityViewSelectedOwnedVehicles
-											             .end())
+											         state.current_city
+											             ->cityViewSelectedOwnedVehicles.end())
 											{
 												vehiclesToDrawBrackets.insert(v);
 												vehiclesBracketsIndex[v] = 1;
@@ -585,11 +585,11 @@ void CityTileView::render()
 										hostile = state.getPlayer()->isRelatedTo(v->owner) ==
 										          Organisation::Relation::Hostile;
 										bool selected =
-										    std::find(
-										        state.current_city->cityViewSelectedOwnedVehicles
-										            .begin(),
-										        state.current_city->cityViewSelectedOwnedVehicles.end(),
-										        v) !=
+										    std::find(state.current_city
+										                  ->cityViewSelectedOwnedVehicles.begin(),
+										              state.current_city
+										                  ->cityViewSelectedOwnedVehicles.end(),
+										              v) !=
 										    state.current_city->cityViewSelectedOwnedVehicles.end();
 
 										if (friendly)

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -135,7 +135,9 @@ sp<Facility> findCurrentResearchFacility(sp<GameState> state, AgentType::Role ro
                                          FacilityType::Capacity capacity)
 {
 	sp<Facility> lab;
-	for (auto &a : state->current_city->cityViewSelectedAgents)
+	for (auto &a : state->current_city->cityViewSelectedBios,
+	     state->current_city->cityViewSelectedEngineers,
+	     state->current_city->cityViewSelectedPhysics)
 	{
 		if (a && a->type->role == role)
 		{
@@ -528,7 +530,7 @@ void CityView::orderGoToBase()
 {
 	if (activeTab == uiTabs[1])
 	{
-		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
@@ -555,7 +557,7 @@ void CityView::orderGoToBase()
 	}
 	if (activeTab == uiTabs[2])
 	{
-		for (auto &a : this->state->current_city->cityViewSelectedAgents)
+		for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 		{
 			LogInfo("Goto base for vehicle \"%s\"", a->name);
 			auto bld = a->homeBuilding;
@@ -579,7 +581,7 @@ void CityView::orderMove(Vec3<float> position, bool alternative, bool portal)
 	{
 		if (portal)
 		{
-			for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+			for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 			{
 				if (v && v->owner == this->state->getPlayer())
 				{
@@ -589,7 +591,7 @@ void CityView::orderMove(Vec3<float> position, bool alternative, bool portal)
 		}
 		else
 		{
-			state->current_city->groupMove(*state, state->current_city->cityViewSelectedVehicles,
+			state->current_city->groupMove(*state, state->current_city->cityViewSelectedOwnedVehicles,
 			                               position, useTeleporter);
 		}
 		return;
@@ -602,7 +604,7 @@ void CityView::orderMove(StateRef<Building> building, bool alternative)
 	    alternative && config().getBool("OpenApoc.NewFeature.AllowManualCityTeleporters");
 	if (activeTab == uiTabs[1])
 	{
-		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
@@ -617,7 +619,7 @@ void CityView::orderMove(StateRef<Building> building, bool alternative)
 	if (activeTab == uiTabs[2])
 	{
 		bool useTaxi = !alternative && config().getBool("OpenApoc.NewFeature.AllowSoldierTaxiUse");
-		for (auto &a : this->state->current_city->cityViewSelectedAgents)
+		for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 		{
 			if (a->type->role != AgentType::Role::Soldier)
 			{
@@ -633,8 +635,8 @@ void CityView::orderMove(StateRef<Building> building, bool alternative)
 
 void CityView::orderSelect(StateRef<Vehicle> vehicle, bool inverse, bool additive)
 {
-	auto pos = std::find(state->current_city->cityViewSelectedVehicles.begin(),
-	                     state->current_city->cityViewSelectedVehicles.end(), vehicle);
+	auto pos = std::find(state->current_city->cityViewSelectedOwnedVehicles.begin(),
+	                     state->current_city->cityViewSelectedOwnedVehicles.end(), vehicle);
 
 	if (vehicle->city != state->current_city)
 	{
@@ -643,47 +645,47 @@ void CityView::orderSelect(StateRef<Vehicle> vehicle, bool inverse, bool additiv
 	if (inverse)
 	{
 		// Vehicle in selection => remove
-		if (pos != state->current_city->cityViewSelectedVehicles.end())
+		if (pos != state->current_city->cityViewSelectedOwnedVehicles.end())
 		{
-			state->current_city->cityViewSelectedVehicles.erase(pos);
+			state->current_city->cityViewSelectedOwnedVehicles.erase(pos);
 		}
 	}
 	else
 	{
 		// Vehicle not selected
-		if (pos == state->current_city->cityViewSelectedVehicles.end())
+		if (pos == state->current_city->cityViewSelectedOwnedVehicles.end())
 		{
 			// Selecting non-owned vehicles is always additive to current selection
 			if (additive || vehicle->owner != state->getPlayer())
 			{
 				// Whenever adding clear any non-player vehicles from selection
-				if (!state->current_city->cityViewSelectedVehicles.empty() &&
-				    state->current_city->cityViewSelectedVehicles.front()->owner !=
+				if (!state->current_city->cityViewSelectedOwnedVehicles.empty() &&
+				    state->current_city->cityViewSelectedOwnedVehicles.front()->owner !=
 				        state->getPlayer())
 				{
-					state->current_city->cityViewSelectedVehicles.pop_front();
+					state->current_city->cityViewSelectedOwnedVehicles.pop_front();
 				}
-				state->current_city->cityViewSelectedVehicles.push_front(vehicle);
+				state->current_city->cityViewSelectedOwnedVehicles.push_front(vehicle);
 			}
 			else
 			{
 				// Vehicle not in selection => replace selection with vehicle
-				state->current_city->cityViewSelectedVehicles.clear();
-				state->current_city->cityViewSelectedVehicles.push_back(vehicle);
+				state->current_city->cityViewSelectedOwnedVehicles.clear();
+				state->current_city->cityViewSelectedOwnedVehicles.push_back(vehicle);
 			}
 		}
 		// Vehicle is selected
 		else
 		{
 			// First move vehicle to front
-			state->current_city->cityViewSelectedVehicles.erase(pos);
+			state->current_city->cityViewSelectedOwnedVehicles.erase(pos);
 			// If moving vehicle to front, deselect any non-owned vehicle, unless it's that one
-			if (!state->current_city->cityViewSelectedVehicles.empty() &&
-			    state->current_city->cityViewSelectedVehicles.front()->owner != state->getPlayer())
+			if (!state->current_city->cityViewSelectedOwnedVehicles.empty() &&
+			    state->current_city->cityViewSelectedOwnedVehicles.front()->owner != state->getPlayer())
 			{
-				state->current_city->cityViewSelectedVehicles.pop_front();
+				state->current_city->cityViewSelectedOwnedVehicles.pop_front();
 			}
-			state->current_city->cityViewSelectedVehicles.push_front(vehicle);
+			state->current_city->cityViewSelectedOwnedVehicles.push_front(vehicle);
 			// Then if not additive then zoom to vehicle
 			if (!additive)
 			{
@@ -699,15 +701,15 @@ void CityView::orderSelect(StateRef<Vehicle> vehicle, bool inverse, bool additiv
 			}
 		}
 	}
-	if (state->current_city->cityViewSelectedVehicles.empty() ||
-	    state->current_city->cityViewSelectedVehicles.front()->owner != state->getPlayer())
+	if (state->current_city->cityViewSelectedOwnedVehicles.empty() ||
+	    state->current_city->cityViewSelectedOwnedVehicles.front()->owner != state->getPlayer())
 	{
 		return;
 	}
-	vehicle = state->current_city->cityViewSelectedVehicles.front();
+	vehicle = state->current_city->cityViewSelectedOwnedVehicles.front();
 	if (vehicle->owner != state->getPlayer())
 	{
-		vehicle = *++state->current_city->cityViewSelectedVehicles.begin();
+		vehicle = *++state->current_city->cityViewSelectedOwnedVehicles.begin();
 	}
 	auto vehicleForm = this->uiTabs[1];
 	// FIXME: Proper multiselect handle for vehicle controls
@@ -752,63 +754,62 @@ void CityView::orderSelect(StateRef<Vehicle> vehicle, bool inverse, bool additiv
 
 void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 {
-	auto pos = std::find(state->current_city->cityViewSelectedAgents.begin(),
-	                     state->current_city->cityViewSelectedAgents.end(), agent);
-	if (inverse)
+	if (agent->type->role == AgentType::Role::Soldier)
 	{
-		// Agent in selection => remove
-		if (pos != state->current_city->cityViewSelectedAgents.end())
+		auto pos = std::find(state->current_city->cityViewSelectedSoldiers.begin(),
+		                     state->current_city->cityViewSelectedSoldiers.end(), agent);
+		if (inverse)
 		{
-			state->current_city->cityViewSelectedAgents.erase(pos);
-		}
-	}
-	else
-	{
-		// Agent not selected
-		if (pos == state->current_city->cityViewSelectedAgents.end())
-		{
-			// If additive add
-			if (additive)
+			// Agent in selection => remove
+			if (pos != state->current_city->cityViewSelectedSoldiers.end())
 			{
-				state->current_city->cityViewSelectedAgents.push_front(agent);
-			}
-			else
-			{
-				// Agent not in selection => replace selection with agent
-				state->current_city->cityViewSelectedAgents.clear();
-				state->current_city->cityViewSelectedAgents.push_back(agent);
+				state->current_city->cityViewSelectedSoldiers.erase(pos);
 			}
 		}
-		// Agent is selected
 		else
 		{
-			// First move vehicle to front
-			state->current_city->cityViewSelectedAgents.erase(pos);
-			state->current_city->cityViewSelectedAgents.push_front(agent);
-			// Then if not additive then zoom to agent
-			if (!additive)
+			// Agent not selected
+			if (pos == state->current_city->cityViewSelectedSoldiers.end())
 			{
-				if (agent->currentVehicle)
+				// If additive add
+				if (additive)
 				{
-					this->setScreenCenterTile(agent->currentVehicle->position);
+					state->current_city->cityViewSelectedSoldiers.push_front(agent);
 				}
 				else
 				{
-					this->setScreenCenterTile(agent->position);
+					// Agent not in selection => replace selection with agent
+					state->current_city->cityViewSelectedSoldiers.clear();
+					state->current_city->cityViewSelectedSoldiers.push_back(agent);
+				}
+			}
+			// Agent is selected
+			else
+			{
+				// First move vehicle to front
+				state->current_city->cityViewSelectedSoldiers.erase(pos);
+				state->current_city->cityViewSelectedSoldiers.push_front(agent);
+				// Then if not additive then zoom to agent
+				if (!additive)
+				{
+					if (agent->currentVehicle)
+					{
+						this->setScreenCenterTile(agent->currentVehicle->position);
+					}
+					else
+					{
+						this->setScreenCenterTile(agent->position);
+					}
 				}
 			}
 		}
-	}
-
-	auto agentForm = this->uiTabs[2];
-	if (state->current_city->cityViewSelectedAgents.empty())
-	{
-		return;
-	}
-	agent = state->current_city->cityViewSelectedAgents.front();
-	LogWarning("FIX: Proper multiselect handle for agent controls");
-	if (agent->type->role == AgentType::Role::Soldier)
-	{
+		auto agentForm = this->uiTabs[2];
+		if (state->current_city->cityViewSelectedSoldiers.empty())
+		{
+			return;
+		}
+		agent = state->current_city->cityViewSelectedSoldiers.front();
+		LogWarning("FIX: Proper multiselect handle for agent controls");
 		switch (agent->trainingAssignment)
 		{
 			case TrainingAssignment::None:
@@ -829,13 +830,160 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 			}
 		}
 	}
+
+	// Biochem dudes
+	if (agent->type->role == AgentType::Role::BioChemist)
+	{
+		auto pos = std::find(state->current_city->cityViewSelectedBios.begin(),
+		                     state->current_city->cityViewSelectedBios.end(), agent);
+		if (inverse)
+		{
+			// Agent in selection => remove
+			if (pos != state->current_city->cityViewSelectedBios.end())
+			{
+				state->current_city->cityViewSelectedBios.erase(pos);
+			}
+		}
+		else
+		{
+			// Agent not selected
+			if (pos == state->current_city->cityViewSelectedBios.end())
+			{
+				// If additive add
+				if (additive)
+				{
+					state->current_city->cityViewSelectedBios.push_front(agent);
+				}
+				else
+				{
+					// Agent not in selection => replace selection with agent
+					state->current_city->cityViewSelectedBios.clear();
+					state->current_city->cityViewSelectedBios.push_back(agent);
+				}
+			}
+			// Agent is selected
+			else
+			{
+				// First move agent to front
+				state->current_city->cityViewSelectedBios.erase(pos);
+				state->current_city->cityViewSelectedBios.push_front(agent);
+				// Then if not additive then zoom to agent
+				if (!additive)
+				{
+					this->setScreenCenterTile(agent->position);
+				}
+			}
+		}
+		if (state->current_city->cityViewSelectedBios.empty())
+		{
+			return;
+		}
+	}
+
+	// Physics guys
+	if (agent->type->role == AgentType::Role::Physicist)
+	{
+		auto pos = std::find(state->current_city->cityViewSelectedPhysics.begin(),
+		                     state->current_city->cityViewSelectedPhysics.end(), agent);
+		if (inverse)
+		{
+			// Agent in selection => remove
+			if (pos != state->current_city->cityViewSelectedPhysics.end())
+			{
+				state->current_city->cityViewSelectedPhysics.erase(pos);
+			}
+		}
+		else
+		{
+			// Agent not selected
+			if (pos == state->current_city->cityViewSelectedPhysics.end())
+			{
+				// If additive add
+				if (additive)
+				{
+					state->current_city->cityViewSelectedPhysics.push_front(agent);
+				}
+				else
+				{
+					// Agent not in selection => replace selection with agent
+					state->current_city->cityViewSelectedPhysics.clear();
+					state->current_city->cityViewSelectedPhysics.push_back(agent);
+				}
+			}
+			// Agent is selected
+			else
+			{
+				// First move agent to front
+				state->current_city->cityViewSelectedPhysics.erase(pos);
+				state->current_city->cityViewSelectedPhysics.push_front(agent);
+				// Then if not additive then zoom to agent
+				if (!additive)
+				{
+					this->setScreenCenterTile(agent->position);
+				}
+			}
+		}
+		if (state->current_city->cityViewSelectedPhysics.empty())
+		{
+			return;
+		}
+	}
+
+	// Engineers
+	if (agent->type->role == AgentType::Role::Engineer)
+	{
+		auto pos = std::find(state->current_city->cityViewSelectedEngineers.begin(),
+		                     state->current_city->cityViewSelectedEngineers.end(), agent);
+		if (inverse)
+		{
+			// Agent in selection => remove
+			if (pos != state->current_city->cityViewSelectedEngineers.end())
+			{
+				state->current_city->cityViewSelectedEngineers.erase(pos);
+			}
+		}
+		else
+		{
+			// Agent not selected
+			if (pos == state->current_city->cityViewSelectedEngineers.end())
+			{
+				// If additive add
+				if (additive)
+				{
+					state->current_city->cityViewSelectedEngineers.push_front(agent);
+				}
+				else
+				{
+					// Agent not in selection => replace selection with agent
+					state->current_city->cityViewSelectedEngineers.clear();
+					state->current_city->cityViewSelectedEngineers.push_back(agent);
+				}
+			}
+			// Agent is selected
+			else
+			{
+				// First move agent to front
+				state->current_city->cityViewSelectedEngineers.erase(pos);
+				state->current_city->cityViewSelectedEngineers.push_front(agent);
+				// Then if not additive then zoom to agent
+				if (!additive)
+				{
+					this->setScreenCenterTile(agent->position);
+				}
+			}
+		}
+		if (state->current_city->cityViewSelectedEngineers.empty())
+		{
+			return;
+		}
+	}
 }
 
 void CityView::orderFire(Vec3<float> position)
 {
 	if (activeTab == uiTabs[1])
 	{
-		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
@@ -850,7 +998,7 @@ void CityView::orderAttack(StateRef<Vehicle> vehicle, bool forced)
 {
 	if (activeTab == uiTabs[1])
 	{
-		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		{
 			if (v && v->owner == this->state->getPlayer() && v != vehicle)
 			{
@@ -914,7 +1062,7 @@ void CityView::orderFollow(StateRef<Vehicle> vehicle)
 {
 	if (activeTab == uiTabs[1])
 	{
-		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		{
 			if (v && v->owner == this->state->getPlayer() && v != vehicle)
 			{
@@ -929,7 +1077,7 @@ void CityView::orderAttack(StateRef<Building> building)
 {
 	if (activeTab == uiTabs[1])
 	{
-		for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		{
 			if (v && v->owner == this->state->getPlayer())
 			{
@@ -944,14 +1092,14 @@ void CityView::orderDisableWeapon(int index, bool disable)
 	weaponDisabled[index] = disable;
 
 	std::vector<sp<VEquipment>> currentWeapons;
-	if (!state->current_city->cityViewSelectedVehicles.empty())
+	if (!state->current_city->cityViewSelectedOwnedVehicles.empty())
 	{
-		auto vehicle = state->current_city->cityViewSelectedVehicles.front();
+		auto vehicle = state->current_city->cityViewSelectedOwnedVehicles.front();
 		if (vehicle->owner != state->getPlayer())
 		{
-			if (state->current_city->cityViewSelectedVehicles.size() > 1)
+			if (state->current_city->cityViewSelectedOwnedVehicles.size() > 1)
 			{
-				vehicle = *++state->current_city->cityViewSelectedVehicles.begin();
+				vehicle = *++state->current_city->cityViewSelectedOwnedVehicles.begin();
 			}
 			else
 			{
@@ -1143,7 +1291,7 @@ CityView::CityView(sp<GameState> state)
 		                  if (playerHasVehicles)
 		                  {
 			                  auto equipScreen = mksp<VEquipScreen>(this->state);
-			                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+			                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 			                  {
 				                  if (v && v->owner == this->state->getPlayer())
 				                  {
@@ -1158,7 +1306,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1172,7 +1320,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1185,7 +1333,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1198,7 +1346,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1211,7 +1359,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1227,7 +1375,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1239,7 +1387,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1251,7 +1399,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1263,7 +1411,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1275,7 +1423,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1287,7 +1435,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1299,7 +1447,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1311,7 +1459,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::CheckBoxSelected,
 	                  [this](Event *)
 	                  {
-		                  for (auto &v : this->state->current_city->cityViewSelectedVehicles)
+		                  for (auto &v : this->state->current_city->cityViewSelectedOwnedVehicles)
 		                  {
 			                  if (v && v->owner == this->state->getPlayer())
 			                  {
@@ -1321,18 +1469,19 @@ CityView::CityView(sp<GameState> state)
 	                  });
 	auto agentForm = this->uiTabs[2];
 	agentForm->findControl("BUTTON_AGENT_BUILDING")
-	    ->addCallback(FormEventType::ButtonClick,
-	                  [this](Event *)
-	                  {
-		                  if (!this->state->current_city->cityViewSelectedAgents.empty())
-		                  {
-			                  fw().stageQueueCommand(
-			                      {StageCmd::Command::PUSH,
-			                       mksp<LocationScreen>(
-			                           this->state,
-			                           this->state->current_city->cityViewSelectedAgents.front())});
-		                  }
-	                  });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        if (!this->state->current_city->cityViewSelectedSoldiers.empty())
+		        {
+			        fw().stageQueueCommand(
+			            {StageCmd::Command::PUSH,
+			             mksp<LocationScreen>(
+			                 this->state,
+			                 this->state->current_city->cityViewSelectedSoldiers.front())});
+		        }
+	        });
 	agentForm->findControl("BUTTON_EQUIP_AGENT")
 	    ->addCallback(
 	        FormEventType::ButtonClick,
@@ -1356,8 +1505,8 @@ CityView::CityView(sp<GameState> state)
 			            {StageCmd::Command::PUSH,
 			             mksp<AEquipScreen>(
 			                 this->state,
-			                 !this->state->current_city->cityViewSelectedAgents.empty()
-			                     ? this->state->current_city->cityViewSelectedAgents.front()
+			                 !this->state->current_city->cityViewSelectedSoldiers.empty()
+			                     ? this->state->current_city->cityViewSelectedSoldiers.front()
 			                     : nullptr)});
 		        }
 	        });
@@ -1366,7 +1515,7 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  if (!this->state->current_city->cityViewSelectedAgents.empty())
+		                  if (!this->state->current_city->cityViewSelectedSoldiers.empty())
 		                  {
 			                  setSelectionState(CitySelectionState::GotoBuilding);
 		                  }
@@ -1375,10 +1524,10 @@ CityView::CityView(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
-		                  if (!this->state->current_city->cityViewSelectedAgents.empty())
+		                  if (!this->state->current_city->cityViewSelectedSoldiers.empty())
 		                  {
 
-			                  auto a = this->state->current_city->cityViewSelectedAgents.front();
+			                  auto a = this->state->current_city->cityViewSelectedSoldiers.front();
 			                  // Don't return to base if in a vehicle
 			                  if (!a->currentVehicle)
 			                  {
@@ -1398,7 +1547,7 @@ CityView::CityView(sp<GameState> state)
 			                      ->findControlTyped<CheckBox>("BUTTON_AGENT_PSI")
 			                      ->setChecked(false);
 		                  }
-		                  for (auto &a : this->state->current_city->cityViewSelectedAgents)
+		                  for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 		                  {
 			                  if (checked)
 			                  {
@@ -1413,7 +1562,7 @@ CityView::CityView(sp<GameState> state)
 		                  if (checked)
 		                  {
 			                  checked = false;
-			                  for (auto &a : this->state->current_city->cityViewSelectedAgents)
+			                  for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 			                  {
 				                  if (a->trainingAssignment != TrainingAssignment::None)
 				                  {
@@ -1429,7 +1578,7 @@ CityView::CityView(sp<GameState> state)
 		                  // Check other button if need to
 		                  else
 		                  {
-			                  for (auto &a : this->state->current_city->cityViewSelectedAgents)
+			                  for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 			                  {
 				                  if (a->trainingAssignment == TrainingAssignment::Psi)
 				                  {
@@ -1457,7 +1606,7 @@ CityView::CityView(sp<GameState> state)
 			                      ->findControlTyped<CheckBox>("BUTTON_AGENT_PHYSICAL")
 			                      ->setChecked(false);
 		                  }
-		                  for (auto &a : this->state->current_city->cityViewSelectedAgents)
+		                  for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 		                  {
 			                  if (checked)
 			                  {
@@ -1472,7 +1621,7 @@ CityView::CityView(sp<GameState> state)
 		                  if (checked)
 		                  {
 			                  checked = false;
-			                  for (auto &a : this->state->current_city->cityViewSelectedAgents)
+			                  for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 			                  {
 				                  if (a->trainingAssignment != TrainingAssignment::None)
 				                  {
@@ -1488,7 +1637,7 @@ CityView::CityView(sp<GameState> state)
 		                  // Check other button if need to
 		                  else
 		                  {
-			                  for (auto &a : this->state->current_city->cityViewSelectedAgents)
+			                  for (auto &a : this->state->current_city->cityViewSelectedSoldiers)
 			                  {
 				                  if (a->trainingAssignment == TrainingAssignment::Physical)
 				                  {
@@ -2100,14 +2249,14 @@ void CityView::update()
 
 		// Update weapon controls
 		std::vector<sp<VEquipment>> currentWeapons;
-		if (!state->current_city->cityViewSelectedVehicles.empty())
+		if (!state->current_city->cityViewSelectedOwnedVehicles.empty())
 		{
-			auto vehicle = state->current_city->cityViewSelectedVehicles.front();
+			auto vehicle = state->current_city->cityViewSelectedOwnedVehicles.front();
 			if (vehicle->owner != state->getPlayer())
 			{
-				if (state->current_city->cityViewSelectedVehicles.size() > 1)
+				if (state->current_city->cityViewSelectedOwnedVehicles.size() > 1)
 				{
-					vehicle = *++state->current_city->cityViewSelectedVehicles.begin();
+					vehicle = *++state->current_city->cityViewSelectedOwnedVehicles.begin();
 				}
 				else
 				{
@@ -2213,14 +2362,14 @@ void CityView::update()
 		auto agentForm = uiTabs[2];
 		sp<Label> agentName = agentForm->findControlTyped<Label>("TEXT_AGENT_NAME");
 		sp<Label> agentAssignment = agentForm->findControlTyped<Label>("TEXT_AGENT_ASSIGNMENT");
-		if (state->current_city->cityViewSelectedAgents.empty())
+		if (state->current_city->cityViewSelectedSoldiers.empty())
 		{
 			agentName->setText("");
 			agentAssignment->setText("");
 		}
 		else
 		{
-			StateRef<Agent> agent = state->current_city->cityViewSelectedAgents.front();
+			StateRef<Agent> agent = state->current_city->cityViewSelectedSoldiers.front();
 			StateRef<Base> base;
 			if (agent->type->role == AgentType::Role::Soldier)
 			{
@@ -2402,14 +2551,14 @@ void CityView::update()
 		auto agentForm = uiTabs[3];
 		sp<Label> agentName = agentForm->findControlTyped<Label>("TEXT_AGENT_NAME");
 		sp<Label> agentAssignment = agentForm->findControlTyped<Label>("TEXT_AGENT_ASSIGNMENT");
-		if (state->current_city->cityViewSelectedAgents.empty())
+		if (state->current_city->cityViewSelectedBios.empty())
 		{
 			agentName->setText("");
 			agentAssignment->setText("");
 		}
 		else
 		{
-			StateRef<Agent> agent = state->current_city->cityViewSelectedAgents.front();
+			StateRef<Agent> agent = state->current_city->cityViewSelectedBios.front();
 			if (agent->type->role == AgentType::Role::BioChemist)
 			{
 				agentName->setText(agent->name);
@@ -2530,14 +2679,14 @@ void CityView::update()
 		auto agentForm = uiTabs[4];
 		sp<Label> agentName = agentForm->findControlTyped<Label>("TEXT_AGENT_NAME");
 		sp<Label> agentAssignment = agentForm->findControlTyped<Label>("TEXT_AGENT_ASSIGNMENT");
-		if (state->current_city->cityViewSelectedAgents.empty())
+		if (state->current_city->cityViewSelectedEngineers.empty())
 		{
 			agentName->setText("");
 			agentAssignment->setText("");
 		}
 		else
 		{
-			StateRef<Agent> agent = state->current_city->cityViewSelectedAgents.front();
+			StateRef<Agent> agent = state->current_city->cityViewSelectedEngineers.front();
 			if (agent->type->role == AgentType::Role::Engineer)
 			{
 				agentName->setText(agent->name);
@@ -2661,14 +2810,14 @@ void CityView::update()
 		auto agentForm = uiTabs[5];
 		sp<Label> agentName = agentForm->findControlTyped<Label>("TEXT_AGENT_NAME");
 		sp<Label> agentAssignment = agentForm->findControlTyped<Label>("TEXT_AGENT_ASSIGNMENT");
-		if (state->current_city->cityViewSelectedAgents.empty())
+		if (state->current_city->cityViewSelectedPhysics.empty())
 		{
 			agentName->setText("");
 			agentAssignment->setText("");
 		}
 		else
 		{
-			StateRef<Agent> agent = state->current_city->cityViewSelectedAgents.front();
+			StateRef<Agent> agent = state->current_city->cityViewSelectedPhysics.front();
 			if (agent->type->role == AgentType::Role::Physicist)
 			{
 				agentName->setText(agent->name);
@@ -2786,9 +2935,9 @@ void CityView::update()
 	{
 		auto hostileVehicleList = uiTabs[6]->findControlTyped<ListBox>("HOSTILE_VEHICLE_LIST");
 
-		if (!state->current_city->cityViewSelectedVehicles.empty())
+		if (!state->current_city->cityViewSelectedOwnedVehicles.empty())
 		{
-			auto selectedVehicle = state->current_city->cityViewSelectedVehicles.front();
+			auto selectedVehicle = state->current_city->cityViewSelectedOwnedVehicles.front();
 			if (selectedVehicle->owner == state->getPlayer())
 			{
 				uiTabs[6]->findControlTyped<Label>("TEXT_VEHICLE_NAME")->setText("");
@@ -2829,8 +2978,8 @@ void CityView::update()
 			if (state->getPlayer()->isRelatedTo(vehicle->owner) != Organisation::Relation::Hostile)
 			{
 				if (vehicle->owner == state->getPlayer() ||
-				    state->current_city->cityViewSelectedVehicles.empty() ||
-				    state->current_city->cityViewSelectedVehicles.front() != v.second)
+				    state->current_city->cityViewSelectedOwnedVehicles.empty() ||
+				    state->current_city->cityViewSelectedOwnedVehicles.front() != v.second)
 				{
 					continue;
 				}
@@ -3036,9 +3185,9 @@ void CityView::update()
 	// this frame
 	if (this->followVehicle && this->updateSpeed != CityUpdateSpeed::Pause)
 	{
-		if (!state->current_city->cityViewSelectedVehicles.empty())
+		if (!state->current_city->cityViewSelectedOwnedVehicles.empty())
 		{
-			auto v = state->current_city->cityViewSelectedVehicles.front();
+			auto v = state->current_city->cityViewSelectedOwnedVehicles.front();
 			if (v->city == state->current_city)
 			{
 				// Don't follow if vehicle is in building
@@ -3048,9 +3197,9 @@ void CityView::update()
 				}
 			}
 		}
-		else if (!state->current_city->cityViewSelectedAgents.empty())
+		else if (!state->current_city->cityViewSelectedSoldiers.empty())
 		{
-			auto a = state->current_city->cityViewSelectedAgents.front();
+			auto a = state->current_city->cityViewSelectedSoldiers.front();
 
 			if (a->city == state->current_city)
 			{
@@ -4114,13 +4263,13 @@ void CityView::updateSelectedUnits()
 	bool foundOwnedVehicle = false;
 	// Vehicles
 	{
-		auto it = state->current_city->cityViewSelectedVehicles.begin();
-		while (it != state->current_city->cityViewSelectedVehicles.end())
+		auto it = state->current_city->cityViewSelectedOwnedVehicles.begin();
+		while (it != state->current_city->cityViewSelectedOwnedVehicles.end())
 		{
 			auto v = *it;
 			if (!v || v->isDead() || v->city != state->current_city)
 			{
-				it = state->current_city->cityViewSelectedVehicles.erase(it);
+				it = state->current_city->cityViewSelectedOwnedVehicles.erase(it);
 			}
 			else
 			{
@@ -4135,13 +4284,13 @@ void CityView::updateSelectedUnits()
 	}
 	// Agents
 	{
-		auto it = state->current_city->cityViewSelectedAgents.begin();
-		while (it != state->current_city->cityViewSelectedAgents.end())
+		auto it = state->current_city->cityViewSelectedSoldiers.begin();
+		while (it != state->current_city->cityViewSelectedSoldiers.end())
 		{
 			auto a = *it;
 			if (!a || a->isDead())
 			{
-				it = state->current_city->cityViewSelectedAgents.erase(it);
+				it = state->current_city->cityViewSelectedSoldiers.erase(it);
 			}
 			else
 			{
@@ -4237,7 +4386,7 @@ void CityView::setSelectionState(CitySelectionState selectionState)
 			UString message;
 			if (activeTab == uiTabs[1])
 			{
-				if (state->current_city->cityViewSelectedVehicles.size() > 1)
+				if (state->current_city->cityViewSelectedOwnedVehicles.size() > 1)
 				{
 					message = tr("Click on destination building for selected vehicles");
 				}
@@ -4248,7 +4397,7 @@ void CityView::setSelectionState(CitySelectionState selectionState)
 			}
 			else
 			{
-				if (state->current_city->cityViewSelectedAgents.size() > 1)
+				if (state->current_city->cityViewSelectedSoldiers.size() > 1)
 				{
 					message = tr("Click on destination building for selected people");
 				}

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -135,9 +135,7 @@ sp<Facility> findCurrentResearchFacility(sp<GameState> state, AgentType::Role ro
                                          FacilityType::Capacity capacity)
 {
 	sp<Facility> lab;
-	for (auto &a : state->current_city->cityViewSelectedBios,
-	     state->current_city->cityViewSelectedEngineers,
-	     state->current_city->cityViewSelectedPhysics)
+	for (auto &a : state->current_city->cityViewSelectedCivilians)
 	{
 		if (a && a->type->role == role)
 		{
@@ -419,6 +417,7 @@ bool CityView::handleClickedAgent(StateRef<Agent> agent, bool rightClick,
                                   CitySelectionState selState [[maybe_unused]])
 {
 	orderSelect(agent, rightClick, modifierLCtrl || modifierRCtrl);
+	LogWarning("%d", state->current_city->cityViewSelectedCivilians.size());
 	return true;
 }
 
@@ -905,8 +904,7 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 			}
 		}
 	}
-
-	// Biochem dudes
+	// Biochem
 	if (agent->type->role == AgentType::Role::BioChemist)
 	{
 		auto pos = std::find(state->current_city->cityViewSelectedBios.begin(),
@@ -949,13 +947,8 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 				}
 			}
 		}
-		if (state->current_city->cityViewSelectedBios.empty())
-		{
-			return;
-		}
 	}
-
-	// Physics guys
+	// Physics
 	if (agent->type->role == AgentType::Role::Physicist)
 	{
 		auto pos = std::find(state->current_city->cityViewSelectedPhysics.begin(),
@@ -998,12 +991,7 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 				}
 			}
 		}
-		if (state->current_city->cityViewSelectedPhysics.empty())
-		{
-			return;
-		}
 	}
-
 	// Engineers
 	if (agent->type->role == AgentType::Role::Engineer)
 	{
@@ -1047,10 +1035,21 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 				}
 			}
 		}
-		if (state->current_city->cityViewSelectedEngineers.empty())
-		{
-			return;
-		}
+	}
+	// Build civilian list
+	state->current_city->cityViewSelectedCivilians.clear();
+
+	for (auto &a : state->current_city->cityViewSelectedBios)
+	{
+		state->current_city->cityViewSelectedCivilians.push_back(a);
+	}
+	for (auto &a : state->current_city->cityViewSelectedPhysics)
+	{
+		state->current_city->cityViewSelectedCivilians.push_back(a);
+	}
+	for (auto &a : state->current_city->cityViewSelectedEngineers)
+	{
+		state->current_city->cityViewSelectedCivilians.push_back(a);
 	}
 }
 


### PR DESCRIPTION
Addresses #1262 

This separates the tabs in the cityview into separate lists, allowing them to function individually. The follow vehicle is based on which tab is open, so it only works when the vehicle or hostile vehicle tabs are open. The Scientists can now be selected and monitored as in OG.

I may leave this as a draft for a bit while I continue to think about how to optimize this. Everything is basically being done multiple times now where it was just once before. I'm sure some of the vehicle logic could be condensed, we'll see. The most important thing is if this works just like the OG. On the surface, it seems to work, but there is room for things to break as usual. Please throw everything you have at this PR to try to break something.