### PR TITLE
Update getUsage type to float

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -569,39 +569,37 @@ int Base::getCapacityTotal(FacilityType::Capacity type) const
 	return total;
 }
 
-int Base::getUsage(GameState &state, sp<Facility> facility, int delta) const
+float Base::getUsage(GameState &state, const sp<Facility> facility, const int delta) const
 {
-	if (facility->lab)
-	{
-		float usage = 0.0f;
-		if (delta != 0)
-		{
-			LogError("Delta is only supposed to be used with stores, alien containment and LQ!");
-		}
-		if (facility->lab->current_project)
-		{
-			usage = (float)facility->lab->assigned_agents.size();
-			usage /= facility->type->capacityAmount;
-		}
-		return static_cast<int>(ceilf(usage * 100.0f));
-	}
-	else
-	{
+	if (!facility->lab)
 		return getUsage(state, facility->type->capacityType, delta);
+
+	float usage = 0.0f;
+	if (delta != 0)
+	{
+		LogError("Delta is only supposed to be used with stores, alien containment and LQ!");
 	}
+
+	if (facility->lab->current_project)
+	{
+		usage = (float)facility->lab->assigned_agents.size();
+		usage /= facility->type->capacityAmount;
+	}
+
+	return static_cast<float>(ceilf(usage * 100.0f));
 }
 
-int Base::getUsage(GameState &state, FacilityType::Capacity type, int delta) const
+float Base::getUsage(GameState &state, const FacilityType::Capacity type, const int delta) const
 {
-	int used = getCapacityUsed(state, type) + delta;
-	int total = getCapacityTotal(type);
+	const auto used = getCapacityUsed(state, type) + delta;
+	const auto total = getCapacityTotal(type);
 	if (total == 0)
 	{
 		return used > 0 ? 999 : 0;
 	}
 
-	double usageValue = (double)used / total * 100;
-	int usage = std::min(999, (int)std::round(usageValue));
+	auto usage = (float)used / total * 100;
+	usage = std::min(999.f, std::round(usage));
 
 	return usage;
 }

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -599,7 +599,7 @@ float Base::getUsage(GameState &state, const FacilityType::Capacity type, const 
 	}
 
 	auto usage = (float)used / total * 100;
-	usage = std::min(999.f, std::round(usage));
+	usage = std::min(999.f, usage);
 
 	return usage;
 }

--- a/game/state/city/base.h
+++ b/game/state/city/base.h
@@ -58,8 +58,8 @@ class Base : public StateObject<Base>, public std::enable_shared_from_this<Base>
 	bool containmentEmpty(GameState &state);
 	int getCapacityUsed(GameState &state, FacilityType::Capacity type) const;
 	int getCapacityTotal(FacilityType::Capacity type) const;
-	int getUsage(GameState &state, sp<Facility> facility, int delta = 0) const;
-	int getUsage(GameState &state, FacilityType::Capacity type, int delta = 0) const;
+	float getUsage(GameState &state, const sp<Facility> facility, const int delta = 0) const;
+	float getUsage(GameState &state, const FacilityType::Capacity type, const int delta = 0) const;
 };
 
 }; // namespace OpenApoc

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -1081,12 +1081,12 @@ void Agent::updateHourly(GameState &state)
 	// Heal
 	if (modified_stats.health < current_stats.health && !recentlyFought)
 	{
-		int usage = base->getUsage(state, FacilityType::Capacity::Medical);
-		if (usage < 999)
+		auto usage = base->getUsage(state, FacilityType::Capacity::Medical);
+		if (usage < 999.f)
 		{
-			usage = std::max(100, usage);
+			usage = std::max(100.f, usage);
 			// As per Roger Wong's guide, healing is 0.8 points an hour
-			healingProgress += 80.0f / (float)usage;
+			healingProgress += 80.0f / usage;
 			if (healingProgress > 1.0f)
 			{
 				healingProgress -= 1.0f;
@@ -1097,14 +1097,14 @@ void Agent::updateHourly(GameState &state)
 	// Train
 	if (trainingAssignment != TrainingAssignment::None)
 	{
-		int usage = base->getUsage(state, trainingAssignment == TrainingAssignment::Physical
-		                                      ? FacilityType::Capacity::Training
-		                                      : FacilityType::Capacity::Psi);
-		if (usage < 999)
+		auto usage = base->getUsage(state, trainingAssignment == TrainingAssignment::Physical
+		                                       ? FacilityType::Capacity::Training
+		                                       : FacilityType::Capacity::Psi);
+		if (usage < 999.f)
 		{
-			usage = std::max(100, usage);
+			usage = std::max(100.f, usage);
 			// As per Roger Wong's guide
-			float mult = config().getFloat("OpenApoc.Cheat.StatGrowthMultiplier");
+			auto mult = config().getFloat("OpenApoc.Cheat.StatGrowthMultiplier");
 			if (trainingAssignment == TrainingAssignment::Physical)
 			{
 				trainPhysical(state, TICKS_PER_HOUR * 100 / usage * mult);

--- a/game/ui/base/aliencontainmentscreen.cpp
+++ b/game/ui/base/aliencontainmentscreen.cpp
@@ -92,7 +92,7 @@ void AlienContainmentScreen::closeScreen()
 		for (auto &b : state->player_bases)
 		{
 			if ((vecChanged[i] || forceLimits) &&
-			    b.second->getUsage(*state, FacilityType::Capacity::Aliens, vecBioDelta[i]) > 100)
+			    b.second->getUsage(*state, FacilityType::Capacity::Aliens, vecBioDelta[i]) > 100.f)
 			{
 				bad_base = b.second->building->base;
 				break;

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -472,7 +472,7 @@ void BaseScreen::eventOccurred(Event *e)
 			statsValues[0]->setText(format("%d", selFacility->type->capacityAmount));
 			statsLabels[1]->setText(tr("Usage"));
 			statsValues[1]->setText(
-			    format("%d%%", state->current_base->getUsage(*state, selFacility)));
+			    format("%.f%%", state->current_base->getUsage(*state, selFacility)));
 		}
 	}
 	else if (selection != NO_SELECTION)

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -148,7 +148,8 @@ void BuyAndSellScreen::closeScreen()
 		for (auto &b : state->player_bases)
 		{
 			if ((vecChanged[i] || forceLimits) && vecCargoDelta[i] > 0 &&
-			    b.second->getUsage(*state, FacilityType::Capacity::Stores, vecCargoDelta[i]) > 100)
+			    b.second->getUsage(*state, FacilityType::Capacity::Stores, vecCargoDelta[i]) >
+			        100.f)
 			{
 				bad_base = b.second->building->base;
 				break;

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -349,7 +349,7 @@ void RecruitScreen::updateBaseHighlight()
 	    state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
 	fillBaseBar(usage);
 	auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
-	facilityLabel->setText(format("%.4g%%", usage));
+	facilityLabel->setText(format("%i%%", usage));
 }
 
 void RecruitScreen::fillBaseBar(int percent)

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -109,7 +109,7 @@ RecruitScreen::RecruitScreen(sp<GameState> state)
 				    }
 				    else if (this->state->current_base->getUsage(*(this->state),
 				                                                 FacilityType::Capacity::Quarters,
-				                                                 lqDelta + 1) > 100)
+				                                                 lqDelta + 1) > 100.f)
 				    {
 					    fw().stageQueueCommand(
 					        {StageCmd::Command::PUSH,
@@ -345,10 +345,11 @@ void RecruitScreen::updateFormValues()
 
 void RecruitScreen::updateBaseHighlight()
 {
-	int usage = state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
+	const auto usage =
+	    state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
 	fillBaseBar(usage);
 	auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
-	facilityLabel->setText(format("%i%%", usage));
+	facilityLabel->setText(format("%.2g%%", usage));
 }
 
 void RecruitScreen::fillBaseBar(int percent)
@@ -641,7 +642,8 @@ void RecruitScreen::closeScreen(bool confirmed)
 	StateRef<Base> bad_base;
 	for (auto &b : state->player_bases)
 	{
-		if (b.second->getUsage(*state, FacilityType::Capacity::Quarters, vecLqDelta[bindex]) > 100)
+		if (b.second->getUsage(*state, FacilityType::Capacity::Quarters, vecLqDelta[bindex]) >
+		    100.f)
 		{
 			bad_base = b.second->building->base;
 			break;

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -349,7 +349,7 @@ void RecruitScreen::updateBaseHighlight()
 	    state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
 	fillBaseBar(usage);
 	auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
-	facilityLabel->setText(format("%.2g%%", usage));
+	facilityLabel->setText(format("%.4g%%", usage));
 }
 
 void RecruitScreen::fillBaseBar(int percent)

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -349,7 +349,7 @@ void RecruitScreen::updateBaseHighlight()
 	    state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
 	fillBaseBar(usage);
 	auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
-	facilityLabel->setText(format("%i%%", usage));
+	facilityLabel->setText(format("%.f%%", usage));
 }
 
 void RecruitScreen::fillBaseBar(int percent)

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -498,7 +498,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.4g%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -512,7 +512,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.4g%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -526,7 +526,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.4g%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -493,12 +493,12 @@ void TransactionScreen::updateBaseHighlight()
 			facilityPic->setVisible(true);
 			facilityPic->setImage(state->facility_types["FACILITYTYPE_LIVING_QUARTERS"]->sprite);
 			form->findControlTyped<Graphic>("FACILITY_FIRST_BAR")->setVisible(true);
-			int usage =
+			const auto usage =
 			    state->current_base->getUsage(*state, FacilityType::Capacity::Quarters, lqDelta);
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.2g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -507,12 +507,12 @@ void TransactionScreen::updateBaseHighlight()
 			facilityPic->setVisible(true);
 			facilityPic->setImage(state->facility_types["FACILITYTYPE_STORES"]->sprite);
 			form->findControlTyped<Graphic>("FACILITY_FIRST_BAR")->setVisible(true);
-			int usage =
+			const auto usage =
 			    state->current_base->getUsage(*state, FacilityType::Capacity::Stores, cargoDelta);
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.2g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -521,12 +521,12 @@ void TransactionScreen::updateBaseHighlight()
 			facilityPic->setVisible(true);
 			facilityPic->setImage(state->facility_types["FACILITYTYPE_ALIEN_CONTAINMENT"]->sprite);
 			form->findControlTyped<Graphic>("FACILITY_FIRST_BAR")->setVisible(true);
-			int usage =
+			const auto usage =
 			    state->current_base->getUsage(*state, FacilityType::Capacity::Aliens, bioDelta);
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.2g%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -498,7 +498,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.2g%%", usage));
+			facilityLabel->setText(format("%.4g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -512,7 +512,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.2g%%", usage));
+			facilityLabel->setText(format("%.4g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -526,7 +526,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.2g%%", usage));
+			facilityLabel->setText(format("%.4g%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transactionscreen.cpp
+++ b/game/ui/base/transactionscreen.cpp
@@ -498,7 +498,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.f%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -512,7 +512,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.f%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -526,7 +526,7 @@ void TransactionScreen::updateBaseHighlight()
 			fillBaseBar(true, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_FIRST_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.f%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -171,7 +171,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.f%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -185,7 +185,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.f%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -199,7 +199,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.f%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -171,7 +171,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.4g%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -185,7 +185,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.4g%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -199,7 +199,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.4g%%", usage));
+			facilityLabel->setText(format("%d%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -171,7 +171,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.2g%%", usage));
+			facilityLabel->setText(format("%.4g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -185,7 +185,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.2g%%", usage));
+			facilityLabel->setText(format("%.4g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -199,7 +199,7 @@ void TransferScreen::updateBaseHighlight()
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%.2g%%", usage));
+			facilityLabel->setText(format("%.4g%%", usage));
 			break;
 		}
 		default:

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -166,11 +166,12 @@ void TransferScreen::updateBaseHighlight()
 			facilityPic->setVisible(true);
 			facilityPic->setImage(state->facility_types["FACILITYTYPE_LIVING_QUARTERS"]->sprite);
 			form->findControlTyped<Graphic>("FACILITY_SECOND_BAR")->setVisible(true);
-			int usage = second_base->getUsage(*state, FacilityType::Capacity::Quarters, lq2Delta);
+			const auto usage =
+			    second_base->getUsage(*state, FacilityType::Capacity::Quarters, lq2Delta);
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.2g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Stores:
@@ -179,11 +180,12 @@ void TransferScreen::updateBaseHighlight()
 			facilityPic->setVisible(true);
 			facilityPic->setImage(state->facility_types["FACILITYTYPE_STORES"]->sprite);
 			form->findControlTyped<Graphic>("FACILITY_SECOND_BAR")->setVisible(true);
-			int usage = second_base->getUsage(*state, FacilityType::Capacity::Stores, cargo2Delta);
+			const auto usage =
+			    second_base->getUsage(*state, FacilityType::Capacity::Stores, cargo2Delta);
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.2g%%", usage));
 			break;
 		}
 		case BaseGraphics::FacilityHighlight::Aliens:
@@ -192,11 +194,12 @@ void TransferScreen::updateBaseHighlight()
 			facilityPic->setVisible(true);
 			facilityPic->setImage(state->facility_types["FACILITYTYPE_ALIEN_CONTAINMENT"]->sprite);
 			form->findControlTyped<Graphic>("FACILITY_SECOND_BAR")->setVisible(true);
-			int usage = second_base->getUsage(*state, FacilityType::Capacity::Aliens, bio2Delta);
+			const auto usage =
+			    second_base->getUsage(*state, FacilityType::Capacity::Aliens, bio2Delta);
 			fillBaseBar(false, usage);
 			auto facilityLabel = form->findControlTyped<Label>("FACILITY_SECOND_TEXT");
 			facilityLabel->setVisible(true);
-			facilityLabel->setText(format("%d%%", usage));
+			facilityLabel->setText(format("%.2g%%", usage));
 			break;
 		}
 		default:
@@ -300,13 +303,13 @@ void TransferScreen::closeScreen()
 			{
 				crewOverLimit = vecCrewDelta[i] > 0 &&
 				                b.second->getUsage(*state, FacilityType::Capacity::Quarters,
-				                                   vecCrewDelta[i]) > 100;
+				                                   vecCrewDelta[i]) > 100.f;
 				cargoOverLimit = vecCargoDelta[i] > 0 &&
 				                 b.second->getUsage(*state, FacilityType::Capacity::Stores,
-				                                    vecCargoDelta[i]) > 100;
+				                                    vecCargoDelta[i]) > 100.f;
 				alienOverLimit =
 				    vecBioDelta[i] > 0 && b.second->getUsage(*state, FacilityType::Capacity::Aliens,
-				                                             vecBioDelta[i]) > 100;
+				                                             vecBioDelta[i]) > 100.f;
 				if (crewOverLimit || cargoOverLimit || alienOverLimit)
 				{
 					bad_base = b.second->building->base;

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -2585,7 +2585,7 @@ void CityView::update()
 							UString efficiency = tr("Combat training (efficiency=");
 							auto usage = base->getUsage(*state, FacilityType::Capacity::Training);
 							usage = (100.0f / std::max(100.f, usage)) * 100;
-							efficiency += format("%d%%", usage) + UString(")");
+							efficiency += format("%.f%%", usage) + UString(")");
 							agentAssignment->setText(efficiency);
 							break;
 						}
@@ -2594,7 +2594,7 @@ void CityView::update()
 							UString efficiency = tr("Psionic training (efficiency=");
 							auto usage = base->getUsage(*state, FacilityType::Capacity::Psi);
 							usage = (100.0f / std::max(100.f, usage)) * 100;
-							efficiency += format("%d%%", usage) + UString(")");
+							efficiency += format("%.f%%", usage) + UString(")");
 							agentAssignment->setText(efficiency);
 							break;
 						}

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -2583,8 +2583,8 @@ void CityView::update()
 						case TrainingAssignment::Physical:
 						{
 							UString efficiency = tr("Combat training (efficiency=");
-							int usage = base->getUsage(*state, FacilityType::Capacity::Training);
-							usage = (100.0f / std::max(100, usage)) * 100;
+							auto usage = base->getUsage(*state, FacilityType::Capacity::Training);
+							usage = (100.0f / std::max(100.f, usage)) * 100;
 							efficiency += format("%d%%", usage) + UString(")");
 							agentAssignment->setText(efficiency);
 							break;
@@ -2592,8 +2592,8 @@ void CityView::update()
 						case TrainingAssignment::Psi:
 						{
 							UString efficiency = tr("Psionic training (efficiency=");
-							int usage = base->getUsage(*state, FacilityType::Capacity::Psi);
-							usage = (100.0f / std::max(100, usage)) * 100;
+							auto usage = base->getUsage(*state, FacilityType::Capacity::Psi);
+							usage = (100.0f / std::max(100.f, usage)) * 100;
 							efficiency += format("%d%%", usage) + UString(")");
 							agentAssignment->setText(efficiency);
 							break;


### PR DESCRIPTION
Since getUsage is returning the result of a division operation, it makes more sense the function return be float instead of int.

- Updated texts format and number comparisons to proper float type
- Added `const` and `auto` modifiers whenever possible
- Removed unnecessary `std::round` at getUsage

Obs.: as indicated by the branch name, my original idea was to convert it to double, but then I checked that all existing references to getUsage function are already using float. 