### PR TITLE
Fix non-bio items missing when sold out

### DIFF
--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -157,8 +157,10 @@ void TransactionScreen::setDisplayType(Type type)
 	for (auto &c : transactionControls[type])
 	{
 		// If control is not set to show, remove its visibility
-		c->setVisible(c->tradeState.isActive());
-
+		if (c->isBio)
+		{
+			c->setVisible(c->tradeState.isActive());
+		}
 		list->addItem(c);
 	}
 	// Update display for bases


### PR DESCRIPTION
Fixes #1414 

Now only aliens should disappear when inactive, everything else is grayed out.