### PR TITLE
Fix civilians appearing as hostile on battlescape.

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -677,6 +677,7 @@ void BattleUnit::refreshUnitVision(GameState &state, bool forceBlind,
 			battle.visibleUnits[owner].insert(vu);
 			if (owner == state.current_battle->currentPlayer &&
 			    owner->isRelatedTo(vu->owner) == Organisation::Relation::Hostile &&
+			    vu->owner != state.getCivilian() &&
 			    (battle.lastVisibleTime[owner].find(vu) == battle.lastVisibleTime[owner].end() ||
 			     battle.lastVisibleTime[owner][vu] + TICKS_SUPPRESS_SPOTTED_MESSAGES <= ticks))
 			{
@@ -686,7 +687,7 @@ void BattleUnit::refreshUnitVision(GameState &state, bool forceBlind,
 		}
 		// battle and units's visible enemies list (Do not count civilians as enemy)
 		if (owner->isRelatedTo(vu->owner) == Organisation::Relation::Hostile &&
-		    vu->getAIType() != AIType::Civilian)
+		    vu->owner != state.getCivilian())
 		{
 			visibleEnemies.insert(vu);
 			battle.visibleEnemies[owner].insert(vu);

--- a/game/ui/tileview/battletileview.cpp
+++ b/game/ui/tileview/battletileview.cpp
@@ -616,7 +616,8 @@ void BattleTileView::render()
 						         battle.visibleUnits[battle.currentPlayer].end()))
 						{
 							if (battle.currentPlayer->isRelatedTo(unit->owner) ==
-							    Organisation::Relation::Hostile)
+							        Organisation::Relation::Hostile &&
+							    unit->owner != state.getCivilian())
 							{
 								selectionImageBack = selectedTileFireImageBack;
 								selectionImageFront = selectedTileFireImageFront;


### PR DESCRIPTION
Addresses #849.

Removes hostile unit spotted messages from civilians and prevents the selection box from targeting civilians as hostile.

The previous attempt to fix didn't work because the check for civilian AI didn't work correctly when they were panicking, which they do quite often. This doesn't touch the negative effects of killing civilians, it will still hurt your status with the civilian org.