### PR TITLE
Fix various equipment placement issues.

### DIFF
--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -1414,6 +1414,8 @@ bool AEquipScreen::tryPlaceItem(sp<Agent> agent, Vec2<int> slotPos, bool *insuff
 			{
 				canAdd = true;
 				slotPos = offsetPosition;
+				equipmentUnderCursor =
+				    std::dynamic_pointer_cast<AEquipment>(agent->getEquipmentAt(slotPos));
 				break;
 			}
 		}
@@ -1442,6 +1444,7 @@ bool AEquipScreen::tryPlaceItem(sp<Agent> agent, Vec2<int> slotPos, bool *insuff
 		else
 		{
 			equipmentUnderCursor->loadAmmo(*state, draggedEquipment);
+
 			if (draggedEquipment->ammo > 0)
 			{
 				if (draggedEquipmentOrigin.x != -1 && draggedEquipmentOrigin.y != -1 &&


### PR DESCRIPTION
Addresses #1296.

I was poking around at the agent equip screen code and I may have accidentally fixed the disappearing item problem. I noticed that grenades could be loaded into weapons, so I fixed that by only allowing ammo type equipment to be loaded (sounds obvious).

https://github.com/OpenApoc/OpenApoc/blob/0864ff5ccc0d88969f234dfaf7df3a239144c9e3/game/ui/general/aequipscreen.cpp#L1445

I believe this line in the adding ammo code was causing some items to disappear. Items like the medkit have 0 ammo while grenades have 1 ammo. Any item that got to this point in the code with 0 ammo would be nullified, causing it to disappear forever. The grenades, having 1 ammo, were loaded into the weapon, causing the logerror message.

While this needs more testing with many different item combinations, it seems to fix any issues I was seeing on my end.