### PR TITLE
Stop adding empty cargo at vehicle when exiting battle

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3361,12 +3361,9 @@ void Battle::exitBattle(GameState &state)
 		}
 	}
 
-	// Give player vehicle a null cargo just so it comes back to base once
+	// Sending vehicles back to base
 	for (auto &v : playerVehicles)
 	{
-		v->cargo.emplace_front(
-		    state, StateRef<AEquipmentType>(&state, state.agent_equipment.begin()->first), 0, 0,
-		    nullptr, v->homeBuilding);
 		if (v->city.id == "CITYMAP_HUMAN")
 		{
 			v->setMission(state, VehicleMission::gotoBuilding(state, *v));


### PR DESCRIPTION
Fixes #1482

Vehicles leaving a mission used to have an empty "alien artifact" item, with count zeroed.
This item is not added anymore, which means that vehicles with no loot are now empty for good.

As a consequence, the dialog "Items from tactical combat zone have arrived" now will only appear when landed vehicle really have something to unload at base, since it used to appear for every single vehicle landing.