### PR TITLE
Changing log type at buildFacility and destroyFacility

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -284,7 +284,7 @@ void Base::buildFacility(GameState &state, StateRef<FacilityType> type, Vec2<int
 {
 	if (canBuildFacility(type, pos, free) != BuildError::NoError)
 	{
-		LogError("Error when trying to build facility!");
+		LogWarning("Error when trying to build facility!");
 		return;
 	}
 
@@ -407,7 +407,7 @@ void Base::destroyFacility(GameState &state, Vec2<int> pos)
 {
 	if (canDestroyFacility(state, pos) != BuildError::NoError)
 	{
-		LogError("Error when trying to destroy facility!");
+		LogWarning("Error when trying to destroy facility!");
 		return;
 	}
 


### PR DESCRIPTION
As described [here](https://www.reddit.com/r/OpenApoc/comments/1drmirh/game_crash_on_starting_a_new_campaign/), the game will throw a bunch of errors when starting a new campaign. That's because both `buildFacility` and `destroyFacility` are called during new campaign creation at a time where their validation fails - which seems to be the normal process during new campaign.

Changing log type from `LogError` to `LogWarning` so we can avoid blocking when starting a new campaign, while still warning that these checks didn't work when needed to follow these errors.