### PR TITLE
Consider nearby vehicles for score math related to loot pickup

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2687,7 +2687,6 @@ void Battle::finishBattle(GameState &state)
 		const auto baseDefenseWithAlienStorage =
 		    isBaseDefenseWithStorage(state, FacilityType::Capacity::Aliens);
 
-		// Compile list of player vehicles
 		const auto playerVehicles = Battle::getPlayerVehicles(state);
 		const auto playerHasCraftBioStorage = Battle::isBioCarrierPresent(playerVehicles);
 
@@ -3027,6 +3026,7 @@ void Battle::exitBattle(GameState &state)
 
 	// LOOT!
 
+	// Compile list of player vehicles
 	const auto playerVehicles = Battle::getPlayerVehicles(state);
 	std::set<StateRef<Vehicle>> returningVehicles;
 

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2684,13 +2684,13 @@ void Battle::finishBattle(GameState &state)
 	// - give him alien remains
 	if (state.current_battle->playerWon && !state.current_battle->winnerHasRetreated)
 	{
-		const auto playerHasBaseAlienStorage =
+		const auto baseDefenseWithAlienStorage =
 		    isBaseDefenseWithStorage(state, FacilityType::Capacity::Aliens);
 
-		const auto playerHasCraftBioStorage = state.current_battle->player_craft &&
-		                                      state.current_battle->player_craft->getMaxBio() > 0;
+		const auto playerVehicles = Battle::getPlayerVehicles(state);
+		const auto playerHasCraftBioStorage = Battle::isBioCarrierPresent(playerVehicles);
 
-		const auto playerHasAlienStorage = playerHasCraftBioStorage || playerHasBaseAlienStorage;
+		const auto playerHasAlienStorage = playerHasCraftBioStorage || baseDefenseWithAlienStorage;
 
 		// Live alien loot
 		for (auto &u : liveAliens)
@@ -2702,15 +2702,14 @@ void Battle::finishBattle(GameState &state)
 					state.current_battle->score.liveAlienCaptured +=
 					    u->agent->type->liveSpeciesItem->score;
 				}
+
 				if (u->agent->type->liveSpeciesItem->bioStorage)
 				{
-					state.current_battle->bioLoot[u->agent->type->liveSpeciesItem] =
-					    state.current_battle->bioLoot[u->agent->type->liveSpeciesItem] + 1;
+					state.current_battle->bioLoot[u->agent->type->liveSpeciesItem] += 1;
 				}
 				else
 				{
-					state.current_battle->cargoLoot[u->agent->type->liveSpeciesItem] =
-					    state.current_battle->cargoLoot[u->agent->type->liveSpeciesItem] + 1;
+					state.current_battle->cargoLoot[u->agent->type->liveSpeciesItem] += 1;
 				}
 			}
 			else
@@ -2726,13 +2725,11 @@ void Battle::finishBattle(GameState &state)
 			{
 				if (u->agent->type->deadSpeciesItem->bioStorage)
 				{
-					state.current_battle->bioLoot[u->agent->type->deadSpeciesItem] =
-					    state.current_battle->bioLoot[u->agent->type->deadSpeciesItem] + 1;
+					state.current_battle->bioLoot[u->agent->type->deadSpeciesItem] += 1;
 				}
 				else
 				{
-					state.current_battle->cargoLoot[u->agent->type->deadSpeciesItem] =
-					    state.current_battle->cargoLoot[u->agent->type->deadSpeciesItem] + 1;
+					state.current_battle->cargoLoot[u->agent->type->deadSpeciesItem] += 1;
 				}
 			}
 		}
@@ -2775,8 +2772,7 @@ void Battle::finishBattle(GameState &state)
 			{
 				for (auto &a : liveAliens)
 				{
-					location->current_crew[a->agent->type] =
-					    location->current_crew[a->agent->type] + 1;
+					location->current_crew[a->agent->type] += 1;
 				}
 			}
 			else
@@ -2794,15 +2790,15 @@ void Battle::finishBattle(GameState &state)
 		{
 			state.current_battle->score.equipmentCaptured += e->type->score;
 		}
+
 		int mult = e->type->type == AEquipmentType::Type::Ammo ? e->ammo : 1;
 		if (e->type->bioStorage)
 		{
-			state.current_battle->bioLoot[e->type] = state.current_battle->bioLoot[e->type] + mult;
+			state.current_battle->bioLoot[e->type] += mult;
 		}
 		else
 		{
-			state.current_battle->cargoLoot[e->type] =
-			    state.current_battle->cargoLoot[e->type] + mult;
+			state.current_battle->cargoLoot[e->type] += mult;
 		}
 	}
 	// Regardless of what happened, retreated aliens go to a nearby building
@@ -2844,8 +2840,7 @@ void Battle::finishBattle(GameState &state)
 		}
 		for (auto &a : retreatedAliens)
 		{
-			closestBuilding->current_crew[a->agent->type] =
-			    closestBuilding->current_crew[a->agent->type] + 1;
+			closestBuilding->current_crew[a->agent->type] += 1;
 		}
 	}
 	// Remove dead player agents and all enemy agents from the game and from vehicles
@@ -3031,50 +3026,12 @@ void Battle::exitBattle(GameState &state)
 
 	// LOOT!
 
-	// Compile list of player vehicles
-	std::list<StateRef<Vehicle>> playerVehicles;
+	auto playerVehicles = Battle::getPlayerVehicles(state);
 	std::set<StateRef<Vehicle>> returningVehicles;
+
 	if (state.current_battle->player_craft)
 	{
-		playerVehicles.push_back(state.current_battle->player_craft);
 		returningVehicles.insert(state.current_battle->player_craft);
-	}
-	if (config().getBool("OpenApoc.NewFeature.AllowNearbyVehicleLootPickup"))
-	{
-		if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
-		{
-			StateRef<City> city;
-			StateRef<Vehicle> location = {&state, state.current_battle->mission_location_id};
-			city = location->city;
-
-			for (auto &v : state.vehicles)
-			{
-				// Check every player owned vehicle located in city
-				if (v.second->owner != player || v.second->city != city ||
-				    v.second->currentBuilding
-				    // Player's vehicle was already added and has priority
-				    || v.first == state.current_battle->player_craft.id)
-				{
-					continue;
-				}
-				if (glm::length(location->position - v.second->position) < VEHICLE_NEARBY_THRESHOLD)
-				{
-					playerVehicles.emplace_back(&state, v.first);
-				}
-			}
-		}
-		else
-		{
-			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
-			for (auto &v : location->currentVehicles)
-			{
-				// Player's vehicle was already added and has priority
-				if (v->owner == player && v != state.current_battle->player_craft)
-				{
-					playerVehicles.push_back(v);
-				}
-			}
-		}
 	}
 
 	// List of vehicle loot
@@ -3111,28 +3068,14 @@ void Battle::exitBattle(GameState &state)
 	// If player has vehicle with bio capacity then all bio loot goes to leftover loot
 	// This is regardless of "enforce limits" which only makes us enforce it
 	// on vehicles that have capacity in the first place
-	auto cargoCarrierPresent = false;
-	auto bioCarrierPresent = false;
-	const auto playerHasBaseItemStorage =
+	const auto cargoCarrierPresent = Battle::isCargoCarrierPresent(playerVehicles);
+	const auto bioCarrierPresent = Battle::isBioCarrierPresent(playerVehicles);
+	const auto baseDefenseWithItemStorage =
 	    isBaseDefenseWithStorage(state, FacilityType::Capacity::Stores);
-	const auto playerHasBaseAlienStorage =
+	const auto baseDefenseWithAlienStorage =
 	    isBaseDefenseWithStorage(state, FacilityType::Capacity::Aliens);
-	for (auto &v : playerVehicles)
-	{
-		if (v->getMaxCargo() > 0)
-		{
-			cargoCarrierPresent = true;
-		}
-		if (v->getMaxBio() > 0)
-		{
-			bioCarrierPresent = true;
-		}
 
-		// If both variables are true, there is no reason to keep going with this loop
-		if (cargoCarrierPresent && bioCarrierPresent)
-			break;
-	}
-	if (!cargoCarrierPresent && !playerHasBaseItemStorage)
+	if (!cargoCarrierPresent && !baseDefenseWithItemStorage)
 	{
 		for (auto &e : state.current_battle->cargoLoot)
 		{
@@ -3144,7 +3087,7 @@ void Battle::exitBattle(GameState &state)
 		}
 		state.current_battle->cargoLoot.clear();
 	}
-	if (!bioCarrierPresent && !playerHasBaseAlienStorage)
+	if (!bioCarrierPresent && !baseDefenseWithAlienStorage)
 	{
 		for (auto &e : state.current_battle->bioLoot)
 		{
@@ -3847,6 +3790,82 @@ void Battle::loadMessages(GameState &state)
 		}
 		state.cityMessages.clear();
 	}
+}
+
+const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
+{
+	// Compile list of player vehicles
+	std::list<StateRef<Vehicle>> playerVehicles;
+	if (state.current_battle->player_craft)
+	{
+		playerVehicles.push_back(state.current_battle->player_craft);
+	}
+
+	if (config().getBool("OpenApoc.NewFeature.AllowNearbyVehicleLootPickup"))
+	{
+		if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
+		{
+			StateRef<City> city;
+			StateRef<Vehicle> location = {&state, state.current_battle->mission_location_id};
+			city = location->city;
+
+			for (auto &v : state.vehicles)
+			{
+				// Check every player owned vehicle located in city
+				if (v.second->owner != state.player || v.second->city != city ||
+				    v.second->currentBuilding
+				    // Player's vehicle was already added and has priority
+				    || v.first == state.current_battle->player_craft.id)
+				{
+					continue;
+				}
+				if (glm::length(location->position - v.second->position) < VEHICLE_NEARBY_THRESHOLD)
+				{
+					playerVehicles.emplace_back(&state, v.first);
+				}
+			}
+		}
+		else
+		{
+			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+			for (auto &v : location->currentVehicles)
+			{
+				// Player's vehicle was already added and has priority
+				if (v->owner == state.player && v != state.current_battle->player_craft)
+				{
+					playerVehicles.push_back(v);
+				}
+			}
+		}
+	}
+
+	return playerVehicles;
+}
+
+const bool Battle::isCargoCarrierPresent(const std::list<StateRef<Vehicle>> &playerVehicles)
+{
+	for (auto &v : playerVehicles)
+	{
+		if (v->getMaxCargo() > 0)
+		{
+			return true;
+		}
+	}
+
+	return false;
+}
+
+const bool Battle::isBioCarrierPresent(const std::list<StateRef<Vehicle>> &playerVehicles)
+{
+	for (auto &v : playerVehicles)
+	{
+		if (v->getMaxBio() > 0)
+		{
+			return true;
+		}
+	}
+
+	return false;
 }
 
 int BattleScore::getLeadershipBonus()

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3796,9 +3796,11 @@ void Battle::loadMessages(GameState &state)
 const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 {
 	std::list<StateRef<Vehicle>> playerVehicles;
-	if (state.current_battle->player_craft)
+	const auto playerCraft = &state.current_battle->player_craft;
+
+	if (playerCraft)
 	{
-		playerVehicles.push_back(state.current_battle->player_craft);
+		playerVehicles.push_back(*playerCraft);
 	}
 
 	if (config().getBool("OpenApoc.NewFeature.AllowNearbyVehicleLootPickup"))
@@ -3815,10 +3817,11 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 				if (v.second->owner != state.player || v.second->city != city ||
 				    v.second->currentBuilding
 				    // Player's vehicle was already added and has priority
-				    || v.first == state.current_battle->player_craft.id)
+				    || v.first == playerCraft->id)
 				{
 					continue;
 				}
+
 				if (glm::length(location->position - v.second->position) < VEHICLE_NEARBY_THRESHOLD)
 				{
 					playerVehicles.emplace_back(&state, v.first);
@@ -3831,7 +3834,7 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 			for (const auto &v : location->currentVehicles)
 			{
 				// Player's vehicle was already added and has priority
-				if (v->owner == state.player && v != state.current_battle->player_craft)
+				if (v->owner == state.player && v != *playerCraft)
 				{
 					playerVehicles.push_back(v);
 				}

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3026,7 +3026,7 @@ void Battle::exitBattle(GameState &state)
 
 	// LOOT!
 
-	auto playerVehicles = Battle::getPlayerVehicles(state);
+	const auto playerVehicles = Battle::getPlayerVehicles(state);
 	std::set<StateRef<Vehicle>> returningVehicles;
 
 	if (state.current_battle->player_craft)

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3027,7 +3027,7 @@ void Battle::exitBattle(GameState &state)
 	// LOOT!
 
 	// Compile list of player vehicles
-	const auto playerVehicles = Battle::getPlayerVehicles(state);
+	auto playerVehicles = Battle::getPlayerVehicles(state);
 	std::set<StateRef<Vehicle>> returningVehicles;
 
 	if (state.current_battle->player_craft)

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3809,7 +3809,7 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 			StateRef<Vehicle> location = {&state, state.current_battle->mission_location_id};
 			city = location->city;
 
-			for (auto &v : state.vehicles)
+			for (const auto &v : state.vehicles)
 			{
 				// Check every player owned vehicle located in city
 				if (v.second->owner != state.player || v.second->city != city ||
@@ -3828,7 +3828,7 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 		else
 		{
 			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
-			for (auto &v : location->currentVehicles)
+			for (const auto &v : location->currentVehicles)
 			{
 				// Player's vehicle was already added and has priority
 				if (v->owner == state.player && v != state.current_battle->player_craft)
@@ -3844,7 +3844,7 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 
 const bool Battle::isCargoCarrierPresent(const std::list<StateRef<Vehicle>> &playerVehicles)
 {
-	for (auto &v : playerVehicles)
+	for (const auto &v : playerVehicles)
 	{
 		if (v->getMaxCargo() > 0)
 		{
@@ -3857,7 +3857,7 @@ const bool Battle::isCargoCarrierPresent(const std::list<StateRef<Vehicle>> &pla
 
 const bool Battle::isBioCarrierPresent(const std::list<StateRef<Vehicle>> &playerVehicles)
 {
-	for (auto &v : playerVehicles)
+	for (const auto &v : playerVehicles)
 	{
 		if (v->getMaxBio() > 0)
 		{

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2687,6 +2687,7 @@ void Battle::finishBattle(GameState &state)
 		const auto baseDefenseWithAlienStorage =
 		    isBaseDefenseWithStorage(state, FacilityType::Capacity::Aliens);
 
+		// Compile list of player vehicles
 		const auto playerVehicles = Battle::getPlayerVehicles(state);
 		const auto playerHasCraftBioStorage = Battle::isBioCarrierPresent(playerVehicles);
 
@@ -3794,7 +3795,6 @@ void Battle::loadMessages(GameState &state)
 
 const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 {
-	// Compile list of player vehicles
 	std::list<StateRef<Vehicle>> playerVehicles;
 	if (state.current_battle->player_craft)
 	{

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3814,10 +3814,14 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 			for (const auto &v : state.vehicles)
 			{
 				// Check every player owned vehicle located in city
-				if (v.second->owner != state.player || v.second->city != city ||
-				    v.second->currentBuilding
-				    // Player's vehicle was already added and has priority
-				    || v.first == playerCraft->id)
+				const auto isVehiclePlayerOwned = v.second->owner == state.player;
+				const auto isVehicleInTheCity =
+				    v.second->city == city && !v.second->currentBuilding;
+
+				// Player's vehicle was already added and has priority
+				const auto isVehiclePlayerCraft = v.first == playerCraft->id;
+
+				if (!isVehiclePlayerOwned || !isVehicleInTheCity || isVehiclePlayerCraft)
 				{
 					continue;
 				}

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -329,6 +329,15 @@ class Battle : public std::enable_shared_from_this<Battle>
 	// To be called after battle was finished and before returning to cityscape
 	static void exitBattle(GameState &state);
 
+	// Get list of player vehicles in battle
+	static const std::list<StateRef<Vehicle>> getPlayerVehicles(GameState &state);
+
+	// Check if cargo carrier is present at player vehicles list
+	static const bool isCargoCarrierPresent(const std::list<StateRef<Vehicle>> &playerVehicles);
+
+	// Check if bio carrier is present at player vehicles list
+	static const bool isBioCarrierPresent(const std::list<StateRef<Vehicle>> &playerVehicles);
+
 	// Pathfinding functions
 
   public:
@@ -352,7 +361,10 @@ class Battle : public std::enable_shared_from_this<Battle>
 	    bool approachOnly = false, bool ignoreStaticUnits = false, bool ignoreMovingUnits = true,
 	    bool ignoreAllUnits = false, float *cost = nullptr, float maxCost = 0.0f);
 
+	// Returns defended base if mission is base defense, returns null otherwise
 	static sp<Base> getCurrentDefendedBase(GameState &state);
+
+	// Check if mission is base defense and has storage for specified capacity type
 	static bool isBaseDefenseWithStorage(GameState &state,
 	                                     const FacilityType::Capacity capacityType);
 


### PR DESCRIPTION
Like stated in #1447, #1456 and #1422, when "consider nearby vehicles" option is set to True, nearby vehicles were considered for loot pickup, but NOT for score math in `Battle::finishBattle`

- Moved to `Battle::getPlayerVehicles` code related to list all player vehicles in battle, considering if nearby vehicles are allowed to get post-battle loot.
- Updated score math in `Battle::finishBattle` to consider all player vehicles in battle, not only `state.current_battle->player_craft` like it was doing before fix
- Moved logic related to carrier presence check to `Battle::isCargoCarrierPresent` and `Battle::isBioCarrierPresent`
- Added some comments and simplified some previous logic