### PR TITLE
Clamp moving BattleItem/BattleUnits to map edge

### DIFF
--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -265,14 +265,16 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 			velocity = {0.0f, 0.0f, 0.0f};
 		}
 		// Collision with map edge
-		if (newPosition.x < 0 || newPosition.y < 0 || newPosition.y >= mapSize.y ||
-		    newPosition.x >= mapSize.x || newPosition.y >= mapSize.y)
+		if (newPosition.x < 0 || newPosition.x >= mapSize.x || newPosition.y < 0 ||
+		    newPosition.y >= mapSize.y)
 		{
 			collision = true;
 			velocity.x = -velocity.x / 4;
 			velocity.y = -velocity.y / 4;
 			velocity.z = 0;
-			newPosition = previousPosition;
+			newPosition.x = glm::clamp(newPosition.x, 0.0f, mapSize.x - 0.01f);
+			newPosition.y = glm::clamp(newPosition.y, 0.0f, mapSize.y - 0.01f);
+			newPosition.z = glm::clamp(newPosition.z, 0.0f, mapSize.z - 0.01f);
 		}
 		// Fell below 0???
 		if (newPosition.z < 0)

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2830,13 +2830,15 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 			velocity = {0.0f, 0.0f, 0.0f};
 		}
 		// Collision with map edge
-		if (newPosition.x < 0 || newPosition.y < 0 || newPosition.y >= mapSize.y ||
-		    newPosition.x >= mapSize.x || newPosition.y >= mapSize.y)
+		if (newPosition.x < 0 || newPosition.x >= mapSize.x || newPosition.y < 0 ||
+		    newPosition.y >= mapSize.y)
 		{
 			velocity.x = -velocity.x / 4;
 			velocity.y = -velocity.y / 4;
 			velocity.z = 0;
-			newPosition = previousPosition;
+			newPosition.x = glm::clamp(newPosition.x, 0.0f, mapSize.x - 0.01f);
+			newPosition.y = glm::clamp(newPosition.y, 0.0f, mapSize.y - 0.01f);
+			newPosition.z = glm::clamp(newPosition.z, 0.0f, mapSize.z - 0.01f);
 		}
 		// Fell below 0???
 		if (newPosition.z < 0)


### PR DESCRIPTION
I think this may be a cause of a number of "fell out of the world" errors - if a object started the tick close enough to the edge the motion may take it some distance out of the map, so that the "bounce" at velocity/4 isn't sufficient for it to move back in next tick.