### PR TITLE
Format everything in the lint CI step

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,6 +69,8 @@ jobs:
       run: |
         cmake --build ${{runner.workspace}}/build -t format-sources
         if [[ `git -C $GITHUB_WORKSPACE status --porcelain` ]]; then
+          echo "Format mismatch:";
+          git -C $GITHUB_WORKSPACE diff;
           exit 1;
         fi
         

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -67,14 +67,9 @@ jobs:
       working-directory: ${{runner.workspace}}
       shell: bash
       run: |
-        cd $GITHUB_WORKSPACE
-        if [ "${{env.BEFORE_COMMIT_SHA}}" == "0000000000000000000000000000000000000000" ]
-        then
-          echo '$GITHUB_WORKSPACE/tools/lint.sh ${{env.AFTER_COMMIT_SHA}}'
-          $GITHUB_WORKSPACE/tools/lint.sh ${{env.AFTER_COMMIT_SHA}}
-        else
-          echo '$GITHUB_WORKSPACE/tools/lint.sh ${{env.BEFORE_COMMIT_SHA}}..${{env.AFTER_COMMIT_SHA}}'
-          $GITHUB_WORKSPACE/tools/lint.sh ${{env.BEFORE_COMMIT_SHA}}..${{env.AFTER_COMMIT_SHA}}
+        cmake --build ${{runner.workspace}}/build -t format-sources
+        if [[ `git -C $GITHUB_WORKSPACE status --porcelain` ]]; then
+          exit 1;
         fi
         
 


### PR DESCRIPTION
The previous linter was fragile around removing files or figuring out what git refs to use, so just format *Everything* and fail if there's any changes made.