### PR TITLE
Fix Brainsucker Pod store space

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -209,7 +209,14 @@ void GameState::initState()
 		{
 			w->ammo_types.emplace(this, t.first);
 		}
+
+		// Fixing brainsucker pod store space for older saves
+		if (t.first == "AEQUIPMENTTYPE_BRAINSUCKER_POD")
+		{
+			t.second->store_space = 1;
+		}
 	}
+
 	for (auto &a : this->agent_types)
 	{
 		a.second->gravLiftSfx = battle_common_sample_list->gravlift;

--- a/tools/extractors/extract_agent_equipment.cpp
+++ b/tools/extractors/extract_agent_equipment.cpp
@@ -741,7 +741,18 @@ void InitialGameStateExtractor::extractAgentEquipment(GameState &state) const
 
 		e->manufacturer = {&state, data_u.getOrgId(edata.manufacturer)};
 
-		e->store_space = edata.store_space;
+		switch (edata.sprite_idx)
+		{
+			// Fix store space for brainsucker pod
+			// It is set as 16 from edata when it should be 1
+			case IT_BRAINSUCKERPOD:
+				e->store_space = 1;
+				break;
+			default:
+				e->store_space = edata.store_space;
+				break;
+		}
+
 		e->armor = edata.armor;
 		e->score = edata.score;
 


### PR DESCRIPTION
Fixes #1383 (also mentioned in #608 and #1374)

- `tools/extractors/extract_agent_equipment.cpp`: agent equipment extractor is setting Brainsucker Pod store space as 16 via `tacp` / `data_t`, so here we set the correct store space of 1.
- `game/state/gamestate.cpp`: running DataExtractor updates `base_gamestate` values but it seems that this change is only reflected in new games, and older saved games have their own gamestate, is that correct? Because of that problem, it was also needed to update store space value from gamestate when reading an older savefile.

Now 1 Brainsucker Pod will account for only 5% of Alien Containment space (1/20 = 0.05)

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/cda76173-5e6d-4a02-8391-a058c5c08720)
