### PR TITLE
Fix #1310 Turning Slow Down Mechanic

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -36,6 +36,8 @@
 #include <limits>
 #include <queue>
 #include <random>
+#include <fstream>
+#include <iostream>
 
 namespace OpenApoc
 {
@@ -573,6 +575,19 @@ class FlyingVehicleMover : public VehicleMover
 						{
 							vehicle.velocity *= (float)ticksToMove / (float)vehicle.ticksToTurn;
 						}
+
+						//@kgd192 log velocity data in relation to angular velocity for research
+						std::ofstream velocityLog("velocitylog.csv", std::ios_base::app);
+						velocityLog << ("angular, " + std::to_string(vehicle.angularVelocity) + "\n");
+						velocityLog << ("old velocity," + std::to_string(vehicle.velocity.x) +
+						           "," + std::to_string(vehicle.velocity.y) + "," +
+						                std::to_string(vehicle.velocity.z) + "\n");
+						// Slow down in relation to angular Velocity
+						auto turningV = vehicle.velocity;
+						turningV = vehicle.velocity * std::abs(vehicle.angularVelocity);
+						velocityLog << ("new velocity," + std::to_string(turningV.x) +
+						           "," + std::to_string(turningV.y) + "," +
+						                std::to_string(turningV.z) + "\n");
 					}
 				}
 			}

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1,7 +1,8 @@
 #ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#include "game/state/gametime.h"
+#include <cstdlib>
 #endif
-#include "game/state/city/vehicle.h"
 #include "framework/configfile.h"
 #include "framework/framework.h"
 #include "framework/logger.h"
@@ -11,6 +12,7 @@
 #include "game/state/city/building.h"
 #include "game/state/city/city.h"
 #include "game/state/city/scenery.h"
+#include "game/state/city/vehicle.h"
 #include "game/state/city/vehiclemission.h"
 #include "game/state/city/vequipment.h"
 #include "game/state/gameevent.h"
@@ -31,13 +33,13 @@
 #include "game/state/tilemap/tileobject_vehicle.h"
 #include "game/ui/general/messagebox.h"
 #include "library/sp.h"
+#include <fstream>
 #include <glm/glm.hpp>
 #include <glm/gtx/vector_angle.hpp>
+#include <iostream>
 #include <limits>
 #include <queue>
 #include <random>
-#include <fstream>
-#include <iostream>
 
 namespace OpenApoc
 {
@@ -560,7 +562,6 @@ class FlyingVehicleMover : public VehicleMover
 					// d += 0.12f * (float)M_PI;
 					vehicle.ticksToTurn = floorf(d / vehicle.angularVelocity);
 
-					// FIXME: Introduce proper turning speed
 					// Here we just slow down velocity if we're moving too quickly
 					if (vehicle.position != vehicle.goalPosition)
 					{
@@ -573,21 +574,9 @@ class FlyingVehicleMover : public VehicleMover
 						             2.0f);
 						if (ticksToMove < vehicle.ticksToTurn)
 						{
-							vehicle.velocity *= (float)ticksToMove / (float)vehicle.ticksToTurn;
+							vehicle.velocity *=
+							    std::abs(vehicle.angularVelocity) * TURNING_SLOW_DOWN_CORRECTION;
 						}
-
-						//@kgd192 log velocity data in relation to angular velocity for research
-						std::ofstream velocityLog("velocitylog.csv", std::ios_base::app);
-						velocityLog << ("angular, " + std::to_string(vehicle.angularVelocity) + "\n");
-						velocityLog << ("old velocity," + std::to_string(vehicle.velocity.x) +
-						           "," + std::to_string(vehicle.velocity.y) + "," +
-						                std::to_string(vehicle.velocity.z) + "\n");
-						// Slow down in relation to angular Velocity
-						auto turningV = vehicle.velocity;
-						turningV = vehicle.velocity * std::abs(vehicle.angularVelocity);
-						velocityLog << ("new velocity," + std::to_string(turningV.x) +
-						           "," + std::to_string(turningV.y) + "," +
-						                std::to_string(turningV.z) + "\n");
 					}
 				}
 			}

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -57,6 +57,9 @@ static const int FV_SCRAPPED_COST_PERCENT = 25;
 static const int FUEL_TICKS_PER_SECOND = 144;
 // How much ticks is required to spend one unit of fuel
 static const int FUEL_TICKS_PER_UNIT = 40000;
+// Correction factor for turning slowdown mechanic, purely found by data analysis, could not
+// establish any logical conclusion
+static const float TURNING_SLOW_DOWN_CORRECTION = 38.893f;
 
 class Image;
 class TileObjectVehicle;


### PR DESCRIPTION
This PR should solve Issue #1130 by decoupling the slow down during turns mechanic from the game ticks. It now uses the vehicles angular velocity. This unfortunately lead to another correction value, which is purely based on data analysis. Average deviation of the Slowdown compared to the old method is about 2.5%.
@FilmBoy84 I will do the fix for Lint this weekend, I tried to work with just the command line and without IDE out of curiosity, this somehow disregarded the formatting.