### PR TITLE
Showing weapon name when weapon is researched but not ammo type

### DIFF
--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -855,7 +855,24 @@ void AEquipScreen::selectAgent(sp<Agent> agent, bool inverse, bool additive)
 
 void AEquipScreen::displayItem(sp<AEquipment> item)
 {
-	bool researched = item->type->canBeUsed(*state, state->getPlayer());
+	StateRef<ResearchTopic> equipmentTopic;
+
+	for (auto &topic : item->type->research_dependency.topics)
+	{
+		if (topic->name == item->type->name)
+		{
+			equipmentTopic = topic;
+			break;
+		}
+	}
+
+	// If no research topic is found with same name as equipment, then we use "canBeUsed" function
+	// This is not the prefered method since it will consider not only specific topic but all child
+	// topics as well
+	const bool researched = equipmentTopic
+	                            ? equipmentTopic->man_hours_progress >= equipmentTopic->man_hours
+	                            : item->type->canBeUsed(*state, state->getPlayer());
+
 	AEquipmentSheet(formAgentItem).display(item, researched);
 	formAgentItem->setVisible(true);
 	formAgentStats->setVisible(false);

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -261,7 +261,21 @@ TransactionControl::createControl(GameState &state, StateRef<AEquipmentType> age
 	bool isBio = agentEquipmentType->bioStorage;
 	int price = 0;
 	int storeSpace = agentEquipmentType->store_space;
-	bool researched = isBio ? true : agentEquipmentType->research_dependency.satisfied();
+
+	StateRef<ResearchTopic> equipmentTopic;
+
+	for (auto &topic : agentEquipmentType->research_dependency.topics)
+	{
+		if (topic->name == agentEquipmentType->name)
+		{
+			equipmentTopic = topic;
+			break;
+		}
+	}
+
+	const bool researched =
+	    isBio || (equipmentTopic ? equipmentTopic->man_hours_progress >= equipmentTopic->man_hours
+	                             : agentEquipmentType->research_dependency.satisfied());
 
 	std::vector<int> initialStock;
 	bool hasStock = false;


### PR DESCRIPTION
When a weapon is researched, but not its ammo type, weapon name will be displayed, but game will comply about need to research ammo before using it.

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/decd347f-6033-408f-a45a-905e32609d27)

If weapon is not researched, it's still displayed as Alien Artifact

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/b1285843-3c25-4549-b0cf-206bc49126cc)

Same for Buy and Sell screen:

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/b5a7e266-24e5-44ac-9b58-d42cc7d43d4b)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/7940463d-793d-4efb-8647-b295decc7076)


Research topic will be searched by name, to check if it matches with weapon name. If no topic match is found, then code will use previously `item->type->canBeUsed` function - which is not the best case, since this will consider not only weapon research status but also ammo research status. 