### PR TITLE
Removed duplicated items from alien containment list

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3366,7 +3366,7 @@ void Battle::exitBattle(GameState &state)
 	}
 
 	// Give player vehicle a null cargo just so it comes back to base once
-	for (auto v : playerVehicles)
+	for (auto v : returningVehicles)
 	{
 		v->cargo.emplace_front(
 		    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3366,7 +3366,7 @@ void Battle::exitBattle(GameState &state)
 	}
 
 	// Give player vehicle a null cargo just so it comes back to base once
-	for (auto v : returningVehicles)
+	for (auto v : playerVehicles)
 	{
 		v->cargo.emplace_front(
 		    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -386,8 +386,12 @@ void TransactionScreen::populateControlsAlien()
 {
 	int leftIndex = getLeftIndex();
 	int rightIndex = getRightIndex();
+	auto &alienTransactionControls = transactionControls[type];
+
 	for (auto &ae : state->agent_equipment)
 	{
+		auto &alienTypeName = ae.first;
+
 		if (!ae.second->bioStorage)
 		{
 			continue;
@@ -395,7 +399,16 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
-			if (b.second->inventoryBioEquipment[ae.first] > 0)
+
+			auto it =
+			    std::find_if(alienTransactionControls.begin(), alienTransactionControls.end(),
+			                 [&alienTypeName](const sp<TransactionControl> &transactionControl)
+			                 { return transactionControl->itemId == alienTypeName; });
+
+			// Removing brainsucker pod from alien containment list
+			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
+			    alienTypeName != "AEQUIPMENTTYPE_BRAINSUCKER_POD" &&
+			    it == alienTransactionControls.end())
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);
@@ -403,7 +416,7 @@ void TransactionScreen::populateControlsAlien()
 				{
 					control->addCallback(FormEventType::ScrollBarChange, onScrollChange);
 					control->addCallback(FormEventType::MouseMove, onHover);
-					transactionControls[type].push_back(control);
+					alienTransactionControls.push_back(control);
 				}
 			}
 		}

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -398,7 +398,7 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
-			auto alienTypeExistingControl = findControlById(alienTypeName);
+			auto alienTypeExistingControl = findControlById(type, alienTypeName);
 
 			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
 

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -398,15 +398,10 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
+			// Don't add an alien type if it's already added in transaction controls
 			auto alienTypeExistingControl = findControlById(type, alienTypeName);
 
-			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
-
-			    // Removing brainsucker pod from alien containment list
-			    alienTypeName != "AEQUIPMENTTYPE_BRAINSUCKER_POD" &&
-
-			    // Don't add an alien type if it's already added in transaction controls
-			    !alienTypeExistingControl)
+			if (b.second->inventoryBioEquipment[ae.first] > 0 && !alienTypeExistingControl)
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -386,7 +386,6 @@ void TransactionScreen::populateControlsAlien()
 {
 	int leftIndex = getLeftIndex();
 	int rightIndex = getRightIndex();
-	auto &alienTransactionControls = transactionControls[type];
 
 	for (auto &ae : state->agent_equipment)
 	{
@@ -399,16 +398,15 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
+			auto alienTypeExistingControl = findControlById(alienTypeName);
 
-			auto it =
-			    std::find_if(alienTransactionControls.begin(), alienTransactionControls.end(),
-			                 [&alienTypeName](const sp<TransactionControl> &transactionControl)
-			                 { return transactionControl->itemId == alienTypeName; });
-
-			// Removing brainsucker pod from alien containment list
 			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
+
+			    // Removing brainsucker pod from alien containment list
 			    alienTypeName != "AEQUIPMENTTYPE_BRAINSUCKER_POD" &&
-			    it == alienTransactionControls.end())
+
+			    // Don't add an alien type if it's already added in transaction controls
+			    alienTypeExistingControl)
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);
@@ -416,7 +414,7 @@ void TransactionScreen::populateControlsAlien()
 				{
 					control->addCallback(FormEventType::ScrollBarChange, onScrollChange);
 					control->addCallback(FormEventType::MouseMove, onHover);
-					alienTransactionControls.push_back(control);
+					transactionControls[type].push_back(control);
 				}
 			}
 		}

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -389,7 +389,7 @@ void TransactionScreen::populateControlsAlien()
 
 	for (auto &ae : state->agent_equipment)
 	{
-		auto &alienTypeName = ae.first;
+		const auto &alienTypeName = ae.first;
 
 		if (!ae.second->bioStorage)
 		{
@@ -398,19 +398,20 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
-			// Don't add an alien type if it's already added in transaction controls
-			auto alienTypeExistingControl = findControlById(type, alienTypeName);
+			const auto alienTypeControl = findControlById(type, alienTypeName);
 
-			if (b.second->inventoryBioEquipment[ae.first] > 0 && !alienTypeExistingControl)
+			// Don't add an alien type if its count is zero or if it's already added in transaction
+			// controls
+			if (b.second->inventoryBioEquipment[ae.first] == 0 || alienTypeControl)
+				continue;
+
+			auto control = TransactionControl::createControl(
+			    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);
+			if (control)
 			{
-				auto control = TransactionControl::createControl(
-				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);
-				if (control)
-				{
-					control->addCallback(FormEventType::ScrollBarChange, onScrollChange);
-					control->addCallback(FormEventType::MouseMove, onHover);
-					transactionControls[type].push_back(control);
-				}
+				control->addCallback(FormEventType::ScrollBarChange, onScrollChange);
+				control->addCallback(FormEventType::MouseMove, onHover);
+				transactionControls[type].push_back(control);
 			}
 		}
 	}

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -406,7 +406,7 @@ void TransactionScreen::populateControlsAlien()
 			    alienTypeName != "AEQUIPMENTTYPE_BRAINSUCKER_POD" &&
 
 			    // Don't add an alien type if it's already added in transaction controls
-			    alienTypeExistingControl)
+			    !alienTypeExistingControl)
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);


### PR DESCRIPTION
Fixes #1302 and #608

Aliens in containment list were appearing duplicated whenever an alien type exists in more than one base.

Before:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/8ecb7811-2c53-4bc2-97c9-9c0b112994be)

After:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/2b06ec31-c54f-418d-bcad-e716eb282cc5)
