### PR TITLE
Remove brainsucker pod from alien containment

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -540,16 +540,12 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 		{
 			UString brainSuckerPodName = "AEQUIPMENTTYPE_BRAINSUCKER_POD";
 
-			// Brainsucker pod SHOULD NOT be in alien containment math!
-			std::vector<std::pair<UString, unsigned>> containmentBioEquipment = {};
-			std::remove_copy_if(
-			    inventoryBioEquipment.begin(), inventoryBioEquipment.end(),
-			    std::back_inserter(containmentBioEquipment),
-			    [&brainSuckerPodName](const std::pair<UString, unsigned> &bioEquipmentItem)
-			    { return bioEquipmentItem.first == brainSuckerPodName; });
-
-			for (auto &e : containmentBioEquipment)
+			for (auto &e : inventoryBioEquipment)
 			{
+				// Brainsucker pod SHOULD NOT be in alien containment math!
+				if (e.first == brainSuckerPodName || e.second == 0)
+					continue;
+
 				StateRef<AEquipmentType> ae = {&state, e.first};
 				total += ae->store_space * e.second;
 			}
@@ -607,7 +603,9 @@ int Base::getUsage(GameState &state, FacilityType::Capacity type, int delta) con
 		return used > 0 ? 999 : 0;
 	}
 
-	// + total / 2  due to rounding
-	return std::min(999, (100 * used + total / 2) / total);
+	double usageValue = (double) used / total * 100;
+	int usage = std::min(999, (int) std::round(usageValue));
+
+	return usage;
 }
 }; // namespace OpenApoc

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -538,12 +538,10 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 			break;
 		case FacilityType::Capacity::Aliens:
 		{
-			UString brainSuckerPodName = "AEQUIPMENTTYPE_BRAINSUCKER_POD";
-
 			for (auto &e : inventoryBioEquipment)
 			{
 				// Brainsucker pod SHOULD NOT be in alien containment math!
-				if (e.first == brainSuckerPodName || e.second == 0)
+				if (e.first == "AEQUIPMENTTYPE_BRAINSUCKER_POD" || e.second == 0)
 					continue;
 
 				StateRef<AEquipmentType> ae = {&state, e.first};
@@ -603,8 +601,8 @@ int Base::getUsage(GameState &state, FacilityType::Capacity type, int delta) con
 		return used > 0 ? 999 : 0;
 	}
 
-	double usageValue = (double) used / total * 100;
-	int usage = std::min(999, (int) std::round(usageValue));
+	double usageValue = (double)used / total * 100;
+	int usage = std::min(999, (int)std::round(usageValue));
 
 	return usage;
 }

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -537,12 +537,24 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 			}
 			break;
 		case FacilityType::Capacity::Aliens:
-			for (auto &e : inventoryBioEquipment)
+		{
+			UString brainSuckerPodName = "AEQUIPMENTTYPE_BRAINSUCKER_POD";
+
+			// Brainsucker pod SHOULD NOT be in alien containment math!
+			std::vector<std::pair<UString, unsigned>> containmentBioEquipment = {};
+			std::remove_copy_if(
+			    inventoryBioEquipment.begin(), inventoryBioEquipment.end(),
+			    std::back_inserter(containmentBioEquipment),
+			    [&brainSuckerPodName](const std::pair<UString, unsigned> &bioEquipmentItem)
+			    { return bioEquipmentItem.first == brainSuckerPodName; });
+
+			for (auto &e : containmentBioEquipment)
 			{
 				StateRef<AEquipmentType> ae = {&state, e.first};
 				total += ae->store_space * e.second;
 			}
-			break;
+		}
+		break;
 		case FacilityType::Capacity::Nothing:
 			// Nothing needs to be handled
 			break;

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -384,6 +384,8 @@ void TransactionScreen::populateControlsVehicleEquipment()
 
 void TransactionScreen::populateControlsAlien()
 {
+	// TODO: Fix why aliens are being shown twice
+	// TODO: Show only rows for aliens that exists in this base!
 	int leftIndex = getLeftIndex();
 	int rightIndex = getRightIndex();
 	for (auto &ae : state->agent_equipment)

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -395,6 +395,7 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
+			// Removing brainsucker pod from alien containment list
 			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
 			    ae.first != "AEQUIPMENTTYPE_BRAINSUCKER_POD")
 			{

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -384,9 +384,6 @@ void TransactionScreen::populateControlsVehicleEquipment()
 
 void TransactionScreen::populateControlsAlien()
 {
-	// TODO: Fix why aliens are being shown twice
-	// TODO: Show only rows for aliens that exists in this base!
-
 	int leftIndex = getLeftIndex();
 	int rightIndex = getRightIndex();
 	for (auto &ae : state->agent_equipment)
@@ -398,7 +395,8 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
-			if (b.second->inventoryBioEquipment[ae.first] > 0 && ae.first != "AEQUIPMENTTYPE_BRAINSUCKER_POD")
+			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
+			    ae.first != "AEQUIPMENTTYPE_BRAINSUCKER_POD")
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -386,6 +386,7 @@ void TransactionScreen::populateControlsAlien()
 {
 	// TODO: Fix why aliens are being shown twice
 	// TODO: Show only rows for aliens that exists in this base!
+
 	int leftIndex = getLeftIndex();
 	int rightIndex = getRightIndex();
 	for (auto &ae : state->agent_equipment)
@@ -397,7 +398,7 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
-			if (b.second->inventoryBioEquipment[ae.first] > 0)
+			if (b.second->inventoryBioEquipment[ae.first] > 0 && ae.first != "AEQUIPMENTTYPE_BRAINSUCKER_POD")
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);


### PR DESCRIPTION
This partially solves issues #1302 and #608, since brainsucker pod is not being considered in either alien containment usage calculation or aliens listing, but we still have duplicated aliens.

I also tried to simplify usage percentage math.