### PR TITLE
Ask if uses want to overwrite save file when creating save with existing name

### DIFF
--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -171,9 +171,9 @@ bool SaveManager::findFreePath(UString &path, const UString &name) const
 
 sp<SaveMetadata> SaveManager::getSaveGameIfExists(const UString &name) const
 {
-	auto saveList = getSaveList();
+	const auto saveList = getSaveList();
 	auto it = std::find_if(saveList.begin(), saveList.end(),
-	                       [&name](SaveMetadata &obj) { return obj.getName() == name; });
+	                       [&name](const SaveMetadata &obj) { return obj.getName() == name; });
 
 	if (it != saveList.end())
 	{

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -163,23 +163,27 @@ bool writeArchiveWithBackup(SerializationArchive *archive, const UString &path, 
 
 bool SaveManager::findFreePath(UString &path, const UString &name) const
 {
-	path = createSavePath("save_" + name);
-	if (fs::exists(path))
-	{
-		for (int retries = 5; retries > 0; retries--)
-		{
-			path = createSavePath("save_" + name + std::to_string(rand()));
-			if (!fs::exists(path))
-			{
-				return true;
-			}
-		}
+	path = createSavePath(name);
+	bool pathExists = fs::exists(path);
 
-		LogError("Unable to generate filename for save %s", name);
-		return false;
+	return !pathExists;
+}
+
+SaveMetadata SaveManager::getSaveGameIfExists(const UString &name) const
+{
+	auto saveList = getSaveList();
+	auto it = std::find_if(saveList.begin(), saveList.end(),
+	                       [&name](SaveMetadata *obj) { return obj->getName() == name; });
+
+	if (it != saveList.end())
+	{
+		return *it;
 	}
 
-	return true;
+	//UString path;
+	//return !findFreePath(path, name);
+
+	return {};
 }
 
 bool SaveManager::newSaveGame(const UString &name, const sp<GameState> gameState) const

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -169,21 +169,19 @@ bool SaveManager::findFreePath(UString &path, const UString &name) const
 	return !pathExists;
 }
 
-SaveMetadata SaveManager::getSaveGameIfExists(const UString &name) const
+sp<SaveMetadata> SaveManager::getSaveGameIfExists(const UString &name) const
 {
 	auto saveList = getSaveList();
 	auto it = std::find_if(saveList.begin(), saveList.end(),
-	                       [&name](SaveMetadata *obj) { return obj->getName() == name; });
+	                       [&name](SaveMetadata &obj) { return obj.getName() == name; });
 
 	if (it != saveList.end())
 	{
-		return *it;
+		auto sp_save = mksp<SaveMetadata>(*it);
+		return sp_save;
 	}
 
-	//UString path;
-	//return !findFreePath(path, name);
-
-	return {};
+	return nullptr;
 }
 
 bool SaveManager::newSaveGame(const UString &name, const sp<GameState> gameState) const

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -97,6 +97,7 @@ class SaveManager
 
 	bool deleteGame(const sp<SaveMetadata> &slot) const;
 
+	// Search savefile in folder via file name
 	sp<SaveMetadata> getSaveGameIfExists(const UString &name) const;
 };
 } // namespace OpenApoc

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -96,5 +96,7 @@ class SaveManager
 	std::vector<SaveMetadata> getSaveList() const;
 
 	bool deleteGame(const sp<SaveMetadata> &slot) const;
+
+	SaveMetadata getSaveGameIfExists(const UString &name) const;
 };
 } // namespace OpenApoc

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -97,6 +97,6 @@ class SaveManager
 
 	bool deleteGame(const sp<SaveMetadata> &slot) const;
 
-	SaveMetadata getSaveGameIfExists(const UString &name) const;
+	sp<SaveMetadata> getSaveGameIfExists(const UString &name) const;
 };
 } // namespace OpenApoc

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -282,12 +282,12 @@ void SaveMenu::tryToLoadGame(sp<Control> slotControl)
 	}
 }
 
-void SaveMenu::tryToSaveGame(const UString &saveName, sp<Control> parent)
+void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 {
 	// If saving new item from first row
 	if (parent->Name == newSaveItemId)
 	{
-		auto saveGameMetadata = saveManager.getSaveGameIfExists(saveName);
+		const auto saveGameMetadata = saveManager.getSaveGameIfExists(saveName);
 
 		// If no game with same name exists in folder
 		if (!saveGameMetadata)
@@ -316,13 +316,13 @@ void SaveMenu::tryToSaveGame(const UString &saveName, sp<Control> parent)
 	}
 }
 
-void SaveMenu::askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata)
+void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata)
 {
-	auto saveName = saveMetadata->getName();
-	auto messageBoxTitle = "Override saved game";
-	auto messageBoxContent = "Do you really want to override " + saveName + "?";
+	const auto &saveName = saveMetadata->getName();
+	const auto messageBoxTitle = "Override saved game";
+	const auto messageBoxContent = "Do you really want to override " + saveName + "?";
 
-	std::function<void()> onYes = std::function<void()>(
+	auto onYes = std::function<void()>(
 	    [this, saveMetadata, saveName]
 	    {
 		    if (saveManager.overrideGame(*saveMetadata, saveName, currentState))
@@ -335,7 +335,7 @@ void SaveMenu::askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata)
 		    }
 	    });
 
-	std::function<void()> onNo = std::function<void()>([this] { clearTextEdit(activeTextEdit); });
+	auto onNo = std::function<void()>([this] { clearTextEdit(activeTextEdit); });
 
 	sp<MessageBox> messageBox = mksp<MessageBox>(MessageBox(messageBoxTitle, messageBoxContent,
 	                                                        MessageBox::ButtonOptions::YesNo,

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -284,40 +284,65 @@ void SaveMenu::tryToLoadGame(sp<Control> slotControl)
 
 void SaveMenu::tryToSaveGame(const UString &saveName, sp<Control> parent)
 {
+	// If saving new item from first row
 	if (parent->Name == newSaveItemId)
 	{
-		if (saveManager.newSaveGame(saveName, currentState))
+		auto saveGameMetadata = saveManager.getSaveGameIfExists(saveName);
+
+		// If no game with same name exists in folder
+		if (true)
 		{
-			fw().stageQueueCommand({StageCmd::Command::POP});
+			if (saveManager.newSaveGame(saveName, currentState))
+			{
+				fw().stageQueueCommand({StageCmd::Command::POP});
+			}
+			else
+			{
+				clearTextEdit(activeTextEdit);
+			}
 		}
+		// If the user use the first row but wrote the name of an already existing save game
 		else
 		{
-			clearTextEdit(activeTextEdit);
+			//SaveMenu::askUserIfWantToOverrideSavedGame(saveGameMetadata);
 		}
 	}
+
+	// If saving item using row for existing item
 	else
 	{
-		sp<SaveMetadata> slot = parent->getData<SaveMetadata>();
-		std::function<void()> onSuccess = std::function<void()>(
-		    [this, slot, saveName]
-		    {
-			    if (saveManager.overrideGame(*slot, saveName, currentState))
-			    {
-				    fw().stageQueueCommand({StageCmd::Command::POP});
-			    }
-			    else
-			    {
-				    clearTextEdit(activeTextEdit);
-			    }
-		    });
-		std::function<void()> onCancel =
-		    std::function<void()>([this] { clearTextEdit(activeTextEdit); });
-		sp<MessageBox> messageBox = mksp<MessageBox>(MessageBox(
-		    "Override saved game", "Do you really want to override " + slot->getName() + "?",
-		    MessageBox::ButtonOptions::YesNo, std::move(onSuccess), std::move(onCancel)));
-
-		fw().stageQueueCommand({StageCmd::Command::PUSH, messageBox});
+		auto slot = parent->getData<SaveMetadata>();
+		SaveMenu::askUserIfWantToOverrideSavedGame(slot);
 	}
+}
+
+void SaveMenu::askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata)
+{
+	auto saveName = saveMetadata->getName();
+	auto messageBoxTitle = "Override saved game";
+	auto messageBoxContent = "Do you really want to override " + saveName + "?";
+
+	std::function<void()> onYes = std::function<void()>(
+	    [this, saveMetadata, saveName]
+	    {
+		    if (saveManager.overrideGame(*saveMetadata, saveName, currentState))
+		    {
+			    fw().stageQueueCommand({StageCmd::Command::POP});
+		    }
+		    else
+		    {
+			    clearTextEdit(activeTextEdit);
+		    }
+	    });
+
+	std::function<void()> onNo =
+	    std::function<void()>([this] { clearTextEdit(activeTextEdit); });
+
+	sp<MessageBox> messageBox = mksp<MessageBox>(
+	    MessageBox(messageBoxTitle, messageBoxContent,
+	               MessageBox::ButtonOptions::YesNo, std::move(onYes), std::move(onNo)));
+
+	fw().stageQueueCommand({StageCmd::Command::PUSH, messageBox});
 }
 
 void SaveMenu::tryToDeleteSavedGame(sp<Control> &slotControl)

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -290,7 +290,7 @@ void SaveMenu::tryToSaveGame(const UString &saveName, sp<Control> parent)
 		auto saveGameMetadata = saveManager.getSaveGameIfExists(saveName);
 
 		// If no game with same name exists in folder
-		if (true)
+		if (!saveGameMetadata)
 		{
 			if (saveManager.newSaveGame(saveName, currentState))
 			{
@@ -304,7 +304,7 @@ void SaveMenu::tryToSaveGame(const UString &saveName, sp<Control> parent)
 		// If the user use the first row but wrote the name of an already existing save game
 		else
 		{
-			//SaveMenu::askUserIfWantToOverrideSavedGame(saveGameMetadata);
+			SaveMenu::askUserIfWantToOverrideSavedGame(saveGameMetadata);
 		}
 	}
 

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -335,12 +335,11 @@ void SaveMenu::askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata)
 		    }
 	    });
 
-	std::function<void()> onNo =
-	    std::function<void()>([this] { clearTextEdit(activeTextEdit); });
+	std::function<void()> onNo = std::function<void()>([this] { clearTextEdit(activeTextEdit); });
 
-	sp<MessageBox> messageBox = mksp<MessageBox>(
-	    MessageBox(messageBoxTitle, messageBoxContent,
-	               MessageBox::ButtonOptions::YesNo, std::move(onYes), std::move(onNo)));
+	sp<MessageBox> messageBox = mksp<MessageBox>(MessageBox(messageBoxTitle, messageBoxContent,
+	                                                        MessageBox::ButtonOptions::YesNo,
+	                                                        std::move(onYes), std::move(onNo)));
 
 	fw().stageQueueCommand({StageCmd::Command::PUSH, messageBox});
 }

--- a/game/ui/general/savemenu.h
+++ b/game/ui/general/savemenu.h
@@ -39,7 +39,7 @@ class SaveMenu : public Stage
 	void tryToSaveGame(const UString &textEdit, sp<Control> parent);
 	void tryToDeleteSavedGame(sp<Control> &control);
 
-	// opens pop-up asking the user if wants to override existing saved game
+	// Opens pop-up asking the user if wants to override existing saved game
 	void askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata);
 
   public:

--- a/game/ui/general/savemenu.h
+++ b/game/ui/general/savemenu.h
@@ -39,6 +39,9 @@ class SaveMenu : public Stage
 	void tryToSaveGame(const UString &textEdit, sp<Control> parent);
 	void tryToDeleteSavedGame(sp<Control> &control);
 
+	// opens pop-up asking the user if wants to override existing saved game
+	void askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata);
+
   public:
 	SaveMenu(SaveMenuAction saveMenuAction, sp<GameState> gameState);
 	~SaveMenu() override;


### PR DESCRIPTION
Fix #1347

After discussion in issue thread, I implemented the following logic:

- If writing name in first slot
  - If no savefile exists with same name, then create savefile
  - If savefile found, open overwrite messagebox
- If writing in existing slot, open overwrite messagebox

I also encapsulated overwrite messagebox call in `SaveMenu::askUserIfWantToOverrideSavedGame`