### PR TITLE
Issue 1387: restored renaming savefile feature

### DIFF
--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -164,7 +164,7 @@ bool writeArchiveWithBackup(SerializationArchive *archive, const UString &path, 
 bool SaveManager::findFreePath(UString &path, const UString &name) const
 {
 	path = createSavePath(name);
-	bool pathExists = fs::exists(path);
+	const auto pathExists = fs::exists(path);
 
 	return !pathExists;
 }
@@ -172,12 +172,13 @@ bool SaveManager::findFreePath(UString &path, const UString &name) const
 sp<SaveMetadata> SaveManager::getSaveGameIfExists(const UString &name) const
 {
 	const auto saveList = getSaveList();
-	auto it = std::find_if(saveList.begin(), saveList.end(),
-	                       [&name](const SaveMetadata &obj) { return obj.getName() == name; });
+	const auto it =
+	    std::find_if(saveList.begin(), saveList.end(),
+	                 [&name](const SaveMetadata &obj) { return obj.getName() == name; });
 
 	if (it != saveList.end())
 	{
-		auto sp_save = mksp<SaveMetadata>(*it);
+		const auto sp_save = mksp<SaveMetadata>(*it);
 		return sp_save;
 	}
 

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -223,19 +223,6 @@ bool SaveManager::overrideGame(const SaveMetadata &metadata, const UString &newN
 	return result;
 }
 
-bool SaveManager::saveGameViaView(const sp<SaveMetadata> saveMetadata,
-                                  const sp<GameState> currentState,
-                                  const bool deleteOlderSaveGame) const
-{
-	const auto &saveName = saveMetadata->getName();
-
-	const auto savingResult = deleteOlderSaveGame
-	                              ? overrideGame(*saveMetadata, saveName, currentState)
-	                              : newSaveGame(saveName, currentState);
-
-	return savingResult;
-}
-
 bool SaveManager::saveGame(const SaveMetadata &metadata, const sp<GameState> gameState) const
 {
 	bool pack = Options::packSaveOption.get();

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -223,6 +223,19 @@ bool SaveManager::overrideGame(const SaveMetadata &metadata, const UString &newN
 	return result;
 }
 
+bool SaveManager::saveGameViaView(const sp<SaveMetadata> saveMetadata,
+                                  const sp<GameState> currentState,
+                                  const bool deleteOlderSaveGame) const
+{
+	const auto &saveName = saveMetadata->getName();
+
+	const auto savingResult = deleteOlderSaveGame
+	                              ? overrideGame(*saveMetadata, saveName, currentState)
+	                              : newSaveGame(saveName, currentState);
+
+	return savingResult;
+}
+
 bool SaveManager::saveGame(const SaveMetadata &metadata, const sp<GameState> gameState) const
 {
 	bool pack = Options::packSaveOption.get();

--- a/game/state/savemanager.cpp
+++ b/game/state/savemanager.cpp
@@ -169,7 +169,7 @@ bool SaveManager::findFreePath(UString &path, const UString &name) const
 	return !pathExists;
 }
 
-sp<SaveMetadata> SaveManager::getSaveGameIfExists(const UString &name) const
+std::optional<SaveMetadata> SaveManager::getSaveGameIfExists(const UString &name) const
 {
 	const auto saveList = getSaveList();
 	const auto it =
@@ -178,11 +178,10 @@ sp<SaveMetadata> SaveManager::getSaveGameIfExists(const UString &name) const
 
 	if (it != saveList.end())
 	{
-		const auto sp_save = mksp<SaveMetadata>(*it);
-		return sp_save;
+		return *it;
 	}
 
-	return nullptr;
+	return {};
 }
 
 bool SaveManager::newSaveGame(const UString &name, const sp<GameState> gameState) const

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -69,6 +69,10 @@ class SaveManager
 
 	bool saveGame(const SaveMetadata &metadata, const sp<GameState> gameState) const;
 
+	// saves game to location pointed by metadata, also updates metadata from gamestate
+	bool overrideGame(const SaveMetadata &metadata, const UString &newFile,
+	                  const sp<GameState> gameState) const;
+
   public:
 	SaveManager();
 
@@ -85,10 +89,6 @@ class SaveManager
 	// WARNING! Name MUST NOT contain invalid filename characters!
 	bool newSaveGame(const UString &name, const sp<GameState> gameState) const;
 
-	// saves game to location pointed by metadata, also updates metadata from gamestate
-	bool overrideGame(const SaveMetadata &metadata, const UString &newFile,
-	                  const sp<GameState> gameState) const;
-
 	// can be used for autosaves, quicksaves etc.
 	bool specialSaveGame(SaveType type, const sp<GameState> gameState) const;
 
@@ -99,5 +99,9 @@ class SaveManager
 
 	// Search savefile in folder via file name
 	sp<SaveMetadata> getSaveGameIfExists(const UString &name) const;
+
+	// Save game via Options->Save Game view
+	bool saveGameViaView(const sp<SaveMetadata> saveMetadata, const sp<GameState> currentState,
+	                     const bool deleteOlderSaveGame = false) const;
 };
 } // namespace OpenApoc

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -4,6 +4,7 @@
 #include "library/strings.h"
 #include <cstdint>
 #include <future>
+#include <optional>
 #include <vector>
 
 namespace OpenApoc
@@ -98,6 +99,6 @@ class SaveManager
 	bool deleteGame(const sp<SaveMetadata> &slot) const;
 
 	// Search savefile in folder via file name
-	sp<SaveMetadata> getSaveGameIfExists(const UString &name) const;
+	std::optional<SaveMetadata> getSaveGameIfExists(const UString &name) const;
 };
 } // namespace OpenApoc

--- a/game/state/savemanager.h
+++ b/game/state/savemanager.h
@@ -69,10 +69,6 @@ class SaveManager
 
 	bool saveGame(const SaveMetadata &metadata, const sp<GameState> gameState) const;
 
-	// saves game to location pointed by metadata, also updates metadata from gamestate
-	bool overrideGame(const SaveMetadata &metadata, const UString &newFile,
-	                  const sp<GameState> gameState) const;
-
   public:
 	SaveManager();
 
@@ -89,6 +85,10 @@ class SaveManager
 	// WARNING! Name MUST NOT contain invalid filename characters!
 	bool newSaveGame(const UString &name, const sp<GameState> gameState) const;
 
+	// saves game to location pointed by metadata, also updates metadata from gamestate
+	bool overrideGame(const SaveMetadata &metadata, const UString &newFile,
+	                  const sp<GameState> gameState) const;
+
 	// can be used for autosaves, quicksaves etc.
 	bool specialSaveGame(SaveType type, const sp<GameState> gameState) const;
 
@@ -99,9 +99,5 @@ class SaveManager
 
 	// Search savefile in folder via file name
 	sp<SaveMetadata> getSaveGameIfExists(const UString &name) const;
-
-	// Save game via Options->Save Game view
-	bool saveGameViaView(const sp<SaveMetadata> saveMetadata, const sp<GameState> currentState,
-	                     const bool deleteOlderSaveGame = false) const;
 };
 } // namespace OpenApoc

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -304,7 +304,7 @@ void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 		// If the user use the first row but wrote the name of an already existing save game
 		else
 		{
-			SaveMenu::askUserIfWantToOverrideSavedGame(saveGameMetadata);
+			SaveMenu::askUserIfWantToOverrideSavedGame(saveGameMetadata, saveName);
 		}
 	}
 
@@ -312,23 +312,25 @@ void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 	else
 	{
 		const auto slot = parent->getData<SaveMetadata>();
-		SaveMenu::askUserIfWantToOverrideSavedGame(slot, true);
+		SaveMenu::askUserIfWantToOverrideSavedGame(slot, saveName);
 	}
 }
 
 void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata,
-                                                const bool deleteOlderSaveGame)
+                                                const UString &saveName)
 {
-	const auto &saveName = saveMetadata->getName();
+	const auto &metadataSaveName = saveMetadata->getName();
 	const auto messageBoxTitle = "Override saved game";
-	const auto messageBoxContent = "Do you really want to override " + saveName + "?";
+	const auto messageBoxContent = "Do you really want to override " + metadataSaveName + "?";
 
 	auto onYes = std::function<void()>(
-	    [this, saveMetadata, saveName, deleteOlderSaveGame]
+	    [this, saveMetadata, saveName]
 	    {
-		    const auto savingResult = saveManager.saveGameViaView(saveMetadata, currentState, deleteOlderSaveGame);
+		    const auto savingResult =
+		        saveManager.overrideGame(*saveMetadata, saveName, currentState);
 
-		    savingResult ? fw().stageQueueCommand({StageCmd::Command::POP}) : clearTextEdit(activeTextEdit);
+		    savingResult ? fw().stageQueueCommand({StageCmd::Command::POP})
+		                 : clearTextEdit(activeTextEdit);
 	    });
 
 	auto onNo = std::function<void()>([this] { clearTextEdit(activeTextEdit); });

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -304,7 +304,7 @@ void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 		// If the user use the first row but wrote the name of an already existing save game
 		else
 		{
-			SaveMenu::askUserIfWantToOverrideSavedGame(saveGameMetadata, saveName);
+			SaveMenu::askUserIfWantToOverrideSavedGame(*saveGameMetadata, saveName);
 		}
 	}
 
@@ -312,21 +312,21 @@ void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 	else
 	{
 		const auto slot = parent->getData<SaveMetadata>();
-		SaveMenu::askUserIfWantToOverrideSavedGame(slot, saveName);
+		SaveMenu::askUserIfWantToOverrideSavedGame(*slot, saveName);
 	}
 }
 
-void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata,
+void SaveMenu::askUserIfWantToOverrideSavedGame(const SaveMetadata &saveMetadata,
                                                 const UString &saveName)
 {
-	const auto &metadataSaveName = saveMetadata->getName();
+	const auto &metadataSaveName = saveMetadata.getName();
 	const auto messageBoxTitle = tr("Override saved game");
 	const auto messageBoxContent = tr("Do you really want to override " + metadataSaveName + "?");
 
 	auto onYes = std::function<void()>(
 	    [this, saveMetadata, saveName]
 	    {
-		    if (saveManager.overrideGame(*saveMetadata, saveName, currentState))
+		    if (saveManager.overrideGame(saveMetadata, saveName, currentState))
 		    {
 			    fw().stageQueueCommand({StageCmd::Command::POP});
 		    }

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -312,27 +312,23 @@ void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 	else
 	{
 		const auto slot = parent->getData<SaveMetadata>();
-		SaveMenu::askUserIfWantToOverrideSavedGame(slot);
+		SaveMenu::askUserIfWantToOverrideSavedGame(slot, true);
 	}
 }
 
-void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata)
+void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata,
+                                                const bool deleteOlderSaveGame)
 {
 	const auto &saveName = saveMetadata->getName();
 	const auto messageBoxTitle = "Override saved game";
 	const auto messageBoxContent = "Do you really want to override " + saveName + "?";
 
 	auto onYes = std::function<void()>(
-	    [this, saveMetadata, saveName]
+	    [this, saveMetadata, saveName, deleteOlderSaveGame]
 	    {
-		    if (saveManager.overrideGame(*saveMetadata, saveName, currentState))
-		    {
-			    fw().stageQueueCommand({StageCmd::Command::POP});
-		    }
-		    else
-		    {
-			    clearTextEdit(activeTextEdit);
-		    }
+		    const auto savingResult = saveManager.saveGameViaView(saveMetadata, currentState, deleteOlderSaveGame);
+
+		    savingResult ? fw().stageQueueCommand({StageCmd::Command::POP}) : clearTextEdit(activeTextEdit);
 	    });
 
 	auto onNo = std::function<void()>([this] { clearTextEdit(activeTextEdit); });

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -320,8 +320,8 @@ void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetad
                                                 const UString &saveName)
 {
 	const auto &metadataSaveName = saveMetadata->getName();
-	const auto messageBoxTitle = "Override saved game";
-	const auto messageBoxContent = "Do you really want to override " + metadataSaveName + "?";
+	const auto messageBoxTitle = tr("Override saved game");
+	const auto messageBoxContent = tr("Do you really want to override " + metadataSaveName + "?");
 
 	auto onYes = std::function<void()>(
 	    [this, saveMetadata, saveName]

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -326,11 +326,14 @@ void SaveMenu::askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetad
 	auto onYes = std::function<void()>(
 	    [this, saveMetadata, saveName]
 	    {
-		    const auto savingResult =
-		        saveManager.overrideGame(*saveMetadata, saveName, currentState);
-
-		    savingResult ? fw().stageQueueCommand({StageCmd::Command::POP})
-		                 : clearTextEdit(activeTextEdit);
+		    if (saveManager.overrideGame(*saveMetadata, saveName, currentState))
+		    {
+			    fw().stageQueueCommand({StageCmd::Command::POP});
+		    }
+		    else
+		    {
+			    clearTextEdit(activeTextEdit);
+		    }
 	    });
 
 	auto onNo = std::function<void()>([this] { clearTextEdit(activeTextEdit); });

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -321,7 +321,8 @@ void SaveMenu::askUserIfWantToOverrideSavedGame(const SaveMetadata &saveMetadata
 {
 	const auto &metadataSaveName = saveMetadata.getName();
 	const auto messageBoxTitle = tr("Override saved game");
-	const auto messageBoxContent = tr("Do you really want to override " + metadataSaveName + "?");
+	const auto messageBoxContent =
+	    format(tr("Do you really want to override %s?"), metadataSaveName);
 
 	auto onYes = std::function<void()>(
 	    [this, saveMetadata, saveName]

--- a/game/ui/general/savemenu.cpp
+++ b/game/ui/general/savemenu.cpp
@@ -311,7 +311,7 @@ void SaveMenu::tryToSaveGame(const UString &saveName, const sp<Control> parent)
 	// If saving item using row for existing item
 	else
 	{
-		auto slot = parent->getData<SaveMetadata>();
+		const auto slot = parent->getData<SaveMetadata>();
 		SaveMenu::askUserIfWantToOverrideSavedGame(slot);
 	}
 }

--- a/game/ui/general/savemenu.h
+++ b/game/ui/general/savemenu.h
@@ -41,7 +41,7 @@ class SaveMenu : public Stage
 
 	// Opens pop-up asking the user if wants to override existing saved game
 	void askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata,
-	                                      const bool deleteOlderSaveGame = false);
+	                                      const UString &saveName);
 
   public:
 	SaveMenu(SaveMenuAction saveMenuAction, sp<GameState> gameState);

--- a/game/ui/general/savemenu.h
+++ b/game/ui/general/savemenu.h
@@ -36,11 +36,12 @@ class SaveMenu : public Stage
 	void loadWithWarning(sp<Control> parent);
 	// these functions will display prompt to execute action
 	void tryToLoadGame(sp<Control> slotControl);
-	void tryToSaveGame(const UString &textEdit, sp<Control> parent);
+	void tryToSaveGame(const UString &textEdit, const sp<Control> parent);
 	void tryToDeleteSavedGame(sp<Control> &control);
 
 	// Opens pop-up asking the user if wants to override existing saved game
-	void askUserIfWantToOverrideSavedGame(sp<SaveMetadata> saveMetadata);
+	void askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata,
+	                                      const bool deleteOlderSaveGame = false);
 
   public:
 	SaveMenu(SaveMenuAction saveMenuAction, sp<GameState> gameState);

--- a/game/ui/general/savemenu.h
+++ b/game/ui/general/savemenu.h
@@ -40,7 +40,7 @@ class SaveMenu : public Stage
 	void tryToDeleteSavedGame(sp<Control> &control);
 
 	// Opens pop-up asking the user if wants to override existing saved game
-	void askUserIfWantToOverrideSavedGame(const sp<SaveMetadata> saveMetadata,
+	void askUserIfWantToOverrideSavedGame(const SaveMetadata &saveMetadata,
 	                                      const UString &saveName);
 
   public:


### PR DESCRIPTION
Fixes https://github.com/OpenApoc/OpenApoc/issues/1387

PR https://github.com/OpenApoc/OpenApoc/pull/1371 removed feature of renaming existing save files. In this PR it is being added again with the following behavior:
- When selecting an existing savefile and saving with same name, the savefile will be overwritten
- When selecting an existing savefile and saving with a different name, the savefile will be overwritten and renamed with new name
- When creating a new savefile with same name as existing one, the existing savefile will be overwritten

Minor refactorings:
- Updated `getSaveGameIfExists` to return an `optional` instead of `shared_ptr`, and updated references properly
- Updated some parameters and variable declarations with `const` and `auto` references whenever possible