### PR TITLE
Issue #1380: display credit labels in currency format

### DIFF
--- a/forms/label.cpp
+++ b/forms/label.cpp
@@ -85,11 +85,12 @@ void Label::setText(const UString &Text)
 {
 	if (text == Text)
 		return;
+
 	text = Text;
+
 	if (scroller)
-	{
 		scroller->setValue(0);
-	}
+
 	this->setDirty();
 }
 

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -114,9 +114,14 @@ GameState::~GameState()
 }
 
 // Just a handy shortcut since it's shown on every single screen
-UString GameState::getPlayerBalance() const
+UString GameState::getPlayerBalance(const bool formatAsCurrency) const
 {
-	return Strings::fromInteger(this->getPlayer()->balance);
+	auto playerBalance = Strings::fromInteger(this->getPlayer()->balance);
+
+	if (formatAsCurrency)
+		playerBalance = Strings::formatTextAsCurrency(playerBalance);
+
+	return playerBalance;
 }
 
 StateRef<Organisation> GameState::getOrganisation(const UString &orgID)

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -170,7 +170,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 
 	Xorshift128Plus<uint32_t> rng;
 
-	UString getPlayerBalance() const;
+	UString getPlayerBalance(const bool formatAsCurrency = true) const;
 	StateRef<Organisation> getOrganisation(const UString &orgID);
 	const StateRef<Organisation> &getPlayer() const;
 	StateRef<Organisation> getPlayer();

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -91,10 +91,11 @@ void BuyAndSellScreen::updateFormValues(bool queueHighlightUpdate)
 	TransactionScreen::updateFormValues(queueHighlightUpdate);
 
 	// Update money
-	int balance = state->getPlayer()->balance + moneyDelta;
-	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance));
+	const auto balance = state->getPlayer()->balance + moneyDelta;
+	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance, true));
 	form->findControlTyped<Label>("TEXT_FUNDS_DELTA")
-	    ->setText(format("%s%s", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
+	    ->setText(
+	        format("%s%s", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta, true)));
 }
 
 void BuyAndSellScreen::closeScreen()

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -335,10 +335,11 @@ void RecruitScreen::updateFormValues()
 	}
 
 	// Update money
-	int balance = state->getPlayer()->balance + moneyDelta;
-	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance));
+	const auto balance = state->getPlayer()->balance + moneyDelta;
+	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance, true));
 	form->findControlTyped<Label>("TEXT_FUNDS_DELTA")
-	    ->setText(format("%s%s", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
+	    ->setText(
+	        format("%s%s", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta, true)));
 
 	updateBaseHighlight();
 }

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -134,9 +134,25 @@ bool Strings::isFloat(const UStringView s)
 	return (endpos != u8str.c_str());
 }
 
-UString Strings::fromInteger(int i) { return format("%d", i); }
+UString Strings::fromInteger(int i, const bool formatAsCurrency)
+{
+	auto result = format("%d", i);
 
-UString Strings::fromFloat(float f) { return format("%f", f); }
+	if (formatAsCurrency)
+		result = formatTextAsCurrency(result);
+
+	return result;
+}
+
+UString Strings::fromFloat(float f, const bool formatAsCurrency)
+{
+	auto result = format("%f", f);
+
+	if (formatAsCurrency)
+		result = formatTextAsCurrency(result);
+
+	return result;
+}
 
 bool Strings::isWhiteSpace(char32_t c)
 {
@@ -144,6 +160,50 @@ bool Strings::isWhiteSpace(char32_t c)
 	return isspace(c) != 0;
 }
 
-UString Strings::fromU64(uint64_t i) { return format("%llu", i); }
+UString Strings::fromU64(uint64_t i, const bool formatAsCurrency)
+{
+	auto result = format("%llu", i);
+
+	if (formatAsCurrency)
+		result = formatTextAsCurrency(result);
+
+	return result;
+}
+
+UString Strings::formatTextAsCurrency(const UString &Text)
+{
+	try
+	{
+		const auto textLenght = Text.length();
+
+		if (!Text.empty() && textLenght <= 3)
+			return Text;
+
+		auto isNumber = true;
+
+		for (const auto &ch : Text)
+		{
+			if (!std::isdigit(ch) && ch != '.' && ch != ',')
+			{
+				isNumber = false;
+				break;
+			}
+		}
+
+		if (!isNumber)
+			return Text;
+
+		auto formattedText = Text; // copy text for formatting
+
+		for (auto x = textLenght - 3; x > 0; x -= 3)
+			formattedText.insert(x, ",");
+
+		return formattedText;
+	}
+	catch (const std::exception &err)
+	{
+		return Text;
+	}
+}
 
 }; // namespace OpenApoc

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -183,7 +183,8 @@ UString Strings::formatTextAsCurrency(const UString &Text)
 
 		for (const auto &ch : Text)
 		{
-			if (!std::isdigit(ch) && ch != '.' && ch != ',')
+			// Allowed chars in strings containing monetary values
+			if (!std::isdigit(ch) && ch != '.' && ch != ',' && ch != '-')
 			{
 				isNumber = false;
 				break;
@@ -195,8 +196,11 @@ UString Strings::formatTextAsCurrency(const UString &Text)
 
 		auto formattedText = Text; // copy text for formatting
 
-		for (auto x = textLenght - 3; x > 0; x -= 3)
-			formattedText.insert(x, ",");
+		for (auto i = textLenght - 1; i > 0; i--)
+		{
+			if ((textLenght - i) % 3 == 0 && formattedText[i - 1] != '-')
+				formattedText.insert(i, ",");
+		}
 
 		return formattedText;
 	}

--- a/library/strings.h
+++ b/library/strings.h
@@ -51,10 +51,12 @@ class Strings
 	[[nodiscard]] static int toInteger(const UStringView s);
 	[[nodiscard]] static uint8_t toU8(const UStringView s);
 	[[nodiscard]] static float toFloat(const UStringView s);
-	[[nodiscard]] static UString fromInteger(int i);
-	[[nodiscard]] static UString fromU64(uint64_t i);
-	[[nodiscard]] static UString fromFloat(float f);
+	[[nodiscard]] static UString fromInteger(int i, const bool formatAsCurrency = false);
+	[[nodiscard]] static UString fromU64(uint64_t i, const bool formatAsCurrency = false);
+	[[nodiscard]] static UString fromFloat(float f, const bool formatAsCurrency = false);
 	[[nodiscard]] static bool isWhiteSpace(char32_t c);
+
+	static UString formatTextAsCurrency(const UString &Text);
 };
 
 }; // namespace OpenApoc


### PR DESCRIPTION
Fixes #1380

- Updated `fromInteger`, `fromFloat` and `fromFloat` with optional parameter to return string with currency format
- Updated `GameState::getPlayerBalance` to return balance with currency format, turned on by default

Both credit and delta credit labels are updated to display with currency format.

I tried to use some other library to format string with currency mask but couldn't find a better alternative so I had to implement it manually. If someone find a more elegante solution please let me know, I can't believe C++ doesn't have something better for that.

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/386549c9-991e-497c-82c0-0d230258ac79)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/f4d5c415-b932-420c-9634-eac85af2b41d)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/6345c7b3-3047-483c-92a9-f8a194b6e7b1)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/b15204e3-50bd-41bc-b251-bf1a737e0857)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/d7a40d7c-4753-4634-a0b7-f01942145955)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/49fc7706-69ee-40b5-b118-25d4db66146f)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/a4993e7c-1acc-476d-b53b-c8d65d273d7a)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/2598eed9-b25f-4f72-8132-19e739f946db)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/06078c15-d289-45d7-8d11-bca4048eb3bb)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/5c5cf2e7-8f1b-4879-aab3-7ee6235411a7)

Next steps: add current format in other places such as "Cost to build" in base view and "Price" in buy/sell view.