### PR TITLE
Fix facilities check at non-base

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1734,7 +1734,8 @@ StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 
 	// Only add aliens if alien containment is available at base
 	const auto vehicleContainsAlienLoot = cargoContainsAlienLoot();
-	const auto alienContainmentExists = currentBuilding->base->alienContainmentExists();
+	const auto alienContainmentExists =
+	    currentBuilding->base ? currentBuilding->base->alienContainmentExists() : false;
 
 	// Vehicle must be stopped from unloading alien cargo when vehicle has alien loot but base has
 	// no alien containment


### PR DESCRIPTION
Addresses #1499 

I feel that everything happening regarding aliens at the beginning of getServiceDestination should only be checked at bases. Obviously non-bases won't have alien containment. This should fix this specific issue of checking non-bases for facilities.