### PR TITLE
Live alien recovery after base defense battle

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3194,7 +3194,7 @@ void Battle::exitBattle(GameState &state)
 		}
 	}
 
-	// Base defense missions don't check for vehicles
+	// Base defense missions only check for vehicles if no storage is available
 	if (state.current_battle->mission_type == Battle::MissionType::BaseDefense &&
 	    isBaseDefenseWithAlienStorage(state))
 	{

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3200,7 +3200,7 @@ void Battle::exitBattle(GameState &state)
 	{
 		const auto defendedBase = getCurrentDefendedBase(state);
 
-		for (auto &bio : state.current_battle->bioLoot)
+		for (const auto &bio : state.current_battle->bioLoot)
 		{
 			if (bio.second == 0)
 				continue;

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3203,6 +3203,9 @@ void Battle::exitBattle(GameState &state)
 		{
 			for (auto &facility : defendedBase.value()->facilities)
 			{
+				if (facility->type->capacityType != FacilityType::Capacity::Aliens)
+					continue;
+
 				// TODO: insert alien into alien containment at base
 			}
 		}

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2684,7 +2684,7 @@ void Battle::finishBattle(GameState &state)
 	// - give him alien remains
 	if (state.current_battle->playerWon && !state.current_battle->winnerHasRetreated)
 	{
-		auto playerHasBaseAlienStorage = isBaseDefenseWithAlienStorage(state);
+		const auto playerHasBaseAlienStorage = isBaseDefenseWithAlienStorage(state);
 
 		const auto playerHasCraftBioStorage = state.current_battle->player_craft &&
 		                                      state.current_battle->player_craft->getMaxBio() > 0;
@@ -3112,7 +3112,7 @@ void Battle::exitBattle(GameState &state)
 	// on vehicles that have capacity in the first place
 	auto cargoCarrierPresent = false;
 	auto bioCarrierPresent = false;
-	auto playerHasBaseAlienStorage = isBaseDefenseWithAlienStorage(state);
+	const auto playerHasBaseAlienStorage = isBaseDefenseWithAlienStorage(state);
 	for (auto &v : playerVehicles)
 	{
 		if (v->getMaxCargo() > 0)
@@ -3198,7 +3198,7 @@ void Battle::exitBattle(GameState &state)
 	if (state.current_battle->mission_type == Battle::MissionType::BaseDefense &&
 	    isBaseDefenseWithAlienStorage(state))
 	{
-		auto defendedBase = getCurrentDefendedBase(state);
+		const auto defendedBase = getCurrentDefendedBase(state);
 
 		for (auto &bio : state.current_battle->bioLoot)
 		{
@@ -3394,7 +3394,7 @@ void Battle::exitBattle(GameState &state)
 		}
 
 		// Give player vehicle a null cargo just so it comes back to base once
-		for (auto v : playerVehicles)
+		for (auto &v : playerVehicles)
 		{
 			v->cargo.emplace_front(
 			    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,
@@ -3530,13 +3530,13 @@ bool Battle::isBaseDefenseWithAlienStorage(GameState &state)
 	if (state.current_battle->mission_type != Battle::MissionType::BaseDefense)
 		return false;
 
-	auto defendedBase = getCurrentDefendedBase(state);
+	const auto defendedBase = getCurrentDefendedBase(state);
 
 	// If base not found
 	if (!defendedBase)
 		return false;
 
-	auto availableAlienStorageAtBase =
+	const auto availableAlienStorageAtBase =
 	    defendedBase->getCapacityTotal(FacilityType::Capacity::Aliens) > 0;
 
 	return availableAlienStorageAtBase;

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3148,6 +3148,7 @@ void Battle::exitBattle(GameState &state)
 	if (!leftoverBioLoot.empty())
 	{
 		// Bio loot is wasted if can't be loaded on player craft
+		LogWarning("Bio loot remaining");
 	}
 
 	// Cargo loot remaining?
@@ -3158,6 +3159,7 @@ void Battle::exitBattle(GameState &state)
 			if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
 			{
 				// Still can't do anything if we're recovering UFO
+				LogWarning("AllowBuildingLootDeposit and UfoRecovery mission type");
 			}
 			else
 			{

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -46,7 +46,6 @@
 #include <algorithm>
 #include <glm/glm.hpp>
 #include <limits>
-#include <optional>
 
 namespace OpenApoc
 {
@@ -3158,7 +3157,8 @@ void Battle::exitBattle(GameState &state)
 	}
 
 	// Cargo loot remaining?
-	if (leftoverCargoLoot.empty() && config().getBool("OpenApoc.NewFeature.AllowBuildingLootDeposit"))
+	if (leftoverCargoLoot.empty() &&
+	    config().getBool("OpenApoc.NewFeature.AllowBuildingLootDeposit"))
 	{
 		if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
 		{
@@ -3170,7 +3170,7 @@ void Battle::exitBattle(GameState &state)
 			// Deposit loot into building, call for pickup
 			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
 			auto homeBuilding =
-				playerVehicles.empty() ? nullptr : playerVehicles.front()->homeBuilding;
+			    playerVehicles.empty() ? nullptr : playerVehicles.front()->homeBuilding;
 			if (!homeBuilding)
 			{
 				homeBuilding = state.player_bases.begin()->second->building;
@@ -3179,23 +3179,24 @@ void Battle::exitBattle(GameState &state)
 			// Main loop only starts with leftoverCargoLoot.empty()
 			// This means that the following inner loop will NEVER be executed!
 			// TODO: check if this can be removed
-			for (auto &e : leftoverCargoLoot) 
+			for (auto &e : leftoverCargoLoot)
 			{
 				int price = 0;
 				location->cargo.emplace_back(state, e.first, e.second, price, nullptr,
-					                            homeBuilding);
+				                             homeBuilding);
 			}
 			for (auto &e : leftoverVehicleLoot)
 			{
 				int price = 0;
 				location->cargo.emplace_back(state, e.first, e.second, price, nullptr,
-					                            homeBuilding);
+				                             homeBuilding);
 			}
 		}
 	}
 
 	// Base defense missions don't check for vehicles
-	if (state.current_battle->mission_type == Battle::MissionType::BaseDefense && isBaseDefenseWithAlienStorage(state))
+	if (state.current_battle->mission_type == Battle::MissionType::BaseDefense &&
+	    isBaseDefenseWithAlienStorage(state))
 	{
 		auto defendedBase = getCurrentDefendedBase(state);
 
@@ -3204,7 +3205,7 @@ void Battle::exitBattle(GameState &state)
 			if (bio.second == 0)
 				continue;
 
-			defendedBase.value()->inventoryBioEquipment[bio.first.id] += bio.second;
+			defendedBase->inventoryBioEquipment[bio.first.id] += bio.second;
 		}
 	}
 	else
@@ -3508,12 +3509,12 @@ void Battle::exitBattle(GameState &state)
 	state.cleanUpDeathNote();
 }
 
-std::optional<sp<Base>> Battle::getCurrentDefendedBase(GameState &state)
+sp<Base> Battle::getCurrentDefendedBase(GameState &state)
 {
 	if (state.current_battle->mission_type != Battle::MissionType::BaseDefense)
 		return {};
 
-	for (const auto& base : state.player_bases)
+	for (const auto &base : state.player_bases)
 	{
 		if (base.first == state.current_base.id)
 			return base.second;
@@ -3524,7 +3525,8 @@ std::optional<sp<Base>> Battle::getCurrentDefendedBase(GameState &state)
 
 bool Battle::isBaseDefenseWithAlienStorage(GameState &state)
 {
-	// Check if mission is base defense, and defended base has alien containment facility to store live aliens from battle
+	// Check if mission is base defense, and defended base has alien containment facility to store
+	// live aliens from battle
 	if (state.current_battle->mission_type != Battle::MissionType::BaseDefense)
 		return false;
 
@@ -3535,7 +3537,7 @@ bool Battle::isBaseDefenseWithAlienStorage(GameState &state)
 		return false;
 
 	auto availableAlienStorageAtBase =
-	    defendedBase.value()->getCapacityTotal(FacilityType::Capacity::Aliens) > 0;
+	    defendedBase->getCapacityTotal(FacilityType::Capacity::Aliens) > 0;
 
 	return availableAlienStorageAtBase;
 }

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -14,6 +14,7 @@
 #include <set>
 #include <vector>
 #include <optional>
+#include <game/state/city/base.h>
 
 namespace OpenApoc
 {
@@ -352,8 +353,8 @@ class Battle : public std::enable_shared_from_this<Battle>
 	    bool approachOnly = false, bool ignoreStaticUnits = false, bool ignoreMovingUnits = true,
 	    bool ignoreAllUnits = false, float *cost = nullptr, float maxCost = 0.0f);
 
-	static bool getIfPlayerHasBaseAlienStorage(GameState &state);
 	static std::optional<sp<Base>> getCurrentDefendedBase(GameState &state);
+	static bool getIfPlayerHasBaseAlienStorage(GameState &state);
 
   private:
 	void loadResources(GameState &state);

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -354,7 +354,7 @@ class Battle : public std::enable_shared_from_this<Battle>
 	    bool ignoreAllUnits = false, float *cost = nullptr, float maxCost = 0.0f);
 
 	static std::optional<sp<Base>> getCurrentDefendedBase(GameState &state);
-	static bool getIfPlayerHasBaseAlienStorage(GameState &state);
+	static bool isBaseDefenseWithAlienStorage(GameState &state);
 
   private:
 	void loadResources(GameState &state);

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -9,12 +9,11 @@
 #include "game/state/stateobject.h"
 #include "library/sp.h"
 #include "library/vec.h"
+#include <game/state/city/base.h>
 #include <list>
 #include <map>
 #include <set>
 #include <vector>
-#include <optional>
-#include <game/state/city/base.h>
 
 namespace OpenApoc
 {
@@ -353,7 +352,7 @@ class Battle : public std::enable_shared_from_this<Battle>
 	    bool approachOnly = false, bool ignoreStaticUnits = false, bool ignoreMovingUnits = true,
 	    bool ignoreAllUnits = false, float *cost = nullptr, float maxCost = 0.0f);
 
-	static std::optional<sp<Base>> getCurrentDefendedBase(GameState &state);
+	static sp<Base> getCurrentDefendedBase(GameState &state);
 	static bool isBaseDefenseWithAlienStorage(GameState &state);
 
   private:

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -13,6 +13,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <optional>
 
 namespace OpenApoc
 {
@@ -350,6 +351,9 @@ class Battle : public std::enable_shared_from_this<Battle>
 	    Vec3<int> origin, Vec3<int> destination, const BattleUnitTileHelper &canEnterTile,
 	    bool approachOnly = false, bool ignoreStaticUnits = false, bool ignoreMovingUnits = true,
 	    bool ignoreAllUnits = false, float *cost = nullptr, float maxCost = 0.0f);
+
+	static bool getIfPlayerHasBaseAlienStorage(GameState &state);
+	static std::optional<sp<Base>> getCurrentDefendedBase(GameState &state);
 
   private:
 	void loadResources(GameState &state);


### PR DESCRIPTION
Fixes #1422

Now, after finishing a Base Defense battle, live aliens will be considered for score calculation, and they will NOT be send to any vehicle, but will be added to base alien storage instead.

Updates list:
- For score math, live aliens will be considered if mission is a base defense and base has alien storage **OR** if mission has player craft with available bio storage.
- Similarly, live aliens will be set as "leftover" only when **BOTH** conditions above are false.
- At `battle.cpp`, instructions inside `if (!playerVehicles.empty())` and `for (auto &v : playerVehicles)` will only be executed when mission is **NOT** a base defense one. Since both instruction groups deal with adding stuff at vehicles to be send to base, it seems that they shouldn't execute when defending a base. Let me know if that's correct or needs to be changed.
- Minor refactors merging nested if conditions that could be represented at same if statement

I didn't add any alien storage limit check when recovering live aliens, since it seems we don't have any limit enforcing right now.

Also, I guess that to fix equipment issue reported in #1333, similar changes must be done but regarding item loot instead.