### PR TITLE
Fix unarmed vehicles patrolling when attacked

### DIFF
--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -985,11 +985,14 @@ void Building::underAttack(GameState &state, StateRef<Organisation> attacker)
 	if (owner->isRelatedTo(attacker) == Organisation::Relation::Hostile)
 	{
 		std::list<StateRef<Vehicle>> toLaunch;
-		for (auto v : currentVehicles)
+		for (auto &v : currentVehicles)
 		{
-			toLaunch.push_back(v);
+			if (v->canDefend())
+			{
+				toLaunch.push_back(v);
+			}
 		}
-		for (auto v : toLaunch)
+		for (auto &v : toLaunch)
 		{
 			v->setMission(state, VehicleMission::patrol(state, *v, true, 5));
 		}

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -2025,6 +2025,19 @@ void Vehicle::adjustRelationshipOnDowned(GameState &state, StateRef<Vehicle> att
 
 bool Vehicle::isDead() const { return health <= 0; }
 
+bool Vehicle::canDefend() const
+{
+	bool hasWeapons = false;
+	for (auto &e : this->equipment)
+	{
+		if (e->type->type == EquipmentSlotType::VehicleWeapon)
+		{
+			hasWeapons = true;
+		}
+	}
+	return hasWeapons;
+}
+
 Vec3<float> Vehicle::getMuzzleLocation() const
 {
 	return type->isGround()

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -275,6 +275,7 @@ class Vehicle : public StateObject<Vehicle>,
 	void startFalling(GameState &state, StateRef<Vehicle> attacker = nullptr);
 	void adjustRelationshipOnDowned(GameState &state, StateRef<Vehicle> attacker);
 	bool isDead() const;
+	bool canDefend() const;
 
 	bool canAddEquipment(Vec2<int> pos, StateRef<VEquipmentType> type) const;
 	sp<VEquipment> addEquipment(GameState &state, Vec2<int> pos,


### PR DESCRIPTION
I noticed in the QM stream that when transtellar was attacked, every single space liner and taxi came out to patrol. I checked OG and found that those vehicles don't come out and try to attack as they have no weapons. This PR checks each vehicle in the building when attacked and only sends out vehicles with weapon slots.