### PR TITLE
Fix battleunit pathfinding with unset memory

### DIFF
--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -121,10 +121,10 @@ BattleUnitType BattleUnitTileHelper::getType() const
 bool BattleUnitTileHelper::canEnterTile(Tile *from, Tile *to, bool ignoreStaticUnits,
                                         bool ignoreMovingUnits, bool ignoreAllUnits) const
 {
-	float nothing;
-	bool none1;
-	bool none2;
-	return canEnterTile(from, to, false, none1, nothing, none2, ignoreStaticUnits,
+	float cost = 0.0;
+	bool jumped = false;
+	bool doorInTheWay = false;
+	return canEnterTile(from, to, false, jumped, cost, doorInTheWay, ignoreStaticUnits,
 	                    ignoreMovingUnits, ignoreAllUnits);
 }
 


### PR DESCRIPTION
The wrapper  BattleUnitTileHelper::canEntierTile function never initialized some values, which could be used by the child function, so could cause valid paths to be rejected due to junk memory values.