### PR TITLE
Fix cutoff text in text_funds label

### DIFF
--- a/data/forms/aequipscreen.form
+++ b/data/forms/aequipscreen.form
@@ -21,8 +21,8 @@
         <position x="552" y="9"/>
       </graphic>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/basescreen.form
+++ b/data/forms/basescreen.form
@@ -21,8 +21,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/cheatoptions.form
+++ b/data/forms/cheatoptions.form
@@ -15,8 +15,8 @@
           <font>bigfont</font>
         </label>
         <label id="TEXT_FUNDS">
-          <position x="572" y="11"/>
-          <size width="60" height="10"/>
+          <position x="572" y="9"/>
+          <size width="60" height="14"/>
           <alignment horizontal="left" vertical="centre"/>
           <font>smalfont</font>
         </label>

--- a/data/forms/city/alert.form
+++ b/data/forms/city/alert.form
@@ -17,8 +17,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/basebuy.form
+++ b/data/forms/city/basebuy.form
@@ -27,8 +27,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/baseselect.form
+++ b/data/forms/city/baseselect.form
@@ -18,8 +18,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="14"/>
-        <size width="60" height="10"/>
+        <position x="572" y="12"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/bribe.form
+++ b/data/forms/city/bribe.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/building.form
+++ b/data/forms/city/building.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/diplomatic_treaty.form
+++ b/data/forms/city/diplomatic_treaty.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/infiltration.form
+++ b/data/forms/city/infiltration.form
@@ -20,8 +20,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/location.form
+++ b/data/forms/city/location.form
@@ -9,8 +9,8 @@
         <size width="640" height="480"/>
       </graphic>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/score.form
+++ b/data/forms/city/score.form
@@ -17,8 +17,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/city/weekly_funding.form
+++ b/data/forms/city/weekly_funding.form
@@ -17,8 +17,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/ingameoptions.form
+++ b/data/forms/ingameoptions.form
@@ -15,8 +15,8 @@
           <font>bigfont</font>
         </label>
         <label id="TEXT_FUNDS">
-          <position x="572" y="11"/>
-          <size width="60" height="10"/>
+          <position x="572" y="9"/>
+          <size width="60" height="14"/>
           <alignment horizontal="left" vertical="centre"/>
           <font>smalfont</font>
         </label>

--- a/data/forms/mapselector.form
+++ b/data/forms/mapselector.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/messagelog.form
+++ b/data/forms/messagelog.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/moreoptions.form
+++ b/data/forms/moreoptions.form
@@ -15,8 +15,8 @@
 					<font>bigfont</font>
 				</label>
 				<label id="TEXT_FUNDS">
-					<position x="572" y="11"/>
-					<size width="60" height="10"/>
+					<position x="572" y="9"/>
+					<size width="60" height="14"/>
 					<alignment horizontal="left" vertical="centre"/>
 					<font>smalfont</font>
 				</label>

--- a/data/forms/recruitscreen.form
+++ b/data/forms/recruitscreen.form
@@ -17,8 +17,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>
@@ -34,8 +34,8 @@
         <image>city/dollar-icon.png</image>
       </graphic>
       <label id="TEXT_FUNDS_DELTA">
-        <position x="65" y="11"/>
-        <size width="60" height="10"/>
+        <position x="65" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/researchscreen.form
+++ b/data/forms/researchscreen.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/researchselect.form
+++ b/data/forms/researchselect.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/savemenu.form
+++ b/data/forms/savemenu.form
@@ -11,8 +11,8 @@
         <position x="2" y="2"/>
         <size width="640" height="480"/>
         <label id="TEXT_FUNDS">
-          <position x="572" y="11"/>
-          <size width="60" height="10"/>
+          <position x="572" y="9"/>
+          <size width="60" height="14"/>
           <alignment horizontal="left" vertical="centre"/>
           <font>smalfont</font>
         </label>

--- a/data/forms/selectforces.form
+++ b/data/forms/selectforces.form
@@ -17,8 +17,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/skirmish.form
+++ b/data/forms/skirmish.form
@@ -17,8 +17,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/transactionscreen.form
+++ b/data/forms/transactionscreen.form
@@ -15,8 +15,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>
@@ -31,8 +31,8 @@
         <image>city/dollar-icon.png</image>
       </graphic>
       <label id="TEXT_FUNDS_DELTA">
-        <position x="65" y="11"/>
-        <size width="60" height="10"/>
+        <position x="65" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>

--- a/data/forms/vequipscreen.form
+++ b/data/forms/vequipscreen.form
@@ -16,8 +16,8 @@
         <font>bigfont</font>
       </label>
       <label id="TEXT_FUNDS">
-        <position x="572" y="11"/>
-        <size width="60" height="10"/>
+        <position x="572" y="9"/>
+        <size width="60" height="14"/>
         <alignment horizontal="left" vertical="centre"/>
         <font>smalfont</font>
       </label>


### PR DESCRIPTION
No longer a period
<img width="160" height="79" alt="text-funds-cutoff" src="https://github.com/user-attachments/assets/29724077-d251-4cc1-8911-dc7e4f36e708" />
