### PR TITLE
Fixes for vcpkg on linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ endif()
 
 message("Using CD at \"${CD_PATH}\"")
 
-set(CMAKE_C_FLAGS_SANITIZE "-Og -g -fsanitize=address")
-set(CMAKE_CXX_FLAGS_SANITIZE "-Og -g -fsanitize=address")
+set(CMAKE_C_FLAGS_SANITIZE "-Og -g -fsanitize=address -fno-omit-frame-pointer")
+set(CMAKE_CXX_FLAGS_SANITIZE "-Og -g -fsanitize=address -fno-omit-frame-pointer")
 
 set(CMAKE_C_FLAGS_QUICK "-O1 -g1")
 set(CMAKE_CXX_FLAGS_QUICK "-O1 -g1")

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -249,9 +249,11 @@ endif()
 
 find_path(VORBIS_INCLUDE_DIR vorbis/vorbisfile.h)
 find_library(VORBISFILE_LIBRARY vorbisfile)
+find_library(VORBIS_LIBRARY vorbis)
+find_library(OGG_LIBRARY ogg)
 
 target_include_directories(OpenApoc_Framework PRIVATE ${VORBIS_INCLUDE_DIR})
-target_link_libraries(OpenApoc_Framework PRIVATE ${VORBISFILE_LIBRARY})
+target_link_libraries(OpenApoc_Framework PRIVATE ${VORBISFILE_LIBRARY} ${VORBIS_LIBRARY} ${OGG_LIBRARY})
 
 # Dialog is handled by SDL2
 if(DIALOG_ON_ERROR)

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -2,7 +2,14 @@
   "name": "openapoc",
   "version-string": "0.1.0-dev",
   "dependencies": [
-    "sdl2",
+    {
+      "name": "sdl2",
+      "default-features": false,
+      "features": [
+        { "name": "x11",     "platform": "linux" },
+        { "name": "wayland", "platform": "linux" }
+      ]
+    },
     "boost-locale",
     "boost-program-options",
     "boost-uuid",


### PR DESCRIPTION
A couple of "fixes" for minor issues noticed when trying to use vcpkg instead of system dependencies on linux