### PR TITLE
Fix UFOpaedia form crash

### DIFF
--- a/data/forms/ufopaedia.form
+++ b/data/forms/ufopaedia.form
@@ -85,6 +85,12 @@
           <alignment horizontal="left" vertical="centre"/>
           <font>smalfont</font>
         </label>
+        <label id="LABEL_10" text="LABEL_10">
+          <position x="340" y="210"/>
+          <size width="260" height="15"/>
+          <alignment horizontal="left" vertical="centre"/>
+        <font>smalfont</font>
+        </label>        
         <label id="VALUE_1" text="VALUE_1">
           <position x="360" y="66"/>
           <size width="250" height="15"/>
@@ -135,6 +141,12 @@
         </label>
         <label id="VALUE_9" text="VALUE_9">
           <position x="360" y="194"/>
+          <size width="250" height="15"/>
+          <alignment horizontal="right" vertical="centre"/>
+          <font>smalfont</font>
+        </label>
+        <label id="VALUE_10" text="VALUE_10">
+          <position x="360" y="210"/>
           <size width="250" height="15"/>
           <alignment horizontal="right" vertical="centre"/>
           <font>smalfont</font>

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -76,7 +76,7 @@ void UfopaediaCategoryView::begin()
 	}
 	baseY = infoLabel->Location.y;
 	baseH = infoLabel->Size.y;
-	for (int i = 0; i < 9; i++)
+	for (int i = 0; i < 10; i++)
 	{
 		auto labelName = format("LABEL_%d", i + 1);
 		auto label = menuform->findControlTyped<Label>(labelName);


### PR DESCRIPTION
A value was added to the UFOpaedia screen without changing the form, causing a crash in certain situations. This adds an extra label and value for this situation.