### PR TITLE
fix: improve currency formatting

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -112,14 +112,16 @@ GameState::~GameState()
 }
 
 // Just a handy shortcut since it's shown on every single screen
-UString GameState::getPlayerBalance() const
+UString GameState::getPlayerBalance() const { return formatCurrency(this->getPlayer()->balance); }
+
+UString GameState::formatCurrency(int64_t amount) const
 {
-	auto playerBalance = Strings::fromInteger(this->getPlayer()->balance);
+	auto formatted = Strings::fromInteger(amount);
 
 	if (config().getBool("OpenApoc.NewFeature.formatAsCurrency"))
-		playerBalance = Strings::formatTextAsCurrency(playerBalance);
+		formatted = Strings::formatTextAsCurrency(formatted);
 
-	return playerBalance;
+	return formatted;
 }
 
 StateRef<Organisation> GameState::getOrganisation(const UString &orgID)

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -178,6 +178,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 	Xorshift128Plus<uint32_t> rng;
 
 	UString getPlayerBalance() const;
+	UString formatCurrency(int64_t amount) const;
 	StateRef<Organisation> getOrganisation(const UString &orgID);
 	const StateRef<Organisation> &getPlayer() const;
 	StateRef<Organisation> getPlayer();

--- a/game/ui/base/basescreen.cpp
+++ b/game/ui/base/basescreen.cpp
@@ -466,11 +466,11 @@ void BaseScreen::eventOccurred(Event *e)
 		selText->setText(dragFacility->name);
 		selGraphic->setImage(dragFacility->sprite);
 		statsLabels[0]->setText(tr("Cost to build"));
-		statsValues[0]->setText(format("${0}", Strings::fromInteger(dragFacility->buildCost)));
+		statsValues[0]->setText(format("${0}", state->formatCurrency(dragFacility->buildCost)));
 		statsLabels[1]->setText(tr("Days to build"));
 		statsValues[1]->setText(format("{0}", dragFacility->buildTime));
 		statsLabels[2]->setText(tr("Maintenance cost"));
-		statsValues[2]->setText(format("${0}", Strings::fromInteger(dragFacility->weeklyCost)));
+		statsValues[2]->setText(format("${0}", state->formatCurrency(dragFacility->weeklyCost)));
 	}
 	else if (selFacility != nullptr)
 	{

--- a/game/ui/base/buyandsellscreen.cpp
+++ b/game/ui/base/buyandsellscreen.cpp
@@ -91,9 +91,9 @@ void BuyAndSellScreen::updateFormValues(bool queueHighlightUpdate)
 
 	// Update money
 	const auto balance = state->getPlayer()->balance + moneyDelta;
-	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance));
+	form->findControlTyped<Label>("TEXT_FUNDS")->setText(state->formatCurrency(balance));
 	form->findControlTyped<Label>("TEXT_FUNDS_DELTA")
-	    ->setText(format("{0}{1}", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
+	    ->setText(format("{0}{1}", moneyDelta > 0 ? "+" : "", state->formatCurrency(moneyDelta)));
 }
 
 void BuyAndSellScreen::closeScreen()

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -332,9 +332,9 @@ void RecruitScreen::updateFormValues()
 
 	// Update money
 	const auto balance = state->getPlayer()->balance + moneyDelta;
-	form->findControlTyped<Label>("TEXT_FUNDS")->setText(Strings::fromInteger(balance));
+	form->findControlTyped<Label>("TEXT_FUNDS")->setText(state->formatCurrency(balance));
 	form->findControlTyped<Label>("TEXT_FUNDS_DELTA")
-	    ->setText(format("{0}{1}", moneyDelta > 0 ? "+" : "", Strings::fromInteger(moneyDelta)));
+	    ->setText(format("{0}{1}", moneyDelta > 0 ? "+" : "", state->formatCurrency(moneyDelta)));
 
 	updateBaseHighlight();
 }

--- a/game/ui/base/researchselect.cpp
+++ b/game/ui/base/researchselect.cpp
@@ -254,7 +254,7 @@ void ResearchSelect::populateResearchList()
 		{
 			UString progress_text;
 			if (this->lab->type == ResearchTopic::Type::Engineering)
-				progress_text = format("${0}", Strings::fromInteger(t->cost));
+				progress_text = format("${0}", state->formatCurrency(t->cost));
 			else
 				progress_text = tr("Complete");
 			auto progress_label =

--- a/game/ui/city/basebuyscreen.cpp
+++ b/game/ui/city/basebuyscreen.cpp
@@ -40,7 +40,7 @@ void BaseBuyScreen::begin()
 	form->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
 
 	auto text = form->findControlTyped<Label>("TEXT_PRICE");
-	text->setText(format(tr("This Building will cost ${0}"), Strings::fromInteger(price)));
+	text->setText(format(tr("This Building will cost ${0}"), state->formatCurrency(price)));
 
 	form->findControlTyped<Graphic>("GRAPHIC_MINIMAP")
 	    ->setImage(BaseGraphics::drawMinimap(state, *building));

--- a/game/ui/city/bribescreen.cpp
+++ b/game/ui/city/bribescreen.cpp
@@ -92,7 +92,7 @@ void BribeScreen::updateInfo()
 UString BribeScreen::getOfferString(int itWillCost, const UString &newAttitude) const
 {
 	return format(tr("It will cost: ${0} to improve relations to: {1}"),
-	              Strings::fromInteger(itWillCost), newAttitude);
+	              state->formatCurrency(itWillCost), newAttitude);
 }
 
 void BribeScreen::begin()

--- a/game/ui/city/diplomatictreatyscreen.cpp
+++ b/game/ui/city/diplomatictreatyscreen.cpp
@@ -31,7 +31,7 @@ void DiplomaticTreatyScreen::begin()
 	labelOffer->setText(tr("We are unhappy with the recent activity of your organization and "
 	                       "request compensation to restore normal diplomatic relations. If you do "
 	                       "not comply your craft and Agents may be subject to hostile actions."));
-	labelBribe->setText(format("Pay: $ {0} ?", Strings::fromInteger(bribeAmount)));
+	labelBribe->setText(format("Pay: $ {0} ?", state->formatCurrency(bribeAmount)));
 }
 
 void DiplomaticTreatyScreen::pause() {}

--- a/game/ui/city/scorescreen.cpp
+++ b/game/ui/city/scorescreen.cpp
@@ -156,15 +156,15 @@ void ScoreScreen::setFinanceMode()
 		int agentsSalary = soldiers + biochemists + engineers + physicists;
 
 		formFinance->findControlTyped<Label>("AGENTS_W")
-		    ->setText(format("${0}", Strings::fromInteger(soldiers)));
+		    ->setText(format("${0}", state->formatCurrency(soldiers)));
 		formFinance->findControlTyped<Label>("BIOCHEMISTS_W")
-		    ->setText(format("${0}", Strings::fromInteger(biochemists)));
+		    ->setText(format("${0}", state->formatCurrency(biochemists)));
 		formFinance->findControlTyped<Label>("ENGINEERS_W")
-		    ->setText(format("${0}", Strings::fromInteger(engineers)));
+		    ->setText(format("${0}", state->formatCurrency(engineers)));
 		formFinance->findControlTyped<Label>("PHYSICISTS_W")
-		    ->setText(format("${0}", Strings::fromInteger(physicists)));
+		    ->setText(format("${0}", state->formatCurrency(physicists)));
 		formFinance->findControlTyped<Label>("TOTAL_W")->setText(
-		    format("${0}", Strings::fromInteger(agentsSalary)));
+		    format("${0}", state->formatCurrency(agentsSalary)));
 
 		int basesCosts = 0;
 		for (auto &b : state->player_bases)
@@ -175,9 +175,9 @@ void ScoreScreen::setFinanceMode()
 			}
 		}
 		formFinance->findControlTyped<Label>("BASES_TOTAL_W")
-		    ->setText(format("${0}", Strings::fromInteger(basesCosts)));
+		    ->setText(format("${0}", state->formatCurrency(basesCosts)));
 		formFinance->findControlTyped<Label>("OVERHEADS_W")
-		    ->setText(format("${0}", Strings::fromInteger(agentsSalary + basesCosts)));
+		    ->setText(format("${0}", state->formatCurrency(agentsSalary + basesCosts)));
 
 		int balance = state->getPlayer()->balance;
 
@@ -189,10 +189,10 @@ void ScoreScreen::setFinanceMode()
 		}
 
 		formFinance->findControlTyped<Label>("INITIAL")->setText(
-		    format(tr("Initial funds> ${0}"), Strings::fromInteger(balance)));
+		    format(tr("Initial funds> ${0}"), state->formatCurrency(balance)));
 		formFinance->findControlTyped<Label>("REMAINING")
 		    ->setText(format(tr("Remaining funds> ${0}"),
-		                     Strings::fromInteger(balance - agentsSalary - basesCosts)));
+		                     state->formatCurrency(balance - agentsSalary - basesCosts)));
 	}
 
 	title->setText(tr("FINANCE"));

--- a/game/ui/city/weeklyfundingscreen.cpp
+++ b/game/ui/city/weeklyfundingscreen.cpp
@@ -108,13 +108,13 @@ void WeeklyFundingScreen::begin()
 		const int adjustment = (modifier == 0) ? 0 : player->income / modifier;
 
 		labelAdjustment->setText(
-		    format(tr("Funding adjustment> ${0}"), Strings::fromInteger(adjustment)));
+		    format(tr("Funding adjustment> ${0}"), state->formatCurrency(adjustment)));
 		labelNextWeekIncome->setText(format(tr("Income for next week> ${0}"),
-		                                    Strings::fromInteger(currentIncome + adjustment)));
+		                                    state->formatCurrency(currentIncome + adjustment)));
 	}
 
 	labelCurrentIncome->setText(
-	    format(tr("Current income> ${0}"), Strings::fromInteger(currentIncome)));
+	    format(tr("Current income> ${0}"), state->formatCurrency(currentIncome)));
 	labelRatingDescription->setText(ratingDescription);
 
 	state->weekScore.reset();

--- a/game/ui/general/transactioncontrol.cpp
+++ b/game/ui/general/transactioncontrol.cpp
@@ -654,8 +654,10 @@ TransactionControl::createControl(const UString &id, Type type, const UString &n
 	// Price
 	if (price != 0 && (indexLeft == ECONOMY_IDX || indexRight == ECONOMY_IDX))
 	{
-		auto label = control->createChild<Label>(
-		    format("${0}", Strings::fromInteger(control->price)), labelFont);
+		auto priceText = Strings::fromInteger(control->price);
+		if (config().getBool("OpenApoc.NewFeature.formatAsCurrency"))
+			priceText = Strings::formatTextAsCurrency(priceText);
+		auto label = control->createChild<Label>(format("${0}", priceText), labelFont);
 		label->Location = {290, 3};
 		label->Size = {47, 16};
 		label->TextHAlign = HorizontalAlignment::Right;

--- a/game/ui/ufopaedia/ufopaediacategoryview.cpp
+++ b/game/ui/ufopaedia/ufopaediacategoryview.cpp
@@ -271,9 +271,9 @@ void UfopaediaCategoryView::setFormStats()
 					if (data_id != "ORG_ALIEN")
 					{
 						orgLabels[1]->setText(tr("Balance"));
-						orgValues[1]->setText(format("${0}", Strings::fromInteger(ref->balance)));
+						orgValues[1]->setText(format("${0}", state->formatCurrency(ref->balance)));
 						orgLabels[2]->setText(tr("Income"));
-						orgValues[2]->setText(format("${0}", Strings::fromInteger(ref->income)));
+						orgValues[2]->setText(format("${0}", state->formatCurrency(ref->income)));
 
 						if (ref != player)
 						{
@@ -512,12 +512,12 @@ void UfopaediaCategoryView::setFormStats()
 					StateRef<FacilityType> ref = {state.get(), data_id};
 					statsLabels[row]->setText(tr("Construction cost"));
 					statsValues[row++]->setText(
-					    format("${0}", Strings::fromInteger(ref->buildCost)));
+					    format("${0}", state->formatCurrency(ref->buildCost)));
 					statsLabels[row]->setText(tr("Days to build"));
 					statsValues[row++]->setText(Strings::fromInteger(ref->buildTime));
 					statsLabels[row]->setText(tr("Weekly cost"));
 					statsValues[row++]->setText(
-					    format("${0}", Strings::fromInteger(ref->weeklyCost)));
+					    format("${0}", state->formatCurrency(ref->weeklyCost)));
 					if (ref->capacityAmount > 0)
 					{
 						statsLabels[row]->setText(tr("Capacity"));

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -213,7 +213,8 @@ UString Strings::formatTextAsCurrency(const UString &Text)
 	const auto firstGroupSize = digits.length() % 3 == 0 ? 3 : digits.length() % 3;
 	for (size_t i = 0; i < digits.length(); i++)
 	{
-		if (i != 0 && (i == firstGroupSize || (i > firstGroupSize && (i - firstGroupSize) % 3 == 0)))
+		if (i != 0 &&
+		    (i == firstGroupSize || (i > firstGroupSize && (i - firstGroupSize) % 3 == 0)))
 		{
 			formattedText.push_back(',');
 		}

--- a/library/strings.cpp
+++ b/library/strings.cpp
@@ -148,42 +148,84 @@ UString Strings::fromU64(uint64_t i) { return format("{0}", i); }
 
 UString Strings::formatTextAsCurrency(const UString &Text)
 {
-	try
-	{
-		const auto textLenght = Text.length();
-
-		if (!Text.empty() && textLenght <= 3)
-			return Text;
-
-		auto isNumber = true;
-
-		for (const auto &ch : Text)
-		{
-			// Allowed chars in strings containing monetary values
-			if (!std::isdigit(ch) && ch != '.' && ch != ',' && ch != '-')
-			{
-				isNumber = false;
-				break;
-			}
-		}
-
-		if (!isNumber)
-			return Text;
-
-		auto formattedText = Text; // copy text for formatting
-
-		for (auto i = textLenght - 1; i > 0; i--)
-		{
-			if ((textLenght - i) % 3 == 0 && formattedText[i - 1] != '-')
-				formattedText.insert(i, ",");
-		}
-
-		return formattedText;
-	}
-	catch (const std::exception &err)
+	if (Text.empty())
 	{
 		return Text;
 	}
+
+	size_t integerStart = 0;
+	if (Text[integerStart] == '-')
+	{
+		integerStart++;
+		if (integerStart == Text.length())
+		{
+			return Text;
+		}
+	}
+
+	const auto decimalPoint = Text.find('.', integerStart);
+	if (decimalPoint != UString::npos && Text.find('.', decimalPoint + 1) != UString::npos)
+	{
+		return Text;
+	}
+
+	const auto integerEnd = decimalPoint == UString::npos ? Text.length() : decimalPoint;
+	UString digits;
+	digits.reserve(integerEnd - integerStart);
+
+	for (auto i = integerStart; i < integerEnd; i++)
+	{
+		const auto ch = Text[i];
+		if (ch == ',')
+		{
+			continue;
+		}
+		if (!std::isdigit(static_cast<unsigned char>(ch)))
+		{
+			return Text;
+		}
+		digits.push_back(ch);
+	}
+
+	if (digits.empty())
+	{
+		return Text;
+	}
+
+	if (decimalPoint != UString::npos)
+	{
+		for (auto i = decimalPoint + 1; i < Text.length(); i++)
+		{
+			if (!std::isdigit(static_cast<unsigned char>(Text[i])))
+			{
+				return Text;
+			}
+		}
+	}
+
+	UString formattedText;
+	formattedText.reserve(Text.length() + digits.length() / 3);
+	if (integerStart == 1)
+	{
+		formattedText.push_back('-');
+	}
+
+	const auto firstGroupSize = digits.length() % 3 == 0 ? 3 : digits.length() % 3;
+	for (size_t i = 0; i < digits.length(); i++)
+	{
+		if (i != 0 && (i == firstGroupSize || (i > firstGroupSize && (i - firstGroupSize) % 3 == 0)))
+		{
+			formattedText.push_back(',');
+		}
+		formattedText.push_back(digits[i]);
+	}
+
+	if (decimalPoint != UString::npos)
+	{
+		formattedText.append(Text.substr(decimalPoint));
+	}
+
+	return formattedText;
 }
 
 }; // namespace OpenApoc

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 PROJECT (OpenApoc_Tests CXX C)
 
 set (TEST_LIST test_rect test_voxel test_tilemap test_rng test_images
-		test_unicode test_colour test_backtrace)
+		test_unicode test_colour test_backtrace test_strings)
 
 foreach(TEST ${TEST_LIST})
 		add_executable(${TEST} ${TEST}.cpp)

--- a/tests/test_strings.cpp
+++ b/tests/test_strings.cpp
@@ -1,0 +1,53 @@
+#include "framework/configfile.h"
+#include "framework/logger.h"
+#include "library/strings.h"
+
+using namespace OpenApoc;
+
+static bool checkCurrencyFormatting(const UString &input, const UString &expected)
+{
+	const auto actual = Strings::formatTextAsCurrency(input);
+	if (actual != expected)
+	{
+		LogError("formatTextAsCurrency(\"{0}\") returned \"{1}\", expected \"{2}\"", input, actual,
+		         expected);
+		return false;
+	}
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+
+	const std::vector<std::pair<UString, UString>> examples = {
+	    {"", ""},
+	    {"0", "0"},
+	    {"123", "123"},
+	    {"1234", "1,234"},
+	    {"1234567", "1,234,567"},
+	    {"-1234567", "-1,234,567"},
+	    {"1,234", "1,234"},
+	    {"1,2,3,4", "1,234"},
+	    {"1234.56", "1,234.56"},
+	    {"-1234.56", "-1,234.56"},
+	    {"1234.", "1,234."},
+	    {"not money", "not money"},
+	    {"$1234", "$1234"},
+	    {"12-34", "12-34"},
+	    {"1234.56.78", "1234.56.78"},
+	};
+
+	for (const auto &example : examples)
+	{
+		if (!checkCurrencyFormatting(example.first, example.second))
+		{
+			return EXIT_FAILURE;
+		}
+	}
+
+	return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Closes #1469.

## Summary
- replaces the manual length/comma logic with formatting based on sanitized numeric text
- preserves leading signs and decimal portions
- tolerates already-formatted values and invalid/non-numeric input more gracefully
- adds focused coverage for currency formatting edge cases

## Testing
- ctest --test-dir build-local --output-on-failure

Replaces closed PR #1622 after renaming the source branch to include the issue number.