### PR TITLE
Cleanup battle location management

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2673,7 +2673,7 @@ void Battle::finishBattle(GameState &state)
 	// If mission == Alien extermination, remove the red alien spotted circle
 	if (state.current_battle->mission_type == Battle::MissionType::AlienExtermination)
 	{
-		StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+		StateRef<Building> location = state.current_battle->mission_location_building;
 		location->detected = false;
 	}
 
@@ -2765,7 +2765,7 @@ void Battle::finishBattle(GameState &state)
 		// If alien building - all aliens vanish
 		else
 		{
-			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+			StateRef<Building> location = state.current_battle->mission_location_building;
 			if (location->owner != aliens)
 			{
 				for (auto &a : liveAliens)
@@ -2809,13 +2809,13 @@ void Battle::finishBattle(GameState &state)
 		StateRef<City> city;
 		if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
 		{
-			StateRef<Vehicle> location = {&state, state.current_battle->mission_location_id};
+			StateRef<Vehicle> location = state.current_battle->mission_location_vehicle;
 			city = location->city;
 			battleLocation = {location->position.x, location->position.y};
 		}
 		else
 		{
-			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+			StateRef<Building> location = state.current_battle->mission_location_building;
 			city = location->city;
 			battleLocation = location->bounds.p0;
 		}
@@ -3038,7 +3038,7 @@ void Battle::exitBattle(GameState &state)
 
 	if (state.current_battle->mission_type == MissionType::UfoRecovery)
 	{
-		auto vehicle = StateRef<Vehicle>(&state, state.current_battle->mission_location_id);
+		auto vehicle = state.current_battle->mission_location_vehicle;
 		for (auto &e : vehicle->loot)
 		{
 			vehicleLoot[e]++;
@@ -3114,7 +3114,7 @@ void Battle::exitBattle(GameState &state)
 		else
 		{
 			// Deposit loot into building, call for pickup
-			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+			StateRef<Building> location = state.current_battle->mission_location_building;
 			auto homeBuilding =
 			    playerVehicles.empty() ? nullptr : playerVehicles.front()->homeBuilding;
 			if (!homeBuilding)
@@ -3383,8 +3383,7 @@ void Battle::exitBattle(GameState &state)
 			if (state.current_battle->playerWon)
 			{
 				state.eventFromBattle = GameEventType::MissionCompletedBuildingAlien;
-				auto building =
-				    StateRef<Building>(&state, state.current_battle->mission_location_id);
+				auto building = state.current_battle->mission_location_building;
 				for (auto &u : building->researchUnlock)
 				{
 					u->forceComplete();
@@ -3401,7 +3400,7 @@ void Battle::exitBattle(GameState &state)
 		case Battle::MissionType::AlienExtermination:
 		{
 			state.eventFromBattle = GameEventType::MissionCompletedBuildingNormal;
-			state.missionLocationBattle = state.current_battle->mission_location_id;
+			state.missionLocationBattleBuilding = state.current_battle->mission_location_building;
 			break;
 		}
 		case Battle::MissionType::BaseDefense:
@@ -3409,14 +3408,15 @@ void Battle::exitBattle(GameState &state)
 			if (state.current_battle->playerWon)
 			{
 				state.eventFromBattle = GameEventType::MissionCompletedBase;
-				state.missionLocationBattle = state.current_battle->mission_location_id;
+				state.missionLocationBattleBuilding =
+				    state.current_battle->mission_location_building;
 			}
 			else
 			{
-				auto building =
-				    StateRef<Building>{&state, state.current_battle->mission_location_id};
+				auto building = state.current_battle->mission_location_building;
 				state.eventFromBattle = GameEventType::BaseDestroyed;
-				state.missionLocationBattle = state.current_battle->mission_location_id;
+				state.missionLocationBattleBuilding =
+				    state.current_battle->mission_location_building;
 				state.eventFromBattleText = building->base->name;
 				building->base->die(state, false);
 			}
@@ -3425,11 +3425,10 @@ void Battle::exitBattle(GameState &state)
 		case Battle::MissionType::RaidHumans:
 		{
 			state.eventFromBattle = GameEventType::MissionCompletedBuildingRaid;
-			state.missionLocationBattle = state.current_battle->mission_location_id;
+			state.missionLocationBattleBuilding = state.current_battle->mission_location_building;
 			if (state.current_battle->playerWon)
 			{
-				auto building =
-				    StateRef<Building>(&state, state.current_battle->mission_location_id);
+				auto building = state.current_battle->mission_location_building;
 				for (auto &u : building->researchUnlock)
 				{
 					u->forceComplete();
@@ -3450,7 +3449,7 @@ void Battle::exitBattle(GameState &state)
 		case Battle::MissionType::UfoRecovery:
 		{
 			state.eventFromBattle = GameEventType::MissionCompletedVehicle;
-			auto vehicle = StateRef<Vehicle>(&state, state.current_battle->mission_location_id);
+			auto vehicle = state.current_battle->mission_location_vehicle;
 			for (auto &u : vehicle->type->researchUnlock)
 			{
 				u->forceComplete();
@@ -3803,7 +3802,7 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 		if (state.current_battle->mission_type == Battle::MissionType::UfoRecovery)
 		{
 			StateRef<City> city;
-			StateRef<Vehicle> location = {&state, state.current_battle->mission_location_id};
+			StateRef<Vehicle> location = state.current_battle->mission_location_vehicle;
 			city = location->city;
 
 			for (const auto &v : state.vehicles)
@@ -3829,7 +3828,7 @@ const std::list<StateRef<Vehicle>> Battle::getPlayerVehicles(GameState &state)
 		}
 		else
 		{
-			StateRef<Building> location = {&state, state.current_battle->mission_location_id};
+			StateRef<Building> location = state.current_battle->mission_location_building;
 			for (const auto &v : location->currentVehicles)
 			{
 				// Player's vehicle was already added and has priority

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -131,7 +131,8 @@ class Battle : public std::enable_shared_from_this<Battle>
 	// - Map part which is door opening/closing
 	std::set<Vec3<int>> tilesChangedForVision;
 	MissionType mission_type = MissionType::AlienExtermination;
-	UString mission_location_id;
+	StateRef<Building> mission_location_building;
+	StateRef<Vehicle> mission_location_vehicle;
 	Mode mode = Mode::RealTime;
 	BattleScore score = {};
 	unsigned missionEndTimer = 0;

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1619,25 +1619,24 @@ void GameState::updateAfterBattle()
 		}
 		case GameEventType::MissionCompletedBuildingNormal:
 		{
-			fw().pushEvent(new GameBuildingEvent(eventFromBattle, {this, missionLocationBattle}));
+			fw().pushEvent(new GameBuildingEvent(eventFromBattle, missionLocationBattleBuilding));
 			break;
 		}
 		case GameEventType::MissionCompletedBase:
 		{
-			fw().pushEvent(new GameBaseEvent(
-			    eventFromBattle, StateRef<Building>(this, missionLocationBattle)->base));
+			fw().pushEvent(new GameBaseEvent(eventFromBattle, missionLocationBattleBuilding->base));
 			break;
 		}
 		case GameEventType::BaseDestroyed:
 		{
-			auto building = StateRef<Building>{this, missionLocationBattle};
+			auto building = missionLocationBattleBuilding;
 			fw().pushEvent(new GameSomethingDiedEvent(eventFromBattle, eventFromBattleText,
 			                                          "bySomeone", building->crewQuarters));
 			break;
 		}
 		case GameEventType::MissionCompletedBuildingRaid:
 		{
-			fw().pushEvent(new GameBuildingEvent(eventFromBattle, {this, missionLocationBattle}));
+			fw().pushEvent(new GameBuildingEvent(eventFromBattle, missionLocationBattleBuilding));
 			break;
 		}
 		case GameEventType::MissionCompletedVehicle:

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -156,7 +156,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 	// Used to move events from battle to city and remember time
 
 	GameTime gameTimeBeforeBattle = GameTime(0);
-	UString missionLocationBattle;
+	StateRef<Building> missionLocationBattleBuilding;
 	UString eventFromBattleText;
 	GameEventType eventFromBattle = GameEventType::None;
 

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -53,7 +53,7 @@
     <member>rng</member>
     <member>gameTime</member>
     <member>gameTimeBeforeBattle</member>
-    <member>missionLocationBattle</member>
+    <member>missionLocationBattleBuilding</member>
     <member>eventFromBattleText</member>
     <member>eventFromBattle</member>
     <member type="SectionMap">battle_maps</member>
@@ -635,7 +635,8 @@
     <member>linkNeedsUpdate</member>
     <member>tilesChangedForVision</member>
     <member>mission_type</member>
-    <member>mission_location_id</member>
+    <member>mission_location_building</member>
+    <member>mission_location_vehicle</member>
     <member>mode</member>
     <member>score</member>
     <member>missionEndTimer</member>

--- a/game/state/rules/battle/battlemap.h
+++ b/game/state/rules/battle/battlemap.h
@@ -83,20 +83,23 @@ class BattleMap : public StateObject<BattleMap>
 	sp<Battle> createBattle(GameState &state, StateRef<Organisation> propertyOwner,
 	                        StateRef<Organisation> opponent, std::list<StateRef<Agent>> &agents,
 	                        StateRef<Vehicle> player_craft, Battle::MissionType mission_type,
-	                        UString mission_location_id);
+	                        StateRef<Building> mission_location_building,
+	                        StateRef<Vehicle> mission_location_vehicle);
 
 	bool generateMap(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int> &size, GameState &state,
 	                 GenerationSize genSize);
 
 	bool generateBase(std::vector<sp<BattleMapSector>> &sec_map, Vec3<int> &size, GameState &state,
-	                  UString mission_location_id);
+	                  StateRef<Building> mission_location);
 
 	sp<Battle> fillMap(std::vector<std::list<std::pair<Vec3<int>, sp<BattleMapPart>>>> &doors,
 	                   bool &spawnCivilians, std::vector<sp<BattleMapSector>> sec_map,
 	                   Vec3<int> size, GameState &state, StateRef<Organisation> propertyOwner,
 	                   StateRef<Organisation> target_organisation,
 	                   std::list<StateRef<Agent>> &agents, StateRef<Vehicle> player_craft,
-	                   Battle::MissionType mission_type, UString mission_location_id);
+	                   Battle::MissionType mission_type,
+	                   StateRef<Building> mission_location_building,
+	                   StateRef<Vehicle> mission_location_vehicle);
 
 	void linkDoors(sp<Battle> b,
 	               std::vector<std::list<std::pair<Vec3<int>, sp<BattleMapPart>>>> doors,


### PR DESCRIPTION
A code cleanup split out of some ongoing re-work of StateRef<> stuff, shouldn't cause any functional changes - Except it'll change the save format slightly breaking saves if you have an ongoing battle

Rather than casting between string IDs and StateRef<Building> and StateRef<Vehicle> all the time just store the StateRefs directly, as typed objects tend to be less error-prone.