### PR TITLE
Fix alien craft having 0 speed

### DIFF
--- a/game/state/rules/city/vehicletype.h
+++ b/game/state/rules/city/vehicletype.h
@@ -281,11 +281,6 @@ class VehicleType : public StateObject<VehicleType>
 		int weight = this->getWeight(first, last);
 		float speed = this->top_speed;
 		bool hasEngine = false;
-		// Light vehicles have +4 speed
-		if (weight < 350)
-		{
-			speed += 4;
-		}
 		while (first != last)
 		{
 			if ((*first)->type == EquipmentSlotType::VehicleEngine)
@@ -295,10 +290,10 @@ class VehicleType : public StateObject<VehicleType>
 			}
 			++first;
 		}
-		// Vehicle without engine has 0 speed
-		if (!hasEngine)
+		// Light vehicles have +4 speed
+		if (weight < 350 && hasEngine)
 		{
-			return 0;
+			speed += 4;
 		}
 		return speed;
 	}


### PR DESCRIPTION
I didn't realize alien craft have no engine, this meant they could not move with my change. It is fixed now. The 03162025 release is completely broken and should be destroyed.