### PR TITLE
Change vehicle reload time to every 5 minutes

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1100,45 +1100,6 @@ void GameState::updateEndOfSecond()
 	for (auto &b : current_city->buildings)
 	{
 		b.second->updateCargo(*this);
-		if (!b.second->base || b.second->owner != getPlayer())
-		{
-			continue;
-		}
-		auto base = b.second->base;
-		for (auto v : b.second->currentVehicles)
-		{
-			for (auto &e : v->equipment)
-			{
-				// We only can reload VehicleWeapon and VehicleEngine(?)
-				if (e->type->type != EquipmentSlotType::VehicleWeapon &&
-				    e->type->type != EquipmentSlotType::VehicleEngine) //  e->type->max_ammo == 0
-				{
-					continue;
-				}
-				// Only show events for vehicles owned by current player
-				if (v->owner->name == getPlayer()->name)
-				{
-					if (e->reload(*this, base))
-					{
-						switch (e->type->type)
-						{
-							case EquipmentSlotType::VehicleEngine:
-								fw().pushEvent(
-								    new GameVehicleEvent(GameEventType::VehicleRefuelled, v));
-								break;
-							case EquipmentSlotType::VehicleWeapon:
-								fw().pushEvent(
-								    new GameVehicleEvent(GameEventType::VehicleRearmed, v));
-								break;
-							default:
-								LogInfo("Implement the remaining messages for vehicle rearmed / "
-								        "reloaded / refueled / whatever");
-								break;
-						}
-					}
-				}
-			}
-		}
 	}
 	for (auto &v : vehicles)
 	{
@@ -1184,7 +1145,45 @@ void GameState::updateEndOfFiveMinutes()
 	}
 	for (auto &b : current_city->buildings)
 	{
-		b.second->updateCargo(*this);
+		if (!b.second->base || b.second->owner != getPlayer())
+		{
+			continue;
+		}
+		auto base = b.second->base;
+		for (auto v : b.second->currentVehicles)
+		{
+			for (auto &e : v->equipment)
+			{
+				// We only can reload VehicleWeapon and VehicleEngine(?)
+				if (e->type->type != EquipmentSlotType::VehicleWeapon &&
+				    e->type->type != EquipmentSlotType::VehicleEngine) //  e->type->max_ammo == 0
+				{
+					continue;
+				}
+				// Only show events for vehicles owned by current player
+				if (v->owner->name == getPlayer()->name)
+				{
+					if (e->reload(*this, base))
+					{
+						switch (e->type->type)
+						{
+							case EquipmentSlotType::VehicleEngine:
+								fw().pushEvent(
+								    new GameVehicleEvent(GameEventType::VehicleRefuelled, v));
+								break;
+							case EquipmentSlotType::VehicleWeapon:
+								fw().pushEvent(
+								    new GameVehicleEvent(GameEventType::VehicleRearmed, v));
+								break;
+							default:
+								LogInfo("Implement the remaining messages for vehicle rearmed / "
+								        "reloaded / refueled / whatever");
+								break;
+						}
+					}
+				}
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
As in OG, vehicles now reload every 5 minutes instead of instantly. Because of how the event system works, the vehicles will be reloaded in 5 minutes, but the message won't be sent until 10 minutes. That is above my paygrade as they say. There was also a redundant cargo update that was removed. It was called every 5 minutes even though it is also called every second.