### PR TITLE
Removed default value for isResearched in VehicleSheet::display

### DIFF
--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -28,7 +28,13 @@ void VehicleSheet::display(sp<VehicleType> vehicleType)
 void VehicleSheet::display(sp<VEquipment> item)
 {
 	clear();
-	displayEquipImplementation(item, item->type);
+	displayEquipImplementation(item, item->type, item->type->research_dependency.satisfied());
+}
+
+void VehicleSheet::display(sp<VEquipmentType> itemType)
+{
+	clear();
+	displayEquipImplementation(nullptr, itemType, itemType->research_dependency.satisfied());
 }
 
 void VehicleSheet::display(sp<VEquipmentType> itemType, bool researched)
@@ -132,13 +138,14 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 	form->findControlTyped<Label>("LABEL_2_L")->setText(tr("Storage"));
 	form->findControlTyped<Label>("LABEL_2_R")->setText(format("%d", type->store_space));
 
+	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")->setText("");
+
 	if (!isResearched)
 	{
 		form->findControlTyped<Label>("ITEM_NAME")->setText(tr("Alien Artifact"));
 		return;
 	}
 
-	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")->setText("");
 	form->findControlTyped<Label>("ITEM_NAME")->setText(item ? item->type->name : type->name);
 
 	// Draw equipment stats

--- a/game/ui/general/vehiclesheet.h
+++ b/game/ui/general/vehiclesheet.h
@@ -20,14 +20,15 @@ class VehicleSheet
 	void display(sp<Vehicle> vehicle);
 	void display(sp<VehicleType> vehicleType);
 	void display(sp<VEquipment> item);
-	void display(sp<VEquipmentType> itemType, bool researched = true);
+	void display(sp<VEquipmentType> itemType);
+	void display(sp<VEquipmentType> itemType, const bool isResearched);
 	void clear();
 
   private:
 	void displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> vehicleType);
 
 	void displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> itemType,
-	                                const bool isResearched = true);
+	                                const bool isResearched);
 	void displayEngine(sp<VEquipment> item, sp<VEquipmentType> type);
 	void displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type);
 	void displayGeneral(sp<VEquipment> item, sp<VEquipmentType> type);


### PR DESCRIPTION
Partially fixes #1455

Now vehicle equipment will show "Alien Artifact" instead of name when equipment is not researched.
Also removed default value for `isResearched` parameter.

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/46a9a6e2-7222-4b82-95f5-be7581a8fee2)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/9599f64a-59a6-456d-9a33-34193c62c9eb)

Save used: [Unresearched Alien Artifacts.zip](https://github.com/OpenApoc/OpenApoc/files/15421891/Unresearched.Alien.Artifacts.zip)