### PR TITLE
Fix crash on "Vehicle manufacturing halted" message

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -4341,7 +4341,7 @@ bool CityView::handleGameStateEvent(Event *e)
 					item_name = game_state->agent_equipment[ev->topic->itemId]->name;
 					break;
 				case ResearchTopic::ItemType::Craft:
-					item_name = game_state->vehicles[ev->topic->itemId]->name;
+					item_name = game_state->vehicle_types[ev->topic->itemId]->name;
 					break;
 			}
 			setUpdateSpeed(CityUpdateSpeed::Pause);


### PR DESCRIPTION
The event contained a VehicleType ID, but was indexing the Vehicle list to get the name, which wasn't correct.

Should fix #1378 