### PR TITLE
Adding buttons to new numeric options

### DIFF
--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -100,8 +100,8 @@ static const auto FLOAT_NOTIFICATIONS_LIST = {"OpenApoc.Mod.SceneryRepairCostFac
 static const std::regex NUMERIC_CHARS_REGEX("[^0-9.]");
 sp<BitmapFont> font = nullptr;
 
-static const auto NUMERIC_OPTION_MAX_LIMIT = (float)100.0;
-static const auto NUMERIC_OPTION_MIN_LIMIT = (float)0;
+static const float NUMERIC_OPTION_MAX_LIMIT = 100.0;
+static const float NUMERIC_OPTION_MIN_LIMIT = 0;
 
 } // namespace
 MoreOptions::MoreOptions(sp<GameState> state)

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -1,10 +1,12 @@
 #include "game/ui/general/moreoptions.h"
 #include "forms/checkbox.h"
 #include "forms/form.h"
+#include "forms/graphicbutton.h"
 #include "forms/label.h"
 #include "forms/listbox.h"
 #include "forms/scrollbar.h"
 #include "forms/textbutton.h"
+#include "forms/textedit.h"
 #include "forms/ui.h"
 #include "framework/configfile.h"
 #include "framework/data.h"
@@ -156,7 +158,8 @@ void MoreOptions::saveLists()
 
 			if (isOptionInt)
 			{
-				const auto value = std::stoi(std::dynamic_pointer_cast<Label>(control)->getText());
+				const auto value =
+				    std::stoi(std::dynamic_pointer_cast<TextEdit>(control)->getText());
 				config().set(*name, value);
 				continue;
 			}
@@ -165,7 +168,8 @@ void MoreOptions::saveLists()
 
 			if (isOptionFloat)
 			{
-				const auto value = std::stof(std::dynamic_pointer_cast<Label>(control)->getText());
+				const auto value =
+				    std::stof(std::dynamic_pointer_cast<TextEdit>(control)->getText());
 				config().set(*name, value);
 				continue;
 			}
@@ -219,13 +223,48 @@ void MoreOptions::loadLists()
 
 			if (isOptionInt)
 			{
-				const auto label = mksp<Label>(
+				const auto textEdit = mksp<TextEdit>(
 				    tr(config().describe(notification.first, notification.second)), font);
 				const auto labelText = std::to_string(config().getInt(fullName));
-				label->setText(labelText);
+				textEdit->setText(labelText);
 
-				configureOptionControlAndAddToControlListBox(
-				    label, notification.first, notification.second, font, listControl);
+				// configureOptionControlAndAddToControlListBox(
+				//    textEdit, notification.first, notification.second, font, listControl);
+
+				textEdit->Size = {240, listControl->ItemSize};
+				textEdit->setData(mksp<UString>(fullName));
+
+				const auto buttonUp = textEdit->createChild<GraphicButton>(
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:13:ui/menuopt.pal"),
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:14:ui/menuopt.pal"));
+
+				buttonUp->Size = {20, listControl->ItemSize};
+				buttonUp->Location = {27, 0};
+
+				const auto buttonDown = textEdit->createChild<GraphicButton>(
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:15:ui/menuopt.pal"),
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:16:ui/menuopt.pal"));
+
+				buttonDown->Size = {20, listControl->ItemSize};
+				// buttonDown->SelectionSize = {216, listControl->ItemSize};
+				buttonDown->Location = {45, 0};
+
+				const auto chidlLabel = textEdit->createChild<Label>(
+				    tr(config().describe(notification.first, notification.second)), font);
+				chidlLabel->Size = {216, listControl->ItemSize};
+				chidlLabel->Location = {65, 0};
+				chidlLabel->ToolTipText =
+				    tr(config().describe(notification.first, notification.second));
+				chidlLabel->ToolTipFont = font;
+
+				// chidlLabel->ToolTipText = tr(config().describe(notification.first,
+				// notification.second)); chidlLabel->ToolTipFont = font;
+
+				listControl->addItem(textEdit);
 
 				continue;
 			}
@@ -234,17 +273,45 @@ void MoreOptions::loadLists()
 
 			if (isOptionFloat)
 			{
-				auto label = mksp<Label>(
+				auto textEdit = mksp<TextEdit>(
 				    tr(config().describe(notification.first, notification.second)), font);
 
 				std::stringstream stream;
 				stream << std::fixed << std::setprecision(2) << config().getFloat(fullName);
 				const auto labelText = stream.str();
 
-				label->setText(labelText);
+				textEdit->setText(labelText);
 
-				configureOptionControlAndAddToControlListBox(
-				    label, notification.first, notification.second, font, listControl);
+				textEdit->Size = {240, listControl->ItemSize};
+				textEdit->setData(mksp<UString>(fullName));
+
+				const auto buttonUp = textEdit->createChild<GraphicButton>(
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:13:ui/menuopt.pal"),
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:14:ui/menuopt.pal"));
+
+				buttonUp->Size = {216, 0};
+				buttonUp->Location = {27, 0};
+
+				const auto buttonDown = textEdit->createChild<GraphicButton>(
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:15:ui/menuopt.pal"),
+				    fw().data->loadImage(
+				        "PCK:xcom3/ufodata/icons.pck:xcom3/ufodata/icons.tab:16:ui/menuopt.pal"));
+
+				buttonDown->Size = {216, 0};
+				buttonDown->Location = {45, 0};
+
+				const auto chidlLabel = textEdit->createChild<Label>(
+				    tr(config().describe(notification.first, notification.second)), font);
+				chidlLabel->Size = {216, listControl->ItemSize};
+				chidlLabel->Location = {65, 0};
+				chidlLabel->ToolTipText =
+				    tr(config().describe(notification.first, notification.second));
+				chidlLabel->ToolTipFont = font;
+
+				listControl->addItem(textEdit);
 
 				continue;
 			}

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -246,6 +246,9 @@ void MoreOptions::loadLists()
 
 	font = ui().getFont("smalfont");
 
+	// This text edit list will be used to remove focus from a text edit when another one is clicked
+	std::list<sp<TextEdit>> textEditList = {};
+
 	for (const auto &notificationControlPair : notificationControlPairList)
 	{
 		const auto &notificationList = notificationControlPair.first;
@@ -312,6 +315,7 @@ void MoreOptions::loadLists()
 				                       listControl, 65);
 
 				listControl->addItem(textEdit);
+				textEditList.push_back(textEdit);
 
 				continue;
 			}
@@ -382,6 +386,7 @@ void MoreOptions::loadLists()
 				                       listControl, 65);
 
 				listControl->addItem(textEdit);
+				textEditList.push_back(textEdit);
 
 				continue;
 			}
@@ -394,6 +399,8 @@ void MoreOptions::loadLists()
 			                                             notification.second, listControl, 24);
 		}
 	}
+
+	addFocusControlCallbackToNumberTextEdit(textEditList);
 }
 
 void MoreOptions::configureOptionControlAndAddToControlListBox(const sp<Control> &control,
@@ -528,6 +535,28 @@ void MoreOptions::addChildLabelToControl(const sp<Control> &control, const UStri
 	chidlLabel->Location = {labelLocationHeight, 0};
 	chidlLabel->ToolTipText = tr(config().describe(optionSection, optionName));
 	chidlLabel->ToolTipFont = font;
+}
+
+void MoreOptions::addFocusControlCallbackToNumberTextEdit(
+    const std::list<sp<TextEdit>> &textEditList)
+{
+	for (const auto &textEdit : textEditList)
+	{
+		textEdit->addCallback(FormEventType::MouseClick,
+		                      [textEditList, textEdit](Event *e)
+		                      {
+			                      for (auto &textEditItem : textEditList)
+			                      {
+				                      // When the user clicks on a text edit, every other text edit
+				                      // with focus will lose it
+				                      // That way, only the last clicked text edit will have focus
+				                      if (textEditItem != textEdit && textEditItem->isFocused())
+				                      {
+					                      // TODO: find a way to remove focus
+				                      }
+			                      }
+		                      });
+	}
 }
 
 bool MoreOptions::isTransition() { return false; }

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -136,8 +136,8 @@ bool MoreOptions::getIfOptionInt(const UString &optionSection, const UString &op
 bool MoreOptions::getIfOptionFloat(const UString &optionFullName) const
 {
 	const auto isOptionFloat =
-	    std::find(FLOAT_NOTIFICATIONS_LIST.begin(), FLOAT_NOTIFICATIONS_LIST.end(), optionFullName) !=
-	    FLOAT_NOTIFICATIONS_LIST.end();
+	    std::find(FLOAT_NOTIFICATIONS_LIST.begin(), FLOAT_NOTIFICATIONS_LIST.end(),
+	              optionFullName) != FLOAT_NOTIFICATIONS_LIST.end();
 
 	return isOptionFloat;
 }
@@ -265,15 +265,16 @@ void MoreOptions::loadLists()
 				const auto textEdit = createTextEditForNumericOptions(
 				    notification.first, notification.second, listControl, labelText);
 
-				auto buttonUpCallback = [this, textEdit, fullName](Event *)
+				const auto buttonUpCallback = [this, textEdit, fullName](const Event *)
 				{
 					try
 					{
-						int value = std::stoi(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
+						auto value =
+						    std::stoi(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
 
 						if (value >= NUMERIC_OPTION_MAX_LIMIT)
-							return;						
-							
+							return;
+
 						value += 1;
 
 						const auto labelText = std::to_string(value);
@@ -284,11 +285,12 @@ void MoreOptions::loadLists()
 					}
 				};
 
-				auto buttonDownCallback = [this, textEdit, fullName](Event *)
+				const auto buttonDownCallback = [this, textEdit, fullName](const Event *)
 				{
 					try
 					{
-						int value = std::stoi(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
+						auto value =
+						    std::stoi(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
 
 						if (value <= NUMERIC_OPTION_MIN_LIMIT)
 							return;
@@ -327,11 +329,12 @@ void MoreOptions::loadLists()
 				const auto textEdit = createTextEditForNumericOptions(
 				    notification.first, notification.second, listControl, labelText);
 
-				auto buttonUpCallback = [this, textEdit, fullName](Event *)
+				const auto buttonUpCallback = [this, textEdit, fullName](const Event *)
 				{
 					try
 					{
-						float value = std::stof(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
+						auto value =
+						    std::stof(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
 
 						if (value >= NUMERIC_OPTION_MAX_LIMIT)
 							return;
@@ -349,11 +352,12 @@ void MoreOptions::loadLists()
 					}
 				};
 
-				auto buttonDownCallback = [this, textEdit, fullName](Event *)
+				const auto buttonDownCallback = [this, textEdit, fullName](const Event *)
 				{
 					try
 					{
-						float value = std::stof(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
+						auto value =
+						    std::stof(std::dynamic_pointer_cast<TextEdit>(textEdit)->getText());
 
 						if (value <= NUMERIC_OPTION_MIN_LIMIT)
 							return;

--- a/game/ui/general/moreoptions.h
+++ b/game/ui/general/moreoptions.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "forms/listbox.h"
+#include "forms/textedit.h"
 #include "framework/stage.h"
 #include "library/sp.h"
 
@@ -18,21 +19,31 @@ class MoreOptions : public Stage
 
 	UString getOptionFullName(const UString &optionSection, const UString &optionName) const;
 
-	bool GetIfOptionInt(const UString &optionFullName) const;
-	bool GetIfOptionInt(const UString &optionSection, const UString &optionName) const;
+	bool getIfOptionInt(const UString &optionFullName) const;
+	bool getIfOptionInt(const UString &optionSection, const UString &optionName) const;
 
-	bool GetIfOptionFloat(const UString &optionFullName) const;
-	bool GetIfOptionFloat(const UString &optionSection, const UString &optionName) const;
+	bool getIfOptionFloat(const UString &optionFullName) const;
+	bool getIfOptionFloat(const UString &optionSection, const UString &optionName) const;
 
 	void configureOptionControlAndAddToControlListBox(const sp<Control> &control,
 	                                                  const UString &optionSection,
 	                                                  const UString &optionName,
-	                                                  const sp<BitmapFont> &font,
-	                                                  const sp<ListBox> &listControl);
+	                                                  const sp<ListBox> &listControl,
+	                                                  const int &labelLocationHeight);
 
 	void addChildLabelToControl(const sp<Control> &control, const UString &optionSection,
-	                            const UString &optionName, const sp<BitmapFont> &font,
-	                            const sp<ListBox> &listControl);
+	                            const UString &optionName, const sp<ListBox> &listControl,
+	                            const int &labelLocationHeight);
+
+	sp<TextEdit> createTextEditForNumericOptions(const UString &optionSection,
+	                                             const UString &optionName,
+	                                             const sp<ListBox> &listControl,
+	                                             const UString &labelText) const;
+
+	void
+	addButtonsToNumericOption(const sp<Control> &control, const sp<ListBox> &listControl,
+	                          const std::function<void(FormsEvent *e)> &buttonUpClickCallback,
+	                          const std::function<void(FormsEvent *e)> &buttonDownClickCallback);
 
   public:
 	MoreOptions(sp<GameState> state);

--- a/game/ui/general/moreoptions.h
+++ b/game/ui/general/moreoptions.h
@@ -35,6 +35,8 @@ class MoreOptions : public Stage
 	                            const UString &optionName, const sp<ListBox> &listControl,
 	                            const int &labelLocationHeight);
 
+	void addFocusControlCallbackToNumberTextEdit(const std::list<sp<TextEdit>> &textEditList);
+
 	sp<TextEdit> createTextEditForNumericOptions(const UString &optionSection,
 	                                             const UString &optionName,
 	                                             const sp<ListBox> &listControl,

--- a/library/colour.h
+++ b/library/colour.h
@@ -39,5 +39,6 @@ struct ColourArgB8888Le
 
 static constexpr Colour COLOUR_BLACK{0, 0, 0};
 static constexpr Colour COLOUR_RED{255, 0, 0};
+static constexpr Colour COLOUR_WHITE{255, 255, 255};
 
 }; // namespace OpenApoc


### PR DESCRIPTION
Another partial fix addressing https://github.com/OpenApoc/OpenApoc/issues/1319

Adds feature to update "MaxTileRepair" and "SceneryRepairCostFactor" values at More Options screen:
- Updates can be done either via pressing buttons up and down, or manually inserting numeric values.
- Both fields validates input and allows only numbers; "percentage" field also allows dot for decimal places
- Values limit set from 0 to 100

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/19ba6420-107d-4023-8ae8-b934b9c2b458)

**Known bug:**

When clicking an input field, there's no way to unselect it, so if you click on both fields, they will be selected and editable at the same time. I couldn't find a way to unfocus the text field after clicking on it and some comments in the code suggests that there's no such feature for text edit fields right now. If that's the case, then the text edit field implementation will have to be updated to allow unfocusing before updating to fix this issue.

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/235b08e4-32cd-47a3-ba58-3605b0b20096)