### PR TITLE
Add option to only auto reload same ammo type.

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -138,6 +138,7 @@ void dumpOptionsToLog()
 	dumpOption(optionATVUFOMission);
 	dumpOption(optionMaxTileRepair);
 	dumpOption(optionSceneryRepairCostFactor);
+	dumpOption(optionLoadSameAmmo);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -437,6 +438,8 @@ ConfigOptionFloat
                                   "Determines the percentage of the original Price ORGs have to "
                                   "pay for a Scenery Tile to be repaired",
                                   10.0f);
+ConfigOptionBool optionLoadSameAmmo("OpenApoc.NewFeature", "LoadSameAmmo",
+                                    "Weapons autoreload only same ammo type", false);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -116,6 +116,7 @@ extern ConfigOptionBool optionSingleSquadSelect;
 extern ConfigOptionBool optionATVUFOMission;
 extern ConfigOptionInt optionMaxTileRepair;
 extern ConfigOptionFloat optionSceneryRepairCostFactor;
+extern ConfigOptionBool optionLoadSameAmmo;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -220,13 +220,28 @@ void BattleUnit::reloadWeapons(GameState &state)
 	{
 		auto weaponRight = agent->getFirstItemInSlot(EquipmentSlotType::RightHand);
 		auto weaponLeft = agent->getFirstItemInSlot(EquipmentSlotType::LeftHand);
-		if (weaponRight && weaponRight->needsReload())
+		if (weaponRight)
 		{
-			weaponRight->loadAmmo(state);
+
+			if (weaponRight->needsReload())
+			{
+				weaponRight->loadAmmo(state);
+			}
+			else
+			{
+				weaponRight->lastLoadedAmmoType = weaponRight->payloadType;
+			}
 		}
-		if (weaponLeft && weaponLeft->needsReload())
+		if (weaponLeft)
 		{
-			weaponLeft->loadAmmo(state);
+			if (weaponLeft->needsReload())
+			{
+				weaponLeft->loadAmmo(state);
+			}
+			else
+			{
+				weaponLeft->lastLoadedAmmoType = weaponLeft->payloadType;
+			}
 		}
 	}
 }

--- a/game/state/shared/aequipment.cpp
+++ b/game/state/shared/aequipment.cpp
@@ -310,13 +310,16 @@ static sp<AEquipment> getAutoreloadAmmoType(const AEquipment &weapon)
 		}
 	}
 	// Otherwise find any possible ammo on the agent
-	for (const auto &ammoType : weapon.type->ammo_types)
+	if (!config().getBool("OpenApoc.NewFeature.LoadSameAmmo"))
 	{
-		auto equippedAmmo = weapon.ownerAgent->getFirstItemByType(ammoType);
-		if (equippedAmmo)
+		for (const auto &ammoType : weapon.type->ammo_types)
 		{
-			LogAssert(equippedAmmo->type->type == AEquipmentType::Type::Ammo);
-			return equippedAmmo;
+			auto equippedAmmo = weapon.ownerAgent->getFirstItemByType(ammoType);
+			if (equippedAmmo)
+			{
+				LogAssert(equippedAmmo->type->type == AEquipmentType::Type::Ammo);
+				return equippedAmmo;
+			}
 		}
 	}
 	// No ammo found

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -63,6 +63,7 @@ std::list<std::pair<UString, UString>> battlescapeList = {
     {"OpenApoc.NewFeature", "AutoReload"},
     {"OpenApoc.NewFeature", "BattlescapeVertScroll"},
     {"OpenApoc.NewFeature", "SingleSquadSelect"},
+    {"OpenApoc.NewFeature", "LoadSameAmmo"},
     {"OpenApoc.Mod", "StunHostileAction"},
     {"OpenApoc.Mod", "BSKLauncherSound"},
 };


### PR DESCRIPTION
Addresses #1340.

Weapons with multiple ammo types should only reload the previously loaded type or the weapon is considered out of ammo and must be manually loaded.

Tested lightly, did not seem to mind weapons with one ammo type or none such as the mind bender. Probably should be run through a late game scenario with many different weapon types. The problem was the "lastLoadedAmmoType" didn't exist unless the weapon was manually loaded in battle. This forced me to assign a value to it if the weapon didn't need to be reloaded at the start of the battle. This could in theory cause issues with different ammo types.