### PR TITLE
Move SceneryTileType to a single StateRefMap

### DIFF
--- a/game/state/city/city.cpp
+++ b/game/state/city/city.cpp
@@ -63,11 +63,6 @@ City::~City()
 		b.second->city.clear();
 		b.second->base.clear();
 	}
-	for (auto &t : this->tile_types)
-	{
-		// Some damaged tile links can loop, causing a leak if they're not broken
-		t.second->damagedTile.clear();
-	}
 }
 
 void City::initCity(GameState &state)

--- a/game/state/city/city.h
+++ b/game/state/city/city.h
@@ -84,7 +84,6 @@ class City : public StateObject<City>, public std::enable_shared_from_this<City>
 	UString id;
 	Vec3<int> size = {0, 0, 0};
 
-	StateRefMap<SceneryTileType> tile_types;
 	std::map<Vec3<int>, StateRef<SceneryTileType>> initial_tiles;
 	std::list<Vec3<int>> initial_portals;
 	StateRefMap<Building> buildings;

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -87,6 +87,11 @@ GameState::~GameState()
 	{
 		org.second->current_relations.clear();
 	}
+	for (auto &t : this->scenery_tile_types)
+	{
+		// Some damaged tile links can loop, causing a leak if they're not broken
+		t.second->damagedTile.clear();
+	}
 	for (auto &city : this->cities)
 	{
 		for (auto &building : city.second->buildings)
@@ -429,63 +434,59 @@ void GameState::validateResearch()
 
 void GameState::validateScenery()
 {
-	for (auto &c : cities)
+	for (auto &sc : scenery_tile_types)
 	{
-		for (auto &sc : c.second->tile_types)
+		auto thisSc = StateRef<SceneryTileType>{this, sc.first};
+		std::set<StateRef<SceneryTileType>> seenTypes;
+		while (thisSc->damagedTile)
 		{
-			auto thisSc = StateRef<SceneryTileType>{this, sc.first};
-			std::set<StateRef<SceneryTileType>> seenTypes;
-			while (thisSc->damagedTile)
+			seenTypes.insert(thisSc);
+			bool roadAlive = false;
+			bool roadDead = false;
+			bool newRoad = false;
+			if (thisSc->tile_type != SceneryTileType::TileType::Road &&
+			    thisSc->damagedTile->tile_type == SceneryTileType::TileType::Road)
 			{
-				seenTypes.insert(thisSc);
-				bool roadAlive = false;
-				bool roadDead = false;
-				bool newRoad = false;
-				if (thisSc->tile_type != SceneryTileType::TileType::Road &&
-				    thisSc->damagedTile->tile_type == SceneryTileType::TileType::Road)
+				newRoad = true;
+			}
+			else
+			{
+				for (int i = 0; i < 4; i++)
 				{
-					newRoad = true;
-				}
-				else
-				{
-					for (int i = 0; i < 4; i++)
+					if (thisSc->connection[i] &&
+					    thisSc->connection[i] == thisSc->damagedTile->connection[i])
 					{
-						if (thisSc->connection[i] &&
-						    thisSc->connection[i] == thisSc->damagedTile->connection[i])
-						{
-							roadAlive = true;
-						}
-						if (thisSc->connection[i] &&
-						    thisSc->connection[i] != thisSc->damagedTile->connection[i])
-						{
-							roadDead = true;
-						}
-						if (!thisSc->connection[i] &&
-						    thisSc->connection[i] != thisSc->damagedTile->connection[i])
-						{
-							newRoad = true;
-						}
+						roadAlive = true;
+					}
+					if (thisSc->connection[i] &&
+					    thisSc->connection[i] != thisSc->damagedTile->connection[i])
+					{
+						roadDead = true;
+					}
+					if (!thisSc->connection[i] &&
+					    thisSc->connection[i] != thisSc->damagedTile->connection[i])
+					{
+						newRoad = true;
 					}
 				}
-				if (newRoad || (roadAlive && roadDead))
-				{
-					LogError("ROAD MUTATION: In {0} when damaged from {1} to {2} roads go "
-					         "[{3}{4}{5}{6}] "
-					         "to [{7}{8}{9}{10}]",
-					         sc.first, thisSc.id, thisSc->damagedTile.id,
-					         (int)thisSc->connection[0], (int)thisSc->connection[1],
-					         (int)thisSc->connection[2], (int)thisSc->connection[3],
-					         (int)thisSc->damagedTile->connection[0],
-					         (int)thisSc->damagedTile->connection[1],
-					         (int)thisSc->damagedTile->connection[2],
-					         (int)thisSc->damagedTile->connection[3]);
-				}
-				if (seenTypes.find(thisSc->damagedTile) != seenTypes.end())
-				{
-					break;
-				}
-				thisSc = thisSc->damagedTile;
 			}
+			if (newRoad || (roadAlive && roadDead))
+			{
+				LogError("ROAD MUTATION: In {0} when damaged from {1} to {2} roads go "
+				         "[{3}{4}{5}{6}] "
+				         "to [{7}{8}{9}{10}]",
+				         sc.first, thisSc.id, thisSc->damagedTile.id, (int)thisSc->connection[0],
+				         (int)thisSc->connection[1], (int)thisSc->connection[2],
+				         (int)thisSc->connection[3], (int)thisSc->damagedTile->connection[0],
+				         (int)thisSc->damagedTile->connection[1],
+				         (int)thisSc->damagedTile->connection[2],
+				         (int)thisSc->damagedTile->connection[3]);
+			}
+			if (seenTypes.find(thisSc->damagedTile) != seenTypes.end())
+			{
+				break;
+			}
+			thisSc = thisSc->damagedTile;
 		}
 	}
 }

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -36,6 +36,7 @@ class UFOIncursion;
 class Vehicle;
 class UfopaediaCategory;
 class UfopaediaEntry;
+class SceneryTileType;
 class BattleMap;
 class EquipmentSet;
 class Battle;
@@ -84,6 +85,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 	StateRefMap<UFOIncursion> ufo_incursions;
 	StateRefMap<Base> player_bases;
 	StateRefMap<City> cities;
+	StateRefMap<SceneryTileType> scenery_tile_types;
 	StateRefMap<Vehicle> vehicles;
 	std::set<UString> vehiclesDeathNote;
 	StateRefMap<UfopaediaCategory> ufopaedia;

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -9,6 +9,7 @@
     <member type="Section">vehicle_equipment</member>
     <member type="Section">vehicle_ammo</member>
     <member type="SectionMap">cities</member>
+    <member type="Section">scenery_tile_types</member>
     <member type="Section">ufo_growth_lists</member>
     <member type="Section">ufo_mission_preference</member>
     <member type="Section">ufo_incursions</member>
@@ -964,7 +965,6 @@
     <name>City</name>
     <member>id</member>
     <member>size</member>
-    <member type="Section">tile_types</member>
     <member type="Section">initial_tiles</member>
     <member type="Section">buildings</member>
     <member type="Section">scenery</member>

--- a/game/state/rules/city/scenerytiletype.cpp
+++ b/game/state/rules/city/scenerytiletype.cpp
@@ -8,14 +8,13 @@ namespace OpenApoc
 template <>
 sp<SceneryTileType> StateObject<SceneryTileType>::get(const GameState &state, const UString &id)
 {
-	for (auto &pair : state.cities)
+	auto it = state.scenery_tile_types.find(id);
+	if (it == state.scenery_tile_types.end())
 	{
-		auto it = pair.second->tile_types.find(id);
-		if (it != pair.second->tile_types.end())
-			return it->second;
+		LogError("No scenery tile type matching ID \"{0}\"", id);
+		return nullptr;
 	}
-	LogError("No scenery tile type matching ID \"{0}\"", id);
-	return nullptr;
+	return it->second;
 }
 
 template <> const UString &StateObject<SceneryTileType>::getPrefix()

--- a/tools/extractors/extract_city_scenery.cpp
+++ b/tools/extractors/extract_city_scenery.cpp
@@ -2,6 +2,7 @@
 #include "framework/framework.h"
 #include "framework/palette.h"
 #include "game/state/city/city.h"
+#include "game/state/gamestate.h"
 #include "game/state/rules/city/scenerytiletype.h"
 #include "library/strings_format.h"
 #include "library/voxel.h"
@@ -303,7 +304,7 @@ void InitialGameStateExtractor::extractCityScenery(GameState &state, UString til
 
 		tile->imageOffset = CITY_IMAGE_OFFSET;
 
-		city->tile_types[id] = tile;
+		state.scenery_tile_types[id] = tile;
 	}
 }
 


### PR DESCRIPTION
Note: Will break all saves, and mods that touch battle maps.

More "Single StateRefMap per type" work.