### PR TITLE
Don't follow vehicle when idle

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -142,6 +142,7 @@ void dumpOptionsToLog()
 	dumpOption(optionLoadSameAmmo);
 	dumpOption(optionShowCurrentDimensionVehicles);
 	dumpOption(optionShowNonXCOMVehiclesPrefix);
+	dumpOption(isoOnlyFollow);
 
 	dumpOption(optionStunHostileAction);
 	dumpOption(optionRaidHostileAction);
@@ -456,7 +457,8 @@ ConfigOptionBool
                                        true);
 ConfigOptionBool optionShowNonXCOMVehiclesPrefix("OpenApoc.NewFeature", "ShowNonXCOMVehiclesPrefix",
                                                  tr("Add prefix to non-X-COM vehicles"), true);
-
+ConfigOptionBool isoOnlyFollow("OpenApoc.NewFeature", "IsoOnlyFollow",
+                               tr("Don't follow vehicles in strategy view"), false);
 ConfigOptionBool optionStunHostileAction("OpenApoc.Mod", "StunHostileAction",
                                          "Stunning hurts relationships", false);
 ConfigOptionBool optionRaidHostileAction("OpenApoc.Mod", "RaidHostileAction",

--- a/framework/options.h
+++ b/framework/options.h
@@ -122,6 +122,7 @@ extern ConfigOptionFloat optionSceneryRepairCostFactor;
 extern ConfigOptionBool optionLoadSameAmmo;
 extern ConfigOptionBool optionShowCurrentDimensionVehicles;
 extern ConfigOptionBool optionShowNonXCOMVehiclesPrefix;
+extern ConfigOptionBool isoOnlyFollow;
 
 extern ConfigOptionBool optionStunHostileAction;
 extern ConfigOptionBool optionRaidHostileAction;

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -45,6 +45,7 @@ static const std::list<std::pair<UString, UString>> cityscapeList = {
     {"OpenApoc.NewFeature", "ATVUFOMission"},
     {"OpenApoc.NewFeature", "ShowCurrentDimensionVehicles"},
     {"OpenApoc.NewFeature", "ShowNonXCOMVehiclesPrefix"},
+    {"OpenApoc.NewFeature", "IsoOnlyFollow"},
     {"OpenApoc.Mod", "MaxTileRepair"},
     {"OpenApoc.Mod", "SceneryRepairCostFactor"},
     {"OpenApoc.Mod", "RaidHostileAction"},

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3328,8 +3328,8 @@ void CityView::update()
 			auto v = state->current_city->cityViewSelectedOwnedVehicles.front();
 			if (v->city == state->current_city)
 			{
-				// Don't follow if vehicle is in building
-				if (!v->currentBuilding)
+				// Don't follow if vehicle is in building or idle
+				if (!v->currentBuilding && !v->missions.empty())
 				{
 					this->setScreenCenterTile(v->position);
 				}
@@ -3343,8 +3343,8 @@ void CityView::update()
 			{
 				if (a->currentVehicle)
 				{
-					// Don't follow if current vehicle is in building
-					if (!a->currentVehicle->currentBuilding)
+					// Don't follow if current vehicle is in building or idle
+					if (!a->currentVehicle->currentBuilding && !a->currentVehicle->missions.empty())
 					{
 						this->setScreenCenterTile(a->currentVehicle->position);
 					}

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -3319,9 +3319,12 @@ void CityView::update()
 	baseForm->update();
 	overlayTab->update();
 
+	auto isoFollow =
+	    config().getBool("OpenApoc.NewFeature.IsoOnlyFollow") && viewMode == TileViewMode::Strategy;
+
 	// If we have 'follow vehicle' enabled we clobber any other movement that may have occurred in
 	// this frame
-	if (this->followVehicle && this->updateSpeed != CityUpdateSpeed::Pause)
+	if (this->followVehicle && this->updateSpeed != CityUpdateSpeed::Pause && !isoFollow)
 	{
 		if (activeTab == uiTabs[1] && !state->current_city->cityViewSelectedOwnedVehicles.empty())
 		{
@@ -3335,7 +3338,8 @@ void CityView::update()
 				}
 			}
 		}
-		else if (activeTab == uiTabs[2] && !state->current_city->cityViewSelectedSoldiers.empty())
+		else if (activeTab == uiTabs[2] && !state->current_city->cityViewSelectedSoldiers.empty() &&
+		         !isoFollow)
 		{
 			auto a = state->current_city->cityViewSelectedSoldiers.front();
 


### PR DESCRIPTION
Vehicles are not followed when idle, same with the soldiers in vehicles. An option has been added to prevent the following of vehicles on the strategy map as per OG, off by default.