### PR TITLE
fix(city): use-after-free in Base::die() when the base still has occupants

### DIFF
--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -121,11 +121,17 @@ void Base::die(GameState &state, bool collapse)
 			}
 		}
 	}
-	for (auto a : building->currentAgents)
+	// Copy both lists before iterating: Agent::die() erases from currentBuilding->currentAgents
+	// and Vehicle::die() from currentBuilding->currentVehicles, so a range-for over the live set
+	// increments an iterator whose node has already been freed. Vehicle::die() already guards its
+	// own agent loop the same way.
+	auto agentsCopy = building->currentAgents;
+	for (auto a : agentsCopy)
 	{
 		a->die(state, true);
 	}
-	for (auto v : building->currentVehicles)
+	auto vehiclesCopy = building->currentVehicles;
+	for (auto v : vehiclesCopy)
 	{
 		v->die(state, true);
 	}


### PR DESCRIPTION
## What

`Base::die()` iterates two live `std::set`s while calling `die()` on each element, and those `die()` calls erase from the very sets being iterated:

```cpp
for (auto a : building->currentAgents)   { a->die(state, true); }
for (auto v : building->currentVehicles) { v->die(state, true); }
```

- `Agent::die()` → `currentBuilding->currentAgents.erase(thisRef)` (`game/state/shared/agent.cpp`)
- `Vehicle::die()` → `currentBuilding->currentVehicles.erase(...)` (`game/state/city/vehicle.cpp`)

This copies each container before iterating it. Six lines plus a comment; one file, +8/−2.

## Why

Incrementing a range-for's iterator after its underlying tree node has been freed is undefined behaviour. On libc++ it dereferences a freed red-black-tree node and segfaults.

That is the crash in #915, whose backtrace runs `Base::die` → `Battle::exitBattle` → the `BattleDebriefing` OK-button lambda — returning from a lost base-defence mission. The reporter also noted the `currentVehicles` loop looked like it had the same problem. It does, and both are fixed here.

`Vehicle::die()` already guards its own agent loop exactly this way, with a comment explaining the hazard. These two loops were simply missed.

## Testing

- Compiles clean against current `master` (`cmake --build build --target OpenApoc_GameState`).
- I have a regression test in my fork that reproduces the crash — exits 139 without this change, passes with it — but it leans on test helpers that don't exist here yet. Happy to follow up with it if you want the harness; I kept this PR to the fix alone so it stays easy to read.
- Originally found by running the engine unattended for long stretches. The crash reproduces reliably once a base with several occupants falls.

## Risks

Low. No API or behaviour change beyond not crashing — the same elements are killed in the same order. The only cost is copying two small containers on a path that runs once, when a base is destroyed.

## Links

- Fixes #915

## Checklist

- [x] Single-purpose change, one file
- [x] Builds against current `master`
- [x] Existing behaviour preserved
- [ ] Regression test — available on request, needs test-helper infrastructure not yet upstream