### PR TITLE
Adding currency formatting to all label texts starting with dollar sign char

### DIFF
--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -456,11 +456,12 @@ void BaseScreen::eventOccurred(Event *e)
 		selText->setText(tr(dragFacility->name));
 		selGraphic->setImage(dragFacility->sprite);
 		statsLabels[0]->setText(tr("Cost to build"));
-		statsValues[0]->setText(format("$%d", dragFacility->buildCost));
+		statsValues[0]->setText(format("$%s", Strings::fromInteger(dragFacility->buildCost, true)));
 		statsLabels[1]->setText(tr("Days to build"));
 		statsValues[1]->setText(format("%d", dragFacility->buildTime));
 		statsLabels[2]->setText(tr("Maintenance cost"));
-		statsValues[2]->setText(format("$%d", dragFacility->weeklyCost));
+		statsValues[2]->setText(
+		    format("$%s", Strings::fromInteger(dragFacility->weeklyCost, true)));
 	}
 	else if (selFacility != nullptr)
 	{

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -254,7 +254,7 @@ void ResearchSelect::populateResearchList()
 		{
 			UString progress_text;
 			if (this->lab->type == ResearchTopic::Type::Engineering)
-				progress_text = format("$%d", t->cost);
+				progress_text = format("$%s", Strings::fromInteger(t->cost, true));
 			else
 				progress_text = tr("Complete");
 			auto progress_label =

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -40,7 +40,7 @@ void BaseBuyScreen::begin()
 	form->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 
 	auto text = form->findControlTyped<Label>("TEXT_PRICE");
-	text->setText(format(tr("This Building will cost $%d"), price));
+	text->setText(format(tr("This Building will cost $%s"), Strings::fromInteger(price, true)));
 
 	form->findControlTyped<Graphic>("GRAPHIC_MINIMAP")
 	    ->setImage(BaseGraphics::drawMinimap(state, *base->building));

--- a/game/ui/city/bribescreen.cpp
+++ b/game/ui/city/bribescreen.cpp
@@ -91,7 +91,7 @@ void BribeScreen::updateInfo()
  */
 UString BribeScreen::getOfferString(int itWillCost, const UString &newAttitude) const
 {
-	return format("%s %d  %s  %s", tr("It will cost: $"), itWillCost,
+	return format("%s %s  %s  %s", tr("It will cost: $"), Strings::fromInteger(itWillCost, true),
 	              tr("to improve relations to:"), newAttitude);
 }
 

--- a/game/ui/city/diplomatictreatyscreen.cpp
+++ b/game/ui/city/diplomatictreatyscreen.cpp
@@ -31,7 +31,7 @@ void DiplomaticTreatyScreen::begin()
 	labelOffer->setText(tr("We are unhappy with the recent activity of your organization and "
 	                       "request compensation to restore normal diplomatic relations. If you do "
 	                       "not comply your craft and Agents may be subject to hostile actions."));
-	labelBribe->setText(format("Pay: $ %d ?", bribeAmount));
+	labelBribe->setText(format("Pay: $ %s ?", Strings::fromInteger(bribeAmount, true)));
 }
 
 void DiplomaticTreatyScreen::pause() {}

--- a/game/ui/city/scorescreen.cpp
+++ b/game/ui/city/scorescreen.cpp
@@ -155,11 +155,16 @@ void ScoreScreen::setFinanceMode()
 		physicists *= getSalary(AgentType::Role::Physicist);
 		int agentsSalary = soldiers + biochemists + engineers + physicists;
 
-		formFinance->findControlTyped<Label>("AGENTS_W")->setText(format("$%d", soldiers));
-		formFinance->findControlTyped<Label>("BIOCHEMISTS_W")->setText(format("$%d", biochemists));
-		formFinance->findControlTyped<Label>("ENGINEERS_W")->setText(format("$%d", engineers));
-		formFinance->findControlTyped<Label>("PHYSICISTS_W")->setText(format("$%d", physicists));
-		formFinance->findControlTyped<Label>("TOTAL_W")->setText(format("$%d", agentsSalary));
+		formFinance->findControlTyped<Label>("AGENTS_W")
+		    ->setText(format("$%s", Strings::fromInteger(soldiers, true)));
+		formFinance->findControlTyped<Label>("BIOCHEMISTS_W")
+		    ->setText(format("$%s", Strings::fromInteger(biochemists, true)));
+		formFinance->findControlTyped<Label>("ENGINEERS_W")
+		    ->setText(format("$%s", Strings::fromInteger(engineers, true)));
+		formFinance->findControlTyped<Label>("PHYSICISTS_W")
+		    ->setText(format("$%s", Strings::fromInteger(physicists, true)));
+		formFinance->findControlTyped<Label>("TOTAL_W")->setText(
+		    format("$%s", Strings::fromInteger(agentsSalary, true)));
 
 		int basesCosts = 0;
 		for (auto &b : state->player_bases)
@@ -169,9 +174,10 @@ void ScoreScreen::setFinanceMode()
 				basesCosts += f->type->weeklyCost;
 			}
 		}
-		formFinance->findControlTyped<Label>("BASES_TOTAL_W")->setText(format("$%d", basesCosts));
+		formFinance->findControlTyped<Label>("BASES_TOTAL_W")
+		    ->setText(format("$%s", Strings::fromInteger(basesCosts, true)));
 		formFinance->findControlTyped<Label>("OVERHEADS_W")
-		    ->setText(format("$%d", agentsSalary + basesCosts));
+		    ->setText(format("$%s", Strings::fromInteger(agentsSalary + basesCosts, true)));
 
 		int balance = state->getPlayer()->balance;
 
@@ -183,10 +189,10 @@ void ScoreScreen::setFinanceMode()
 		}
 
 		formFinance->findControlTyped<Label>("INITIAL")->setText(
-		    format("%s $%d", tr("Initial funds>"), balance));
+		    format("%s $%s", tr("Initial funds>"), Strings::fromInteger(balance, true)));
 		formFinance->findControlTyped<Label>("REMAINING")
-		    ->setText(
-		        format("%s $%d", tr("Remaining funds>"), balance - agentsSalary - basesCosts));
+		    ->setText(format("%s $%s", tr("Remaining funds>"),
+		                     Strings::fromInteger(balance - agentsSalary - basesCosts, true)));
 	}
 
 	title->setText(tr("FINANCE"));

--- a/game/ui/city/weeklyfundingscreen.cpp
+++ b/game/ui/city/weeklyfundingscreen.cpp
@@ -107,12 +107,15 @@ void WeeklyFundingScreen::begin()
 		// Income adjustment is still based on base player funding, not current one
 		const int adjustment = (modifier == 0) ? 0 : player->income / modifier;
 
-		labelAdjustment->setText(format("%s $%d", tr("Funding adjustment>"), adjustment));
+		labelAdjustment->setText(
+		    format("%s $%s", tr("Funding adjustment>"), Strings::fromInteger(adjustment, true)));
 		labelNextWeekIncome->setText(
-		    format("%s $%d", tr("Income for next week>"), currentIncome + adjustment));
+		    format("%s $%s", tr("Income for next week>"),
+		           Strings::fromInteger(currentIncome + adjustment, true)));
 	}
 
-	labelCurrentIncome->setText(format("%s $%d", tr("Current income>"), currentIncome));
+	labelCurrentIncome->setText(
+	    format("%s $%s", tr("Current income>"), Strings::fromInteger(currentIncome, true)));
 	labelRatingDescription->setText(ratingDescription);
 }
 

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -644,7 +644,8 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 	// Price
 	if (price != 0 && (indexLeft == ECONOMY_IDX || indexRight == ECONOMY_IDX))
 	{
-		auto label = control->createChild<Label>(format("$%d", control->price), labelFont);
+		auto label = control->createChild<Label>(
+		    format("$%s", Strings::fromInteger(control->price, true)), labelFont);
 		label->Location = {290, 3};
 		label->Size = {47, 16};
 		label->TextHAlign = HorizontalAlignment::Right;

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -273,9 +273,11 @@ void UfopaediaCategoryView::setFormStats()
 					if (data_id != "ORG_ALIEN")
 					{
 						orgLabels[1]->setText(tr("Balance"));
-						orgValues[1]->setText(format("$%d", ref->balance));
+						orgValues[1]->setText(
+						    format("$%s", Strings::fromInteger(ref->balance, true)));
 						orgLabels[2]->setText(tr("Income"));
-						orgValues[2]->setText(format("$%d", ref->income));
+						orgValues[2]->setText(
+						    format("$%s", Strings::fromInteger(ref->income, true)));
 
 						if (ref != player)
 						{
@@ -504,11 +506,13 @@ void UfopaediaCategoryView::setFormStats()
 				{
 					StateRef<FacilityType> ref = {state.get(), data_id};
 					statsLabels[row]->setText(tr("Construction cost"));
-					statsValues[row++]->setText(format("$%d", ref->buildCost));
+					statsValues[row++]->setText(
+					    format("$%s", Strings::fromInteger(ref->buildCost, true)));
 					statsLabels[row]->setText(tr("Days to build"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->buildTime));
 					statsLabels[row]->setText(tr("Weekly cost"));
-					statsValues[row++]->setText(format("$%d", ref->weeklyCost));
+					statsValues[row++]->setText(
+					    format("$%s", Strings::fromInteger(ref->weeklyCost, true)));
 					if (ref->capacityAmount > 0)
 					{
 						statsLabels[row]->setText(tr("Capacity"));


### PR DESCRIPTION
Following #1467, now adding credit label formatting to all text fields where its content starts with '$' char

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/fa4f96e9-3f0f-481d-875f-1044cf21f2e2)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/b6f6fa9e-4cae-41bc-b93f-1f30efc339bf)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/96db340a-dd5a-46fa-9317-3f219ad8dccb)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/3a1417c3-de0b-4306-ad6e-e324c1d7d13e)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/8f844876-e59c-44e6-9f64-e9cc7f72d16e)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/4e5f1973-f1d0-470c-b264-db91f54a728f)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/b77fc8a2-16ab-408f-8e2f-3d81ff931461)