### PR TITLE
Fix mission count incrementing on load.

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -132,7 +132,6 @@ void Battle::initBattle(GameState &state, bool first)
 		o.second->genericHitSounds = state.battle_common_sample_list->genericHitSounds;
 		o.second->psiSuccessSounds = state.battle_common_sample_list->psiSuccessSounds;
 		o.second->psiFailSounds = state.battle_common_sample_list->psiFailSounds;
-		o.second->activatedInSquad();
 	}
 	if (forces.empty())
 	{
@@ -2875,6 +2874,7 @@ void Battle::finishBattle(GameState &state)
 			continue;
 		}
 		u.second->processExperience(state);
+		u.second->completedMission();
 		unitsByRating[-u.second->combatRating].push_back(u.second);
 	}
 	// Create count of ranks

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -5967,7 +5967,7 @@ bool BattleUnit::addMission(GameState &state, BattleUnitMission *mission, bool t
 	return !mission->cancelled;
 }
 
-void BattleUnit::activatedInSquad()
+void BattleUnit::completedMission()
 {
 	if (agent)
 	{

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -840,7 +840,9 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	// Update both this unit's vision and other unit's vision of this unit
 	void refreshUnitVisibilityAndVision(GameState &state);
 
-	void activatedInSquad();
+	// Increment mission count if agent survives battle
+	void completedMission();
+	// Increment agent kill count
 	void recordKill();
 };
 } // namespace OpenApoc


### PR DESCRIPTION
Fixes #1394.

The mission count now increments if the agent survives the battle, not on battle load.