### PR TITLE
Warning all weapon ammo types that needs to be researched before using

### DIFF
--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -32,6 +32,7 @@
 #include "game/ui/general/aequipmentsheet.h"
 #include "game/ui/general/agentsheet.h"
 #include "game/ui/general/messagebox.h"
+#include <boost/algorithm/string/join.hpp>
 
 namespace OpenApoc
 {
@@ -582,7 +583,10 @@ void AEquipScreen::handleItemPickup(Vec2<int> mousePos)
 		// Check if we're over any equipment in the list at the bottom
 		auto posWithinInventory = mousePos;
 		posWithinInventory.x += inventoryPage * inventoryControl->Size.x;
-		if (tryPickUpItem(posWithinInventory, &alienArtifact))
+
+		const auto tryPickUpItemResult = tryPickUpItem(posWithinInventory, &alienArtifact);
+
+		if (tryPickUpItemResult.second)
 		{
 			refreshInventoryItems();
 
@@ -595,10 +599,37 @@ void AEquipScreen::handleItemPickup(Vec2<int> mousePos)
 		}
 		else if (alienArtifact)
 		{
+			const auto &itemType = tryPickUpItemResult.first->type;
+
+			auto message = tr("You must research Alien technology before you can use it.");
+
+			if (itemType->type == AEquipmentType::Type::Weapon)
+			{
+				std::vector<UString> ammoTypeNameList = {};
+
+				for (const auto &ammoType : itemType->ammo_types)
+				{
+					ammoTypeNameList.push_back(ammoType->name);
+				}
+
+				// ammoTypeNameList = {"Ammo #A", "Ammo #B", "Ammo #C" };
+
+				if (ammoTypeNameList.size() == 1)
+				{
+					message =
+					    tr("You must research this weapon and its ammo before you can use it:") +
+					    " " + ammoTypeNameList[0] + ".";
+				}
+				else if (ammoTypeNameList.size() > 1)
+				{
+					message = tr("You must research this weapon and all its ammo types before you "
+					             "can use it:") +
+					          " " + boost::algorithm::join(ammoTypeNameList, ", ") + ".";
+				}
+			}
+
 			auto message_box =
-			    mksp<MessageBox>(tr("Alien Artifact"),
-			                     tr("You must research Alien technology before you can use it."),
-			                     MessageBox::ButtonOptions::Ok);
+			    mksp<MessageBox>(tr("Alien Artifact"), message, MessageBox::ButtonOptions::Ok);
 			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		}
 	}
@@ -1318,29 +1349,33 @@ bool AEquipScreen::tryPickUpItem(sp<Agent> agent, Vec2<int> slotPos, bool altern
 	return true;
 }
 
-bool AEquipScreen::tryPickUpItem(Vec2<int> inventoryPos, bool *alienArtifact)
+std::pair<sp<AEquipment>, bool> AEquipScreen::tryPickUpItem(Vec2<int> inventoryPos,
+                                                            bool *alienArtifact)
 {
-	for (auto &tuple : inventoryItems)
+	for (const auto &tuple : inventoryItems)
 	{
-		auto rect = std::get<0>(tuple);
+		auto &rect = std::get<0>(tuple);
+
 		if (rect.within(inventoryPos))
 		{
-			if (!std::get<2>(tuple)->type->canBeUsed(*state, state->getPlayer()) &&
-			    getMode() != Mode::Battle)
+			const auto &item = std::get<2>(tuple);
+
+			if (!item->type->canBeUsed(*state, state->getPlayer()) && getMode() != Mode::Battle)
 			{
 				if (alienArtifact)
 				{
 					*alienArtifact = true;
 				}
-				return false;
+				return {item, false};
 			}
 
-			pickUpItem(std::get<2>(tuple));
+			pickUpItem(item);
 			draggedEquipmentOffset = rect.p0 - inventoryPos;
-			return true;
+
+			return {item, true};
 		}
 	}
-	return false;
+	return {nullptr, false};
 }
 
 bool AEquipScreen::tryPickUpItem(const AEquipmentType &item)

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -616,15 +616,17 @@ void AEquipScreen::handleItemPickup(Vec2<int> mousePos)
 
 				if (ammoTypeNameList.size() == 1)
 				{
-					message =
-					    tr("You must research this weapon and its ammo before you can use it:") +
-					    " " + ammoTypeNameList[0] + ".";
+					message = format(
+					    "%s: %s.",
+					    tr("You must research this weapon and its ammo before you can use it"),
+					    ammoTypeNameList[0]);
 				}
 				else if (ammoTypeNameList.size() > 1)
 				{
-					message = tr("You must research this weapon and all its ammo types before you "
-					             "can use it:") +
-					          " " + boost::algorithm::join(ammoTypeNameList, ", ") + ".";
+					message = format("%s: %s.",
+					                 tr("You must research this weapon and all its ammo types "
+					                    "before you can use it"),
+					                 boost::algorithm::join(ammoTypeNameList, ", "));
 				}
 			}
 

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -612,8 +612,6 @@ void AEquipScreen::handleItemPickup(Vec2<int> mousePos)
 					ammoTypeNameList.push_back(ammoType->name);
 				}
 
-				// ammoTypeNameList = {"Ammo #A", "Ammo #B", "Ammo #C" };
-
 				if (ammoTypeNameList.size() == 1)
 				{
 					message = format(
@@ -1358,25 +1356,27 @@ std::pair<sp<AEquipment>, bool> AEquipScreen::tryPickUpItem(Vec2<int> inventoryP
 	{
 		auto &rect = std::get<0>(tuple);
 
-		if (rect.within(inventoryPos))
-		{
-			const auto &item = std::get<2>(tuple);
+		if (!rect.within(inventoryPos))
+			continue;
 
-			if (!item->type->canBeUsed(*state, state->getPlayer()) && getMode() != Mode::Battle)
+		const auto &item = std::get<2>(tuple);
+
+		if (!item->type->canBeUsed(*state, state->getPlayer()) && getMode() != Mode::Battle)
+		{
+			if (alienArtifact)
 			{
-				if (alienArtifact)
-				{
-					*alienArtifact = true;
-				}
-				return {item, false};
+				*alienArtifact = true;
 			}
 
-			pickUpItem(item);
-			draggedEquipmentOffset = rect.p0 - inventoryPos;
-
-			return {item, true};
+			return {item, false};
 		}
+
+		pickUpItem(item);
+		draggedEquipmentOffset = rect.p0 - inventoryPos;
+
+		return {item, true};
 	}
+
 	return {nullptr, false};
 }
 

--- a/game/ui/general/aequipscreen.h
+++ b/game/ui/general/aequipscreen.h
@@ -121,7 +121,8 @@ class AEquipScreen : public Stage
 	// if alternative and forced is set then only do alternative or none at all
 	bool tryPickUpItem(sp<Agent> agent, Vec2<int> slotPos, bool alternative,
 	                   bool *alienArtifact = nullptr, bool forced = false);
-	bool tryPickUpItem(Vec2<int> inventoryPos, bool *alienArtifact = nullptr);
+	std::pair<sp<AEquipment>, bool> tryPickUpItem(Vec2<int> inventoryPos,
+	                                              bool *alienArtifact = nullptr);
 	bool tryPickUpItem(const AEquipmentType &item);
 	void pickUpItem(sp<AEquipment> item);
 	bool tryPlaceItem(sp<Agent> agent, Vec2<int> slotPos, bool *insufficientTU = nullptr,


### PR DESCRIPTION
Following with #1455, game will now inform user all the ammo types that needs to be researched together with weapon before you can be able to use it.

Also updated `tryPickUpItem` to not only return pickup result but also which item was selected.

Example where Brainsucker Launcher is researched, but Brainsucker Pod is not:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/25f10d72-d5d2-414e-8aa9-dfb340707124)

Let's say that a weapon has multiple ammo types. Warn message will properly display list of ammo types that need to be researched:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/1fdc2b80-762d-4b22-a384-0dd0326a6793)

Items that are not weapon, or weapon with no ammo type will display default message. Example with Disruptor Gun:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/6b6e2f94-b47f-4f2b-82ff-42cf142bbddf)
