### PR TITLE
Checks if trade state is active, hides it from rendered list if not.

### DIFF
--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -152,9 +152,13 @@ void TransactionScreen::setDisplayType(Type type)
 			viewHighlight = BaseGraphics::FacilityHighlight::Aliens;
 			break;
 	}
-	// Finally add all controls
+
+	// After all controls are loaded, check their visibility, and add them
 	for (auto &c : transactionControls[type])
 	{
+		// If control is not set to show, remove its visibility
+		c->setVisible(c->tradeState.isActive());
+
 		list->addItem(c);
 	}
 	// Update display for bases

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -783,8 +783,7 @@ void TransactionControl::postRender()
 
 	// Draw shade if inactive
 	static Vec2<int> shadePos = {0, 0};
-	if (tradeState.getLeftIndex() == tradeState.getRightIndex() ||
-	    (tradeState.getLeftStock() == 0 && tradeState.getRightStock() == 0))
+	if (!tradeState.isActive())
 	{
 		fw().renderer->draw(transactionShade, shadePos);
 	}

--- a/game/ui/general/transactioncontrol.h
+++ b/game/ui/general/transactioncontrol.h
@@ -94,6 +94,18 @@ class TransactionControl : public Control
 		int getBalance() const { return getRightStock(true); }
 		// ScrollBar support. Set current value.
 		int setBalance(const int balance);
+
+		/// <summary>
+		/// Checks if trade is active or not. Can be used to determine to draw shades, remove from
+		/// item list, etc.
+		/// </summary>
+		/// <returns>If trade is active or not.</returns>
+		bool isActive() const
+		{
+			auto isActive = (getLeftIndex() == getRightIndex() ||
+			                 (getLeftStock() == 0 && getRightStock() == 0)) == false;
+			return isActive;
+		}
 	};
 
   private:

--- a/game/ui/general/transactioncontrol.h
+++ b/game/ui/general/transactioncontrol.h
@@ -102,9 +102,13 @@ class TransactionControl : public Control
 		/// <returns>If trade is active or not.</returns>
 		bool isActive() const
 		{
-			auto isActive = (getLeftIndex() == getRightIndex() ||
-			                 (getLeftStock() == 0 && getRightStock() == 0)) == false;
-			return isActive;
+			if (getLeftIndex() == getRightIndex())
+				return false;
+
+			if (getLeftStock() == 0 && getRightStock() == 0)
+				return false;
+
+			return true;
 		}
 	};
 


### PR DESCRIPTION
Fixes https://github.com/OpenApoc/OpenApoc/issues/608#issuecomment-502384799

Before rendering transaction control list, set if they are visible based on index and stock conditions. Also isolated condition checks at `Trade.isActive()`

Before:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/32e92210-f63c-43de-86db-24e3c3bf6f8d)

After:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/305906f7-00a0-4c5c-ac87-feb4d6aa0795)

Obs.: as you can see in the second image, the scrollbar is rendered even if the aliens list is smaller than the transaction view.