### PR TITLE
Add option to clear space liners

### DIFF
--- a/data/forms/city/debugoverlay_city.form
+++ b/data/forms/city/debugoverlay_city.form
@@ -149,14 +149,20 @@
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="Base" text="Base Screen - F10 = Finish All Facilities">
+			<label id="MINUS" text="MINUS = Clear Space Liners (If game is running slowly)">
 				<position x="left" y="336"/>
+				<size width="350" height="14"/>
+				<alignment horizontal="left" vertical="top"/>
+				<font>smalfont</font>
+			</label>
+			<label id="Base" text="Base Screen - F10 = Finish All Facilities">
+				<position x="left" y="350"/>
 				<size width="250" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
 			<label id="Research" text="Research Screen - F10 = Complete Project at Next Update (With at least two Scientists Assigned)">
-				<position x="left" y="350"/>
+				<position x="left" y="364"/>
 				<size width="640" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3547,6 +3547,25 @@ bool CityView::handleKeyDown(Event *e)
 					                          *state, *v, false, state->current_base->building));
 					return true;
 				}
+				case SDLK_MINUS:
+				{
+					LogWarning("Clearing Space Liners...");
+					for (auto &v : state->vehicles)
+					{
+						if (v.second->type.id == "VEHICLETYPE_SPACE_LINER")
+						{
+							if (v.second->tileObject)
+							{
+								v.second->die(*state);
+							}
+							else
+							{
+								state->vehiclesDeathNote.insert(v.first);
+							}
+						}
+					}
+					return true;
+				}
 			}
 		}
 	}


### PR DESCRIPTION
In old saves, there seems to be a build up of space liners that causes the game to run slowly on the cityscape. This option clears all space liners from the city so more can be sent. Since the max is 16 liners per spaceport, none would be sent unless the existing ones were cleared. Maybe this should be automatically check when loading a save?