### PR TITLE
Add .gitignore entries for in-source build artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,28 @@ tools/extractors/docs/video.txt
 # CLion temp files
 .idea
 cmake-build-*
+
+# CMake/Ninja in-source build artifacts
+CMakeCache.txt
+CMakeFiles/
+cmake_install.cmake
+compile_commands.json
+CTestTestfile.cmake
+build.ninja
+.ninja_deps
+.ninja_log
+*.lib
+*.pdb
+*.exp
+
+# vcpkg installed packages
+vcpkg_installed/
+
+# Qt autogen
+*_autogen/
+
+# Qt cache
+.qt/
+
+# Claude Code
+.claude/


### PR DESCRIPTION
## Summary
- Add ignore patterns for CMake/Ninja in-source build artifacts (`CMakeCache.txt`, `build.ninja`, `CMakeFiles/`, `.ninja_deps`, `.ninja_log`, `cmake_install.cmake`, `CTestTestfile.cmake`, `compile_commands.json`)
- Add ignore patterns for MSVC intermediate outputs (`*.lib`, `*.pdb`, `*.exp`)
- Add ignore pattern for vcpkg manifest-mode installed packages (`vcpkg_installed/`)
- Add ignore patterns for Qt autogen and cache directories (`*_autogen/`, `.qt/`)

## Why
The CI (`appveyor.yml`) performs in-source builds — it runs `cmake ... .` directly in the repo root. This generates ~50 untracked files that show up in `git status`, making it hard to see actual code changes while developing.

The existing `.gitignore` covers out-of-source builds (`build/`) and some Visual Studio files, but not the artifacts produced by in-source CMake+Ninja builds or vcpkg's manifest mode (`vcpkg_installed/` directory created when `vcpkg.json` is present).

🤖 Generated with [Claude Code](https://claude.com/claude-code)