### PR TITLE
fix: show lab list scrollbars when needed

### DIFF
--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -20,6 +20,26 @@
 
 namespace OpenApoc
 {
+namespace
+{
+
+bool listBoxNeedsHorizontalScroll(const sp<ListBox> &listBox)
+{
+	if (listBox->Controls.empty())
+	{
+		return false;
+	}
+
+	int contentWidth = listBox->ItemSpacing * (static_cast<int>(listBox->Controls.size()) - 1);
+	for (const auto &item : listBox->Controls)
+	{
+		item->update();
+		contentWidth += item->Size.x;
+	}
+	return contentWidth > listBox->Size.x;
+}
+
+} // namespace
 
 ResearchScreen::ResearchScreen(sp<GameState> state, sp<Facility> selected_lab) : BaseStage(state)
 {
@@ -321,6 +341,11 @@ void ResearchScreen::populateUILabList(const UString &listName, std::list<sp<Fac
 		}
 	}
 	uiListLabs->setSelected(selectedItem);
+	if (uiListLabs->scroller)
+	{
+		uiListLabs->scroller->scrollMin();
+		uiListLabs->scroller->setVisible(listBoxNeedsHorizontalScroll(uiListLabs));
+	}
 }
 
 void ResearchScreen::setCurrentLabInfo()


### PR DESCRIPTION
Closes #1579.

## Summary
- shows the existing small/large lab list scrollbars only when their lab icons overflow horizontally
- resets the lab list scroll position after repopulating the list
- keeps the existing research screen form layout intact

## Testing
- cmake --build build --target OpenApoc -- -j2
- ctest --test-dir build --output-on-failure