### PR TITLE
Update appveyor vcpkg version

### DIFF
--- a/appveyor-dev.yml
+++ b/appveyor-dev.yml
@@ -25,7 +25,7 @@ cache: C:\Users\appveyor\AppData\Local\vcpkg\archives -> appveyor-dev.yml
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2023.08.09
+  - git checkout 2024.10.21
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ cache: C:\Users\appveyor\AppData\Local\vcpkg\archives -> appveyor.yml
 before_build:
   - cd c:\tools\vcpkg
   - git pull
-  - git checkout 2023.08.09
+  - git checkout 2024.10.21
   - .\bootstrap-vcpkg.bat
   - cd %APPVEYOR_BUILD_FOLDER%
   - vcpkg install


### PR DESCRIPTION
Seems to be the regular build failure due to MSVC compiler upgrade needing a corresponding boost bump, so update vcpkg