### PR TITLE
Fix day starting after 00:00.

### DIFF
--- a/game/state/gametime.cpp
+++ b/game/state/gametime.cpp
@@ -174,7 +174,7 @@ unsigned int GameTime::getLastDayOfCurrentMonth() const
 	return getPtime(this->ticks).date().end_of_month().year_month_day().day;
 }
 
-unsigned int GameTime::getDay() const { return (this->ticks + TICKS_PER_DAY - 1) / TICKS_PER_DAY; }
+unsigned int GameTime::getDay() const { return (this->ticks + TICKS_PER_DAY) / TICKS_PER_DAY; }
 
 unsigned int GameTime::getMonthDay() const
 {


### PR DESCRIPTION
Addresses #1299.

The new day was starting at 00:01 instead of right at 00:00. This also had an effect on setting the correct hire dates for new hires. If anyone can see a reason this was done originally, let me know.