### PR TITLE
Limit space liners to prevent late game slowdown

### DIFF
--- a/game/state/shared/organisation.cpp
+++ b/game/state/shared/organisation.cpp
@@ -1190,6 +1190,7 @@ void Organisation::RecurringMission::execute(GameState &state, StateRef<City> ci
 		}
 		// Make list of functional spaceports
 		std::list<StateRef<Building>> spaceports;
+		std::list<sp<Vehicle>> linerList;
 		for (auto &b : city->spaceports)
 		{
 			if (b->isAlive())
@@ -1208,9 +1209,26 @@ void Organisation::RecurringMission::execute(GameState &state, StateRef<City> ci
 				{
 					spaceports.push_back(b);
 				}
+				for (auto &v : b->currentVehicles)
+				{
+					if (pattern.allowedTypes.find(v->type) != pattern.allowedTypes.end())
+					{
+						linerList.push_back(v);
+					}
+				}
 			}
 		}
 		if (spaceports.empty())
+		{
+			return;
+		}
+		/* FIXME:
+		 *  This limits the total number of space liners that can be
+		 *  sent from space. This should be removed when the proper economy
+		 *  is working as this would limit the amount of raw materials that
+		 *  come into the city.
+		 */
+		if (linerList.size() > maxLiners)
 		{
 			return;
 		}

--- a/game/state/shared/organisation.h
+++ b/game/state/shared/organisation.h
@@ -88,6 +88,7 @@ class Organisation : public StateObject<Organisation>
 	  public:
 		uint64_t time = 0;
 		MissionPattern pattern;
+		int maxLiners = 16;
 
 		void execute(GameState &state, StateRef<City> city, StateRef<Organisation> owner);
 


### PR DESCRIPTION
I figured this should probably be added because we are seeing massive numbers of space liners in late game saves. I picked the number 16 randomly, obviously it could be changed.