### PR TITLE
Fix VehicleTargetHelper::isReachableForRecovery if reachable

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -945,6 +945,7 @@ Reachability VehicleTargetHelper::isReachableForRecovery(const Vehicle &v, Vec3<
 			}
 		}
 	}
+	return Reachability::Reachable;
 }
 
 Reachability VehicleTargetHelper::isReachableTargetFlying(const Vehicle &v, Vec3<int> target)


### PR DESCRIPTION
This didn't return a valid value if the target is reachable, so could return junk and do... who knows what