### PR TITLE
Using same iteration limit value for both preview and move order

### DIFF
--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -2054,7 +2054,7 @@ void BattleUnitMission::setPathTo(GameState &state, BattleUnit &u, Vec3<int> tar
 
 		auto path = state.current_battle->findShortestPath(
 		    u.goalPosition, target, BattleUnitTileHelper{map, u}, approachOnly, demandGiveWay,
-		    !blockedByMovingUnit);
+		    !blockedByMovingUnit, TileMap::MAX_ITERATION_LIMIT_DIRECT_FOR_BATTLE);
 
 		// Cancel movement if the closest path ends at the current position
 		if (path.size() == 1 && path.back() == Vec3<int>{u.position})

--- a/game/state/tilemap/tilemap.h
+++ b/game/state/tilemap/tilemap.h
@@ -85,6 +85,7 @@ class TileMap
 	std::vector<std::set<TileObject::Type>> layerMap;
 
   public:
+	const static int MAX_ITERATION_LIMIT_DIRECT_FOR_BATTLE = 1000;
 	const bool isTileInBounds(int x, int y, int z) const
 	{
 		if (x < 0 || x >= size.x)

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2368,9 +2368,9 @@ void BattleView::updatePathPreview()
 	// Get path
 	float maxCost =
 	    (float)lastSelectedUnit->agent->modified_stats.time_units * 2 / cost_multiplier_x_2;
-	pathPreview = map.findShortestPath(lastSelectedUnit->goalPosition, target, 1000,
-	                                   BattleUnitTileHelper{map, *lastSelectedUnit}, false, false,
-	                                   true, false, &cost, maxCost);
+	pathPreview = map.findShortestPath(
+	    lastSelectedUnit->goalPosition, target, TileMap::MAX_ITERATION_LIMIT_DIRECT_FOR_BATTLE,
+	    BattleUnitTileHelper{map, *lastSelectedUnit}, false, false, true, false, &cost, maxCost);
 	if (pathPreview.empty())
 	{
 		LogError("Empty path returned for path preview!?");


### PR DESCRIPTION
Like discussed in #1326, sometimes the path calculated in TU math display and the path actually taken by an agent are no the same.

Right now, when you hover a tilemap, `findShortestPath` is called passing parameter `iterationLimit` as 1000. But when calling same function but for move order, this parameter actually gets value of `distance * PATH_ITERATION_LIMIT_MULTIPLIER`.

This PR is setting this value for both cases as 1000, since the path for TU preview is actually the correct one.

Before fix: https://www.youtube.com/watch?v=AAjcc0clThY
After fix: https://www.youtube.com/watch?v=NX0mv26-N4E
Save used: [save_blocked conveyor belt.zip](https://github.com/OpenApoc/OpenApoc/files/14387145/save_blocked.conveyor.belt.zip)

Also 1000 is now a constant in `TileMap`.