### PR TITLE
Fix alertscreen agent icons not appearing.

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1175,16 +1175,6 @@ void GameState::updateEndOfFiveMinutes()
 		}
 	}
 
-	// Detection calculation stops when detection happens
-	for (auto &b : current_city->buildings)
-	{
-		bool detected = b.second->ticksDetectionTimeOut > 0;
-		b.second->updateDetection(*this, TICKS_PER_MINUTE * 5);
-		if (b.second->ticksDetectionTimeOut > 0 && !detected)
-		{
-			break;
-		}
-	}
 	for (auto &b : current_city->buildings)
 	{
 		if (!b.second->base || b.second->owner != getPlayer())
@@ -1225,6 +1215,17 @@ void GameState::updateEndOfFiveMinutes()
 					}
 				}
 			}
+		}
+	}
+
+	// Detection calculation stops when detection happens
+	for (auto &b : current_city->buildings)
+	{
+		bool detected = b.second->ticksDetectionTimeOut > 0;
+		b.second->updateDetection(*this, TICKS_PER_MINUTE * 5);
+		if (b.second->ticksDetectionTimeOut > 0 && !detected)
+		{
+			break;
 		}
 	}
 }


### PR DESCRIPTION
Fixes #1407.


The detection and rearm/refuel checks are both performed at 5 minute intervals. If it happens at the same time, the alertscreen wasn't allowed to fully load and was missing agent icons. Reversing the order of the checks now allows the user to take care of the alert before dismissing the refuel/rearm message.