### PR TITLE
Fix mouse grab on Linux

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -892,6 +892,7 @@ void Framework::displayInitialise()
 
 	auto mouseCapture = Options::mouseCaptureOption.get();
 	SDL_SetWindowMouseGrab(p->window, mouseCapture ? SDL_TRUE : SDL_FALSE);
+	SDL_SetRelativeMouseMode(mouseCapture ? SDL_TRUE : SDL_FALSE);
 
 	// FIXME: Scale is currently stored as an integer in 1/100 units (ie 100 is 1.0 == same
 	// size)


### PR DESCRIPTION
So apparently on Linux, SetRelativeMouseMode also needs to be true for the mouse grab feature to work. I can't test on MacOS so no idea if this is working there. It doesn't seem any UI interactions have been affected with this change.