### PR TITLE
Add debug option to destroy selected vehicles, clean up debug options

### DIFF
--- a/data/forms/city/debugoverlay_city.form
+++ b/data/forms/city/debugoverlay_city.form
@@ -143,32 +143,26 @@
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="VClick" text="V+LeftClick = Fix Stuck Vehicle in CityScape (Deprecated)">
+			<label id="P" text="P = Show Vehicle Targets">
 				<position x="left" y="322"/>
 				<size width="350" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="P" text="P = Show Vehicle Targets">
+			<label id="MINUS" text="MINUS = Destroy Selected Vehicles">
 				<position x="left" y="336"/>
 				<size width="350" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
-			<label id="MINUS" text="MINUS = Clear Space Liners (If game is running slowly)">
-				<position x="left" y="350"/>
-				<size width="350" height="14"/>
-				<alignment horizontal="left" vertical="top"/>
-				<font>smalfont</font>
-			</label>
 			<label id="Base" text="Base Screen - F10 = Finish All Facilities">
-				<position x="left" y="364"/>
+				<position x="left" y="350"/>
 				<size width="250" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>
 			</label>
 			<label id="Research" text="Research Screen - F10 = Complete Project at Next Update (With at least two Scientists Assigned)">
-				<position x="left" y="378"/>
+				<position x="left" y="364"/>
 				<size width="640" height="14"/>
 				<alignment horizontal="left" vertical="top"/>
 				<font>smalfont</font>

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3441,9 +3441,6 @@ bool CityView::handleKeyDown(Event *e)
 		case SDLK_LCTRL:
 			modifierLCtrl = true;
 			return true;
-		case SDLK_v:
-			modifierV = true;
-			return true;
 		case SDLK_F1:
 			if (config().getBool("OpenApoc.NewFeature.DebugCommandsVisible"))
 			{
@@ -3574,31 +3571,16 @@ bool CityView::handleKeyDown(Event *e)
 				}
 				case SDLK_MINUS:
 				{
-					LogWarning("Clearing Space Liners...");
-					for (auto &v : state->vehicles)
+					LogWarning("Destroying selected vehicles...");
+					for (auto &v : state->current_city->cityViewSelectedOwnedVehicles)
 					{
-						if (v.second->type.id == "VEHICLETYPE_SPACE_LINER")
-						{
-							if (v.second->tileObject)
-							{
-								v.second->die(*state);
-							}
-							else
-							{
-								state->vehiclesDeathNote.insert(v.first);
-							}
-						}
+						v->die(*state);
 					}
-					for (auto &b : state->current_city->spaceports)
+					for (auto &o : state->current_city->cityViewSelectedOtherVehicles)
 					{
-						for (auto &v : b->currentVehicles)
-						{
-							if (v->type.id == "VEHICLETYPE_SPACE_LINER")
-							{
-								b->currentVehicles.erase(v);
-							}
-						}
+						o->die(*state);
 					}
+
 					return true;
 				}
 			}
@@ -3696,9 +3678,6 @@ bool CityView::handleKeyUp(Event *e)
 			return true;
 		case SDLK_LCTRL:
 			modifierLCtrl = false;
-			return true;
-		case SDLK_v:
-			modifierV = false;
 			return true;
 	}
 	return false;
@@ -3868,11 +3847,6 @@ bool CityView::handleMouseDown(Event *e)
 					for (auto &c : vehicle->cargo)
 					{
 						LogInfo("Cargo %sx%d", c.id, c.count);
-					}
-					if (modifierV)
-					{
-						// Unfreeze vehicles (hopefully useless except old saves)
-						vehicle->ticksToTurn += 1;
 					}
 					if (modifierLAlt && modifierLCtrl && modifierLShift)
 					{

--- a/game/ui/tileview/cityview.h
+++ b/game/ui/tileview/cityview.h
@@ -82,7 +82,6 @@ class CityView : public CityTileView
 	bool modifierRAlt = false;
 	bool modifierLCtrl = false;
 	bool modifierRCtrl = false;
-	bool modifierV = false;
 
 	bool vanillaControls = false;
 


### PR DESCRIPTION
Addresses #1316.

Adds an option (minus key in debug mode) to destroy selected vehicles on the map or in the vehicle tabs. This replaces the clear space liners debug option as it shouldn't be an issue moving forward. The unfreeze vehicle in cityscape option has also been removed for the same reason.