### PR TITLE
Add correct speed to light vehicle types

### DIFF
--- a/game/state/rules/city/vehicletype.h
+++ b/game/state/rules/city/vehicletype.h
@@ -278,15 +278,27 @@ class VehicleType : public StateObject<VehicleType>
 		                           sp<VEquipmentType>>::value,
 		              "iterator must return sp<VehicleEquipmentType>");
 
-		// FIXME: This is somehow modulated by weight?
+		int weight = this->getWeight(first, last);
 		float speed = this->top_speed;
+		bool hasEngine = false;
+		// Light vehicles have +4 speed
+		if (weight < 350)
+		{
+			speed += 4;
+		}
 		while (first != last)
 		{
 			if ((*first)->type == EquipmentSlotType::VehicleEngine)
 			{
 				speed += (*first)->top_speed;
+				hasEngine = true;
 			}
 			++first;
+		}
+		// Vehicle without engine has 0 speed
+		if (!hasEngine)
+		{
+			return 0;
 		}
 		return speed;
 	}


### PR DESCRIPTION
Fixes #1411 

According to Wong, bikes get +4 speed. A helpful [comment](https://github.com/OpenApoc/OpenApoc/issues/1411#issuecomment-2256734991) by @acejoh pointed to all vehicles under 350 weight getting the boost. This is what I went with.
