### PR TITLE
Fix overlap on transfer screen

### DIFF
--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -90,6 +90,7 @@ void TransactionScreen::setDisplayType(Type type)
 	formItemVehicle->setVisible(false);
 	formAgentStats->setVisible(false);
 	formPersonnelStats->setVisible(false);
+	formAgentProfile->setVisible(false);
 
 	form->findControlTyped<ScrollBar>("LIST_SCROLL")->setValue(0);
 	auto list = form->findControlTyped<ListBox>("LIST");


### PR DESCRIPTION
Addresses #1301 

The profile form wasn't being cleared when switching agent types, now it is.