### PR TITLE
fix: improve currency formatting

### DIFF
--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -148,42 +148,84 @@ UString Strings::fromU64(uint64_t i) { return format("{0}", i); }
 
 UString Strings::formatTextAsCurrency(const UString &Text)
 {
-	try
-	{
-		const auto textLenght = Text.length();
-
-		if (!Text.empty() && textLenght <= 3)
-			return Text;
-
-		auto isNumber = true;
-
-		for (const auto &ch : Text)
-		{
-			// Allowed chars in strings containing monetary values
-			if (!std::isdigit(ch) && ch != '.' && ch != ',' && ch != '-')
-			{
-				isNumber = false;
-				break;
-			}
-		}
-
-		if (!isNumber)
-			return Text;
-
-		auto formattedText = Text; // copy text for formatting
-
-		for (auto i = textLenght - 1; i > 0; i--)
-		{
-			if ((textLenght - i) % 3 == 0 && formattedText[i - 1] != '-')
-				formattedText.insert(i, ",");
-		}
-
-		return formattedText;
-	}
-	catch (const std::exception &err)
+	if (Text.empty())
 	{
 		return Text;
 	}
+
+	size_t integerStart = 0;
+	if (Text[integerStart] == '-')
+	{
+		integerStart++;
+		if (integerStart == Text.length())
+		{
+			return Text;
+		}
+	}
+
+	const auto decimalPoint = Text.find('.', integerStart);
+	if (decimalPoint != UString::npos && Text.find('.', decimalPoint + 1) != UString::npos)
+	{
+		return Text;
+	}
+
+	const auto integerEnd = decimalPoint == UString::npos ? Text.length() : decimalPoint;
+	UString digits;
+	digits.reserve(integerEnd - integerStart);
+
+	for (auto i = integerStart; i < integerEnd; i++)
+	{
+		const auto ch = Text[i];
+		if (ch == ',')
+		{
+			continue;
+		}
+		if (!std::isdigit(static_cast<unsigned char>(ch)))
+		{
+			return Text;
+		}
+		digits.push_back(ch);
+	}
+
+	if (digits.empty())
+	{
+		return Text;
+	}
+
+	if (decimalPoint != UString::npos)
+	{
+		for (auto i = decimalPoint + 1; i < Text.length(); i++)
+		{
+			if (!std::isdigit(static_cast<unsigned char>(Text[i])))
+			{
+				return Text;
+			}
+		}
+	}
+
+	UString formattedText;
+	formattedText.reserve(Text.length() + digits.length() / 3);
+	if (integerStart == 1)
+	{
+		formattedText.push_back('-');
+	}
+
+	const auto firstGroupSize = digits.length() % 3 == 0 ? 3 : digits.length() % 3;
+	for (size_t i = 0; i < digits.length(); i++)
+	{
+		if (i != 0 && (i == firstGroupSize || (i > firstGroupSize && (i - firstGroupSize) % 3 == 0)))
+		{
+			formattedText.push_back(',');
+		}
+		formattedText.push_back(digits[i]);
+	}
+
+	if (decimalPoint != UString::npos)
+	{
+		formattedText.append(Text.substr(decimalPoint));
+	}
+
+	return formattedText;
 }
 
 }; // namespace OpenApoc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 PROJECT (OpenApoc_Tests CXX C)
 
 set (TEST_LIST test_rect test_voxel test_tilemap test_rng test_images
-		test_unicode test_colour test_backtrace)
+		test_unicode test_colour test_backtrace test_strings)
 
 foreach(TEST ${TEST_LIST})
 		add_executable(${TEST} ${TEST}.cpp)

--- a/tests/test_strings.cpp
+++ b/tests/test_strings.cpp
@@ -1,0 +1,53 @@
+#include "framework/configfile.h"
+#include "framework/logger.h"
+#include "library/strings.h"
+
+using namespace OpenApoc;
+
+static bool checkCurrencyFormatting(const UString &input, const UString &expected)
+{
+	const auto actual = Strings::formatTextAsCurrency(input);
+	if (actual != expected)
+	{
+		LogError("formatTextAsCurrency(\"{0}\") returned \"{1}\", expected \"{2}\"", input, actual,
+		         expected);
+		return false;
+	}
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+
+	const std::vector<std::pair<UString, UString>> examples = {
+	    {"", ""},
+	    {"0", "0"},
+	    {"123", "123"},
+	    {"1234", "1,234"},
+	    {"1234567", "1,234,567"},
+	    {"-1234567", "-1,234,567"},
+	    {"1,234", "1,234"},
+	    {"1,2,3,4", "1,234"},
+	    {"1234.56", "1,234.56"},
+	    {"-1234.56", "-1,234.56"},
+	    {"1234.", "1,234."},
+	    {"not money", "not money"},
+	    {"$1234", "$1234"},
+	    {"12-34", "12-34"},
+	    {"1234.56.78", "1234.56.78"},
+	};
+
+	for (const auto &example : examples)
+	{
+		if (!checkCurrencyFormatting(example.first, example.second))
+		{
+			return EXIT_FAILURE;
+		}
+	}
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Closes #1469.

## Summary
- replaces the manual length/comma logic with formatting based on sanitized numeric text
- preserves leading signs and decimal portions
- tolerates already-formatted values and invalid/non-numeric input more gracefully
- adds focused coverage for currency formatting edge cases

## Testing
- ctest --test-dir build-local --output-on-failure