### PR TITLE
Fix clear liners debug command

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3564,6 +3564,16 @@ bool CityView::handleKeyDown(Event *e)
 							}
 						}
 					}
+					for (auto &b : state->current_city->spaceports)
+					{
+						for (auto &v : b->currentVehicles)
+						{
+							if (v->type.id == "VEHICLETYPE_SPACE_LINER")
+							{
+								b->currentVehicles.erase(v);
+							}
+						}
+					}
 					return true;
 				}
 			}


### PR DESCRIPTION
This should fix the issue with the clear liners debug command. Now the liners in the spaceports get removed as well.