### PR TITLE
Fix no manual pickup with CallExistingFerry option

### DIFF
--- a/game/state/city/building.cpp
+++ b/game/state/city/building.cpp
@@ -354,7 +354,6 @@ void Building::updateCargo(GameState &state)
 				}
 			}
 		} while (spawnedFerry);
-		return;
 	}
 
 	// Step 03.02: Compile list of carrying capacity required


### PR DESCRIPTION
As mentioned on Discord, manual pickup is not working under specific circumstances.

If CallExistingFerry is off and transtellar is hostile, you will not be able to manually pick up agents in the city. If the game is unable to spawn a ferry, the code never reaches the manual pickup section of updateCargo. This ensures the manual pickup section will always be evaluated.