### PR TITLE
Fix red square rendering on research complete

### DIFF
--- a/game/ui/base/basestage.cpp
+++ b/game/ui/base/basestage.cpp
@@ -88,6 +88,7 @@ void BaseStage::begin()
 	}
 	textViewBase = form->findControlTyped<Label>("TEXT_BUTTON_BASE");
 	this->textViewBase->setVisible(false);
+	this->update();
 }
 
 void BaseStage::render()


### PR DESCRIPTION
Fixes #1444 

Inspired by conversations in #797. Admittedly I'm not exactly sure why this works, but it does. I'm updating the base screen form after the begin function since the base highlight box is part of that and not the research screen. 