### PR TITLE
Add message when module lost on recovery.

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -387,8 +387,9 @@ ConfigOptionBool optionEnableAgentTemplates("OpenApoc.NewFeature", "EnableAgentT
 ConfigOptionBool optionStoreDroppedEquipment("OpenApoc.NewFeature", "StoreDroppedEquipment",
                                              "Attempt to recover agent equipment dropped in city",
                                              true);
-ConfigOptionBool optionFallingGroundVehicles("OpenApoc.NewFeature", "CrashingGroundVehicles",
-                                             "Unsupported ground vehicles crash", true);
+ConfigOptionBool optionFallingGroundVehicles(
+    "OpenApoc.NewFeature", "CrashingGroundVehicles",
+    "Unsupported ground vehicles crash (Weapons and Modules may be lost in crash)", true);
 
 ConfigOptionBool optionEnforceCargoLimits("OpenApoc.NewFeature", "EnforceCargoLimits",
                                           "Enforce vehicle cargo limits", false);
@@ -407,10 +408,13 @@ ConfigOptionBool
                                      "Any hit on hostile building provokes retaliation", false);
 ConfigOptionBool optionMarketRight("OpenApoc.NewFeature", "MarketOnRight",
                                    "Put market stock on the right side", true);
-ConfigOptionBool optionDGCrashingVehicles("OpenApoc.NewFeature", "CrashingDimensionGate",
-                                          "Uncapable vehicles crash when entering gates", true);
-ConfigOptionBool optionFuelCrashingVehicles("OpenApoc.NewFeature", "CrashingOutOfFuel",
-                                            "Vehicles crash when out of fuel", true);
+ConfigOptionBool optionDGCrashingVehicles(
+    "OpenApoc.NewFeature", "CrashingDimensionGate",
+    "Uncapable vehicles crash when entering gates (Weapons and Modules may be lost in crash)",
+    true);
+ConfigOptionBool optionFuelCrashingVehicles(
+    "OpenApoc.NewFeature", "CrashingOutOfFuel",
+    "Vehicles crash when out of fuel (Weapons and Modules may be lost in crash)", true);
 ConfigOptionBool optionSkipTurbo("OpenApoc.NewFeature", "SkipTurboMovement",
                                  "Skip turbo movement calculations", false);
 ConfigOptionBool optionRunAndKneel("OpenApoc.NewFeature", "RunAndKneel",
@@ -452,8 +456,10 @@ ConfigOptionBool optionATVTank("OpenApoc.Mod", "ATVTank", "(MOD) Griffon becomes
 ConfigOptionBool optionATVAPC("OpenApoc.Mod", "ATVAPC", "(MOD) Wolfhound APC becomes All-Terrain",
                               true);
 
-ConfigOptionBool optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
-                                        "Vehicles crash on low HP", false);
+ConfigOptionBool
+    optionCrashingVehicles("OpenApoc.Mod", "CrashingVehicles",
+                           "Vehicles crash on low HP (Weapons and Modules may be lost in crash)",
+                           false);
 
 ConfigOptionString optionScriptsList("OpenApoc.Mod", "ScriptsList",
                                      "Semicolon-separated list of scripts to load",

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1482,6 +1482,12 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 			auto &economy = state.economy[e->type->ammo_type.id];
 			owner->balance += e->ammo * economy.currentPrice * FV_SCRAPPED_COST_PERCENT / 100;
 		}
+		if (owner == state.getPlayer())
+		{
+			fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleModuleScrapped,
+			                                          format("%s - %s", name, e->type->name),
+			                                          position));
+		}
 	}
 	if (randBoundsExclusive(state.rng, 0, 100) > FV_CHANCE_TO_RECOVER_VEHICLE)
 	{

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -406,6 +406,9 @@ GameSomethingDiedEvent::GameSomethingDiedEvent(GameEventType type, UString name,
 		case GameEventType::VehicleNoFuel:
 			messageInner = format("%s %s", tr("Vehicle out of fuel:"), name);
 			break;
+		case GameEventType::VehicleModuleScrapped:
+			messageInner = format("%s %s", tr("Module lost during recovery:"), name);
+			break;
 		default:
 			LogWarning("GameSomethingDiedEvent %s called on non-death event %d", name,
 			           static_cast<int>(type));

--- a/game/state/gameeventtypes.h
+++ b/game/state/gameeventtypes.h
@@ -21,6 +21,7 @@ enum class GameEventType
 	VehicleRefuelled,
 	VehicleNoEngine,
 	VehicleRecovered,
+	VehicleModuleScrapped,
 	UnauthorizedVehicle,
 	NotEnoughAmmo,
 	NotEnoughFuel,


### PR DESCRIPTION
Address #1287.

Adds a SomethingDiedEvent message when a module is scrapped after a vehicle is recovered. Adds a disclaimer to the tooltips for crashing vehicles explaining the risks.

![1](https://github.com/OpenApoc/OpenApoc/assets/73447098/a6469c29-1834-4ea4-9f55-fbfbbb2d6e7c)

One example, all four have the same message added.
![Screenshot 2024-03-03 160500](https://github.com/OpenApoc/OpenApoc/assets/73447098/eb27c406-e360-450e-9c4e-ac2beb6ebc2d)
