### PR TITLE
Add partial clip refilling in battlescape

### DIFF
--- a/game/state/shared/aequipment.cpp
+++ b/game/state/shared/aequipment.cpp
@@ -367,8 +367,8 @@ void AEquipment::loadAmmo(GameState &state, sp<AEquipment> ammoItem)
 	// Store the loaded ammo type for autoreload
 	lastLoadedAmmoType = ammoItem->type;
 
-	// If this has ammo then swap
-	if (payloadType)
+	// If this has ammo, swap if clip can't be refilled
+	if (payloadType && (ammoItem->ammo + ammo > payloadType->max_ammo))
 	{
 		auto ejectedType = payloadType;
 		auto ejectedAmmo = ammo;
@@ -380,7 +380,8 @@ void AEquipment::loadAmmo(GameState &state, sp<AEquipment> ammoItem)
 	else
 	{
 		payloadType = ammoItem->type;
-		ammo = ammoItem->ammo;
+		// Fill partial clip
+		ammo = ammoItem->ammo + ammo;
 		// Spend ammo
 		ammoItem->ammo = 0;
 		// Remove item from battle/agent


### PR DESCRIPTION
Addresses #1445

If the ammo amount in the clip plus the ammo amount in the gun is less than the max ammo amount, the clip will be loaded in the gun instead of swapped as before and the clip will disappear. This appears to be what OG does.