### PR TITLE
Fix selected non-hostile vehicles not appearing in hostile vehicle list

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3084,7 +3084,7 @@ void CityView::update()
 		{
 			auto vehicle = v.second;
 			if (!v.second->tileObject || v.second->city != state->current_city ||
-			    v.second->isDead() || !v.second->tileObject)
+			    v.second->isDead())
 			{
 				continue;
 			}
@@ -3093,8 +3093,8 @@ void CityView::update()
 			if (state->getPlayer()->isRelatedTo(vehicle->owner) != Organisation::Relation::Hostile)
 			{
 				if (vehicle->owner == state->getPlayer() ||
-				    state->current_city->cityViewSelectedOwnedVehicles.empty() ||
-				    state->current_city->cityViewSelectedOwnedVehicles.front() != v.second)
+				    state->current_city->cityViewSelectedOtherVehicles.empty() ||
+				    state->current_city->cityViewSelectedOtherVehicles.front() != v.second)
 				{
 					continue;
 				}


### PR DESCRIPTION
Fixes #1415

Yet another bug introduced in the multi select update is fixed. Non-hostile, non-owned vehicles will now appear in the hostile vehicle list. A redundant check for vehicle->tileobject was also removed.