### PR TITLE
Remove DataExtractor LogError on no BattleMapSector patch

### DIFF
--- a/game/state/gamestate_serialize.cpp
+++ b/game/state/gamestate_serialize.cpp
@@ -719,7 +719,8 @@ bool BattleMapSectorTiles::loadSector(GameState &state, const UString &path)
 	auto archive = SerializationArchive::readArchive(path);
 	if (!archive)
 	{
-		LogError("Failed to read \"{0}\"", path);
+		// Can fail in normal use - e.g. if trying to load an optional  "patch"
+		LogInfo("Failed to read BattleMapSectorTiles \"{0}\"", path);
 		return false;
 	}
 


### PR DESCRIPTION
LogError() is really to imply /failure/, and *most* don't have patches here, so you get a lot of scary looking errors (and, depending on log setup, backtraces or even failure dialogues).