### PR TITLE
Added optional feature to show prefix for non-XCOM vehicles

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -140,7 +140,7 @@ void dumpOptionsToLog()
 	dumpOption(optionSceneryRepairCostFactor);
 	dumpOption(optionLoadSameAmmo);
 	dumpOption(optionShowCurrentDimensionVehicles);
-	dumpOption(optionVehiclesPrefix);
+	dumpOption(optionShowNonXCOMVehiclesPrefix);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -450,9 +450,8 @@ ConfigOptionBool
     optionShowCurrentDimensionVehicles("OpenApoc.NewFeature", "ShowCurrentDimensionVehicles",
                                        "Show vehicles in current dimension (or entering / leaving)",
                                        true);
-ConfigOptionBool
-    optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
-                         tr("Add prefix to differentiate between X-COM and other vehicles"), true);
+ConfigOptionBool optionShowNonXCOMVehiclesPrefix("OpenApoc.NewFeature", "ShowNonXCOMVehiclesPrefix",
+                                                 tr("Add prefix to non-X-COM vehicles"), true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -140,6 +140,7 @@ void dumpOptionsToLog()
 	dumpOption(optionSceneryRepairCostFactor);
 	dumpOption(optionLoadSameAmmo);
 	dumpOption(optionShowCurrentDimensionVehicles);
+	dumpOption(optionVehiclesPrefix);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -448,6 +449,9 @@ ConfigOptionBool optionLoadSameAmmo("OpenApoc.NewFeature", "LoadSameAmmo",
 ConfigOptionBool
     optionShowCurrentDimensionVehicles("OpenApoc.NewFeature", "ShowCurrentDimensionVehicles",
                                        "Show vehicles in current dimension (or entering / leaving)",
+                                       true);
+ConfigOptionBool optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
+                                       tr("Add prefix to differentiate between X-COM and other vehicles"),
                                        true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -450,9 +450,9 @@ ConfigOptionBool
     optionShowCurrentDimensionVehicles("OpenApoc.NewFeature", "ShowCurrentDimensionVehicles",
                                        "Show vehicles in current dimension (or entering / leaving)",
                                        true);
-ConfigOptionBool optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
-                                       tr("Add prefix to differentiate between X-COM and other vehicles"),
-                                       true);
+ConfigOptionBool
+    optionVehiclesPrefix("OpenApoc.NewFeature", "VehiclesPrefix",
+                         tr("Add prefix to differentiate between X-COM and other vehicles"), true);
 
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);

--- a/framework/options.h
+++ b/framework/options.h
@@ -118,7 +118,7 @@ extern ConfigOptionInt optionMaxTileRepair;
 extern ConfigOptionFloat optionSceneryRepairCostFactor;
 extern ConfigOptionBool optionLoadSameAmmo;
 extern ConfigOptionBool optionShowCurrentDimensionVehicles;
-extern ConfigOptionBool optionVehiclesPrefix;
+extern ConfigOptionBool optionShowNonXCOMVehiclesPrefix;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/framework/options.h
+++ b/framework/options.h
@@ -118,6 +118,7 @@ extern ConfigOptionInt optionMaxTileRepair;
 extern ConfigOptionFloat optionSceneryRepairCostFactor;
 extern ConfigOptionBool optionLoadSameAmmo;
 extern ConfigOptionBool optionShowCurrentDimensionVehicles;
+extern ConfigOptionBool optionVehiclesPrefix;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1487,7 +1487,8 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 		}
 		if (owner == state.getPlayer())
 		{
-			fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleModuleScrapped,
+			fw().pushEvent(new GameSomethingDiedEvent(
+			    GameEventType::VehicleModuleScrapped,
 			    format("%s - %s", getFormattedVehicleNameForEventMessage(state), e->type->name),
 			                                          position));
 		}
@@ -1890,7 +1891,7 @@ void Vehicle::die(GameState &state, bool silent, StateRef<Vehicle> attacker)
 	{
 		fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleDestroyed,
 		                                          getFormattedVehicleNameForEventMessage(state),
-		                                          attacker ? attacker->name : "", position));
+		    attacker ? attacker->getFormattedVehicleNameForEventMessage(state) : "", position));
 	}
 	state.vehiclesDeathNote.insert(id);
 }
@@ -2320,7 +2321,8 @@ void Vehicle::updateEachSecond(GameState &state)
 					{
 						if (owner == state.getPlayer())
 						{
-							fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleNoFuel,
+							fw().pushEvent(new GameSomethingDiedEvent(
+							    GameEventType::VehicleNoFuel,
 							    getFormattedVehicleNameForEventMessage(state), "", position));
 						}
 						die(state, true);
@@ -3855,8 +3857,9 @@ std::list<std::pair<Vec2<int>, sp<Equipment>>> Vehicle::getEquipment() const
 
 const UString Vehicle::getFormattedVehicleNameForEventMessage(GameState &state) const
 {
-	if (config().getBool("OpenApoc.NewFeature.VehiclesPrefix") && owner != state.getPlayer())
-		return "*" + name;
+	if (config().getBool("OpenApoc.NewFeature.ShowNonXCOMVehiclesPrefix") &&
+	    owner != state.getPlayer())
+		return format("%s %s", tr("*"), name);
 
 	return name;
 }

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1490,7 +1490,7 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 			fw().pushEvent(new GameSomethingDiedEvent(
 			    GameEventType::VehicleModuleScrapped,
 			    format("%s - %s", getFormattedVehicleNameForEventMessage(state), e->type->name),
-			                                          position));
+			    position));
 		}
 	}
 	if (randBoundsExclusive(state.rng, 0, 100) > FV_CHANCE_TO_RECOVER_VEHICLE)
@@ -1889,8 +1889,8 @@ void Vehicle::die(GameState &state, bool silent, StateRef<Vehicle> attacker)
 
 	if (!silent && city == state.current_city)
 	{
-		fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleDestroyed,
-		                                          getFormattedVehicleNameForEventMessage(state),
+		fw().pushEvent(new GameSomethingDiedEvent(
+		    GameEventType::VehicleDestroyed, getFormattedVehicleNameForEventMessage(state),
 		    attacker ? attacker->getFormattedVehicleNameForEventMessage(state) : "", position));
 	}
 	state.vehiclesDeathNote.insert(id);

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -3855,16 +3855,10 @@ std::list<std::pair<Vec2<int>, sp<Equipment>>> Vehicle::getEquipment() const
 
 const UString Vehicle::getFormattedVehicleNameForEventMessage(GameState &state) const
 {
-	auto prefix = "";
+	if (config().getBool("OpenApoc.NewFeature.VehiclesPrefix") && owner != state.getPlayer())
+		return "*" + name;
 
-	if (config().getBool("OpenApoc.NewFeature.VehiclesPrefix") && owner == state.getPlayer())
-	{
-		prefix = "* ";
-	}
-
-	auto formattedName = format("%s%s", prefix, name);
-
-	return formattedName;
+	return name;
 }
 
 Cargo::Cargo(GameState &state, StateRef<AEquipmentType> equipment, int count, int price,

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1488,7 +1488,7 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 		if (owner == state.getPlayer())
 		{
 			fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleModuleScrapped,
-			                                          format("%s - %s", name, e->type->name),
+			    format("%s - %s", getFormattedVehicleNameForEventMessage(state), e->type->name),
 			                                          position));
 		}
 	}
@@ -1540,8 +1540,9 @@ void Vehicle::processRecoveredVehicle(GameState &state)
 		owner->balance += price * FV_SCRAPPED_COST_PERCENT / 100;
 		if (owner == state.getPlayer())
 		{
-			fw().pushEvent(
-			    new GameSomethingDiedEvent(GameEventType::VehicleRecovered, name, "", position));
+			fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleRecovered,
+			                                          getFormattedVehicleNameForEventMessage(state),
+			                                          "", position));
 		}
 		die(state, true);
 	}
@@ -1887,7 +1888,8 @@ void Vehicle::die(GameState &state, bool silent, StateRef<Vehicle> attacker)
 
 	if (!silent && city == state.current_city)
 	{
-		fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleDestroyed, name,
+		fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleDestroyed,
+		                                          getFormattedVehicleNameForEventMessage(state),
 		                                          attacker ? attacker->name : "", position));
 	}
 	state.vehiclesDeathNote.insert(id);
@@ -2319,7 +2321,7 @@ void Vehicle::updateEachSecond(GameState &state)
 						if (owner == state.getPlayer())
 						{
 							fw().pushEvent(new GameSomethingDiedEvent(GameEventType::VehicleNoFuel,
-							                                          name, "", position));
+							    getFormattedVehicleNameForEventMessage(state), "", position));
 						}
 						die(state, true);
 					}
@@ -3849,6 +3851,20 @@ std::list<std::pair<Vec2<int>, sp<Equipment>>> Vehicle::getEquipment() const
 	}
 
 	return equipmentList;
+}
+
+const UString Vehicle::getFormattedVehicleNameForEventMessage(GameState &state) const
+{
+	auto prefix = "";
+
+	if (config().getBool("OpenApoc.NewFeature.VehiclesPrefix") && owner == state.getPlayer())
+	{
+		prefix = "* ";
+	}
+
+	auto formattedName = format("%s%s", prefix, name);
+
+	return formattedName;
 }
 
 Cargo::Cargo(GameState &state, StateRef<AEquipmentType> equipment, int count, int price,

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -384,6 +384,8 @@ class Vehicle : public StateObject<Vehicle>,
 	const std::list<EquipmentLayoutSlot> &getSlots() const override;
 	std::list<std::pair<Vec2<int>, sp<Equipment>>> getEquipment() const override;
 
+	const UString getFormattedVehicleNameForEventMessage(GameState &state) const;
+
 	// Following members are not serialized, but rather setup during game
 
 	up<VehicleMover> mover;

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -49,6 +49,7 @@ static const std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
     {"OpenApoc.NewFeature", "ATVUFOMission"},
     {"OpenApoc.NewFeature", "ShowCurrentDimensionVehicles"},
+    {"OpenApoc.NewFeature", "VehiclesPrefix"},
     {"OpenApoc.Mod", "MaxTileRepair"},
     {"OpenApoc.Mod", "SceneryRepairCostFactor"},
     {"OpenApoc.Mod", "RaidHostileAction"},

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -49,7 +49,7 @@ static const std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "CrashingOutOfFuel"},
     {"OpenApoc.NewFeature", "ATVUFOMission"},
     {"OpenApoc.NewFeature", "ShowCurrentDimensionVehicles"},
-    {"OpenApoc.NewFeature", "VehiclesPrefix"},
+    {"OpenApoc.NewFeature", "ShowNonXCOMVehiclesPrefix"},
     {"OpenApoc.Mod", "MaxTileRepair"},
     {"OpenApoc.Mod", "SceneryRepairCostFactor"},
     {"OpenApoc.Mod", "RaidHostileAction"},


### PR DESCRIPTION
Resolves #1312 and finishes #1405

Added optional feature that, when enabled, will add "*" prefix when displaying name of non-X-COM vehicles in alert message. Default option value is true.

Function `Vehicle::getFormattedVehicleNameForEventMessage(GameState &state)` will add prefix when option is true and when vehicle owner is not the player.

More Options view:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/11717da2-c90d-4099-90f0-077baa94fa0b)

X-COM vehicle attacking construction vehicle:
![destroyed-by](https://github.com/OpenApoc/OpenApoc/assets/13112588/78688008-1487-420f-9bc2-0b666246fd34)

X-COM vehicle being attacked by enemy vehicle:
![destroyed-by-2](https://github.com/OpenApoc/OpenApoc/assets/13112588/d7a5d703-1816-44e9-970e-4fbccdda4944)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/dad6aea5-6591-4614-b962-e0319524ed18)