### PR TITLE
Fix weekly stock not updating under certain conditions

### DIFF
--- a/data/scripts/update_economy.lua
+++ b/data/scripts/update_economy.lua
@@ -21,9 +21,9 @@ function updateEconomy()
 			--update stock
 			local r = GS.rng:randBoundsInclusive(0, 100)
 			if r < 30 then
-				eco.currentStock = eco.lastStock * 80 / 100
+				eco.currentStock = math.floor(eco.lastStock * 80 / 100)
 			elseif r < 60 then
-				eco.currentStock = eco.lastStock * 66 / 100
+				eco.currentStock = math.floor(eco.lastStock * 66 / 100)
 			end
 
 			if soldThisWeek > 2 * eco.maxStock then


### PR DESCRIPTION
Addresses #1070.

I think I have tracked down the issue. I believe it is an error in the update_ecomony.lua script that deals with other orgs buying Xcom produced goods each week.

Based on the lua error I was seeing plus some trial and error, this only happened when there were Xcom produced goods on the market in small quantities. It could be reproduced by:

- At game start, quickly produce some bio transport modules.
- Sell at least one.
- Skip to the end of the week.
- Error is thrown (60 percent of the time), some items don't restock.

In order to get this to happen every time, line 23 can be changed to if r < 100.

When the currentStock is set to lastStock * 80 / 100, or * 66 / 100, the resulting number is a float if the currentStock is small enough. I believe this is the root cause of the error. By rounding down to an integer, the script seems to function as intended.

If you sell an even nice even number like 10, there is no error as 10 * 80 / 100 = 8. Any whole number will work just fine.

Depending on how far the script gets, it looks like some items still restock. There is a 40% chance that these calculations will not happen, leading to this issue being infrequent and hard to track down.

This save that was provided to me helped in testing:
[save_MarketExchange_d6_into_d7.zip](https://github.com/OpenApoc/OpenApoc/files/14504113/save_MarketExchange_d6_into_d7.zip)
