### PR TITLE
Refactored check if equipment type is researched

### DIFF
--- a/game/state/rules/aequipmenttype.cpp
+++ b/game/state/rules/aequipmenttype.cpp
@@ -127,6 +127,26 @@ bool AEquipmentType::canBeUsed(GameState &state, StateRef<Organisation> owner) c
 	return true;
 }
 
+bool AEquipmentType::isResearched() const
+{
+	StateRef<ResearchTopic> equipmentTopic;
+
+	for (auto &dependencyTopic : research_dependency.topics)
+	{
+		if (dependencyTopic->name == name)
+		{
+			equipmentTopic = dependencyTopic;
+			break;
+		}
+	}
+
+	// If no research topic is found with same name as type, then we use "satisfied()" instead
+	// This is not the prefered method since it will consider not only specific topic but all
+	// children topics as well
+
+	return equipmentTopic ? equipmentTopic->isComplete() : research_dependency.satisfied();
+}
+
 float AEquipmentType::getRoundsPerSecond() const
 {
 	return (float)TICKS_PER_SECOND / (float)fire_delay;

--- a/game/state/rules/aequipmenttype.h
+++ b/game/state/rules/aequipmenttype.h
@@ -176,6 +176,17 @@ class AEquipmentType : public StateObject<AEquipmentType>
 	std::map<StateRef<AgentType>, int> spawnList;
 
 	bool canBeUsed(GameState &state, StateRef<Organisation> user) const;
+
+	/// <summary>
+	/// Get if type is researched.
+	///
+	/// By default it will search through dependency topics via topic name.
+	/// If no topic with same name is found, then method will call "research_dependency.satisfied()"
+	/// instead, which unfortunately considers not only topic research, but children research status
+	/// as well.
+	/// </summary>
+	/// <returns>Returns if type is already researched.</returns>
+	bool isResearched() const;
 };
 
 class EquipmentSet : public StateObject<EquipmentSet>

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -855,23 +855,7 @@ void AEquipScreen::selectAgent(sp<Agent> agent, bool inverse, bool additive)
 
 void AEquipScreen::displayItem(sp<AEquipment> item)
 {
-	StateRef<ResearchTopic> equipmentTopic;
-
-	for (auto &topic : item->type->research_dependency.topics)
-	{
-		if (topic->name == item->type->name)
-		{
-			equipmentTopic = topic;
-			break;
-		}
-	}
-
-	// If no research topic is found with same name as equipment, then we use "canBeUsed" function
-	// This is not the prefered method since it will consider not only specific topic but all child
-	// topics as well
-	const bool researched = equipmentTopic
-	                            ? equipmentTopic->man_hours_progress >= equipmentTopic->man_hours
-	                            : item->type->canBeUsed(*state, state->getPlayer());
+	const bool researched = item->type->isResearched();
 
 	AEquipmentSheet(formAgentItem).display(item, researched);
 	formAgentItem->setVisible(true);

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -262,20 +262,7 @@ TransactionControl::createControl(GameState &state, StateRef<AEquipmentType> age
 	int price = 0;
 	int storeSpace = agentEquipmentType->store_space;
 
-	StateRef<ResearchTopic> equipmentTopic;
-
-	for (auto &topic : agentEquipmentType->research_dependency.topics)
-	{
-		if (topic->name == agentEquipmentType->name)
-		{
-			equipmentTopic = topic;
-			break;
-		}
-	}
-
-	const bool researched =
-	    isBio || (equipmentTopic ? equipmentTopic->man_hours_progress >= equipmentTopic->man_hours
-	                             : agentEquipmentType->research_dependency.satisfied());
+	const bool researched = isBio || agentEquipmentType->isResearched();
 
 	std::vector<int> initialStock;
 	bool hasStock = false;


### PR DESCRIPTION
Refactoring changes made at #1472 to unify logic into single function.
Now `AEquipmentType::isResearched()` is being used to check if equipment type is already researched.