### PR TITLE
Attempt to fix missing agent message

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1016,6 +1016,47 @@ void OpenApoc::GameState::cleanUpDeathNote()
 		for (auto &name : this->agentsDeathNote)
 		{
 			agents.erase(name);
+
+			// Remove from selection
+			for (const auto &[cityId, city] : cities)
+			{
+				for (auto it = city->cityViewSelectedBios.begin();
+				     it != city->cityViewSelectedBios.end();)
+				{
+					if (it->id == name)
+					{
+						it = city->cityViewSelectedBios.erase(it);
+					}
+					else
+					{
+						++it;
+					}
+				}
+				for (auto it = city->cityViewSelectedPhysics.begin();
+				     it != city->cityViewSelectedPhysics.end();)
+				{
+					if (it->id == name)
+					{
+						it = city->cityViewSelectedPhysics.erase(it);
+					}
+					else
+					{
+						++it;
+					}
+				}
+				for (auto it = city->cityViewSelectedEngineers.begin();
+				     it != city->cityViewSelectedEngineers.end();)
+				{
+					if (it->id == name)
+					{
+						it = city->cityViewSelectedEngineers.erase(it);
+					}
+					else
+					{
+						++it;
+					}
+				}
+			}
 		}
 		agentsDeathNote.clear();
 	}
@@ -1256,7 +1297,8 @@ void GameState::updateEndOfDay()
 
 	luaGameState.callHook("updateEndOfDay", 0, 0);
 	// Check if today is the first day of the week (monday).
-	// In that case, do not show the daily report as it's already part of the weekly report event
+	// In that case, do not show the daily report as it's already part of the weekly report
+	// event
 	if (this->gameTime.getMonthDay() != this->gameTime.getFirstDayOfCurrentWeek())
 		fw().pushEvent(new GameEvent(GameEventType::DailyReport));
 }
@@ -1678,5 +1720,4 @@ bool GameState::appendGameState(const UString &gamestatePath)
 	auto systemPath = fw().data->fs.resolvePath(gamestatePath);
 	return this->loadGame(systemPath);
 }
-
 }; // namespace OpenApoc

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -417,7 +417,6 @@ bool CityView::handleClickedAgent(StateRef<Agent> agent, bool rightClick,
                                   CitySelectionState selState [[maybe_unused]])
 {
 	orderSelect(agent, rightClick, modifierLCtrl || modifierRCtrl);
-	LogWarning("%d", state->current_city->cityViewSelectedCivilians.size());
 	return true;
 }
 

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -4371,13 +4371,13 @@ void CityView::updateSelectedUnits()
 	}
 	// Agents
 	{
-		auto it = state->current_city->cityViewSelectedSoldiers.begin();
-		while (it != state->current_city->cityViewSelectedSoldiers.end())
+		auto itSold = state->current_city->cityViewSelectedSoldiers.begin();
+		while (itSold != state->current_city->cityViewSelectedSoldiers.end())
 		{
-			auto a = *it;
+			auto a = *itSold;
 			if (!a || a->isDead())
 			{
-				it = state->current_city->cityViewSelectedSoldiers.erase(it);
+				itSold = state->current_city->cityViewSelectedSoldiers.erase(itSold);
 			}
 			else
 			{
@@ -4385,10 +4385,62 @@ void CityView::updateSelectedUnits()
 				{
 					foundOwned = true;
 				}
-				it++;
+				itSold++;
+			}
+		}
+		auto itBio = state->current_city->cityViewSelectedBios.begin();
+		while (itBio != state->current_city->cityViewSelectedBios.end())
+		{
+			auto a = *itBio;
+			if (!a || a->isDead())
+			{
+				itBio = state->current_city->cityViewSelectedBios.erase(itBio);
+			}
+			else
+			{
+				if (a->owner == o)
+				{
+					foundOwned = true;
+				}
+				itBio++;
+			}
+		}
+		auto itPhy = state->current_city->cityViewSelectedPhysics.begin();
+		while (itPhy != state->current_city->cityViewSelectedPhysics.end())
+		{
+			auto a = *itPhy;
+			if (!a || a->isDead())
+			{
+				itPhy = state->current_city->cityViewSelectedPhysics.erase(itPhy);
+			}
+			else
+			{
+				if (a->owner == o)
+				{
+					foundOwned = true;
+				}
+				itPhy++;
+			}
+		}
+		auto itEng = state->current_city->cityViewSelectedEngineers.begin();
+		while (itEng != state->current_city->cityViewSelectedEngineers.end())
+		{
+			auto a = *itEng;
+			if (!a || a->isDead())
+			{
+				itEng = state->current_city->cityViewSelectedEngineers.erase(itEng);
+			}
+			else
+			{
+				if (a->owner == o)
+				{
+					foundOwned = true;
+				}
+				itEng++;
 			}
 		}
 	}
+
 	if (!foundOwned && selectionState != CitySelectionState::Normal)
 	{
 		setSelectionState(CitySelectionState::Normal);


### PR DESCRIPTION
Attempting to fix the recent missing agent message, just a guess on my part. The civilian list was not being updated when agents were fired, this could cause issues. The soldier list doesn't need this for some reason, they will drop off when killed or fired. I left a logwarning message I used in debugging in the code, this removes it as well. 