### PR TITLE
Updated ATV option string

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -432,7 +432,7 @@ ConfigOptionBool optionSingleSquadSelect("OpenApoc.NewFeature", "SingleSquadSele
                                          "Select squad with single click", false);
 ConfigOptionBool
     optionATVUFOMission("OpenApoc.NewFeature", "ATVUFOMission",
-                        "Allow ATV vehicles to initiate UFO missions (and recover vehicles)",
+                        tr("Allow All Terrain Vehicles (ATV) to initiate UFO recovery missions"),
                         false);
 ConfigOptionInt
     optionMaxTileRepair("OpenApoc.Mod", "MaxTileRepair",


### PR DESCRIPTION
Updated ATV option string, like described in #1388 

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/20f594ca-98ac-4406-882e-99f161aa8262)