### PR TITLE
Update installer to correct version information

### DIFF
--- a/install/windows/installer.nsi
+++ b/install/windows/installer.nsi
@@ -28,20 +28,20 @@
 ;--------------------------------
 ;General
 
-	;Get major and minor version numbers from the git tag
-	!searchparse /ignorecase /noerrors ${GAME_VERSION} `v` GAME_VERSION_MAJOR `.` GAME_VERSION_MINOR `-` GAME_VERSION_COMMIT `-`
-	!ifndef GAME_VERSION_MAJOR
-		!define GAME_VERSION_MAJOR 0
+	; Get version date, commit count, and commit hash numbers from the GAME_VERSION string
+	!searchparse /ignorecase /noerrors "${GAME_VERSION}" "" GAME_VERSION_DATE "-" GAME_VERSION_COMMIT_COUNT "-"  GAME_VERSION_HASH
+	!ifndef GAME_VERSION_DATE
+		!define GAME_VERSION_DATE 0
 	!endif
-	!ifndef GAME_VERSION_MINOR
-		!define GAME_VERSION_MINOR 0
+	!ifndef GAME_VERSION_COMMIT_COUNT
+		!define GAME_VERSION_COMMIT_COUNT 0
 	!endif
-	!ifndef GAME_VERSION_COMMIT
-		!define GAME_VERSION_COMMIT 0
+	!ifndef GAME_VERSION_HASH
+		!define GAME_VERSION_HASH 0
 	!endif
 
 	;Name and file
-	Name "${GAME_NAME} ${GAME_VERSION_MAJOR}.${GAME_VERSION_MINOR}.${GAME_VERSION_COMMIT}"
+	Name "${GAME_NAME} ${GAME_VERSION_DATE}-${GAME_VERSION_COMMIT_COUNT}-${GAME_VERSION_HASH}"
 	OutFile "install-openapoc-${GAME_VERSION}.exe"
 
 	;Default installation folder
@@ -267,9 +267,9 @@ Section "$(SETUP_GAME)" SecMain
 	WriteRegStr HKLM "Software\${GAME_NAME}" "" $INSTDIR
 	
 	;Write the uninstall keys for Windows
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "DisplayName" "${GAME_NAME} ${GAME_VERSION_MAJOR}.${GAME_VERSION_MINOR}.${GAME_VERSION_COMMIT}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "DisplayName" "${GAME_NAME} ${GAME_VERSION_DATE}-${GAME_VERSION_COMMIT_COUNT}-${GAME_VERSION_HASH}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "DisplayIcon" '"$INSTDIR\OpenApoc.exe",0'
-	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "DisplayVersion" "${GAME_VERSION_MAJOR}.${GAME_VERSION_MINOR}.${GAME_VERSION_COMMIT}"
+	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "DisplayVersion" "${GAME_VERSION_DATE}-${GAME_VERSION_COMMIT_COUNT}-${GAME_VERSION_HASH}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "InstallLocation" "$INSTDIR"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "Publisher" "${GAME_AUTHOR}"
 	WriteRegStr HKLM "Software\Microsoft\Windows\CurrentVersion\Uninstall\${GAME_NAME}" "UninstallString" '"$INSTDIR\Uninstall.exe"'
@@ -478,10 +478,10 @@ SectionEnd
 ;--------------------------------
 ;Version Information
 
-	VIProductVersion "${GAME_VERSION_MAJOR}.${GAME_VERSION_MINOR}.${GAME_VERSION_COMMIT}.0"
+	VIProductVersion "${GAME_VERSION_DATE}.${GAME_VERSION_COMMIT_COUNT}.0.0"
 	VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductName" "${GAME_NAME} Installer"
-	VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${GAME_VERSION_MAJOR}.${GAME_VERSION_MINOR}.${GAME_VERSION_COMMIT}.0"
+	VIAddVersionKey /LANG=${LANG_ENGLISH} "ProductVersion" "${GAME_VERSION_DATE}-${GAME_VERSION_COMMIT_COUNT}-${GAME_VERSION_HASH}"
 	VIAddVersionKey /LANG=${LANG_ENGLISH} "CompanyName" "${GAME_AUTHOR}"
-	VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright 2014-2019 ${GAME_AUTHOR}"
+	VIAddVersionKey /LANG=${LANG_ENGLISH} "LegalCopyright" "Copyright 2014-2024 ${GAME_AUTHOR}"
 	VIAddVersionKey /LANG=${LANG_ENGLISH} "FileDescription" "${GAME_NAME} Installer"
-	VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${GAME_VERSION_MAJOR}.${GAME_VERSION_MINOR}.${GAME_VERSION_COMMIT}.0"
+	VIAddVersionKey /LANG=${LANG_ENGLISH} "FileVersion" "${GAME_VERSION_DATE}-${GAME_VERSION_COMMIT_COUNT}-${GAME_VERSION_HASH}"


### PR DESCRIPTION
The version number has been broken for a while in the Windows installer, we are using a different format now. The installer now uses the commit date, number of commits, and hash. I can't properly test this, but if it fails it will still fall back to 0.0.0

Now:
![installerpic](https://github.com/user-attachments/assets/93c23aed-cef3-44f9-98c1-9655cf4a1f6f)

Fix:
![installpic2](https://github.com/user-attachments/assets/e7bde4a9-b745-489b-b760-e63a3499cde6)
