### PR TITLE
Fix no-agent error on base defense mission.

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2540,6 +2540,7 @@ void Battle::enterBattle(GameState &state)
 
 	// Clear selected units in case they die
 	state.current_city->cityViewSelectedSoldiers.clear();
+	state.current_city->cityViewSelectedCivilians.clear();
 }
 
 // To be called when battle must be finished and before showing score screen

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -955,6 +955,11 @@ void Agent::die(GameState &state, bool silent)
 	{
 		currentVehicle->currentAgents.erase(thisRef);
 	}
+	// Remove from building
+	if (currentBuilding)
+	{
+		currentBuilding->currentAgents.erase(thisRef);
+	}
 
 	// Remove from lab
 	if (assigned_to_lab)


### PR DESCRIPTION
I think the no agent error has been narrowed down. When an agent is killed in a base defense mission, the game would sometimes crash immediately after the mission or when a save is reloaded after that point. It seemed to be the updateCargo function of the base that was causing the issue. 

The killed agents were still technically current agents in the building and the no agent error message was thrown. Obviously the difference with a base defense mission versus any other mission is the agents fighting never leave the building when done. When a typical mission is complete, the agents are loaded onto the vehicle they arrived in and are no longer current agents in the building. It looks like this also applied to soldiers that were killed along with scientists, I am surprised this didn't come up more often.

This fixes the issue by updating the agent->die function to remove agents from any building they currently reside in when killed.

This also addresses a similar issue that could happen if a selected scientist or engineer is killed in a base defense mission, leading to a different no agent error. This means that any selected agents in the cityscape will be reset when the battle ends.


In this save, one scientist is dead and all aliens have retreated. 
[newbase.zip](https://github.com/OpenApoc/OpenApoc/files/14927953/newbase.zip)
