### PR TITLE
Prevent scrapping used modules.

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1463,9 +1463,12 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 	std::list<sp<VEquipment>> scrappedEquipment;
 	for (auto &e : equipment)
 	{
-		if (randBoundsExclusive(state.rng, 0, 100) >= FV_CHANCE_TO_RECOVER_EQUIPMENT)
+		if (!moduleInUse(e))
 		{
-			scrappedEquipment.push_back(e);
+			if (randBoundsExclusive(state.rng, 0, 100) >= FV_CHANCE_TO_RECOVER_EQUIPMENT)
+			{
+				scrappedEquipment.push_back(e);
+			}
 		}
 	}
 	for (auto &e : scrappedEquipment)
@@ -3781,6 +3784,21 @@ void Vehicle::nextFrame(int ticks)
 			animationFrame = type->animation_sprites.begin();
 		}
 	}
+}
+
+bool Vehicle::moduleInUse(sp<VEquipment> &e)
+{
+	if (e->type->passengers &&
+	    this->getPassengers() > (this->getMaxPassengers() - e->type->passengers))
+	{
+		return true;
+	}
+	if (e->type->cargo_space && this->getCargo() > 0)
+	{
+		return true;
+	}
+
+	return false;
 }
 
 template <> sp<Vehicle> StateObject<Vehicle>::get(const GameState &state, const UString &id)

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -352,6 +352,8 @@ class Vehicle : public StateObject<Vehicle>,
 
 	void nextFrame(int ticks);
 
+	bool moduleInUse(sp<VEquipment> &e);
+
 	void setPosition(const Vec3<float> &pos);
 
 	void setManualFirePosition(const Vec3<float> &pos);


### PR DESCRIPTION
Prevents passenger modules from being scrapped if the number of passengers would drop below what the vehicle could support. Prevents cargo modules from being scrapped if any cargo is on board.

Should this destroy extra cargo or passengers and add to the risk of recovery? I don't think so but it is something to think about for the future.