### PR TITLE
Checking if vehicle missions list is empty before calling front()

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -180,7 +180,8 @@ class FlyingVehicleMover : public VehicleMover
 				dodge = 100;
 				break;
 		}
-		if (vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
+		if (not vehicle.missions.empty() &&
+		    vehicle.missions.front().targetBuilding == vehicle.homeBuilding)
 		{
 			return;
 		}


### PR DESCRIPTION
Fixes #1430

Be aware that `list.front()` raises this error only when running the game in Debug mode.