### PR TITLE
Recheck mission end on brainsucker spawn

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -3839,6 +3839,7 @@ void BattleUnit::triggerBrainsuckers(GameState &state)
 				state.current_battle->spawnUnit(state, aliens, {&state, "AGENTTYPE_BRAINSUCKER"},
 				                                i->position, {0, 1}, BodyState::Throwing);
 				i->die(state, false);
+				state.current_battle->checkMissionEnd(state, false, true);
 			}
 		}
 	}


### PR DESCRIPTION
This fixes an interesting problem. 

If you kill the last alien right before a brainsucker hatches in a RT mission, the mission will end. This obviously should not happen as a hostile alien is still alive. I have even seen my units get brainsucked and the mission will still end.

This forces the game to re-check if the mission should end when a brainsucker hatches. I will include a save for ease of testing. The save is right before a brainsucker hatches and the last enemy has been killed.

[battleend.zip](https://github.com/user-attachments/files/18920594/battleend.zip)
