### PR TITLE
Fix BaseScreen not highlighting correct base

### DIFF
--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -96,16 +96,12 @@ void BaseScreen::begin()
 	                  [](Event *) { fw().stageQueueCommand({StageCmd::Command::POP}); });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_BUYSELL")
 	    ->addCallback(
-	        FormEventType::ButtonClick,
-	        [this](Event *) {
-		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BuyAndSellScreen>(state)});
-	        });
+	        FormEventType::ButtonClick, [this](Event *)
+	        { fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BuyAndSellScreen>(state)}); });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_HIREFIRESTAFF")
 	    ->addCallback(
-	        FormEventType::ButtonClick,
-	        [this](Event *) {
-		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<RecruitScreen>(state)});
-	        });
+	        FormEventType::ButtonClick, [this](Event *)
+	        { fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<RecruitScreen>(state)}); });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_TRANSFER")
 	    ->addCallback(
 	        FormEventType::ButtonClick,
@@ -153,54 +149,54 @@ void BaseScreen::begin()
 		        }
 	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPAGENT")
-	    ->addCallback(
-	        FormEventType::ButtonClick,
-	        [this](Event *)
-	        {
-		        bool playerHasSoldiers = false;
-		        for (auto &a : this->state->agents)
-		        {
-			        auto agent = a.second;
-			        if (agent->owner == this->state->getPlayer() &&
-			            agent->type->role == AgentType::Role::Soldier)
-			        {
-				        playerHasSoldiers = true;
-				        break;
-			        }
-		        }
-		        if (playerHasSoldiers)
-		        {
-			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
-		        }
-	        });
+	    ->addCallback(FormEventType::ButtonClick,
+	                  [this](Event *)
+	                  {
+		                  bool playerHasSoldiers = false;
+		                  for (auto &a : this->state->agents)
+		                  {
+			                  auto agent = a.second;
+			                  if (agent->owner == this->state->getPlayer() &&
+			                      agent->type->role == AgentType::Role::Soldier)
+			                  {
+				                  playerHasSoldiers = true;
+				                  break;
+			                  }
+		                  }
+		                  if (playerHasSoldiers)
+		                  {
+			                  fw().stageQueueCommand(
+			                      {StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
+		                  }
+	                  });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPVEHICLE")
-	    ->addCallback(
-	        FormEventType::ButtonClick,
-	        [this](Event *)
-	        {
-		        bool playerHasVehicles = false;
-		        for (auto &v : this->state->vehicles)
-		        {
-			        auto vehicle = v.second;
-			        if (vehicle->owner == this->state->getPlayer())
-			        {
-				        playerHasVehicles = true;
-				        break;
-			        }
-		        }
-		        if (playerHasVehicles)
-		        {
-			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
-		        }
-	        });
+	    ->addCallback(FormEventType::ButtonClick,
+	                  [this](Event *)
+	                  {
+		                  bool playerHasVehicles = false;
+		                  for (auto &v : this->state->vehicles)
+		                  {
+			                  auto vehicle = v.second;
+			                  if (vehicle->owner == this->state->getPlayer())
+			                  {
+				                  playerHasVehicles = true;
+				                  break;
+			                  }
+		                  }
+		                  if (playerHasVehicles)
+		                  {
+			                  fw().stageQueueCommand(
+			                      {StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
+		                  }
+	                  });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_RES_AND_MANUF")
-	    ->addCallback(
-	        FormEventType::ButtonClick,
-	        [this](Event *)
-	        {
-		        // FIXME: If you don't have any facilities this button should do nothing
-		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ResearchScreen>(state)});
-	        });
+	    ->addCallback(FormEventType::ButtonClick,
+	                  [this](Event *)
+	                  {
+		                  // FIXME: If you don't have any facilities this button should do nothing
+		                  fw().stageQueueCommand(
+		                      {StageCmd::Command::PUSH, mksp<ResearchScreen>(state)});
+	                  });
 	// Base name edit
 	form->findControlTyped<TextEdit>("TEXT_BASE_NAME")
 	    ->addCallback(FormEventType::TextEditFinish,
@@ -220,7 +216,11 @@ void BaseScreen::begin()
 
 void BaseScreen::pause() {}
 
-void BaseScreen::resume() { textFunds->setText(state->getPlayerBalance()); }
+void BaseScreen::resume()
+{
+	BaseStage::begin();
+	textFunds->setText(state->getPlayerBalance());
+}
 
 void BaseScreen::finish() {}
 

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -96,12 +96,16 @@ void BaseScreen::begin()
 	                  [](Event *) { fw().stageQueueCommand({StageCmd::Command::POP}); });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_BUYSELL")
 	    ->addCallback(
-	        FormEventType::ButtonClick, [this](Event *)
-	        { fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BuyAndSellScreen>(state)}); });
+	        FormEventType::ButtonClick,
+	        [this](Event *) {
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<BuyAndSellScreen>(state)});
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_HIREFIRESTAFF")
 	    ->addCallback(
-	        FormEventType::ButtonClick, [this](Event *)
-	        { fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<RecruitScreen>(state)}); });
+	        FormEventType::ButtonClick,
+	        [this](Event *) {
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<RecruitScreen>(state)});
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_TRANSFER")
 	    ->addCallback(
 	        FormEventType::ButtonClick,
@@ -149,54 +153,54 @@ void BaseScreen::begin()
 		        }
 	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPAGENT")
-	    ->addCallback(FormEventType::ButtonClick,
-	                  [this](Event *)
-	                  {
-		                  bool playerHasSoldiers = false;
-		                  for (auto &a : this->state->agents)
-		                  {
-			                  auto agent = a.second;
-			                  if (agent->owner == this->state->getPlayer() &&
-			                      agent->type->role == AgentType::Role::Soldier)
-			                  {
-				                  playerHasSoldiers = true;
-				                  break;
-			                  }
-		                  }
-		                  if (playerHasSoldiers)
-		                  {
-			                  fw().stageQueueCommand(
-			                      {StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
-		                  }
-	                  });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        bool playerHasSoldiers = false;
+		        for (auto &a : this->state->agents)
+		        {
+			        auto agent = a.second;
+			        if (agent->owner == this->state->getPlayer() &&
+			            agent->type->role == AgentType::Role::Soldier)
+			        {
+				        playerHasSoldiers = true;
+				        break;
+			        }
+		        }
+		        if (playerHasSoldiers)
+		        {
+			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<AEquipScreen>(state)});
+		        }
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_EQUIPVEHICLE")
-	    ->addCallback(FormEventType::ButtonClick,
-	                  [this](Event *)
-	                  {
-		                  bool playerHasVehicles = false;
-		                  for (auto &v : this->state->vehicles)
-		                  {
-			                  auto vehicle = v.second;
-			                  if (vehicle->owner == this->state->getPlayer())
-			                  {
-				                  playerHasVehicles = true;
-				                  break;
-			                  }
-		                  }
-		                  if (playerHasVehicles)
-		                  {
-			                  fw().stageQueueCommand(
-			                      {StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
-		                  }
-	                  });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        bool playerHasVehicles = false;
+		        for (auto &v : this->state->vehicles)
+		        {
+			        auto vehicle = v.second;
+			        if (vehicle->owner == this->state->getPlayer())
+			        {
+				        playerHasVehicles = true;
+				        break;
+			        }
+		        }
+		        if (playerHasVehicles)
+		        {
+			        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<VEquipScreen>(state)});
+		        }
+	        });
 	form->findControlTyped<GraphicButton>("BUTTON_BASE_RES_AND_MANUF")
-	    ->addCallback(FormEventType::ButtonClick,
-	                  [this](Event *)
-	                  {
-		                  // FIXME: If you don't have any facilities this button should do nothing
-		                  fw().stageQueueCommand(
-		                      {StageCmd::Command::PUSH, mksp<ResearchScreen>(state)});
-	                  });
+	    ->addCallback(
+	        FormEventType::ButtonClick,
+	        [this](Event *)
+	        {
+		        // FIXME: If you don't have any facilities this button should do nothing
+		        fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<ResearchScreen>(state)});
+	        });
 	// Base name edit
 	form->findControlTyped<TextEdit>("TEXT_BASE_NAME")
 	    ->addCallback(FormEventType::TextEditFinish,

--- a/game/ui/base/basestage.cpp
+++ b/game/ui/base/basestage.cpp
@@ -55,6 +55,7 @@ void BaseStage::begin()
 		if (state->current_base == viewBase)
 		{
 			currentView = view;
+			prevBase = viewBase;
 		}
 		view->setData(viewBase);
 		auto viewImage = drawMiniBase(*viewBase, viewHighlight, viewFacility);

--- a/game/ui/base/basestage.h
+++ b/game/ui/base/basestage.h
@@ -23,6 +23,7 @@ class BaseStage : public Stage
 	std::vector<sp<GraphicButton>> miniViews;
 	sp<Label> textFunds, textViewBase;
 
+	sp<Base> prevBase;
 	sp<GraphicButton> currentView;
 	BaseGraphics::FacilityHighlight viewHighlight;
 	sp<Facility> viewFacility;

--- a/game/ui/base/transactionscreen.h
+++ b/game/ui/base/transactionscreen.h
@@ -53,6 +53,7 @@ class TransactionScreen : public BaseStage
 
   protected:
 	void changeBase(sp<Base> newBase) override;
+	void restoreBase();
 
 	// The counter of the highlight update countdown.
 	int framesUntilHighlightUpdate = 0;


### PR DESCRIPTION
Fixes #1298 and #1392

This restores the functionality of the original game. In the transfer, buy and sell, and alien containment screens, you will be returned to the original base that was selected from the base screen. In the research screen, you will be transferred to the base you select regardless of the original selection. Not sure if this is desired but this does fix bases not being highlighted as well. If it would be better to unify the behavior for all screens, it would be an easy fix.