### PR TITLE
Fix scientist reassignment on lab deletion

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -431,6 +431,10 @@ void Base::destroyFacility(GameState &state, Vec2<int> pos)
 
 		if (facility->lab)
 		{
+			for (auto &a : facility->lab->assigned_agents)
+			{
+				a->assigned_to_lab = false;
+			}
 			if (facility->lab->current_project)
 			{
 				facility->lab->current_project->current_lab = "";


### PR DESCRIPTION
Fixes #1516 

Scientists and engineers are now unassigned when the lab or workshop is deleted.