### PR TITLE
Fix scientists able to be assigned when not at base

### DIFF
--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -377,6 +377,9 @@ void ResearchScreen::setCurrentLabInfo()
 		if (agent.second->homeBuilding->base != this->state->current_base)
 			continue;
 
+		if (agent.second->currentBuilding != agent.second->homeBuilding)
+			continue;
+
 		if (agent.second->type->role != listedAgentType)
 			continue;
 


### PR DESCRIPTION
If you recruit a scientist, they immediately  show up in the unassigned agents list and can be assigned to a project even though they aren't physically at the base.

As you can see, I have assigned Steve Green but he is in another building.
![bio](https://github.com/OpenApoc/OpenApoc/assets/73447098/793e9f5c-966b-4748-9615-21277f6bd3a0)

I checked OG, it seems they don't show up in the list until they arrive at the base. Let me know if there is some reason for this that I can't think of.
