### PR TITLE
Check for alien containment at base only

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1736,28 +1736,27 @@ StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 	std::set<StateRef<Organisation>> suppliers;
 	StateRef<Building> destination;
 
-	// Only add aliens if alien containment is available at base
-	const auto vehicleContainsAlienLoot = cargoContainsAlienLoot();
-	const auto alienContainmentExists =
-	    currentBuilding->base ? currentBuilding->base->alienContainmentExists() : false;
-
-	// Vehicle must be stopped from unloading alien cargo when vehicle has alien loot but base has
-	// no alien containment
-	const auto isVehicleAllowedToUnloadAlienCargo =
-	    !(vehicleContainsAlienLoot && !alienContainmentExists);
-
-	if (!isVehicleAllowedToUnloadAlienCargo)
-	{
-		fw().pushEvent(
-		    new GameVehicleEvent(GameEventType::VehicleWithAlienLootInBaseWithNoContainment,
-		                         {&state, shared_from_this()}));
-	}
-
 	// Step 01: Find first cargo destination and remove arrived cargo
 	for (auto it = cargo.begin(); it != cargo.end();)
 	{
 		if (it->destination == currentBuilding)
 		{
+			// Only add aliens if alien containment is available at base
+			const auto vehicleContainsAlienLoot = cargoContainsAlienLoot();
+			const auto alienContainmentExists =
+			    currentBuilding->base ? currentBuilding->base->alienContainmentExists() : false;
+
+			// Vehicle must be stopped from unloading alien cargo when vehicle has alien loot but
+			// base has no alien containment
+			const auto isVehicleAllowedToUnloadAlienCargo =
+			    !(vehicleContainsAlienLoot && !alienContainmentExists);
+
+			if (!isVehicleAllowedToUnloadAlienCargo)
+			{
+				fw().pushEvent(
+				    new GameVehicleEvent(GameEventType::VehicleWithAlienLootInBaseWithNoContainment,
+				                         {&state, shared_from_this()}));
+			}
 			// Only unload alien cargo when base has alien containment
 			if (it->type == Cargo::Type::Bio && !isVehicleAllowedToUnloadAlienCargo)
 			{


### PR DESCRIPTION
I ran into a problem when testing passenger pickup. I was trying to pick up multiple agents in the city in one run, but it failed due to a currentBuilding check when not in a building. This ensures that this check will only occur when the vehicle is landed in a building.

If you try to pick up another agent while already ferrying another, it will simply ignore the request and continue to the base. This was the behavior before the alien containment check.