### PR TITLE
Fix minimum velocity when turning

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -567,7 +567,7 @@ class FlyingVehicleMover : public VehicleMover
 						    std::max(floorf(glm::length(vectorToGoal) /
 						                    glm::length(vehicle.velocity) * (float)TICK_SCALE) -
 						                 5.0f,
-						             1.0f);
+						             2.0f);
 						if (ticksToMove < vehicle.ticksToTurn)
 						{
 							vehicle.velocity *= (float)ticksToMove / (float)vehicle.ticksToTurn;


### PR DESCRIPTION
Addresses #1310 

I found what is causing the slow vehicle problem, but this is just a band-aid approach to fixing it.

On line 573, if ticksToMove is 1 and ticksToTurn is high (100+), the vehicle velocity will be set to a ridiculously small number. If this happens, the vehicle can be stuck moving too slowly to reach its' goal, especially if the vehicle is facing the correct direction. Since the vehicle is facing its' goal, the velocity never changes as it is set when a new goal is selected. This PR sets the minimum ticksToMove to 2, as this seems to be enough to stop the problem. Since this issue only happened on the slowest speed where ticks are set to 1, increasing the number to 2 should be enough.

Rewriting the turning speed mechanic is above my paygrade, so this should stop this problem until the day someone tackles that section.

https://github.com/OpenApoc/OpenApoc/blob/5f18f2759f0770e8bea46c9fb8752a280d31acfe/game/state/city/vehicle.cpp#L560-L575