### PR TITLE
Fix org tab showing incorrect relations with XCOM

### DIFF
--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3251,7 +3251,7 @@ void CityView::update()
 			        ? (Organisation::Relation)0
 			        : (Organisation::Relation)(state->current_city->cityViewOrgButtonIndex - 1);
 			if (state->current_city->cityViewOrgButtonIndex != 0 &&
-			    state->getPlayer()->isRelatedTo({state.get(), o.first}) != rel)
+			    o.second->isRelatedTo(state->getPlayer()) != rel)
 			{
 				continue;
 			}


### PR DESCRIPTION
Fixes #1453 

When displaying the org relations, they use wording implying the orgs relations with XCOM eg: "Allied with XCOM" or "Hostile to XCOM". This leads me to believe that the relation check should take place from the perspective of the org and not XCOM. In this fix, the code was checking XCOMs relation to the org and not the other way around. This led to an edge case where Megapol had a relation of **Allied** with XCOM, but XCOM had a relation of **Friendly** with Megapol. The check for displaying the orgs in the org tab checked from XCOMs perspective while the text at the bottom checked from the orgs perspective. Both now check from the org's point of view. Apologies for the confusing wording, this was a strange issue.

 - Should the relations between orgs and XCOM ever be different or is this another issue?