### PR TITLE
Updating brainsucker launcher reference to use constant

### DIFF
--- a/tools/extractors/extract_agent_equipment.cpp
+++ b/tools/extractors/extract_agent_equipment.cpp
@@ -487,7 +487,7 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 		}
 
 		// Mark brainsucker launcher
-		if (edata.sprite_idx == 44)
+		if (edata.sprite_idx == IT_BRAINSUCKERLAUNCHER)
 		{
 			e->launcher = true;
 		}


### PR DESCRIPTION
Quick update to use constant reference for brainsucker launcher instead of number.