### PR TITLE
Fix out of range message when out of ammo.

### DIFF
--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2450,9 +2450,12 @@ void BattleView::updateAttackCost()
 	}
 	else if (!weapon->canFire(*state, target))
 	{
-		calculatedAttackCost =
-		    static_cast<int>(weapon->type->launcher ? CalculatedAttackCostSpecial::NO_ARC
-		                                            : CalculatedAttackCostSpecial::OUT_OF_RANGE);
+		if (!weapon->needsReload())
+		{
+			calculatedAttackCost = static_cast<int>(
+			    weapon->type->launcher ? CalculatedAttackCostSpecial::NO_ARC
+			                           : CalculatedAttackCostSpecial::OUT_OF_RANGE);
+		}
 	}
 	else
 	{


### PR DESCRIPTION
Addresses #1323 

This *should* fix this issue. The logic is:

If the weapon can't fire,
If the weapon isn't empty,
if the weapon is a launcher, no arc
else out of range.

This means the weapon will never display these other messages if out of ammo. Is this OG?

I find this situation difficult to test, so I can't tell if this will break other things.