### PR TITLE
Refactored TransactionControl::setScrollbarValues()

### DIFF
--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -63,18 +63,24 @@ void TransactionControl::initResources()
 
 void TransactionControl::setScrollbarValues()
 {
-	if (tradeState.getLeftIndex() == tradeState.getRightIndex())
+	auto leftStock = 0;
+	auto rightStock = 0;
+	auto balance = 0;
+
+	if (tradeState.getLeftIndex() != tradeState.getRightIndex())
 	{
-		scrollBar->setMinimum(0);
-		scrollBar->setMaximum(0);
-		scrollBar->setValue(0);
+		leftStock = tradeState.getLeftStock();
+		rightStock = tradeState.getRightStock();
+		balance = tradeState.getBalance();
 	}
-	else
-	{
-		scrollBar->setMinimum(0);
-		scrollBar->setMaximum(tradeState.getLeftStock() + tradeState.getRightStock());
-		scrollBar->setValue(tradeState.getBalance());
-	}
+
+	const auto minimum = 0;
+	const auto maximum = leftStock + rightStock;
+
+	scrollBar->setMinimum(minimum);
+	scrollBar->setMaximum(maximum);
+	scrollBar->setValue(balance);
+
 	updateValues();
 }
 


### PR DESCRIPTION
Fixes #1398 

While I was debugging this issue, I found out that only reworking value calculation for `scrollBar->setMaximum()` with variable declaration already fixed the error. To be honest, I don't know exactly how this fixed the problem, since it doesn't seem to have any difference at all, but the reality is that now this function seems to be working properly.

If anyone has any feedback about how this variable declaration changed the outcome of it, I would be happy to hear. 

Video examples:
- Before fix: https://youtu.be/RPfieRXkVD8
- After fix: https://youtu.be/dyMGoDuLHE8