### PR TITLE
Added "VehiclesPrefix" option

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -140,6 +140,7 @@ void dumpOptionsToLog()
 	dumpOption(optionSceneryRepairCostFactor);
 	dumpOption(optionLoadSameAmmo);
 	dumpOption(optionShowCurrentDimensionVehicles);
+	dumpOption(optionVehiclesPrefix);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -448,6 +449,9 @@ ConfigOptionBool optionLoadSameAmmo("OpenApoc.NewFeature", "LoadSameAmmo",
 ConfigOptionBool
     optionShowCurrentDimensionVehicles("OpenApoc.NewFeature", "ShowCurrentDimensionVehicles",
                                        "Show vehicles in current dimension (or entering / leaving)",
+                                       true);
+ConfigOptionBool optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
+                                       tr("Add prefix to differentiate between X-COM and other vehicles"),
                                        true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -450,9 +450,9 @@ ConfigOptionBool
     optionShowCurrentDimensionVehicles("OpenApoc.NewFeature", "ShowCurrentDimensionVehicles",
                                        "Show vehicles in current dimension (or entering / leaving)",
                                        true);
-ConfigOptionBool optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
-                                       tr("Add prefix to differentiate between X-COM and other vehicles"),
-                                       true);
+ConfigOptionBool
+    optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
+                         tr("Add prefix to differentiate between X-COM and other vehicles"), true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -118,6 +118,7 @@ extern ConfigOptionInt optionMaxTileRepair;
 extern ConfigOptionFloat optionSceneryRepairCostFactor;
 extern ConfigOptionBool optionLoadSameAmmo;
 extern ConfigOptionBool optionShowCurrentDimensionVehicles;
+extern ConfigOptionBool optionVehiclesPrefix;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -49,6 +49,7 @@ static const std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
     {"OpenApoc.NewFeature", "ATVUFOMission"},
     {"OpenApoc.NewFeature", "ShowCurrentDimensionVehicles"},
+    {"OpenApoc.NewFeature", "VehiclesPrefix"},
     {"OpenApoc.Mod", "MaxTileRepair"},
     {"OpenApoc.Mod", "SceneryRepairCostFactor"},
     {"OpenApoc.Mod", "RaidHostileAction"},


### PR DESCRIPTION
Added "Vehicle prefix" option picker at More Options view, like discussed in #1312
It's just the visual part, there's no functionality implemented yet.

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/2ec0d73e-deef-421c-bfa5-115ac52ecd13)
