### PR TITLE
Fixing logic at Base::alienContainmentExists

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -453,7 +453,7 @@ void Base::destroyFacility(GameState &state, Vec2<int> pos)
 
 bool Base::alienContainmentExists(GameState &state)
 {
-	return state.current_base->getCapacityTotal(FacilityType::Capacity::Aliens) == 0;
+	return state.current_base->getCapacityTotal(FacilityType::Capacity::Aliens) > 0;
 }
 
 bool Base::alienContainmentIsEmpty(GameState &state)

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -130,7 +130,7 @@ void BaseScreen::begin()
 	        FormEventType::ButtonClick,
 	        [this](Event *)
 	        {
-		        if (this->state->current_base->alienContainmentExists(*state))
+		        if (!this->state->current_base->alienContainmentExists(*state))
 		        {
 			        fw().stageQueueCommand(
 			            {StageCmd::Command::PUSH,


### PR DESCRIPTION
I realized that the logic at `Base::alienContainmentExists` is wrong and the method name is misleading right now.
Fixing logic so alien containment is True when base has alien capacity.