### PR TITLE
Fix facilities list not populated when opened

### DIFF
--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -90,6 +90,7 @@ void BaseScreen::begin()
 		graphic->Name = "FACILITY_BUILD_TILE";
 		facilities->addItem(graphic);
 	}
+	facilities->update();
 
 	form->findControlTyped<GraphicButton>("BUTTON_OK")
 	    ->addCallback(FormEventType::ButtonClick,


### PR DESCRIPTION
When opening the base screen and not in 640x480, the facility list is not populated until the mouse enters. This addresses this issue.

Problem:
![nofacility](https://github.com/user-attachments/assets/6eefb086-d515-4931-8291-aa2f63925643)