### PR TITLE
Add building collapse when damaged

### DIFF
--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -1102,4 +1102,13 @@ bool Building::occupied() const
 
 bool Building::isAlive() const { return countActiveTiles() > 0; }
 
+bool Building::isStable() const
+{
+	if ((float)this->buildingParts.size() / this->initialParts * 100.0 < this->integrityPercentage)
+	{
+		return false;
+	}
+	return true;
+}
+
 } // namespace OpenApoc

--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -88,6 +88,8 @@ class Building : public StateObject<Building>, public std::enable_shared_from_th
 	StateRef<ResearchTopic> accessTopic;
 	// Victory when successful at raiding this
 	bool victory = false;
+	// Percentage of tiles destroyed before collapse
+	float integrityPercentage;
 
 	// may fire a 'commence investigation' event
 	void decreasePendingInvestigatorCount(GameState &state);
@@ -109,6 +111,7 @@ class Building : public StateObject<Building>, public std::enable_shared_from_th
 	int getAverageConstitution() const;
 	bool isAlive() const;
 	bool occupied() const;
+	bool isStable() const;
 
 	// Following members are not serialized, but rather are set in City::initCity method
 
@@ -116,6 +119,7 @@ class Building : public StateObject<Building>, public std::enable_shared_from_th
 	Vec3<int> carEntranceLocation = {-1, -1, -1};
 	std::set<Vec3<int>> landingPadLocations;
 	std::set<Vec3<int>> buildingParts;
+	int initialParts;
 };
 
 }; // namespace OpenApoc

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -149,12 +149,14 @@ void GameState::initState()
 			{
 				auto &building = b.second;
 				Vec2<int> pos2d{s->initialPosition.x, s->initialPosition.y};
+				building->integrityPercentage = 50.0;
 				if (building->bounds.within(pos2d))
 				{
 					s->building = {this, building};
 					if (s->isAlive() && !s->type->commonProperty)
 					{
 						s->building->buildingParts.insert(s->initialPosition);
+						building->initialParts = s->building->buildingParts.size();
 					}
 					break;
 				}
@@ -202,6 +204,7 @@ void GameState::initState()
 			city->generatePortals(*this);
 		}
 	}
+	this->organisation_raid_rules.max_attack_vehicles = 5;
 	// Fill links for weapon's ammo
 	for (auto &t : this->agent_equipment)
 	{
@@ -1100,6 +1103,10 @@ void GameState::updateEndOfSecond()
 	for (auto &b : current_city->buildings)
 	{
 		b.second->updateCargo(*this);
+		if (!b.second->isStable())
+		{
+			b.second->collapse(*this);
+		}
 	}
 	for (auto &v : vehicles)
 	{

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -1105,6 +1105,7 @@
 		<member>accessTopic</member>
 		<member>victory</member>
 		<member>pendingInvestigatorCount</member>
+		<member>integrityPercentage</member>
 	</object>
 	<object>
 		<name>UFOIncursion</name>
@@ -1339,6 +1340,7 @@
 	<object>
 		<name>OrganisationRaid</name>
 		<member>nextRaidTimer</member>
+		<member>max_attack_vehicles</member>
 		<member>attack_vehicle_types</member>
 		<member>neutral_low_manpower</member>
 		<member>neutral_normal</member>

--- a/game/state/rules/city/organisationraid.h
+++ b/game/state/rules/city/organisationraid.h
@@ -23,7 +23,7 @@ class OrganisationRaid
 
 	int nextRaidTimer = 0;
 
-	int max_attack_vehicles = 5;
+	int max_attack_vehicles;
 	std::vector<StateRef<VehicleType>> attack_vehicle_types;
 	std::map<Type, float> neutral_low_manpower;
 	std::map<Type, float> neutral_normal;


### PR DESCRIPTION
Adds a feature where building will collapse when enough tiles are destroyed. This an initial attempt because I have some questions as to how this worked in OG. I have the number set at 50 percent at the moment, obviously that can be adjusted. I tried to open this up to modding, but am not sure it is correct. Since I was trying to add modability, I went back and tried to add the max_attack_vehicles value to the gamestate_serialize.xml file as well. I have some questions about adding modability.

I added the integrityPercentage variable to the gamestate_serialize.xml file, but it only showed up in a save archive when it was declared in the actual gamestate.cpp file during the game initialization for example. If it was given a value in the building.cpp file, nothing showed up when opening the save archive. Is it required to show up in the save file to be moddable?

The same happened with the max_attack_vehicles int. If I tried to give it a value in the organisations.cpp file, nothing showed up in the save. For now, I added the value in a semi-random spot in the gamestate file and it shows up in the save file.

So what I need to know is:

- Does it matter if the variable doesn't show up in the save archive?
- If it does matter, can the value only be declared in the gamestate?

As it stands now, both values appear in the opened save archive.