### PR TITLE
Fix crash when trying to refuel at base with no fuel.

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -3657,9 +3657,11 @@ sp<VEquipment> Vehicle::addEquipment(GameState &state, Vec2<int> pos,
 	{
 		case EquipmentSlotType::VehicleEngine:
 		{
+			auto thisRef = StateRef<Vehicle>(&state, shared_from_this());
 			auto engine = mksp<VEquipment>();
 			engine->type = equipmentType;
 			this->equipment.emplace_back(engine);
+			engine->owner = thisRef;
 			engine->equippedPosition = slotOrigin;
 			LogInfo("Equipped \"%s\" with engine \"%s\"", this->name, equipmentType->name);
 			return engine;


### PR DESCRIPTION
Addresses #1350.

Interesting bug, the game was trying to push a NotEnoughFuel event but was unable to because the engine had no owner. This only happened at a base with 0 fuel and the vehicle's engine was removed and replaced. It no longer crashes, but the NotEnoughFuel message still does not show up. There has been instances of messages not appearing in the past so this may be a separate issue.