### PR TITLE
Fix training button unchecked when no agents selected

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -881,6 +881,8 @@ void CityView::orderSelect(StateRef<Agent> agent, bool inverse, bool additive)
 		auto agentForm = this->uiTabs[2];
 		if (state->current_city->cityViewSelectedSoldiers.empty())
 		{
+			agentForm->findControlTyped<CheckBox>("BUTTON_AGENT_PHYSICAL")->setChecked(false);
+			agentForm->findControlTyped<CheckBox>("BUTTON_AGENT_PSI")->setChecked(false);
 			return;
 		}
 		agent = state->current_city->cityViewSelectedSoldiers.front();


### PR DESCRIPTION
Simple fix to bring in line with OG. The training button should not be checked when no agent is selected.