### PR TITLE
Recovering aliens and item loot after base defense mission

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3216,22 +3216,22 @@ void Battle::exitBattle(GameState &state)
 			auto &lootList = *std::get<1>(lootType);
 			auto &inventoryEquipment = *std::get<2>(lootType);
 
-			if (isBaseDefenseWithStorage(state, facilityTypeEnum))
+			if (!isBaseDefenseWithStorage(state, facilityTypeEnum))
+				continue;
+
+			std::list<StateRef<AEquipmentType>> lootToRemove = {};
+
+			for (const auto &loot : lootList)
 			{
-				std::list<StateRef<AEquipmentType>> lootToRemove = {};
+				if (loot.second > 0)
+					inventoryEquipment[loot.first.id] += loot.second;
 
-				for (const auto &loot : lootList)
-				{
-					if (loot.second > 0)
-						inventoryEquipment[loot.first.id] += loot.second;
+				lootToRemove.push_back(loot.first);
+			}
 
-					lootToRemove.push_back(loot.first);
-				}
-
-				for (const auto &loot : lootToRemove)
-				{
-					lootList.erase(loot);
-				}
+			for (const auto &loot : lootToRemove)
+			{
+				lootList.erase(loot);
 			}
 		}
 	}

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3199,232 +3199,238 @@ void Battle::exitBattle(GameState &state)
 	}
 
 	// Base defense missions only check for vehicles if no storage is available
+	// Items saved in this condition must NOT be saved again into vehicles!
 	if (state.current_battle->mission_type == Battle::MissionType::BaseDefense)
 	{
 		const auto defendedBase = getCurrentDefendedBase(state);
 
-		if (isBaseDefenseWithStorage(state, FacilityType::Capacity::Stores))
+		const auto lootTypeList = {
+		    std::tuple(FacilityType::Capacity::Stores, &state.current_battle->cargoLoot,
+		               &defendedBase->inventoryAgentEquipment),
+		    std::tuple(FacilityType::Capacity::Aliens, &state.current_battle->bioLoot,
+		               &defendedBase->inventoryBioEquipment)};
+
+		for (const auto &lootType : lootTypeList)
 		{
-			for (const auto &cargo : state.current_battle->cargoLoot)
+			const auto facilityTypeEnum = std::get<0>(lootType);
+			auto &lootList = *std::get<1>(lootType);
+			auto &inventoryEquipment = *std::get<2>(lootType);
+
+			if (isBaseDefenseWithStorage(state, facilityTypeEnum))
 			{
-				if (cargo.second == 0)
-					continue;
+				std::list<StateRef<AEquipmentType>> lootToRemove = {};
 
-				defendedBase->inventoryAgentEquipment[cargo.first.id] += cargo.second;
-			}
-		}
+				for (const auto &loot : lootList)
+				{
+					if (loot.second > 0)
+						inventoryEquipment[loot.first.id] += loot.second;
 
-		if (isBaseDefenseWithStorage(state, FacilityType::Capacity::Aliens))
-		{
-			for (const auto &bio : state.current_battle->bioLoot)
-			{
-				if (bio.second == 0)
-					continue;
+					lootToRemove.push_back(loot.first);
+				}
 
-				defendedBase->inventoryBioEquipment[bio.first.id] += bio.second;
+				for (const auto &loot : lootToRemove)
+				{
+					lootList.erase(loot);
+				}
 			}
 		}
 	}
-	else
+
+	// Load cargo/bio into vehicles
+	if (!playerVehicles.empty())
 	{
-		// Load cargo/bio into vehicles
-		if (!playerVehicles.empty())
+		// Go through every vehicle loot position
+		// Try to load into every vehicle until amount remaining is zero
+		std::list<StateRef<VEquipmentType>> vehicleLootToRemove;
+		for (auto &e : vehicleLoot)
 		{
-			// Go through every vehicle loot position
-			// Try to load into every vehicle until amount remaining is zero
-			std::list<StateRef<VEquipmentType>> vehicleLootToRemove;
-			for (auto &e : vehicleLoot)
+			for (auto &v : playerVehicles)
 			{
-				for (auto &v : playerVehicles)
+				if (v->getMaxCargo() == 0)
 				{
-					if (v->getMaxCargo() == 0)
-					{
-						continue;
-					}
-					if (e.second == 0)
-					{
-						continue;
-					}
-					int maxAmount = config().getBool("OpenApoc.NewFeature.EnforceCargoLimits")
-					                    ? std::min(e.second, (v->getMaxCargo() - v->getCargo()) /
-					                                             e.first->store_space)
-					                    : e.second;
-					if (maxAmount > 0)
-					{
-						e.second -= maxAmount;
-						int price = 0;
-						v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
-						                      v->homeBuilding);
-						returningVehicles.insert(v);
-					}
+					continue;
 				}
 				if (e.second == 0)
 				{
-					vehicleLootToRemove.push_back(e.first);
+					continue;
+				}
+				int maxAmount = config().getBool("OpenApoc.NewFeature.EnforceCargoLimits")
+				                    ? std::min(e.second, (v->getMaxCargo() - v->getCargo()) /
+				                                             e.first->store_space)
+				                    : e.second;
+				if (maxAmount > 0)
+				{
+					e.second -= maxAmount;
+					int price = 0;
+					v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
+					                      v->homeBuilding);
+					returningVehicles.insert(v);
 				}
 			}
-			// Remove stored loot
-			for (auto &e : vehicleLootToRemove)
+			if (e.second == 0)
 			{
-				vehicleLoot.erase(e);
+				vehicleLootToRemove.push_back(e.first);
 			}
-			// Put remainder on first vehicle
-			for (auto &e : vehicleLoot)
+		}
+		// Remove stored loot
+		for (auto &e : vehicleLootToRemove)
+		{
+			vehicleLoot.erase(e);
+		}
+		// Put remainder on first vehicle
+		for (auto &e : vehicleLoot)
+		{
+			for (auto &v : playerVehicles)
 			{
-				for (auto &v : playerVehicles)
+				if (v->getMaxCargo() == 0)
 				{
-					if (v->getMaxCargo() == 0)
-					{
-						continue;
-					}
-					int maxAmount = e.second;
-					if (maxAmount > 0)
-					{
-						e.second -= maxAmount;
-						int price = 0;
-						v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
-						                      v->homeBuilding);
-						returningVehicles.insert(v);
-					}
+					continue;
 				}
-			}
-			// Go through every loot position
-			// Try to load into every vehicle until amount remaining is zero
-			std::list<StateRef<AEquipmentType>> cargoLootToRemove;
-			for (auto &e : state.current_battle->cargoLoot)
-			{
-				for (auto &v : playerVehicles)
+				int maxAmount = e.second;
+				if (maxAmount > 0)
 				{
-					if (v->getMaxCargo() == 0)
-					{
-						continue;
-					}
-					if (e.second == 0)
-					{
-						continue;
-					}
-					int divisor =
-					    e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1;
-					int maxAmount = config().getBool("OpenApoc.NewFeature.EnforceCargoLimits")
-					                    ? std::min(e.second, (v->getMaxCargo() - v->getCargo()) /
-					                                             e.first->store_space * divisor)
-					                    : e.second;
-					if (maxAmount > 0)
-					{
-						e.second -= maxAmount;
-						int price = 0;
-						v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
-						                      v->homeBuilding);
-						returningVehicles.insert(v);
-					}
-				}
-				if (e.second == 0)
-				{
-					cargoLootToRemove.push_back(e.first);
-				}
-			}
-			// Remove stored loot
-			for (auto &e : cargoLootToRemove)
-			{
-				state.current_battle->cargoLoot.erase(e);
-			}
-			// Put remainder on first vehicle
-			for (auto &e : state.current_battle->cargoLoot)
-			{
-				for (auto &v : playerVehicles)
-				{
-					if (v->getMaxCargo() == 0)
-					{
-						continue;
-					}
-					int maxAmount = e.second;
-					if (maxAmount > 0)
-					{
-						e.second -= maxAmount;
-						int price = 0;
-						v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
-						                      v->homeBuilding);
-						returningVehicles.insert(v);
-					}
-				}
-			}
-			// Go through every bio loot position
-			// Try to load into every vehicle until amount remaining is zero
-			std::list<StateRef<AEquipmentType>> bioLootToRemove;
-			for (auto &e : state.current_battle->bioLoot)
-			{
-				for (auto &v : playerVehicles)
-				{
-					if (v->getMaxBio() == 0)
-					{
-						continue;
-					}
-					if (e.second == 0)
-					{
-						continue;
-					}
-					int divisor =
-					    e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1;
-					int maxAmount = config().getBool("OpenApoc.NewFeature.EnforceCargoLimits")
-					                    ? std::min(e.second, (v->getMaxBio() - v->getBio()) /
-					                                             e.first->store_space * divisor)
-					                    : e.second;
-					if (maxAmount > 0)
-					{
-						e.second -= maxAmount;
-						int price = 0;
-						v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
-						                      v->homeBuilding);
-						returningVehicles.insert(v);
-					}
-				}
-				if (e.second == 0)
-				{
-					bioLootToRemove.push_back(e.first);
-				}
-			}
-			// Remove stored loot
-			for (auto &e : bioLootToRemove)
-			{
-				state.current_battle->bioLoot.erase(e);
-			}
-			// Put remainder on first vehicle
-			for (auto &e : state.current_battle->bioLoot)
-			{
-				for (auto &v : playerVehicles)
-				{
-					if (v->getMaxCargo() == 0)
-					{
-						continue;
-					}
-					int maxAmount = e.second;
-					if (maxAmount > 0)
-					{
-						e.second -= maxAmount;
-						int price = 0;
-						v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
-						                      v->homeBuilding);
-						returningVehicles.insert(v);
-					}
+					e.second -= maxAmount;
+					int price = 0;
+					v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
+					                      v->homeBuilding);
+					returningVehicles.insert(v);
 				}
 			}
 		}
-
-		// Give player vehicle a null cargo just so it comes back to base once
-		for (auto &v : playerVehicles)
+		// Go through every loot position
+		// Try to load into every vehicle until amount remaining is zero
+		std::list<StateRef<AEquipmentType>> cargoLootToRemove;
+		for (auto &e : state.current_battle->cargoLoot)
 		{
-			v->cargo.emplace_front(
-			    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,
-			    nullptr, v->homeBuilding);
-			if (v->city.id == "CITYMAP_HUMAN")
+			for (auto &v : playerVehicles)
 			{
-				v->setMission(state, VehicleMission::gotoBuilding(state, *v));
-				v->addMission(state, VehicleMission::offerService(state, *v), true);
+				if (v->getMaxCargo() == 0)
+				{
+					continue;
+				}
+				if (e.second == 0)
+				{
+					continue;
+				}
+				int divisor = e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1;
+				int maxAmount = config().getBool("OpenApoc.NewFeature.EnforceCargoLimits")
+				                    ? std::min(e.second, (v->getMaxCargo() - v->getCargo()) /
+				                                             e.first->store_space * divisor)
+				                    : e.second;
+				if (maxAmount > 0)
+				{
+					e.second -= maxAmount;
+					int price = 0;
+					v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
+					                      v->homeBuilding);
+					returningVehicles.insert(v);
+				}
 			}
-			else
+			if (e.second == 0)
 			{
-				v->setMission(state, VehicleMission::gotoPortal(state, *v));
+				cargoLootToRemove.push_back(e.first);
 			}
+		}
+		// Remove stored loot
+		for (auto &e : cargoLootToRemove)
+		{
+			state.current_battle->cargoLoot.erase(e);
+		}
+		// Put remainder on first vehicle
+		for (auto &e : state.current_battle->cargoLoot)
+		{
+			for (auto &v : playerVehicles)
+			{
+				if (v->getMaxCargo() == 0)
+				{
+					continue;
+				}
+				int maxAmount = e.second;
+				if (maxAmount > 0)
+				{
+					e.second -= maxAmount;
+					int price = 0;
+					v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
+					                      v->homeBuilding);
+					returningVehicles.insert(v);
+				}
+			}
+		}
+		// Go through every bio loot position
+		// Try to load into every vehicle until amount remaining is zero
+		std::list<StateRef<AEquipmentType>> bioLootToRemove;
+		for (auto &e : state.current_battle->bioLoot)
+		{
+			for (auto &v : playerVehicles)
+			{
+				if (v->getMaxBio() == 0)
+				{
+					continue;
+				}
+				if (e.second == 0)
+				{
+					continue;
+				}
+				int divisor = e.first->type == AEquipmentType::Type::Ammo ? e.first->max_ammo : 1;
+				int maxAmount = config().getBool("OpenApoc.NewFeature.EnforceCargoLimits")
+				                    ? std::min(e.second, (v->getMaxBio() - v->getBio()) /
+				                                             e.first->store_space * divisor)
+				                    : e.second;
+				if (maxAmount > 0)
+				{
+					e.second -= maxAmount;
+					int price = 0;
+					v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
+					                      v->homeBuilding);
+					returningVehicles.insert(v);
+				}
+			}
+			if (e.second == 0)
+			{
+				bioLootToRemove.push_back(e.first);
+			}
+		}
+		// Remove stored loot
+		for (auto &e : bioLootToRemove)
+		{
+			state.current_battle->bioLoot.erase(e);
+		}
+		// Put remainder on first vehicle
+		for (auto &e : state.current_battle->bioLoot)
+		{
+			for (auto &v : playerVehicles)
+			{
+				if (v->getMaxCargo() == 0)
+				{
+					continue;
+				}
+				int maxAmount = e.second;
+				if (maxAmount > 0)
+				{
+					e.second -= maxAmount;
+					int price = 0;
+					v->cargo.emplace_back(state, e.first, maxAmount, price, nullptr,
+					                      v->homeBuilding);
+					returningVehicles.insert(v);
+				}
+			}
+		}
+	}
+
+	// Give player vehicle a null cargo just so it comes back to base once
+	for (auto &v : playerVehicles)
+	{
+		v->cargo.emplace_front(
+		    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,
+		    nullptr, v->homeBuilding);
+		if (v->city.id == "CITYMAP_HUMAN")
+		{
+			v->setMission(state, VehicleMission::gotoBuilding(state, *v));
+			v->addMission(state, VehicleMission::offerService(state, *v), true);
+		}
+		else
+		{
+			v->setMission(state, VehicleMission::gotoPortal(state, *v));
 		}
 	}
 

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -353,7 +353,8 @@ class Battle : public std::enable_shared_from_this<Battle>
 	    bool ignoreAllUnits = false, float *cost = nullptr, float maxCost = 0.0f);
 
 	static sp<Base> getCurrentDefendedBase(GameState &state);
-	static bool isBaseDefenseWithAlienStorage(GameState &state);
+	static bool isBaseDefenseWithStorage(GameState &state,
+	                                     const FacilityType::Capacity capacityType);
 
   private:
 	void loadResources(GameState &state);


### PR DESCRIPTION
Fixes #1333, fixes #1422

For both alien and item loot:
- If mission is NOT base defense, then loot will be stored into vehicles
- If mission is base defense but NO storage available, again loot will be stored into vehicles
- If mission is base defense and storage is available, then loot will be stored straight into base storage

After adding a loot element into base, this loot will be removed from loot list, avoiding single loot element from being doubly added to both base and vehicle storage.

Also storage logic should be independent for each type. Example: if base defense mission has both live aliens and item loot, but only item storage available at base, then items should be stored into base, but aliens will be stored into vehicles if possible.