### PR TITLE
Fix vehicles not returning to base empty after mission

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3366,7 +3366,7 @@ void Battle::exitBattle(GameState &state)
 	}
 
 	// Give player vehicle a null cargo just so it comes back to base once
-	for (auto v : returningVehicles)
+	for (auto v : playerVehicles)
 	{
 		v->cargo.emplace_front(
 		    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,


### PR DESCRIPTION
Most likely addresses #1377.

While testing why the vehicle wasn't returning to base in the issue, I found that vehicles with no loot won't automatically return to base. It looks like the wrong variable was used when assigning a null cargo to returning vehicles. I'm not exactly sure if this was the problem in the issue, but I have run the mission in the save and the vehicle returned to base. The save immediately following the mission in the cityscape doesn't address the issue as the vehicle is assigned the return to base mission in the battlescape. 