### PR TITLE
Allow word wrapping in item and ammo names

### DIFF
--- a/forms/label.cpp
+++ b/forms/label.cpp
@@ -15,7 +15,7 @@ namespace OpenApoc
 
 Label::Label(const UString &Text, sp<BitmapFont> font)
     : Control(), text(Text), font(font), scrollOffset(0), TextHAlign(HorizontalAlignment::Left),
-      TextVAlign(VerticalAlignment::Top), WordWrap(true)
+      TextVAlign(VerticalAlignment::Top), WordWrap(false), wordWrapped(false)
 {
 	if (font)
 	{
@@ -43,13 +43,14 @@ void Label::onRender()
 	std::list<UString> lines = font->wordWrapText(text, Size.x);
 
 	int ysize = font->getFontHeight(text, Size.x);
+	int ypos = !WordWrap ? align(TextVAlign, Size.y, ysize) : 0;
+
 	if (scroller)
 	{
 		scroller->setVisible(ysize > this->Size.y && lines.size() > 1);
 		scroller->setMaximum(ysize - this->Size.y);
 	}
 
-	int ypos = align(TextVAlign, Size.y, ysize);
 	if (scroller && scroller->isVisible())
 	{
 		ypos = -scrollOffset;
@@ -90,6 +91,12 @@ void Label::setText(const UString &Text)
 
 	if (scroller)
 		scroller->setValue(0);
+
+	if (WordWrap)
+	{
+		auto lines = font->wordWrapText(text, Size.x);
+		wordWrapped = (lines.size() > 1);
+	}
 
 	this->setDirty();
 }

--- a/forms/label.h
+++ b/forms/label.h
@@ -28,6 +28,7 @@ class Label : public Control
 	VerticalAlignment TextVAlign;
 	bool WordWrap;
 	Colour Tint{255, 255, 255, 255};
+	bool wordWrapped;
 
 	Label(const UString &Text = "", sp<BitmapFont> font = nullptr);
 	~Label() override;

--- a/game/ui/general/aequipmentsheet.cpp
+++ b/game/ui/general/aequipmentsheet.cpp
@@ -51,7 +51,21 @@ void AEquipmentSheet::displayImplementation(sp<AEquipment> item, const AEquipmen
 	const auto selectedImage =
 	    researched && item ? item->getEquipmentImage() : itemType.equipscreen_sprite;
 
-	form->findControlTyped<Label>("ITEM_NAME")->setText(itemName);
+	auto itemLabel = form->findControlTyped<Label>("ITEM_NAME");
+	itemLabel->WordWrap = true;
+	itemLabel->setText(itemName);
+
+	if (itemLabel->wordWrapped)
+	{
+		itemLabel->Size.y = wrappedYSize;
+		shiftLabels(wrappedBaseY);
+	}
+	else
+	{
+		itemLabel->Size.y = singleYSize;
+		shiftLabels(singleBaseY);
+	}
+
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(selectedImage);
 
 	// when possible, the actual item's weight takes precedence
@@ -161,9 +175,19 @@ void AEquipmentSheet::displayWeapon(sp<AEquipment> item [[maybe_unused]],
 
 	form->findControlTyped<Label>("LABEL_6_C")->setText(tr("Ammo types:"));
 	int ammoNum = 1;
+	int currentY = label7CPos;
 	for (auto &ammo : itemType.ammo_types)
 	{
-		form->findControlTyped<Label>(format("LABEL_%d_C", 6 + ammoNum))->setText(ammo->name);
+		auto ammoLabel = form->findControlTyped<Label>(format("LABEL_%d_C", 6 + ammoNum));
+		ammoLabel->WordWrap = true;
+		ammoLabel->setText(ammo->name);
+
+		int height = ammoLabel->wordWrapped ? wrappedYSize : singleYSize;
+		ammoLabel->Size.y = height;
+		ammoLabel->Location.y = currentY;
+
+		currentY += height;
+
 		if (++ammoNum >= 4)
 		{
 			break;
@@ -182,6 +206,23 @@ void AEquipmentSheet::displayArmor(sp<AEquipment> item, const AEquipmentType &it
 void AEquipmentSheet::displayOther(sp<AEquipment> item [[maybe_unused]],
                                    const AEquipmentType &itemType [[maybe_unused]])
 {
+}
+
+void AEquipmentSheet::shiftLabels(const int &baseY)
+{
+	int labelCount = 10;
+	int wrappedOffset = 16;
+
+	for (int i = 1; i <= labelCount; i++)
+	{
+		auto labelLeft = form->findControlTyped<Label>(format("LABEL_%d_L", i));
+		auto labelCenter = form->findControlTyped<Label>(format("LABEL_%d_C", i));
+		auto labelRight = form->findControlTyped<Label>(format("LABEL_%d_R", i));
+
+		labelLeft->Location.y = baseY + wrappedOffset * (i - 1);
+		labelCenter->Location.y = baseY + wrappedOffset * (i - 1);
+		labelRight->Location.y = baseY + wrappedOffset * (i - 1);
+	}
 }
 
 }; // namespace OpenApoc

--- a/game/ui/general/aequipmentsheet.h
+++ b/game/ui/general/aequipmentsheet.h
@@ -18,6 +18,12 @@ class AEquipmentSheet
 	void clear();
 
   private:
+	static constexpr int wrappedYSize = 30;
+	static constexpr int singleYSize = 15;
+	static constexpr int wrappedBaseY = 118;
+	static constexpr int singleBaseY = 106;
+	static constexpr int label7CPos = 202;
+
 	void displayImplementation(sp<AEquipment> item, const AEquipmentType &itemType,
 	                           const bool researched);
 	void displayGrenade(sp<AEquipment> item, const AEquipmentType &itemType);
@@ -25,6 +31,7 @@ class AEquipmentSheet
 	void displayAmmo(sp<AEquipment> item, const AEquipmentType &itemType);
 	void displayArmor(sp<AEquipment> item, const AEquipmentType &itemType);
 	void displayOther(sp<AEquipment> item, const AEquipmentType &itemType);
+	void shiftLabels(const int &baseY);
 	sp<Form> form;
 };
 

--- a/game/ui/general/vehiclesheet.cpp
+++ b/game/ui/general/vehiclesheet.cpp
@@ -63,7 +63,10 @@ void VehicleSheet::clear()
 
 void VehicleSheet::displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> vehicleType)
 {
-	form->findControlTyped<Label>("ITEM_NAME")->setText("");
+	auto itemLabel = form->findControlTyped<Label>("ITEM_NAME");
+	itemLabel->WordWrap = true;
+	itemLabel->setText("");
+
 	form->findControlTyped<TextEdit>("TEXT_VEHICLE_NAME")
 	    ->setText(vehicle ? vehicle->name : vehicleType->name);
 	form->findControlTyped<Graphic>("SELECTED_IMAGE")->setImage(vehicleType->equip_icon_small);
@@ -144,7 +147,19 @@ void VehicleSheet::displayEquipImplementation(sp<VEquipment> item, sp<VEquipment
 		return;
 	}
 
-	form->findControlTyped<Label>("ITEM_NAME")->setText(item ? item->type->name : type->name);
+	auto itemLabel = form->findControlTyped<Label>("ITEM_NAME");
+	itemLabel->setText(item ? item->type->name : type->name);
+
+	if (itemLabel->wordWrapped)
+	{
+		itemLabel->Size.y = wrappedYSize;
+		shiftLabels(wrappedBaseY);
+	}
+	else
+	{
+		itemLabel->Size.y = singleYSize;
+		shiftLabels(singleBaseY);
+	}
 
 	// Draw equipment stats
 	switch (type->type)
@@ -246,6 +261,21 @@ void VehicleSheet::displayGeneral(sp<VEquipment> item [[maybe_unused]], sp<VEqui
 	{
 		form->findControlTyped<Label>(format("LABEL_%d_L", statsCount))->setText(tr("Teleports"));
 		statsCount++;
+	}
+}
+
+void VehicleSheet::shiftLabels(const int &baseY)
+{
+	int labelCount = 10;
+	int wrappedOffset = 16;
+
+	for (int i = 1; i <= labelCount; i++)
+	{
+		auto labelLeft = form->findControlTyped<Label>(format("LABEL_%d_L", i));
+		auto labelRight = form->findControlTyped<Label>(format("LABEL_%d_R", i));
+
+		labelLeft->Location.y = baseY + wrappedOffset * (i - 1);
+		labelRight->Location.y = baseY + wrappedOffset * (i - 1);
 	}
 }
 

--- a/game/ui/general/vehiclesheet.h
+++ b/game/ui/general/vehiclesheet.h
@@ -27,6 +27,11 @@ class VehicleSheet
 	void clear();
 
   private:
+	static constexpr int wrappedYSize = 30;
+	static constexpr int singleYSize = 15;
+	static constexpr int singleBaseY = 106;
+	static constexpr int wrappedBaseY = 118;
+
 	void displayImplementation(sp<Vehicle> vehicle, sp<VehicleType> vehicleType);
 
 	void displayEquipImplementation(sp<VEquipment> item, sp<VEquipmentType> itemType,
@@ -34,7 +39,7 @@ class VehicleSheet
 	void displayEngine(sp<VEquipment> item, sp<VEquipmentType> type);
 	void displayWeapon(sp<VEquipment> item, sp<VEquipmentType> type);
 	void displayGeneral(sp<VEquipment> item, sp<VEquipmentType> type);
-
+	void shiftLabels(const int &baseY);
 	sp<Form> form;
 };
 


### PR DESCRIPTION
Addresses #1438.

This seems like the best way to handle this since we can't edit the background picture.

The name is extended below the line.
<img width="191" height="300" alt="longitem1" src="https://github.com/user-attachments/assets/3f4e32b1-c5f8-493e-8b9d-f3e38844ac1d" />

<img width="188" height="307" alt="longitem2" src="https://github.com/user-attachments/assets/7a55f45f-777d-4a82-a47a-94111fdfb8d4" />

There is no way to add more horizontal room here. This would be the hard limit for characters in an item name.
<img width="572" height="313" alt="longitem3" src="https://github.com/user-attachments/assets/aaa42504-78a6-41a1-8ac7-0f5ec01827a8" />

Ammo can also be word wrapped.
<img width="191" height="303" alt="longitem4" src="https://github.com/user-attachments/assets/045c247e-fe29-4540-80c3-543e4d43d328" />

Obviously this is designed to work with the extended weapons mod since most of the fixes apply to those weapon names. This should probably be extensively tested with every long name, I didn't get that far yet. In theory this should work for armor and everything else.