### PR TITLE
Updating base facility error logs with magic_enum

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -23,3 +23,6 @@
 [submodule "dependencies/fmt"]
 	path = dependencies/fmt
 	url = https://github.com/fmtlib/fmt.git
+[submodule "dependencies/magic_enum"]
+	path = dependencies/magic_enum
+	url = https://github.com/Neargye/magic_enum.git

--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ The following libraries are also used, but are shipped as submodules in the repo
 * [physfs](https://icculus.org/physfs/) - Library for reading data from .iso files or directory trees (Note: We use a patched version, available on [GitHub](https://github.com/JonnyH/physfs-hg-import/tree/fix-iso) - required to read the .iso files we use).
 * [pugixml](https://pugixml.org) - XML library used for reading/writing the game data files.
 * [fmtlib](https://github.com/fmtlib/fmt) - A c++ string formatting library - proposed for c++20 standard.
+* [magic_enum](https://github.com/Neargye/magic_enum) - Header-only C++17 library provides static reflection for enums, work with any enum type without any macro or boilerplate code.
 
 
 ### Building on Windows

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -1,4 +1,5 @@
 #include "game/state/city/base.h"
+#include "dependencies/magic_enum/include/magic_enum/magic_enum.hpp"
 #include "framework/framework.h"
 #include "game/state/city/building.h"
 #include "game/state/city/city.h"
@@ -282,9 +283,14 @@ Base::BuildError Base::canBuildFacility(StateRef<FacilityType> type, Vec2<int> p
 
 void Base::buildFacility(GameState &state, StateRef<FacilityType> type, Vec2<int> pos, bool free)
 {
-	if (canBuildFacility(type, pos, free) != BuildError::NoError)
+	const auto canBuildFacilityResult = canBuildFacility(type, pos, free);
+
+	if (canBuildFacilityResult != BuildError::NoError)
 	{
-		LogWarning("Error when trying to build facility!");
+		const auto canBuildFacilityEnum = magic_enum::enum_name(canBuildFacilityResult);
+		const auto logMessage =
+		    format("Error when trying to build facility: %s", canBuildFacilityEnum);
+		LogWarning(logMessage);
 		return;
 	}
 
@@ -405,9 +411,14 @@ Base::BuildError Base::canDestroyFacility(GameState &state, Vec2<int> pos) const
 
 void Base::destroyFacility(GameState &state, Vec2<int> pos)
 {
-	if (canDestroyFacility(state, pos) != BuildError::NoError)
+	const auto canDestroyFacilityResult = canDestroyFacility(state, pos);
+
+	if (canDestroyFacilityResult != BuildError::NoError)
 	{
-		LogWarning("Error when trying to destroy facility!");
+		const auto canDestroyFacilityEnum = magic_enum::enum_name(canDestroyFacilityResult);
+		const auto logMessage =
+		    format("Error when trying to destroy facility: %s", canDestroyFacilityEnum);
+		LogWarning(logMessage);
 		return;
 	}
 


### PR DESCRIPTION
- Added magic_enum lib to dependencies. It can be used to get enum value as astring
- Updated `Base::buildFacility` and `Base::destroyFacility` to print a log warning with specific error if validation doesn't go well