### PR TITLE
Alien infiltration screen update

### DIFF
--- a/data/forms/city/infiltration.form
+++ b/data/forms/city/infiltration.form
@@ -45,7 +45,7 @@
 		<listbox id="ORG_SELECT_BOX" scrollbarid="ORG_SELECT_SCROLL">
 			<position x="420" y="60"/>
 			<size width="140" height="298"/>
-			<item size="0" spacing="0"/>
+			<item size="0" spacing="2"/>
 			<selcolour r="255" g="255" b="255" a="0"/>
 		</listbox>
 		<graphicbutton id="ORG_SCROLL_UP" scrollprev="ORG_SELECT_SCROLL">

--- a/data/forms/city/infiltration.form
+++ b/data/forms/city/infiltration.form
@@ -38,6 +38,30 @@
         <image/>
         <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
       </graphicbutton>
+		<scroll id="ORG_SELECT_SCROLL">
+			<position x="566" y="71"/>
+			<size width="26" height="278"/>
+		</scroll>
+		<listbox id="ORG_SELECT_BOX" scrollbarid="ORG_SELECT_SCROLL">
+			<position x="420" y="60"/>
+			<size width="140" height="298"/>
+			<item size="0" spacing="0"/>
+			<selcolour r="255" g="255" b="255" a="0"/>
+		</listbox>
+		<graphicbutton id="ORG_SCROLL_UP" scrollprev="ORG_SELECT_SCROLL">
+			<tooltip text="Scroll Up" font="smallset"/>
+			<position x="568" y="46"/>
+			<size width="22" height="21"/>
+			<image/>
+			<imagedepressed>BUTTON_SCROLL_UP_DEPRESSED</imagedepressed>
+		</graphicbutton>
+		<graphicbutton id="ORG_SCROLL_DOWN" scrollnext="ORG_SELECT_SCROLL">
+			<tooltip text="Scroll Down" font="smallset"/>
+			<position x="568" y="352"/>
+			<size width="22" height="21"/>
+			<image/>
+			<imagedepressed>BUTTON_SCROLL_DOWN_DEPRESSED</imagedepressed>
+		</graphicbutton>
       <label id="ORG_NAME_0">
         <position x="38" y="386"/>
         <size width="260" height="14"/>

--- a/game/state/shared/organisation.h
+++ b/game/state/shared/organisation.h
@@ -124,6 +124,7 @@ class Organisation : public StateObject<Organisation>
 	bool militarized = false;
 	bool initiatesDiplomacy = false;
 	bool providesTransportationServices = false;
+	bool infiltrationSelected = false;
 
 	sp<Image> icon;
 

--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -22,7 +22,7 @@ constexpr int num_steps = 6 * 7;
 static void drawOrgLine(sp<RGBImage> image, const Organisation &org, const Colour &colour,
                         int steps)
 {
-	const float step_width = static_cast<float>(image->size.x - 1) / static_cast<float>(steps);
+	const float step_width = static_cast<float>(image->size.x - 1) / static_cast<float>(42);
 	constexpr int max_infiltration_value = 100;
 	float infiltration_y_scale =
 	    static_cast<float>(image->size.y - 1) / static_cast<float>(max_infiltration_value);
@@ -237,7 +237,7 @@ void InfiltrationScreen::reset_shown_orgs()
 	{
 		if (org.second->id == "ORG_ALIEN" || org.second->id == "ORG_X-COM")
 			continue;
-		if (org.second->infiltrationValue == 0)
+		if (org.second->infiltrationValue == 0 || org.second->infiltrationValue == 200)
 			continue;
 		orgs.push_back(org.second.get());
 	}

--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -1,4 +1,4 @@
-#include "game/ui/city/infiltrationscreen.h"
+﻿#include "game/ui/city/infiltrationscreen.h"
 #include "forms/form.h"
 #include "forms/graphic.h"
 #include "forms/label.h"
@@ -22,7 +22,7 @@ constexpr int num_steps = 6 * 7;
 static void drawOrgLine(sp<RGBImage> image, const Organisation &org, const Colour &colour,
                         int steps)
 {
-	const float step_width = static_cast<float>(image->size.x - 1) / static_cast<float>(42);
+	const float step_width = static_cast<float>(image->size.x - 1) / static_cast<float>(steps);
 	constexpr int max_infiltration_value = 100;
 	float infiltration_y_scale =
 	    static_cast<float>(image->size.y - 1) / static_cast<float>(max_infiltration_value);
@@ -43,16 +43,20 @@ static void drawOrgLine(sp<RGBImage> image, const Organisation &org, const Colou
 
 	auto image_lock = RGBImageLock(image);
 
+	float x_offset = step_width;
+
 	// TODO: Make curved lines
 	for (step = 0; step < steps - 1; step++)
 	{
 		const Vec3<float> start_point = {
-		    static_cast<float>(image->size.x - 1) - static_cast<float>(step) * step_width,
+		    static_cast<float>(image->size.x - 1) - static_cast<float>(step) * step_width -
+		        x_offset,
 		    static_cast<float>(image->size.y - 1) - step_values[step] * infiltration_y_scale, 0};
-		const Vec3<float> end_point = {
-		    static_cast<float>(image->size.x - 1) - static_cast<float>(step + 1) * step_width,
-		    static_cast<float>(image->size.y - 1) - step_values[step + 1] * infiltration_y_scale,
-		    0};
+		const Vec3<float> end_point = {static_cast<float>(image->size.x - 1) -
+		                                   static_cast<float>(step + 1) * step_width - x_offset,
+		                               static_cast<float>(image->size.y - 1) -
+		                                   step_values[step + 1] * infiltration_y_scale,
+		                               0};
 
 		const auto start_point_int = Vec3<int>(start_point);
 		const auto end_point_int = Vec3<int>(end_point);

--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -108,6 +108,7 @@ InfiltrationScreen::~InfiltrationScreen() = default;
 void InfiltrationScreen::begin()
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
+	this->reset_shown_orgs();
 	this->updateOrgs();
 	this->update_view();
 	this->update();

--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -81,8 +81,6 @@ constexpr std::array<Colour, 10> line_colors = {
 InfiltrationScreen::InfiltrationScreen(sp<GameState> state)
     : Stage(), menuform(ui().getForm("city/infiltration")), state(state)
 {
-	updateAll();
-
 	auto orgBox = menuform->findControlTyped<ListBox>(format("ORG_SELECT_BOX"));
 	orgBox->addCallback(FormEventType::MouseClick,
 	                    [this](FormsEvent *e)
@@ -106,7 +104,9 @@ InfiltrationScreen::~InfiltrationScreen() = default;
 void InfiltrationScreen::begin()
 {
 	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
+	this->updateOrgs();
 	this->update_view();
+	this->update();
 }
 
 void InfiltrationScreen::pause() {}
@@ -139,13 +139,13 @@ void InfiltrationScreen::eventOccurred(Event *e)
 		if (e->forms().RaisedBy->Name == "BUTTON_TOPTEN")
 		{
 			this->reset_shown_orgs();
-			updateAll();
+			updateOrgs();
 			return;
 		}
 	}
 }
 
-void InfiltrationScreen::updateAll()
+void InfiltrationScreen::updateOrgs()
 {
 	// OG organisation order
 	std::vector<std::string> organisationOrder = {
@@ -162,16 +162,15 @@ void InfiltrationScreen::updateAll()
 	auto orgBox = menuform->findControlTyped<ListBox>(format("ORG_SELECT_BOX"));
 	orgBox->clear();
 
-	for (const auto &orgID : organisationOrder)
+	for (const auto &orgId : organisationOrder)
 	{
-		auto orgIt = state->organisations.find(orgID);
+		auto orgIt = state->organisations.find(orgId);
 		if (orgIt != state->organisations.end())
 		{
 			auto org = orgIt->second;
 			org->infiltrationSelected = false;
 
-			auto info = ControlGenerator::createLargeOrganisationInfo(*state, org);
-			auto control = ControlGenerator::createLargeOrganisationControl(*state, info);
+			auto control = ControlGenerator::createLargeOrganisationControl(*state, org);
 			orgBox->replaceItem(control);
 		}
 	}
@@ -183,8 +182,7 @@ void InfiltrationScreen::updateAll()
 			auto org = orgPos->second;
 			org->infiltrationSelected = true;
 
-			auto info = ControlGenerator::createLargeOrganisationInfo(*state, org);
-			auto control = ControlGenerator::createLargeOrganisationControl(*state, info);
+			auto control = ControlGenerator::createLargeOrganisationControl(*state, org);
 			orgBox->replaceItem(control);
 		}
 	}
@@ -194,8 +192,7 @@ void InfiltrationScreen::updateOrgControl(sp<Organisation> org)
 {
 	auto orgBox = menuform->findControlTyped<ListBox>(format("ORG_SELECT_BOX"));
 
-	auto info = ControlGenerator::createLargeOrganisationInfo(*state, org);
-	auto control = ControlGenerator::createLargeOrganisationControl(*state, info);
+	auto control = ControlGenerator::createLargeOrganisationControl(*state, org);
 	orgBox->replaceItem(control);
 }
 

--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -234,9 +234,9 @@ void InfiltrationScreen::add_orgs(Organisation &org)
 
 void InfiltrationScreen::reset_shown_orgs()
 {
-	std::vector<Organisation *> orgs;
+	std::vector<const Organisation *> orgs;
 
-	for (auto &org : state->organisations)
+	for (const auto &org : state->organisations)
 	{
 		if (org.second->id == "ORG_ALIEN" || org.second->id == "ORG_X-COM")
 			continue;
@@ -245,7 +245,7 @@ void InfiltrationScreen::reset_shown_orgs()
 		orgs.push_back(org.second.get());
 	}
 
-	auto infiltration_comparer = [](Organisation *org1, Organisation *org2)
+	auto infiltration_comparer = [](const Organisation *org1, const Organisation *org2)
 	{ return org1->infiltrationValue > org2->infiltrationValue; };
 	std::sort(orgs.begin(), orgs.end(), infiltration_comparer);
 

--- a/game/ui/city/infiltrationscreen.h
+++ b/game/ui/city/infiltrationscreen.h
@@ -24,12 +24,11 @@ class InfiltrationScreen : public Stage
 	std::array<Label *, 10> shown_org_names;
 	std::array<const Organisation *, 10> shown_orgs;
 	std::vector<const Organisation *> selectedOrgs;
-	// std::list<sp<Organisation>> selectedOrgs;
 	void reset_shown_orgs();
 	void update_view();
 	void add_orgs(Organisation &org);
 	void updateOrgControl(sp<Organisation> org);
-	void updateAll();
+	void updateOrgs();
 
   public:
 	InfiltrationScreen(sp<GameState> state);

--- a/game/ui/city/infiltrationscreen.h
+++ b/game/ui/city/infiltrationscreen.h
@@ -23,8 +23,13 @@ class InfiltrationScreen : public Stage
 	sp<GameState> state;
 	std::array<Label *, 10> shown_org_names;
 	std::array<const Organisation *, 10> shown_orgs;
+	std::vector<const Organisation *> selectedOrgs;
+	// std::list<sp<Organisation>> selectedOrgs;
 	void reset_shown_orgs();
 	void update_view();
+	void add_orgs(Organisation &org);
+	void updateOrgControl(sp<Organisation> org);
+	void updateAll();
 
   public:
 	InfiltrationScreen(sp<GameState> state);

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -750,6 +750,12 @@ sp<Control> ControlGenerator::createLargeOrganisationControl(GameState &state,
 	return baseControl;
 }
 
+sp<Control> ControlGenerator::createLargeOrganisationControl(GameState &state, sp<Organisation> org)
+{
+	auto i = createLargeOrganisationInfo(state, org);
+	return createLargeOrganisationControl(state, i);
+}
+
 sp<Control> ControlGenerator::createOrganisationControl(GameState &state, sp<Organisation> org)
 {
 	auto i = createOrganisationInfo(state, org);

--- a/game/ui/components/controlgenerator.cpp
+++ b/game/ui/components/controlgenerator.cpp
@@ -693,6 +693,15 @@ OrganisationInfo ControlGenerator::createOrganisationInfo(GameState &state, sp<O
 	return i;
 }
 
+OrganisationInfo ControlGenerator::createLargeOrganisationInfo(GameState &state,
+                                                               sp<Organisation> org)
+{
+	auto i = OrganisationInfo();
+	i.organisation = org;
+	i.selected = org->infiltrationSelected;
+	return i;
+}
+
 sp<Control> ControlGenerator::createOrganisationControl(GameState &state,
                                                         const OrganisationInfo &info)
 {
@@ -714,6 +723,29 @@ sp<Control> ControlGenerator::createOrganisationControl(GameState &state,
 	orgIcon->Location = {1, 1};
 	orgIcon->Name = "ORG_ICON_" + info.organisation->name;
 	orgIcon->ToolTipText = tr(info.organisation->name);
+
+	return baseControl;
+}
+
+sp<Control> ControlGenerator::createLargeOrganisationControl(GameState &state,
+                                                             const OrganisationInfo &info)
+{
+	if (!singleton.initialised)
+	{
+		singleton.init(state);
+	}
+	auto frame = singleton.citySelect[info.selected ? 2 : 0];
+	auto baseControl = mksp<Graphic>(frame);
+	baseControl->setData(info.organisation);
+	baseControl->Size = {140, singleton.labelFont->getFontHeight() * 2};
+
+	auto orgIcon = baseControl->createChild<Graphic>(info.organisation->icon);
+	orgIcon->AutoSize = true;
+	orgIcon->Location = {1, 1};
+
+	auto orgLabel = baseControl->createChild<Label>(info.organisation->name, singleton.labelFont);
+	orgLabel->Location = {40, 3};
+	orgLabel->Size = {baseControl->Size.x, singleton.labelFont->getFontHeight() * 2};
 
 	return baseControl;
 }

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -124,6 +124,7 @@ class ControlGenerator
 	static sp<Control> createLargeOrganisationControl(GameState &state,
 	                                                  const OrganisationInfo &info);
 	static sp<Control> createOrganisationControl(GameState &state, sp<Organisation> org);
+	static sp<Control> createLargeOrganisationControl(GameState &state, sp<Organisation> org);
 
 	static int getFontHeight(GameState &state);
 };

--- a/game/ui/components/controlgenerator.h
+++ b/game/ui/components/controlgenerator.h
@@ -119,7 +119,10 @@ class ControlGenerator
 	static sp<Control> createDoubleListControl(const int controlLength);
 
 	static OrganisationInfo createOrganisationInfo(GameState &state, sp<Organisation> org);
+	static OrganisationInfo createLargeOrganisationInfo(GameState &state, sp<Organisation> org);
 	static sp<Control> createOrganisationControl(GameState &state, const OrganisationInfo &info);
+	static sp<Control> createLargeOrganisationControl(GameState &state,
+	                                                  const OrganisationInfo &info);
 	static sp<Control> createOrganisationControl(GameState &state, sp<Organisation> org);
 
 	static int getFontHeight(GameState &state);


### PR DESCRIPTION
Addresses #1211 
Here is the updated alien infiltration screen, changes:

- [x] Organizations added
- [x] Proper org order as per OG
- [x] Individual org select while keeping position
- [x] Fix curve? NO
- [x] Fix 640 x 480 glitch

Org spacing isn't perfect, but pretty close. I don't think the icon size is exact either, but I used the existing cityview org icons.

There is a problem on 640 x 480 where the icons won't appear until moused over. This is an issue that has popped up before.

There is a TODO about making curved lines, that may be above my skills.

Let me know if anything else is broken.