### PR TITLE
Fix infiltration screen blank when exceeding 42 days

### DIFF
--- a/game/ui/city/infiltrationscreen.cpp
+++ b/game/ui/city/infiltrationscreen.cpp
@@ -36,7 +36,7 @@ static void drawOrgLine(sp<RGBImage> image, const Organisation &org, const Colou
 	for (const auto step_value : org.infiltrationHistory)
 	{
 		if (step > steps)
-			return;
+			break;
 		step_values[step] = static_cast<float>(std::min(max_infiltration_value, step_value));
 		step++;
 	}


### PR DESCRIPTION
The infiltration screen would not draw lines if the number of days in game exceeded the number of steps in the graph (42). 

Save to test:
[Sickve.-fixed.zip](https://github.com/user-attachments/files/19618687/Sickve.-fixed.zip)
