### PR TITLE
New dialog message for base without any Alien Containment module, and base.cpp code refactorings

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -375,6 +375,7 @@ Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 		case FacilityType::Capacity::Quarters:
 		case FacilityType::Capacity::Stores:
 		case FacilityType::Capacity::Aliens:
+		{
 			const auto capacityUsed = getCapacityUsed(state, facility->type->capacityType);
 			const auto capacityTotal = getCapacityTotal(facility->type->capacityType);
 			const auto capacityAmount = facility->type->capacityAmount;
@@ -384,6 +385,7 @@ Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 				return BuildError::Occupied;
 			}
 			break;
+		}
 		case FacilityType::Capacity::Physics:
 		case FacilityType::Capacity::Chemistry:
 		case FacilityType::Capacity::Workshop:

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -282,86 +282,89 @@ Base::BuildError Base::canBuildFacility(StateRef<FacilityType> type, Vec2<int> p
 
 void Base::buildFacility(GameState &state, StateRef<FacilityType> type, Vec2<int> pos, bool free)
 {
-	if (canBuildFacility(type, pos, free) == BuildError::NoError)
+	if (canBuildFacility(type, pos, free) != BuildError::NoError)
+		return;
+
+	auto facility = mksp<Facility>(type);
+	facilities.push_back(facility);
+	facility->pos = pos;
+	if (!free)
 	{
-		auto facility = mksp<Facility>(type);
-		facilities.push_back(facility);
-		facility->pos = pos;
-		if (!free)
+		if (!building)
 		{
-			if (!building)
-			{
-				LogError("Building disappeared");
-			}
-			else
-			{
-				building->owner->balance -= type->buildCost;
-			}
-			facility->buildTime = type->buildTime;
+			LogError("Building disappeared");
 		}
-		if (type->capacityAmount > 0)
+		else
 		{
-			ResearchTopic::LabSize size;
-			// FIXME: Make LabSize set-able outside of the facility size?
-			if (type->size > 1)
+			building->owner->balance -= type->buildCost;
+		}
+		facility->buildTime = type->buildTime;
+	}
+	if (type->capacityAmount > 0)
+	{
+		ResearchTopic::LabSize size;
+		// FIXME: Make LabSize set-able outside of the facility size?
+		if (type->size > 1)
+		{
+			size = ResearchTopic::LabSize::Large;
+		}
+		else
+		{
+			size = ResearchTopic::LabSize::Small;
+		}
+		switch (type->capacityType)
+		{
+			case FacilityType::Capacity::Chemistry:
 			{
-				size = ResearchTopic::LabSize::Large;
+				auto lab = mksp<Lab>();
+				lab->size = size;
+				lab->type = ResearchTopic::Type::BioChem;
+				auto id = Lab::generateObjectID(state);
+				state.research.labs[id] = lab;
+				facility->lab = {&state, id};
+				break;
 			}
-			else
+			case FacilityType::Capacity::Physics:
 			{
-				size = ResearchTopic::LabSize::Small;
+				auto lab = mksp<Lab>();
+				lab->size = size;
+				lab->type = ResearchTopic::Type::Physics;
+				auto id = Lab::generateObjectID(state);
+				state.research.labs[id] = lab;
+				facility->lab = {&state, id};
+				break;
 			}
-			switch (type->capacityType)
+			case FacilityType::Capacity::Workshop:
 			{
-				case FacilityType::Capacity::Chemistry:
-				{
-					auto lab = mksp<Lab>();
-					lab->size = size;
-					lab->type = ResearchTopic::Type::BioChem;
-					auto id = Lab::generateObjectID(state);
-					state.research.labs[id] = lab;
-					facility->lab = {&state, id};
-					break;
-				}
-				case FacilityType::Capacity::Physics:
-				{
-					auto lab = mksp<Lab>();
-					lab->size = size;
-					lab->type = ResearchTopic::Type::Physics;
-					auto id = Lab::generateObjectID(state);
-					state.research.labs[id] = lab;
-					facility->lab = {&state, id};
-					break;
-				}
-				case FacilityType::Capacity::Workshop:
-				{
-					auto lab = mksp<Lab>();
-					lab->size = size;
-					lab->type = ResearchTopic::Type::Engineering;
-					auto id = Lab::generateObjectID(state);
-					state.research.labs[id] = lab;
-					facility->lab = {&state, id};
-					break;
-				}
-				default:
-					// Non-lab modules don't need special handling
-					break;
+				auto lab = mksp<Lab>();
+				lab->size = size;
+				lab->type = ResearchTopic::Type::Engineering;
+				auto id = Lab::generateObjectID(state);
+				state.research.labs[id] = lab;
+				facility->lab = {&state, id};
+				break;
 			}
+			default:
+				// Non-lab modules don't need special handling
+				break;
 		}
 	}
 }
 
 Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 {
-	auto facility = getFacility(pos);
+	const auto facility = getFacility(pos);
+
 	if (facility == nullptr)
 	{
 		return BuildError::OutOfBounds;
 	}
+
 	if (facility->type->fixed)
 	{
 		return BuildError::Indestructible;
 	}
+
 	if (facility->buildTime > 0)
 	{
 		return BuildError::NoError;
@@ -372,8 +375,11 @@ Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 		case FacilityType::Capacity::Quarters:
 		case FacilityType::Capacity::Stores:
 		case FacilityType::Capacity::Aliens:
-			if (getCapacityUsed(state, facility->type->capacityType) >
-			    getCapacityTotal(facility->type->capacityType) - facility->type->capacityAmount)
+			const auto capacityUsed = getCapacityUsed(state, facility->type->capacityType);
+			const auto capacityTotal = getCapacityTotal(facility->type->capacityType);
+			const auto capacityAmount = facility->type->capacityAmount;
+
+			if (capacityUsed > capacityTotal - capacityAmount)
 			{
 				return BuildError::Occupied;
 			}
@@ -381,12 +387,9 @@ Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 		case FacilityType::Capacity::Physics:
 		case FacilityType::Capacity::Chemistry:
 		case FacilityType::Capacity::Workshop:
-			if (facility->lab)
+			if (facility->lab && facility->lab->current_project)
 			{
-				if (facility->lab->current_project)
-				{
-					return BuildError::Occupied;
-				}
+				return BuildError::Occupied;
 			}
 			break;
 		default:
@@ -397,46 +400,52 @@ Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 
 void Base::destroyFacility(GameState &state, Vec2<int> pos)
 {
-	if (canDestroyFacility(state, pos) == BuildError::NoError)
+	if (canDestroyFacility(state, pos) != BuildError::NoError)
+		return;
+
+	const auto facility = getFacility(pos);
+
+	for (auto f = facilities.begin(); f != facilities.end(); ++f)
 	{
-		auto facility = getFacility(pos);
-		for (auto f = facilities.begin(); f != facilities.end(); ++f)
+		if (*f != facility)
+			continue;
+
+		if (facility->lab)
 		{
-			if (*f == facility)
+			const auto &id = facility->lab.id;
+			if (facility->lab->current_project)
 			{
-				if (facility->lab)
-				{
-					auto id = facility->lab.id;
-					if (facility->lab->current_project)
-					{
-						facility->lab->current_project->current_lab = "";
-						facility->lab->current_project = "";
-					}
-					facility->lab = "";
-					state.research.labs.erase(id);
-				}
-				if (facility->type->buildTime > 0)
-				{
-					building->owner->balance +=
-					    facility->type->buildCost * facility->buildTime / facility->type->buildTime;
-				}
-				facilities.erase(f);
-				break;
+				facility->lab->current_project->current_lab = "";
+				facility->lab->current_project = "";
 			}
+			facility->lab = "";
+			state.research.labs.erase(id);
 		}
+
+		if (facility->type->buildTime > 0)
+		{
+			building->owner->balance +=
+			    facility->type->buildCost * facility->buildTime / facility->type->buildTime;
+		}
+
+		facilities.erase(f);
+		break;
 	}
 }
 
-bool Base::containmentEmpty(GameState &state)
+bool Base::alienContainmentExists(GameState &state)
 {
-	for (auto &f : facilities)
+	return state.current_base->getCapacityTotal(FacilityType::Capacity::Aliens) == 0;
+}
+
+bool Base::alienContainmentIsEmpty(GameState &state)
+{
+	for (const auto &f : facilities)
 	{
-		if (f->type->capacityType == FacilityType::Capacity::Aliens)
+		if (f->type->capacityType == FacilityType::Capacity::Aliens &&
+		    getCapacityUsed(state, f->type->capacityType) != 0)
 		{
-			if (getCapacityUsed(state, f->type->capacityType) != 0)
-			{
-				return false;
-			}
+			return false;
 		}
 	}
 	return true;
@@ -448,35 +457,35 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 	switch (type)
 	{
 		case FacilityType::Capacity::Repair:
-			for (auto &v : state.vehicles)
+			for (const auto &v : state.vehicles)
 			{
-				if (v.second->homeBuilding == building &&
-				    v.second->getMaxHealth() > v.second->getHealth())
+				const auto maxHealth = v.second->getMaxHealth();
+				const auto health = v.second->getHealth();
+
+				if (v.second->homeBuilding == building && maxHealth > health)
 				{
-					total += v.second->getMaxHealth() - v.second->getHealth();
+					total += maxHealth - health;
 				}
 			}
 			// Show percentage of repair bay used if it can repair in one hour, or 100% if can't
 			if (total > 0)
 			{
-				int max = getCapacityTotal(type);
+				const auto max = getCapacityTotal(type);
 				return std::min(total, max);
 			}
 			break;
 		case FacilityType::Capacity::Medical:
-			for (auto &a : state.agents)
+			for (const auto &a : state.agents)
 			{
-				if (a.second->homeBuilding == building)
+				if (a.second->homeBuilding == building &&
+				    a.second->modified_stats.health < a.second->current_stats.health)
 				{
-					if (a.second->modified_stats.health < a.second->current_stats.health)
-					{
-						total++;
-					}
+					total++;
 				}
 			}
 			break;
 		case FacilityType::Capacity::Training:
-			for (auto &a : state.agents)
+			for (const auto &a : state.agents)
 			{
 				if (a.second->homeBuilding == building &&
 				    a.second->trainingAssignment == TrainingAssignment::Physical)
@@ -486,7 +495,7 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 			}
 			break;
 		case FacilityType::Capacity::Psi:
-			for (auto &a : state.agents)
+			for (const auto &a : state.agents)
 			{
 				if (a.second->homeBuilding == building &&
 				    a.second->trainingAssignment == TrainingAssignment::Psi)
@@ -500,16 +509,16 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 		case FacilityType::Capacity::Physics:
 			[[fallthrough]];
 		case FacilityType::Capacity::Workshop:
-			for (auto f = facilities.begin(); f != facilities.end(); ++f)
+			for (const auto &f : facilities)
 			{
-				if ((*f)->type->capacityType == type && (*f)->lab)
+				if (f->type->capacityType == type && f->lab)
 				{
-					total += (int)(*f)->lab->assigned_agents.size();
+					total += (int)f->lab->assigned_agents.size();
 				}
 			}
 			break;
 		case FacilityType::Capacity::Quarters:
-			for (auto &a : state.agents)
+			for (const auto &a : state.agents)
 			{
 				if (a.second->homeBuilding == building)
 				{
@@ -518,19 +527,19 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 			}
 			break;
 		case FacilityType::Capacity::Stores:
-			for (auto &e : inventoryAgentEquipment)
+			for (const auto &e : inventoryAgentEquipment)
 			{
 				StateRef<AEquipmentType> ae = {&state, e.first};
 				total += ae->type == AEquipmentType::Type::Ammo
 				             ? ae->store_space * ((e.second + ae->max_ammo - 1) / ae->max_ammo)
 				             : ae->store_space * e.second;
 			}
-			for (auto &e : inventoryVehicleEquipment)
+			for (const auto &e : inventoryVehicleEquipment)
 			{
 				StateRef<VEquipmentType> ve = {&state, e.first};
 				total += ve->store_space * e.second;
 			}
-			for (auto &e : inventoryVehicleAmmo)
+			for (const auto &e : inventoryVehicleAmmo)
 			{
 				StateRef<VAmmoType> va = {&state, e.first};
 				total += va->store_space * e.second;
@@ -538,7 +547,7 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 			break;
 		case FacilityType::Capacity::Aliens:
 		{
-			for (auto &e : inventoryBioEquipment)
+			for (const auto &e : inventoryBioEquipment)
 			{
 				if (e.second == 0)
 					continue;
@@ -559,11 +568,11 @@ int Base::getCapacityUsed(GameState &state, FacilityType::Capacity type) const
 int Base::getCapacityTotal(FacilityType::Capacity type) const
 {
 	int total = 0;
-	for (auto f = facilities.begin(); f != facilities.end(); ++f)
+	for (const auto &f : facilities)
 	{
-		if ((*f)->type->capacityType == type && (*f)->buildTime == 0)
+		if (f->type->capacityType == type && f->buildTime == 0)
 		{
-			total += (*f)->type->capacityAmount;
+			total += f->type->capacityAmount;
 		}
 	}
 	return total;

--- a/game/state/city/base.h
+++ b/game/state/city/base.h
@@ -55,7 +55,12 @@ class Base : public StateObject<Base>, public std::enable_shared_from_this<Base>
 	                   bool free = false);
 	BuildError canDestroyFacility(GameState &state, Vec2<int> pos) const;
 	void destroyFacility(GameState &state, Vec2<int> pos);
-	bool containmentEmpty(GameState &state);
+
+	// Returns if an Alien Containment module exists at base
+	bool alienContainmentExists(GameState &state);
+
+	// Returns if Alien Containment capacity is empty at base
+	bool alienContainmentIsEmpty(GameState &state);
 	int getCapacityUsed(GameState &state, FacilityType::Capacity type) const;
 	int getCapacityTotal(FacilityType::Capacity type) const;
 	float getUsage(GameState &state, const sp<Facility> facility, const int delta = 0) const;

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -130,7 +130,15 @@ void BaseScreen::begin()
 	        FormEventType::ButtonClick,
 	        [this](Event *)
 	        {
-		        if (this->state->current_base->containmentEmpty(*state))
+		        if (this->state->current_base->alienContainmentExists(*state))
+		        {
+			        fw().stageQueueCommand(
+			            {StageCmd::Command::PUSH,
+			             mksp<MessageBox>(tr("Alien Containment"),
+			                              tr("Alien Containment does not exist at this base."),
+			                              MessageBox::ButtonOptions::Ok)});
+		        }
+		        else if (this->state->current_base->alienContainmentIsEmpty(*state))
 		        {
 			        fw().stageQueueCommand(
 			            {StageCmd::Command::PUSH,


### PR DESCRIPTION
Added new message at base to show when base has no Alien Containment module at all.

Base with no Alien Containment module:
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/4c73c48e-8325-43af-9e26-a3ef7f924fed)

Base with empty Alien Containment module (already existing message):
![image](https://github.com/OpenApoc/OpenApoc/assets/13112588/eb1b8eff-d77c-4d76-9960-9602a14dc075)

Also refactored some methods at `base.cpp` to simplify code.