### PR TITLE
Move github builder to ubuntu 24.04 and gcc-14

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -12,7 +12,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
 
     steps:
     - uses: actions/checkout@v2
@@ -34,7 +34,13 @@ jobs:
       run: sudo apt-get update
 
     - name: Install dependencies
-      run: sudo apt-get install libsdl2-dev cmake build-essential git libunwind8-dev libboost-locale-dev libboost-filesystem-dev libboost-program-options-dev qtbase5-dev libvorbis-dev ninja-build g++-14
+      run: sudo apt-get install libsdl2-dev cmake build-essential git libunwind8-dev libboost-locale-dev libboost-filesystem-dev libboost-program-options-dev qtbase5-dev libvorbis-dev ninja-build 
+
+    - name: Install gcc-14
+      run: sudo apt install gcc-14 g++-14
+
+    - name: GCC 14 version check
+      run: echo "GCC-14:"; which gcc-14;gcc-14 --version;
 
     - name: Configure CMake
       # Use a bash shell so we can use the same syntax for environment variable


### PR DESCRIPTION
We were using gcc-13 but that seems to have been removed from the 22.04 image that "ubuntu-latest" actually gave us.

May as well move to gcc-14 at the same time.