### PR TITLE
Add option to only show vehicles in current dimension.

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -139,6 +139,7 @@ void dumpOptionsToLog()
 	dumpOption(optionMaxTileRepair);
 	dumpOption(optionSceneryRepairCostFactor);
 	dumpOption(optionLoadSameAmmo);
+	dumpOption(optionShowCurrentDimensionVehicles);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -444,6 +445,10 @@ ConfigOptionFloat
                                   10.0f);
 ConfigOptionBool optionLoadSameAmmo("OpenApoc.NewFeature", "LoadSameAmmo",
                                     "Weapons autoreload only same ammo type", false);
+ConfigOptionBool
+    optionShowCurrentDimensionVehicles("OpenApoc.NewFeature", "ShowCurrentDimensionVehicles",
+                                       "Show vehicles in current dimension (or entering / leaving)",
+                                       true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -117,6 +117,7 @@ extern ConfigOptionBool optionATVUFOMission;
 extern ConfigOptionInt optionMaxTileRepair;
 extern ConfigOptionFloat optionSceneryRepairCostFactor;
 extern ConfigOptionBool optionLoadSameAmmo;
+extern ConfigOptionBool optionShowCurrentDimensionVehicles;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -44,6 +44,7 @@ std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "SkipTurboMovement"},
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
     {"OpenApoc.NewFeature", "ATVUFOMission"},
+    {"OpenApoc.NewFeature", "ShowCurrentDimensionVehicles"},
     {"OpenApoc.Mod", "MaxTileRepair"},
     {"OpenApoc.Mod", "SceneryRepairCostFactor"},
     {"OpenApoc.Mod", "RaidHostileAction"},

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -2239,7 +2239,9 @@ void CityView::update()
 		for (auto &v : state->vehicles)
 		{
 			auto vehicle = v.second;
-			if (vehicle->owner != state->getPlayer() || v.second->isDead())
+			if (vehicle->owner != state->getPlayer() || v.second->isDead() ||
+			    (config().getBool("OpenApoc.NewFeature.ShowCurrentDimensionVehicles") &&
+			     vehicle->city != state->current_city && !vehicle->betweenDimensions))
 			{
 				continue;
 			}


### PR DESCRIPTION
Addresses #1318.

Adds an option to show only vehicles in the current dimension or between dimensions. This option is on by default.