### PR TITLE
FIX - setPosition called on vehicle with no tile object crash #1109

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1372,14 +1372,13 @@ void Vehicle::enterBuilding(GameState &state, StateRef<Building> b)
 	crashed = false;
 	if (this->currentBuilding)
 	{
-		LogError("Vehicle already in a building?");
+  		LogError("Vehicle already in a building?");
 		return;
 	}
 	this->currentBuilding = b;
 	b->currentVehicles.insert({&state, shared_from_this()});
 
-	if (carriedVehicle && carriedByVehicle &&
-	    carriedVehicle->position == carriedByVehicle->position)
+	if (carriedVehicle)
 	{
 		carriedVehicle->enterBuilding(state, b);
 		carriedVehicle->processRecoveredVehicle(state);

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1372,7 +1372,7 @@ void Vehicle::enterBuilding(GameState &state, StateRef<Building> b)
 	crashed = false;
 	if (b->currentVehicles.find(&state) != b->currentVehicles.end())
 	{
-  		LogError("Vehicle already in a building?");
+		LogError("Vehicle already in a building?");
 		return;
 	}
 	this->currentBuilding = b;

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -385,11 +385,14 @@ class FlyingVehicleMover : public VehicleMover
 		}
 		if (vehicle.carriedByVehicle)
 		{
-			auto newPos = vehicle.carriedByVehicle->position;
-			newPos.z = std::max(0.0f, newPos.z - 0.5f);
-			vehicle.setPosition(newPos);
-			vehicle.facing = vehicle.carriedByVehicle->facing;
-			vehicle.updateSprite(state);
+			if (vehicle.tileObject)
+			{
+				auto newPos = vehicle.carriedByVehicle->position;
+				newPos.z = std::max(0.0f, newPos.z - 0.5f);
+				vehicle.setPosition(newPos);
+				vehicle.facing = vehicle.carriedByVehicle->facing;
+				vehicle.updateSprite(state);
+			}
 			return;
 		}
 		if (vehicle.crashed)
@@ -1374,7 +1377,9 @@ void Vehicle::enterBuilding(GameState &state, StateRef<Building> b)
 	}
 	this->currentBuilding = b;
 	b->currentVehicles.insert({&state, shared_from_this()});
-	if (carriedVehicle)
+
+	if (carriedVehicle && carriedByVehicle &&
+	    carriedVehicle->position == carriedByVehicle->position)
 	{
 		carriedVehicle->enterBuilding(state, b);
 		carriedVehicle->processRecoveredVehicle(state);

--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1370,7 +1370,7 @@ void Vehicle::enterBuilding(GameState &state, StateRef<Building> b)
 {
 	carriedByVehicle.clear();
 	crashed = false;
-	if (this->currentBuilding)
+	if (b->currentVehicles.find(&state) != b->currentVehicles.end())
 	{
   		LogError("Vehicle already in a building?");
 		return;

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -1269,6 +1269,9 @@ bool VehicleMission::getNextDestination(GameState &state, Vehicle &v, Vec3<float
 			return false;
 		}
 		case MissionType::GotoBuilding:
+		{
+			return false;
+		}
 		case MissionType::InvestigateBuilding:
 		{
 			if (v.currentBuilding != this->targetBuilding)


### PR DESCRIPTION
The issue turned out to be more complex than it initially seemed. Rescue V. 77 was trying to rescue Construction V. 76, which had crashed and was located inside a building. Since it didn't have a 'tileObject,' fixing that introduced new issues. These were also resolved. However, further testing is needed to ensure that Rescue V. still functions properly.