### PR TITLE
Add store space item info

### DIFF
--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -42,22 +42,25 @@ void AEquipmentSheet::clear()
 }
 
 void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmentType &itemType,
-                                            bool researched)
+                                            const bool researched)
 {
-	if (!researched)
-	{
-		displayAlien(item, itemType);
-		return;
-	}
+	const auto itemName = researched
+	                          ? itemType.name
+	                          : (itemType.bioStorage ? tr("Alien Organism") : tr("Alien Artifact"));
 
-	form->findControlTyped<Label>("ITEM_NAME")->setText(itemType.name);
-	form->findControlTyped<Graphic>("SELECTED_IMAGE")
-	    ->setImage(item ? item->getEquipmentImage() : itemType.equipscreen_sprite);
+	const auto selectedImage =
+	    researched && item ? item->getEquipmentImage() : itemType.equipscreen_sprite;
+
+	form->findControlTyped<Label>("ITEM_NAME")->setText(itemName);
+	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(selectedImage);
 
 	// when possible, the actual item's weight takes precedence
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")
 	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
+
+	if (!researched)
+		return;
 
 	switch (itemType.type)
 	{
@@ -176,17 +179,6 @@ void AEquipmentSheet::displayArmor(sp<AEquipment> item, const AEquipmentType &it
 void AEquipmentSheet::displayOther(sp<AEquipment> item [[maybe_unused]],
                                    const AEquipmentType &itemType [[maybe_unused]])
 {
-}
-
-void AEquipmentSheet::displayAlien(sp<AEquipment> item, const AEquipmentType &itemType)
-{
-	form->findControlTyped<Label>("ITEM_NAME")
-	    ->setText(itemType.bioStorage ? tr("Alien Organism") : tr("Alien Artifact"));
-	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(itemType.equipscreen_sprite);
-
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
-	form->findControlTyped<Label>("LABEL_1_R")
-	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
 }
 
 }; // namespace OpenApoc

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -59,6 +59,9 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 	form->findControlTyped<Label>("LABEL_1_R")
 	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
 
+	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", 99));
+
 	if (!researched)
 		return;
 
@@ -102,23 +105,23 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 void AEquipmentSheet::displayGrenade(sp<AEquipment> item [[maybe_unused]],
                                      const AEquipmentType &itemType)
 {
-	form->findControlTyped<Label>("LABEL_2_C")->setText(itemType.damage_type->name);
+	form->findControlTyped<Label>("LABEL_3_C")->setText(itemType.damage_type->name);
 
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Power"));
-	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", itemType.damage));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Power"));
+	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", itemType.damage));
 }
 
 void AEquipmentSheet::displayAmmo(sp<AEquipment> item, const AEquipmentType &itemType)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", itemType.accuracy));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", itemType.accuracy));
 
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Fire rate"));
-	form->findControlTyped<Label>("LABEL_3_R")
+	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Fire rate"));
+	form->findControlTyped<Label>("LABEL_4_R")
 	    ->setText(format("%.2f", itemType.getRoundsPerSecond()));
 
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
-	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", itemType.getRangeInTiles()));
+	form->findControlTyped<Label>("LABEL_5_L")->setText(tr("Range"));
+	form->findControlTyped<Label>("LABEL_5_R")->setText(format("%d", itemType.getRangeInTiles()));
 
 	form->findControlTyped<Label>("LABEL_6_C")->setText(tr("Ammo Type:"));
 	form->findControlTyped<Label>("LABEL_7_C")->setText(itemType.damage_type->name);
@@ -146,21 +149,21 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 	}
 
 	auto &ammoType = *itemType.ammo_types.begin();
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", ammoType->accuracy));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", ammoType->accuracy));
 
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Fire rate"));
-	form->findControlTyped<Label>("LABEL_3_R")
+	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Fire rate"));
+	form->findControlTyped<Label>("LABEL_4_R")
 	    ->setText(format("%.2f", ammoType->getRoundsPerSecond()));
 
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
-	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", ammoType->getRangeInTiles()));
+	form->findControlTyped<Label>("LABEL_5_L")->setText(tr("Range"));
+	form->findControlTyped<Label>("LABEL_5_R")->setText(format("%d", ammoType->getRangeInTiles()));
 
-	form->findControlTyped<Label>("LABEL_5_C")->setText(tr("Ammo types:"));
+	form->findControlTyped<Label>("LABEL_6_C")->setText(tr("Ammo types:"));
 	int ammoNum = 1;
 	for (auto &ammo : itemType.ammo_types)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_C", 5 + ammoNum))->setText(ammo->name);
+		form->findControlTyped<Label>(format("LABEL_%d_C", 6 + ammoNum))->setText(ammo->name);
 		if (++ammoNum >= 4)
 		{
 			break;
@@ -170,8 +173,8 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 
 void AEquipmentSheet::displayArmor(sp<AEquipment> item, const AEquipmentType &itemType)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Protection"));
-	form->findControlTyped<Label>("LABEL_2_R")
+	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Protection"));
+	form->findControlTyped<Label>("LABEL_3_R")
 	    ->setText(item ? format("%d / %d", item->armor, itemType.armor)
 	                   : format("%d", itemType.armor));
 }

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -60,9 +60,7 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
 
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
-	form->findControlTyped<Label>("LABEL_2_R")
-	    ->setText(
-	        format("%d (%.2g%%)", itemType.store_space, (double)itemType.store_space / 40 * 100));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", itemType.store_space));
 
 	if (!researched)
 		return;

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -60,7 +60,9 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 	    ->setText(format("%d", item ? item->getWeight() : itemType.weight));
 
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", 99));
+	form->findControlTyped<Label>("LABEL_2_R")
+	    ->setText(
+	        format("%d (%.2g%%)", itemType.store_space, (double)itemType.store_space / 40 * 100));
 
 	if (!researched)
 		return;

--- a/game/ui/general/aequipmentsheet.h
+++ b/game/ui/general/aequipmentsheet.h
@@ -22,13 +22,12 @@ class AEquipmentSheet
 
   private:
 	void displayImplementation(sp<AEquipment> item, const AEquipmentType &itemType,
-	                           bool researched);
+	                           const bool researched);
 	void displayGrenade(sp<AEquipment> item, const AEquipmentType &itemType);
 	void displayWeapon(sp<AEquipment> item, const AEquipmentType &itemType);
 	void displayAmmo(sp<AEquipment> item, const AEquipmentType &itemType);
 	void displayArmor(sp<AEquipment> item, const AEquipmentType &itemType);
 	void displayOther(sp<AEquipment> item, const AEquipmentType &itemType);
-	void displayAlien(sp<AEquipment> item, const AEquipmentType &itemType);
 	sp<Form> form;
 };
 

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -34,14 +34,7 @@ void VehicleSheet::display(sp<VEquipment> item)
 void VehicleSheet::display(sp<VEquipmentType> itemType, bool researched)
 {
 	clear();
-	if (researched)
-	{
-		displayEquipImplementation(nullptr, itemType);
-	}
-	else
-	{
-		displayAlien(itemType);
-	}
+	displayEquipImplementation(nullptr, itemType, researched);
 }
 
 void VehicleSheet::clear()
@@ -128,14 +121,22 @@ void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> ve
 	}
 }
 
-void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> type)
+void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> type,
+                                              const bool isResearched = true)
 {
-	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")->setText("");
-	form->findControlTyped<Label>("ITEM_NAME")->setText(item ? item->type->name : type->name);
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
 
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
+
+	if (!isResearched)
+	{
+		form->findControlTyped<Label>("ITEM_NAME")->setText(tr("Alien Artifact"));
+		return;
+	}
+
+	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")->setText("");
+	form->findControlTyped<Label>("ITEM_NAME")->setText(item ? item->type->name : type->name);
 
 	// Draw equipment stats
 	switch (type->type)
@@ -238,14 +239,6 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Teleports"));
 		statsCount++;
 	}
-}
-
-void VehicleSheet::displayAlien(sp<VEquipmentType> type)
-{
-	form->findControlTyped<Label>("ITEM_NAME")->setText(tr("Alien Artifact"));
-	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
-	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
-	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
 }
 
 }; // namespace OpenApoc

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -130,7 +130,8 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
 
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", 99));
+	form->findControlTyped<Label>("LABEL_2_R")
+	    ->setText(format("%d (%.2g%%)", type->store_space, (double)type->store_space / 20 * 100));
 
 	if (!isResearched)
 	{

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -122,12 +122,15 @@ void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> ve
 }
 
 void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> type,
-                                              const bool isResearched = true)
+                                              const bool isResearched)
 {
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(type->equipscreen_sprite);
 
 	form->findControlTyped<Label>("LABEL_1_L")->setText(tr("Weight"));
 	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
+
+	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", 99));
 
 	if (!isResearched)
 	{
@@ -158,20 +161,20 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 
 void VehicleSheet::displayEngine(sp<VEquipment> item [[maybe_unused]], sp<VEquipmentType> type)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Top Speed"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->top_speed));
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Power"));
-	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->power));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Top Speed"));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->top_speed));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Power"));
+	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", type->power));
 }
 
 void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 {
-	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Damage"));
-	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->damage));
-	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Range"));
-	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->getRangeInTiles()));
-	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Accuracy"));
-	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d%%", type->accuracy));
+	form->findControlTyped<Label>("LABEL_3_L")->setText(tr("Damage"));
+	form->findControlTyped<Label>("LABEL_3_R")->setText(format("%d", type->damage));
+	form->findControlTyped<Label>("LABEL_4_L")->setText(tr("Range"));
+	form->findControlTyped<Label>("LABEL_4_R")->setText(format("%d", type->getRangeInTiles()));
+	form->findControlTyped<Label>("LABEL_5_L")->setText(tr("Accuracy"));
+	form->findControlTyped<Label>("LABEL_5_R")->setText(format("%d%%", type->accuracy));
 
 	// Only show rounds if non-zero (IE not infinite ammo)
 	if (type->max_ammo != 0)
@@ -185,7 +188,7 @@ void VehicleSheet::displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type)
 
 void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEquipmentType> type)
 {
-	int statsCount = 2;
+	int statsCount = 3;
 	if (type->accuracy_modifier)
 	{
 		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Accuracy"));

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -130,8 +130,7 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 	form->findControlTyped<Label>("LABEL_1_R")->setText(format("%d", type->weight));
 
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
-	form->findControlTyped<Label>("LABEL_2_R")
-	    ->setText(format("%d (%.2g%%)", type->store_space, (double)type->store_space / 20 * 100));
+	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->store_space));
 
 	if (!isResearched)
 	{

--- a/game/ui/general/vehiclesheet.h
+++ b/game/ui/general/vehiclesheet.h
@@ -26,11 +26,11 @@ class VehicleSheet
   private:
 	void displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> vehicleType);
 
-	void displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> itemType);
+	void displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> itemType,
+	                                const bool isResearched = true);
 	void displayEngine(sp<VEquipment> item, sp<VEquipmentType> type);
 	void displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type);
 	void displayGeneral(sp<VEquipment> item, sp<VEquipmentType> type);
-	void displayAlien(sp<VEquipmentType> type);
 
 	sp<Form> form;
 };


### PR DESCRIPTION
Resolves #1429

Right now it only adds absolute value for store space. To display this information as percentage value, I will have to think a way to let the sheet view knows which screen is calling it, since the available space can come from item storage or alien containment. I guess it makes more sense to leave this for another PR in the future.

Files `aequipmentsheet.cpp` and `vehiclesheet.cpp`:
- Added store space as "Storage" in second line
- Refactored code to remove duplicated function that displayed info of unsearched items
- Updated label references for lines below Storage label

Alien Containment:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/c1d5f5fd-b0e5-4a16-942b-ee4d68eb5f77)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/1d0744af-c90e-43e0-95d8-a39368b1fbe4)

Vehicles:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/4e2f12f1-335f-4fdd-b780-3b6e6ba3af41)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/28c49e44-936d-40ec-9c8a-b0eb64c638d6)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/67c83788-af12-4005-ae74-a3e4cccee68d)

Agent:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/09e7d170-030f-47ad-a9d4-76934feb93af)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/974db6d5-c6ec-4fb4-a6e9-0bb465955913)