### PR TITLE
Removing filters that removed Brainsucker Pod references.

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -540,8 +540,7 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 		{
 			for (auto &e : inventoryBioEquipment)
 			{
-				// Brainsucker pod SHOULD NOT be in alien containment math!
-				if (e.first == "AEQUIPMENTTYPE_BRAINSUCKER_POD" || e.second == 0)
+				if (e.second == 0)
 					continue;
 
 				StateRef<AEquipmentType> ae = {&state, e.first};

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -395,9 +395,7 @@ void TransactionScreen::populateControlsAlien()
 		// Add alien
 		for (auto &b : state->player_bases)
 		{
-			// Removing brainsucker pod from alien containment list
-			if (b.second->inventoryBioEquipment[ae.first] > 0 &&
-			    ae.first != "AEQUIPMENTTYPE_BRAINSUCKER_POD")
+			if (b.second->inventoryBioEquipment[ae.first] > 0)
 			{
 				auto control = TransactionControl::createControl(
 				    *state, StateRef<AEquipmentType>{state.get(), ae.first}, leftIndex, rightIndex);


### PR DESCRIPTION
After discussion in https://github.com/OpenApoc/OpenApoc/pull/1374, it was decide to revert changes made in https://github.com/OpenApoc/OpenApoc/pull/1372

Now Brainsucker Pod is being listed again at Alien Containment screen:

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/c29750a6-ce28-45a1-a6f4-cb98d3de84f4)
