### PR TITLE
Removing incorrect presentScenery check at VehicleMover::updateCrashed

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1127,12 +1127,8 @@ void VehicleMover::updateCrashed(GameState &state, unsigned int ticks [[maybe_un
 	if (vehicle.tileObject && vehicle.tileObject->getOwningTile() &&
 	    vehicle.tileObject->getOwningTile()->presentScenery)
 	{
-		auto presentScenery = vehicle.tileObject->getOwningTile()->presentScenery;
-		if (!presentScenery)
-		{
-			vehicle.setCrashed(state, false);
-			vehicle.startFalling(state);
-		}
+		vehicle.setCrashed(state, false);
+		vehicle.startFalling(state);
 	}
 }
 


### PR DESCRIPTION
Fixes #1487

Removing incorrect `presentScenery` check at `VehicleMover::updateCrashed`

I couldn't find a situation where this update would crash, and I also used [last update done at this function](https://github.com/OpenApoc/OpenApoc/commit/e5fc6da130f8321a5789eea3bff9ad81e2ce8c5a#diff-3616dc8eea6e5f773f9434f708c2ac82234b86686e06fb238986ae3d8f8793f7R1126) as reference.