### PR TITLE
Fix aliens starting in player base on new game

### DIFF
--- a/game/state/city/building.h
+++ b/game/state/city/building.h
@@ -88,6 +88,8 @@ class Building : public StateObject<Building>, public std::enable_shared_from_th
 	StateRef<ResearchTopic> accessTopic;
 	// Victory when successful at raiding this
 	bool victory = false;
+	// Initial alien building
+	bool initialInfiltration = false;
 
 	// may fire a 'commence investigation' event
 	void decreasePendingInvestigatorCount(GameState &state);

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -628,6 +628,7 @@ void GameState::startGame()
 		buildingIt->second->current_crew[l.first] =
 		    randBoundsExclusive(rng, l.second.x, l.second.y);
 	}
+	buildingIt->second->initialInfiltration = true;
 
 	gameTime = GameTime::midday();
 
@@ -650,7 +651,7 @@ void GameState::fillPlayerStartingProperty()
 	std::vector<sp<Building>> buildingsWithBases;
 	for (auto &b : humanCity->buildings)
 	{
-		if (b.second->base_layout)
+		if (b.second->base_layout && !b.second->initialInfiltration)
 			buildingsWithBases.push_back(b.second);
 	}
 


### PR DESCRIPTION
Adds a check that makes sure the player base is not the same building that the aliens start in.