### PR TITLE
Renaming property to "Max Samples" and adding "Storage" property at ufopaedia

### DIFF
--- a/data/languages/ufo_string.pot
+++ b/data/languages/ufo_string.pot
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string.pot
+++ b/data/languages/ufo_string.pot
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string_cs.po
+++ b/data/languages/ufo_string_cs.po
@@ -4450,7 +4450,7 @@ msgstr "Zásoba munice"
 msgid "Cargo"
 msgstr "Náklad"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Cizác. náklad"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_cs.po
+++ b/data/languages/ufo_string_cs.po
@@ -4450,7 +4450,7 @@ msgstr "Zásoba munice"
 msgid "Cargo"
 msgstr "Náklad"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Cizác. náklad"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_de_DE.po
+++ b/data/languages/ufo_string_de_DE.po
@@ -4449,7 +4449,7 @@ msgstr "Munitionskapazität"
 msgid "Cargo"
 msgstr "Fracht"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Fstglt. Aliens"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_de_DE.po
+++ b/data/languages/ufo_string_de_DE.po
@@ -4449,7 +4449,7 @@ msgstr "Munitionskapazität"
 msgid "Cargo"
 msgstr "Fracht"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Fstglt. Aliens"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_en_GB.po
+++ b/data/languages/ufo_string_en_GB.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string_en_GB.po
+++ b/data/languages/ufo_string_en_GB.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string_es.po
+++ b/data/languages/ufo_string_es.po
@@ -4449,7 +4449,7 @@ msgstr "Capacidad de Munición"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Alienígenas"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_es.po
+++ b/data/languages/ufo_string_es.po
@@ -4449,7 +4449,7 @@ msgstr "Capacidad de Munición"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Alienígenas"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_fr_FR.po
+++ b/data/languages/ufo_string_fr_FR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacité de munitions"
 msgid "Cargo"
 msgstr "Cargaison"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Aliens pris"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_fr_FR.po
+++ b/data/languages/ufo_string_fr_FR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacité de munitions"
 msgid "Cargo"
 msgstr "Cargaison"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Aliens pris"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_it.po
+++ b/data/languages/ufo_string_it.po
@@ -4450,7 +4450,7 @@ msgstr "Munizioni"
 msgid "Cargo"
 msgstr "Cargo"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Alieni cont."
 
 msgid "Jamming"

--- a/data/languages/ufo_string_it.po
+++ b/data/languages/ufo_string_it.po
@@ -4450,7 +4450,7 @@ msgstr "Munizioni"
 msgid "Cargo"
 msgstr "Cargo"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Alieni cont."
 
 msgid "Jamming"

--- a/data/languages/ufo_string_pl.po
+++ b/data/languages/ufo_string_pl.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string_pl.po
+++ b/data/languages/ufo_string_pl.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string_pt_BR.po
+++ b/data/languages/ufo_string_pt_BR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacidade p/ munição"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Alienígenas Aprisionados"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_pt_BR.po
+++ b/data/languages/ufo_string_pt_BR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacidade p/ munição"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Alienígenas Aprisionados"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_ru_RU.po
+++ b/data/languages/ufo_string_ru_RU.po
@@ -4455,7 +4455,7 @@ msgstr "Боезапас"
 msgid "Cargo"
 msgstr "Груз"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Пришельцев удерживается"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_ru_RU.po
+++ b/data/languages/ufo_string_ru_RU.po
@@ -4455,7 +4455,7 @@ msgstr "Боезапас"
 msgid "Cargo"
 msgstr "Груз"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Пришельцев удерживается"
 
 msgid "Jamming"

--- a/data/languages/ufo_string_uk.po
+++ b/data/languages/ufo_string_uk.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_string_uk.po
+++ b/data/languages/ufo_string_uk.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_cs.po
+++ b/data/languages/ufo_stringpo_cs.po
@@ -4452,7 +4452,7 @@ msgstr "Zásoba munice"
 msgid "Cargo"
 msgstr "Náklad"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Cizác. náklad"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_cs.po
+++ b/data/languages/ufo_stringpo_cs.po
@@ -4452,7 +4452,7 @@ msgstr "Zásoba munice"
 msgid "Cargo"
 msgstr "Náklad"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Cizác. náklad"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_de_DE.po
+++ b/data/languages/ufo_stringpo_de_DE.po
@@ -4449,7 +4449,7 @@ msgstr "Munitionskapazität"
 msgid "Cargo"
 msgstr "Fracht"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Fstglt. Aliens"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_de_DE.po
+++ b/data/languages/ufo_stringpo_de_DE.po
@@ -4449,7 +4449,7 @@ msgstr "Munitionskapazität"
 msgid "Cargo"
 msgstr "Fracht"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Fstglt. Aliens"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_en.po
+++ b/data/languages/ufo_stringpo_en.po
@@ -4448,8 +4448,8 @@ msgstr "Ammo capacity"
 msgid "Cargo"
 msgstr "Cargo"
 
-msgid "Max Lifeforms"
-msgstr "Max Lifeforms"
+msgid "Max Samples"
+msgstr "Max Samples"
 
 msgid "Jamming"
 msgstr "Jamming"

--- a/data/languages/ufo_stringpo_en.po
+++ b/data/languages/ufo_stringpo_en.po
@@ -4448,8 +4448,8 @@ msgstr "Ammo capacity"
 msgid "Cargo"
 msgstr "Cargo"
 
-msgid "Aliens Held"
-msgstr "Aliens Held"
+msgid "Max Lifeforms"
+msgstr "Max Lifeforms"
 
 msgid "Jamming"
 msgstr "Jamming"

--- a/data/languages/ufo_stringpo_en_GB.po
+++ b/data/languages/ufo_stringpo_en_GB.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_en_GB.po
+++ b/data/languages/ufo_stringpo_en_GB.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_es.po
+++ b/data/languages/ufo_stringpo_es.po
@@ -4450,7 +4450,7 @@ msgstr "Capacidad de Munición"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Alienígenas"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_es.po
+++ b/data/languages/ufo_stringpo_es.po
@@ -4450,7 +4450,7 @@ msgstr "Capacidad de Munición"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Alienígenas"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_et_EE.po
+++ b/data/languages/ufo_stringpo_et_EE.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_et_EE.po
+++ b/data/languages/ufo_stringpo_et_EE.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_fi.po
+++ b/data/languages/ufo_stringpo_fi.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_fi.po
+++ b/data/languages/ufo_stringpo_fi.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_fil_PH.po
+++ b/data/languages/ufo_stringpo_fil_PH.po
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_fil_PH.po
+++ b/data/languages/ufo_stringpo_fil_PH.po
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_fr_FR.po
+++ b/data/languages/ufo_stringpo_fr_FR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacité de munitions"
 msgid "Cargo"
 msgstr "Cargaison"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Aliens pris"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_fr_FR.po
+++ b/data/languages/ufo_stringpo_fr_FR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacité de munitions"
 msgid "Cargo"
 msgstr "Cargaison"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Aliens pris"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_hu_HU.po
+++ b/data/languages/ufo_stringpo_hu_HU.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_hu_HU.po
+++ b/data/languages/ufo_stringpo_hu_HU.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_it.po
+++ b/data/languages/ufo_stringpo_it.po
@@ -4450,7 +4450,7 @@ msgstr "Munizioni"
 msgid "Cargo"
 msgstr "Cargo"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Alieni cont."
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_it.po
+++ b/data/languages/ufo_stringpo_it.po
@@ -4450,7 +4450,7 @@ msgstr "Munizioni"
 msgid "Cargo"
 msgstr "Cargo"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Alieni cont."
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ja.po
+++ b/data/languages/ufo_stringpo_ja.po
@@ -4448,7 +4448,7 @@ msgstr "装弾数"
 msgid "Cargo"
 msgstr "貨物"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "捕獲中のエイリアン"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ja.po
+++ b/data/languages/ufo_stringpo_ja.po
@@ -4448,7 +4448,7 @@ msgstr "装弾数"
 msgid "Cargo"
 msgstr "貨物"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "捕獲中のエイリアン"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ja_JP.po
+++ b/data/languages/ufo_stringpo_ja_JP.po
@@ -4449,7 +4449,7 @@ msgstr "装弾数"
 msgid "Cargo"
 msgstr "貨物"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "捕獲中のエイリアン"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ja_JP.po
+++ b/data/languages/ufo_stringpo_ja_JP.po
@@ -4449,7 +4449,7 @@ msgstr "装弾数"
 msgid "Cargo"
 msgstr "貨物"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "捕獲中のエイリアン"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_lt.po
+++ b/data/languages/ufo_stringpo_lt.po
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_lt.po
+++ b/data/languages/ufo_stringpo_lt.po
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_nb_NO.po
+++ b/data/languages/ufo_stringpo_nb_NO.po
@@ -4449,7 +4449,7 @@ msgstr "Ammunisjonskapasitet"
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_nb_NO.po
+++ b/data/languages/ufo_stringpo_nb_NO.po
@@ -4449,7 +4449,7 @@ msgstr "Ammunisjonskapasitet"
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_pl.po
+++ b/data/languages/ufo_stringpo_pl.po
@@ -4454,7 +4454,7 @@ msgstr "Pojemność amunicji"
 msgid "Cargo"
 msgstr "Ładunek"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Pod kontrolą obcych"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_pl.po
+++ b/data/languages/ufo_stringpo_pl.po
@@ -4454,7 +4454,7 @@ msgstr "Pojemność amunicji"
 msgid "Cargo"
 msgstr "Ładunek"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Pod kontrolą obcych"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_pt_BR.po
+++ b/data/languages/ufo_stringpo_pt_BR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacidade p/ munição"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Alienígenas Aprisionados"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_pt_BR.po
+++ b/data/languages/ufo_stringpo_pt_BR.po
@@ -4450,7 +4450,7 @@ msgstr "Capacidade p/ munição"
 msgid "Cargo"
 msgstr "Carga"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Alienígenas Aprisionados"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_pt_PT.po
+++ b/data/languages/ufo_stringpo_pt_PT.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_pt_PT.po
+++ b/data/languages/ufo_stringpo_pt_PT.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ro_RO.po
+++ b/data/languages/ufo_stringpo_ro_RO.po
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ro_RO.po
+++ b/data/languages/ufo_stringpo_ro_RO.po
@@ -4449,7 +4449,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ru_RU.po
+++ b/data/languages/ufo_stringpo_ru_RU.po
@@ -4453,7 +4453,7 @@ msgstr "Боезапас"
 msgid "Cargo"
 msgstr "Груз"
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr "Пришельцев удерживается"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_ru_RU.po
+++ b/data/languages/ufo_stringpo_ru_RU.po
@@ -4453,7 +4453,7 @@ msgstr "Боезапас"
 msgid "Cargo"
 msgstr "Груз"
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr "Пришельцев удерживается"
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_sk.po
+++ b/data/languages/ufo_stringpo_sk.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_sk.po
+++ b/data/languages/ufo_stringpo_sk.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_sl_SI.po
+++ b/data/languages/ufo_stringpo_sl_SI.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_sl_SI.po
+++ b/data/languages/ufo_stringpo_sl_SI.po
@@ -4450,7 +4450,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_tr_TR.po
+++ b/data/languages/ufo_stringpo_tr_TR.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_tr_TR.po
+++ b/data/languages/ufo_stringpo_tr_TR.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_uk.po
+++ b/data/languages/ufo_stringpo_uk.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_uk.po
+++ b/data/languages/ufo_stringpo_uk.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_zh_TW.po
+++ b/data/languages/ufo_stringpo_zh_TW.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Max Lifeforms"
+msgid "Max Samples"
 msgstr ""
 
 msgid "Jamming"

--- a/data/languages/ufo_stringpo_zh_TW.po
+++ b/data/languages/ufo_stringpo_zh_TW.po
@@ -4448,7 +4448,7 @@ msgstr ""
 msgid "Cargo"
 msgstr ""
 
-msgid "Aliens Held"
+msgid "Max Lifeforms"
 msgstr ""
 
 msgid "Jamming"

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -219,8 +219,7 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 	}
 	if (type->alien_space)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
-		    ->setText(tr("Max Lifeforms"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Max Samples"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->alien_space));
 		statsCount++;

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -219,7 +219,8 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 	}
 	if (type->alien_space)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Aliens Held"));
+		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))
+		    ->setText(tr("Max Lifeforms"));
 		form->findControlTyped<Label>(format("LABEL_%d_R", statsCount))
 		    ->setText(format("%d", type->alien_space));
 		statsCount++;

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -415,7 +415,7 @@ void UfopaediaCategoryView::setFormStats()
 							}
 							if (ref->alien_space > 0)
 							{
-								statsLabels[row]->setText(tr("Aliens Held"));
+								statsLabels[row]->setText(tr("Max Lifeforms"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->alien_space));
 							}
 							if (ref->missile_jamming > 0)

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -365,6 +365,8 @@ void UfopaediaCategoryView::setFormStats()
 					statsLabels[row]->setText(tr("Size"));
 					statsValues[row++]->setText(
 					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
+					statsLabels[row]->setText(tr("Storage"));
+					statsValues[row++]->setText(Strings::fromInteger(ref->store_space));
 					switch (ref->type)
 					{
 						case EquipmentSlotType::VehicleEngine:
@@ -415,7 +417,7 @@ void UfopaediaCategoryView::setFormStats()
 							}
 							if (ref->alien_space > 0)
 							{
-								statsLabels[row]->setText(tr("Max Lifeforms"));
+								statsLabels[row]->setText(tr("Max Samples"));
 								statsValues[row++]->setText(Strings::fromInteger(ref->alien_space));
 							}
 							if (ref->missile_jamming > 0)
@@ -451,6 +453,8 @@ void UfopaediaCategoryView::setFormStats()
 					statsLabels[row]->setText(tr("Size"));
 					statsValues[row++]->setText(
 					    format("%dx%d", ref->equipscreen_size.x, ref->equipscreen_size.y));
+					statsLabels[row]->setText(tr("Storage"));
+					statsValues[row++]->setText(Strings::fromInteger(ref->store_space));
 					if (ref->type == AEquipmentType::Type::Ammo ||
 					    (ref->type == AEquipmentType::Type::Weapon && ref->ammo_types.empty()))
 					{


### PR DESCRIPTION
Fixes #1470

1. Renamed label "Aliens Held" to "Max Samples" in Bio-Transport Module.

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/7ba01216-5ee2-4a2b-b3f9-efc5ad821c52)

2. Added label "Storage" at ufopaedia for agent and vehicle equipments

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/f0b443dd-7d7d-4358-969e-0eb2bf405353)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/cf32153b-3ce9-4f72-8215-c9c7098ab07e)
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/0ac979a8-cac0-4295-95db-f7e87e66135c)

Obs.: besides "Max Samples", the label "Max Lifeforms" was also suggested, but its length is greater than what view can properly display:

![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/176e01fc-e11a-4981-bed5-bd840ab25d47)