### PR TITLE
Build fix: Jukebox uses chrono

### DIFF
--- a/framework/jukebox.cpp
+++ b/framework/jukebox.cpp
@@ -6,6 +6,7 @@
 #include "framework/sound.h"
 #include "library/xorshift.h"
 #include <array>
+#include <chrono>
 
 namespace OpenApoc
 {


### PR DESCRIPTION
This seems to be needed to newer MSVC, likely we were relying on transitive includes previously?