### PR TITLE
Remove baseline from vcpkg

### DIFF
--- a/vcpkg.json
+++ b/vcpkg.json
@@ -17,6 +17,5 @@
         "qt5-base"
       ]
     }
-  },
-  "builtin-baseline": "9edb1b8e590cc086563301d735cae4b6e732d2d2"
+  }
 }


### PR DESCRIPTION
As vcpkg and boost need updates for even "minor" compiler updates, trying to lock to a version just ends up being more hassle than tracking head