### PR TITLE
feat(ui): add skirmish mode to the main menu

### DIFF
--- a/data/aliases/graphics.alias
+++ b/data/aliases/graphics.alias
@@ -10,6 +10,7 @@
   <alias type="image" id="BUTTON_SLIDER_LEFT">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</alias>
   <alias type="image" id="BUTTON_SLIDER_RIGHT_DEPRESSED">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:54:ui/menuopt.pal</alias>
   <alias type="image" id="BUTTON_SLIDER_RIGHT">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</alias>
+  <alias type="image" id="BUTTON_SLIDER_TRACK">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:63:ui/menuopt.pal</alias>
   <alias type="image" id="BUTTON_SCROLL_LEFT_DEPRESSED">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:2:ui/menuopt.pal</alias>
   <alias type="image" id="BUTTON_SCROLL_RIGHT_DEPRESSED">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:3:ui/menuopt.pal</alias>
   <alias type="image" id="BUTTON_SCROLL_UP_DEPRESSED">PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:1:ui/menuopt.pal</alias>

--- a/data/forms/mainmenu.form
+++ b/data/forms/mainmenu.form
@@ -24,23 +24,28 @@
 				</label>
 			</graphic>
 			<textbutton id="BUTTON_NEWGAME" text="Start Campaign Game">
-				<position x="centre" y="190"/>
+				<position x="centre" y="180"/>
+				<size width="300" height="32"/>
+				<font>smalfont</font>
+			</textbutton>
+			<textbutton id="BUTTON_SKIRMISH" text="Skirmish Mode">
+				<position x="centre" y="220"/>
 				<size width="300" height="32"/>
 				<font>smalfont</font>
 			</textbutton>
 			<textbutton id="BUTTON_LOADGAME" text="Load Saved Game">
-				<position x="centre" y="240"/>
+				<position x="centre" y="260"/>
 				<size width="300" height="32"/>
 				<font>smalfont</font>
 			</textbutton>
 			<!-- Options menu commented out until useful -->
 			<!-- <textbutton id="BUTTON_OPTIONS" text="Options">
-				<position x="centre" y="290"/>
+				<position x="centre" y="300"/>
 				<size width="300" height="32"/>
 				<font>smalfont</font>
 			</textbutton> -->
 			<textbutton id="BUTTON_CREDITS" text="Credits">
-				<position x="centre" y="290"/>
+				<position x="centre" y="300"/>
 				<size width="300" height="32"/>
 				<font>smalfont</font>
 			</textbutton>

--- a/data/forms/selectforces.form
+++ b/data/forms/selectforces.form
@@ -28,12 +28,11 @@
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
-      <label text = "_____________________________________________________">
-        <position x="36" y="95"/>
-        <size width="500" height="16"/>
-        <alignment horizontal="left" vertical="top"/>
-        <font>smalfont</font>
-      </label>
+      <control>
+        <position x="36" y="103"/>
+        <size width="500" height="1"/>
+        <backcolour r="160" g="160" b="160" a="255"/>
+      </control>
 
       <label text = "ALIENS">
         <position x="36" y="115"/>
@@ -60,6 +59,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="160"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_BSK_SLIDER">
         <position x="61" y="155"/>
         <size width="105" height="15"/>
@@ -90,6 +95,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="160"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_CHRYS_SLIDER">
         <position x="231" y="155"/>
         <size width="105" height="15"/>
@@ -120,6 +131,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="160"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_EGG_SLIDER">
         <position x="401" y="155"/>
         <size width="105" height="15"/>
@@ -150,6 +167,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="210"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_SPITTER_SLIDER">
         <position x="61" y="205"/>
         <size width="105" height="15"/>
@@ -180,6 +203,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="210"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_ANTHROPOD_SLIDER">
         <position x="231" y="205"/>
         <size width="105" height="15"/>
@@ -210,6 +239,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="210"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_MULTIWORM_SLIDER">
         <position x="401" y="205"/>
         <size width="105" height="15"/>
@@ -240,6 +275,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="260"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_POPPER_SLIDER">
         <position x="61" y="255"/>
         <size width="105" height="15"/>
@@ -270,6 +311,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="260"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_SKEL_SLIDER">
         <position x="231" y="255"/>
         <size width="105" height="15"/>
@@ -300,6 +347,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="260"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_HYPERWORM_SLIDER">
         <position x="401" y="255"/>
         <size width="105" height="15"/>
@@ -330,6 +383,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="310"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_MEGA_SLIDER">
         <position x="61" y="305"/>
         <size width="105" height="15"/>
@@ -360,6 +419,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="310"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_PSI_SLIDER">
         <position x="231" y="305"/>
         <size width="105" height="15"/>
@@ -390,6 +455,12 @@
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="310"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_MICRO_SLIDER">
         <position x="401" y="305"/>
         <size width="105" height="15"/>
@@ -429,12 +500,11 @@
         <font>smalfont</font>
       </label>
 
-      <label text = "_____________________________________________________">
-        <position x="36" y="365"/>
-        <size width="500" height="16"/>
-        <alignment horizontal="left" vertical="top"/>
-        <font>smalfont</font>
-      </label>
+      <control>
+        <position x="36" y="373"/>
+        <size width="500" height="1"/>
+        <backcolour r="160" g="160" b="160" a="255"/>
+      </control>
 
       <label id="GUARDS_LABEL2" text = "Guards">
         <position x="61" y="385"/>
@@ -442,6 +512,12 @@
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="410"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_GUARD_SLIDER">
         <position x="61" y="405"/>
         <size width="105" height="15"/>
@@ -485,6 +561,12 @@
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="410"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_CIVILIAN_SLIDER">
         <position x="231" y="405"/>
         <size width="105" height="15"/>
@@ -539,9 +621,11 @@
       </graphic>
 
       <graphicbutton id="BUTTON_OK">
-        <position x="604" y="445"/>
-        <size width="50" height="48"/>
-        <imagedepressed>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:5:xcom3/tacdata/tactical.pal</imagedepressed>
+        <tooltip text="Confirm these forces" font="smallset"/>
+        <position x="602" y="443"/>
+        <size width="35" height="34"/>
+        <image/>
+        <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
       </graphicbutton>
     </style>
   </form>

--- a/data/forms/skirmish.form
+++ b/data/forms/skirmish.form
@@ -23,342 +23,433 @@
         <font>smalfont</font>
       </label>
       <label id="LOCATION">
+        <tooltip text="The building, UFO or base the battle is fought in" font="smallset"/>
         <position x="36" y="80"/>
-        <size width="500" height="16"/>
+        <size width="450" height="16"/>
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
       <textbutton id="BUTTON_SELECTMAP" text="Select">
+        <tooltip text="Choose where the battle takes place" font="smallset"/>
         <position x="494" y="74"/>
         <size width="70" height="28"/>
         <font>smalfont</font>
       </textbutton>
-      <label text = "_____________________________________________________">
-        <position x="36" y="95"/>
-        <size width="500" height="16"/>
-        <alignment horizontal="left" vertical="top"/>
-        <font>smalfont</font>
-      </label>
-      <label text = "PLAYER / TECH LEVEL / SCORE SETTINGS">
-        <position x="36" y="115"/>
-        <size width="500" height="16"/>
+      <control>
+        <position x="36" y="106"/>
+        <size width="528" height="1"/>
+        <backcolour r="160" g="160" b="160" a="255"/>
+      </control>
+
+      <label text="SQUAD">
+        <position x="36" y="114"/>
+        <size width="528" height="16"/>
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Number of Human Agents">
-        <position x="36" y="135"/>
+      <label text="Number of human agents">
+        <position x="36" y="134"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="159"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_HUMANS_SLIDER">
-        <position x="61" y="155"/>
+        <tooltip text="How many human agents fight for you" font="smallset"/>
+        <position x="61" y="154"/>
         <size width="105" height="15"/>
         <range min="0" max="36"/>
       </scroll>
       <graphicbutton scrollprev="NUM_HUMANS_SLIDER">
-        <position x="46" y="153"/>
+        <position x="46" y="152"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="NUM_HUMANS_SLIDER">
-        <position x="167" y="153"/>
+        <position x="167" y="152"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "NUM_HUMANS" text = "0">
-        <position x="184" y="153"/>
+      <label id="NUM_HUMANS" text="0">
+        <position x="184" y="152"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Number of Hybrid Agents">
-        <position x="206" y="135"/>
+      <label text="Number of hybrid agents">
+        <position x="206" y="134"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="159"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_HYBRIDS_SLIDER">
-        <position x="231" y="155"/>
+        <tooltip text="How many mutant hybrid agents fight for you" font="smallset"/>
+        <position x="231" y="154"/>
         <size width="105" height="15"/>
         <range min="0" max="36"/>
       </scroll>
       <graphicbutton scrollprev="NUM_HYBRIDS_SLIDER">
-        <position x="216" y="153"/>
+        <position x="216" y="152"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="NUM_HYBRIDS_SLIDER">
-        <position x="337" y="153"/>
+        <position x="337" y="152"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "NUM_HYBRIDS" text = "0">
-        <position x="354" y="153"/>
+      <label id="NUM_HYBRIDS" text="0">
+        <position x="354" y="152"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Number of Android Agents">
-        <position x="376" y="135"/>
+      <label text="Number of android agents">
+        <position x="376" y="134"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="159"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="NUM_ANDROIDS_SLIDER">
-        <position x="401" y="155"/>
+        <tooltip text="How many android agents fight for you" font="smallset"/>
+        <position x="401" y="154"/>
         <size width="105" height="15"/>
         <range min="0" max="36"/>
       </scroll>
       <graphicbutton scrollprev="NUM_ANDROIDS_SLIDER">
-        <position x="386" y="153"/>
+        <position x="386" y="152"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="NUM_ANDROIDS_SLIDER">
-        <position x="507" y="153"/>
+        <position x="507" y="152"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "NUM_ANDROIDS" text = "0">
-        <position x="524" y="153"/>
+      <label id="NUM_ANDROIDS" text="0">
+        <position x="524" y="152"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Days of Physical Gym Training">
-        <position x="36" y="185"/>
+      <label text="TRAINING AND EQUIPMENT">
+        <position x="36" y="210"/>
+        <size width="528" height="16"/>
+        <alignment horizontal="left" vertical="top"/>
+        <font>smalfont</font>
+      </label>
+
+      <label text="Days of physical training">
+        <position x="36" y="230"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="255"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="DAYS_PHYSICAL_SLIDER">
-        <position x="61" y="205"/>
+        <tooltip text="Days of gym training applied to your agents" font="smallset"/>
+        <position x="61" y="250"/>
         <size width="105" height="15"/>
         <range min="0" max="180"/>
       </scroll>
       <graphicbutton scrollprev="DAYS_PHYSICAL_SLIDER">
-        <position x="46" y="203"/>
+        <position x="46" y="248"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="DAYS_PHYSICAL_SLIDER">
-        <position x="167" y="203"/>
+        <position x="167" y="248"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "DAYS_PHYSICAL" text = "0">
-        <position x="184" y="203"/>
+      <label id="DAYS_PHYSICAL" text="0">
+        <position x="184" y="248"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Days of Psi Gym Training">
-        <position x="206" y="185"/>
+      <label text="Days of psi training">
+        <position x="206" y="230"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="255"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="DAYS_PSI_SLIDER">
-        <position x="231" y="205"/>
+        <tooltip text="Days of psi gym training applied to your agents" font="smallset"/>
+        <position x="231" y="250"/>
         <size width="105" height="15"/>
         <range min="0" max="180"/>
       </scroll>
       <graphicbutton scrollprev="DAYS_PSI_SLIDER">
-        <position x="216" y="203"/>
+        <position x="216" y="248"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="DAYS_PSI_SLIDER">
-        <position x="337" y="203"/>
+        <position x="337" y="248"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "DAYS_PSI" text = "0">
-        <position x="354" y="203"/>
+      <label id="DAYS_PSI" text="0">
+        <position x="354" y="248"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Default equipment tech level">
-        <position x="376" y="185"/>
+      <label text="Equipment tech level">
+        <position x="376" y="230"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="255"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="PLAYER_TECH_SLIDER">
-        <position x="401" y="205"/>
+        <tooltip text="Tech level of the equipment your agents start with" font="smallset"/>
+        <position x="401" y="250"/>
         <size width="105" height="15"/>
         <range min="0" max="12"/>
       </scroll>
       <graphicbutton scrollprev="PLAYER_TECH_SLIDER">
-        <position x="386" y="203"/>
+        <position x="386" y="248"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="PLAYER_TECH_SLIDER">
-        <position x="507" y="203"/>
+        <position x="507" y="248"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "PLAYER_TECH" text = "0">
-        <position x="524" y="203"/>
+      <label id="PLAYER_TECH" text="0">
+        <position x="524" y="248"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Alien Score Level">
-        <position x="36" y="235"/>
+      <label text="DIFFICULTY AND ARMOR">
+        <position x="36" y="306"/>
+        <size width="528" height="16"/>
+        <alignment horizontal="left" vertical="top"/>
+        <font>smalfont</font>
+      </label>
+
+      <label text="Alien score level">
+        <position x="36" y="326"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="61" y="351"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="ALIEN_SCORE_SLIDER">
-        <position x="61" y="255"/>
+        <tooltip text="Alien score in thousands - higher means tougher aliens" font="smallset"/>
+        <position x="61" y="346"/>
         <size width="105" height="15"/>
         <range min="0" max="42"/>
       </scroll>
       <graphicbutton scrollprev="ALIEN_SCORE_SLIDER">
-        <position x="46" y="253"/>
+        <position x="46" y="344"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="ALIEN_SCORE_SLIDER">
-        <position x="167" y="253"/>
+        <position x="167" y="344"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "ALIEN_SCORE" text = "0">
-        <position x="184" y="253"/>
+      <label id="ALIEN_SCORE" text="0">
+        <position x="184" y="344"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Organisation Tech Level">
-        <position x="206" y="235"/>
+      <label text="Organisation tech level">
+        <position x="206" y="326"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="231" y="351"/>
+        <size width="105" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="ORG_SCORE_SLIDER">
-        <position x="231" y="255"/>
+        <tooltip text="Tech level of the defending organisation" font="smallset"/>
+        <position x="231" y="346"/>
         <size width="105" height="15"/>
         <range min="1" max="12"/>
       </scroll>
       <graphicbutton scrollprev="ORG_SCORE_SLIDER">
-        <position x="216" y="253"/>
+        <position x="216" y="344"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="ORG_SCORE_SLIDER">
-        <position x="337" y="253"/>
+        <position x="337" y="344"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "ORG_SCORE" text = "0">
-        <position x="354" y="253"/>
+      <label id="ORG_SCORE" text="0">
+        <position x="354" y="344"/>
         <size width="20" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
 
-      <label text = "Default equipped armor">
-        <position x="376" y="235"/>
+      <label text="Default equipped armor">
+        <position x="376" y="326"/>
         <size width="170" height="16"/>
         <alignment horizontal="centre" vertical="top"/>
         <font>smalfont</font>
       </label>
+      <graphic>
+        <position x="401" y="351"/>
+        <size width="55" height="6"/>
+        <image>BUTTON_SLIDER_TRACK</image>
+        <imageposition>stretch</imageposition>
+      </graphic>
       <scroll id="ARMOR_SLIDER">
-        <position x="401" y="255"/>
+        <tooltip text="Armor your agents start the battle wearing" font="smallset"/>
+        <position x="401" y="346"/>
         <size width="55" height="15"/>
         <range min="0" max="5"/>
       </scroll>
       <graphicbutton scrollprev="ARMOR_SLIDER">
-        <position x="386" y="253"/>
+        <position x="386" y="344"/>
         <size width="16" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:55:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_LEFT_DEPRESSED</imagedepressed>
       </graphicbutton>
       <graphicbutton scrollnext="ARMOR_SLIDER">
-        <position x="457" y="253"/>
+        <position x="457" y="344"/>
         <size width="17" height="20"/>
         <image>PCK:xcom3/ufodata/newbut.pck:xcom3/ufodata/newbut.tab:56:ui/menuopt.pal</image>
         <imagedepressed>BUTTON_SLIDER_RIGHT_DEPRESSED</imagedepressed>
       </graphicbutton>
-      <label id = "ARMOR" text = "0">
-        <position x="474" y="253"/>
+      <label id="ARMOR" text="0">
+        <position x="474" y="344"/>
         <size width="100" height="16"/>
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
 
+      <label text="BATTLE OPTIONS">
+        <position x="36" y="396"/>
+        <size width="528" height="16"/>
+        <alignment horizontal="left" vertical="top"/>
+        <font>smalfont</font>
+      </label>
+
       <checkbox id="CUSTOMISE_FORCES">
-        <position x="46" y="300"/>
+        <tooltip text="Pick the enemy forces yourself on the next screen" font="smallset"/>
+        <position x="46" y="418"/>
         <size width="19" height="16"/>
         <image>BUTTON_CHECKBOX_FALSE</image>
         <imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
       </checkbox>
-      <label  text = "Customize forces">
-        <position x="76" y="300"/>
-        <size width="110" height="16"/>
+      <label text="Customize forces">
+        <position x="76" y="418"/>
+        <size width="130" height="16"/>
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
 
       <checkbox id="ALTERNATIVE_ATTACK">
-        <position x="216" y="300"/>
+        <tooltip text="Raid an organisation's building - its guards defend it" font="smallset"/>
+        <position x="216" y="418"/>
         <size width="19" height="16"/>
         <image>BUTTON_CHECKBOX_FALSE</image>
         <imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
       </checkbox>
-      <label  text = "Raid mode">
-        <position x="246" y="300"/>
-        <size width="110" height="16"/>
+      <label text="Raid mode">
+        <position x="246" y="418"/>
+        <size width="130" height="16"/>
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
 
       <checkbox id="HOTSEAT">
-        <position x="386" y="300"/>
+        <tooltip text="Both sides played on this machine, taking turns" font="smallset"/>
+        <position x="386" y="418"/>
         <size width="19" height="16"/>
         <image>BUTTON_CHECKBOX_FALSE</image>
         <imagechecked>BUTTON_CHECKBOX_TRUE</imagechecked>
       </checkbox>
-      <label  text = "Hotseat multiplayer">
-        <position x="416" y="300"/>
-        <size width="110" height="16"/>
+      <label text="Hotseat multiplayer">
+        <position x="416" y="418"/>
+        <size width="130" height="16"/>
         <alignment horizontal="left" vertical="top"/>
         <font>smalfont</font>
       </label>
 
       <graphicbutton id="BUTTON_OK">
+        <tooltip text="Start the battle" font="smallset"/>
         <position x="602" y="443"/>
-        <size width="50" height="48"/>
-        <imagedepressed>PCK:xcom3/tacdata/tacbut.pck:xcom3/tacdata/tacbut.tab:5:xcom3/tacdata/tactical.pal</imagedepressed>
+        <size width="35" height="34"/>
+        <image/>
+        <imagedepressed>BUTTON_OK_DEPRESSED</imagedepressed>
       </graphicbutton>
     </style>
   </form>

--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2976,19 +2976,14 @@ void Battle::exitBattle(GameState &state)
 			}
 		}
 
-		// Erase base and building
-		StateRef<Base> fakeBase = {&state, "BASE_SKIRMISH"};
-		auto city = fakeBase->building->city;
+		// Erase base and building. They were never added to city->buildings, so there is
+		// nothing to unpick there.
+		StateRef<Base> fakeBase = {&state, SKIRMISH_BASE_ID};
 		fakeBase->building->currentAgents.clear();
 		fakeBase->building->base.clear();
 		fakeBase->building.clear();
-		auto &cityBuildings = city->buildings;
-		cityBuildings.erase(std::remove_if(cityBuildings.begin(), cityBuildings.end(),
-		                                   [](const StateRef<Building> &b)
-		                                   { return b.id == "BUILDING_SKIRMISH"; }),
-		                    cityBuildings.end());
-		state.buildings.erase("BUILDING_SKIRMISH");
-		state.player_bases.erase("BASE_SKIRMISH");
+		state.buildings.erase(SKIRMISH_BUILDING_ID);
+		state.player_bases.erase(SKIRMISH_BASE_ID);
 
 		// Erase vehicle
 		if (state.current_battle->player_craft)

--- a/game/state/battle/battle.h
+++ b/game/state/battle/battle.h
@@ -192,6 +192,11 @@ class Battle : public std::enable_shared_from_this<Battle>
 	bool skirmish = false;
 	std::map<StateRef<Organisation>, float> relationshipsBeforeSkirmish;
 	int scoreBeforeSkirmish = 0;
+	// A skirmish is staged from a synthetic base and building, built in
+	// Skirmish::goToBattle and torn down in Battle::exitBattle. Both ends need the
+	// same ids, so they live here rather than being spelled out in each file.
+	static constexpr const char *SKIRMISH_BUILDING_ID = "BUILDING_SKIRMISH";
+	static constexpr const char *SKIRMISH_BASE_ID = "BASE_SKIRMISH";
 
 	// BattleView and BattleTileView settings, saved here so that we can return to them
 

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -271,6 +271,9 @@ class GameState : public std::enable_shared_from_this<GameState>
 	// Following members are not serialized
 	bool newGame = false;
 	bool skipTurboCalculations = false;
+	// Set when Skirmish is launched from the main menu (no CityView underneath). Debrief
+	// must return to MainMenu instead of constructing a CityView on a disposable state.
+	bool skirmishFromMainMenu = false;
 
 	// Loads all mods set in the options - note this likely requires the mod data directories to
 	// already be added to the filesystem

--- a/game/ui/battle/battledebriefing.cpp
+++ b/game/ui/battle/battledebriefing.cpp
@@ -9,6 +9,7 @@
 #include "game/state/battle/battle.h"
 #include "game/state/battle/battleunit.h"
 #include "game/state/gamestate.h"
+#include "game/ui/general/mainmenu.h"
 #include "game/ui/tileview/cityview.h"
 
 namespace OpenApoc
@@ -20,9 +21,18 @@ BattleDebriefing::BattleDebriefing(sp<GameState> state)
 	    ->addCallback(FormEventType::ButtonClick,
 	                  [this](Event *)
 	                  {
+		                  const bool returnToMainMenu = this->state->skirmishFromMainMenu;
 		                  Battle::exitBattle(*this->state);
-		                  fw().stageQueueCommand(
-		                      {StageCmd::Command::REPLACEALL, mksp<CityView>(this->state)});
+		                  if (returnToMainMenu)
+		                  {
+			                  fw().stageQueueCommand(
+			                      {StageCmd::Command::REPLACEALL, mksp<MainMenu>()});
+		                  }
+		                  else
+		                  {
+			                  fw().stageQueueCommand(
+			                      {StageCmd::Command::REPLACEALL, mksp<CityView>(this->state)});
+		                  }
 	                  });
 
 	menuform->findControlTyped<Label>("TEXT_SCORE_COMBAT_RATING")

--- a/game/ui/general/mainmenu.cpp
+++ b/game/ui/general/mainmenu.cpp
@@ -7,15 +7,35 @@
 #include "framework/framework.h"
 #include "framework/jukebox.h"
 #include "framework/keycodes.h"
+#include "game/state/gamestate.h"
 #include "game/ui/debugtools/debugmenu.h"
 #include "game/ui/general/difficultymenu.h"
 #include "game/ui/general/loadingscreen.h"
 #include "game/ui/general/savemenu.h"
+#include "game/ui/skirmish/skirmish.h"
 #include "game/ui/tileview/cityview.h"
 #include "version.h"
+#include <future>
 
 namespace OpenApoc
 {
+namespace
+{
+
+std::shared_future<void> loadSkirmishState(sp<GameState> state)
+{
+	return fw().threadPoolEnqueue(
+	    [state]()
+	    {
+		    state->loadMods();
+		    state->startGame();
+		    state->initState();
+		    state->fillPlayerStartingProperty();
+		    state->fillOrgStartingProperty();
+	    });
+}
+
+} // namespace
 
 MainMenu::MainMenu() : Stage(), mainmenuform(ui().getForm("mainmenu"))
 {
@@ -76,6 +96,17 @@ void MainMenu::eventOccurred(Event *e)
 		if (e->forms().RaisedBy->Name == "BUTTON_NEWGAME")
 		{
 			fw().stageQueueCommand({StageCmd::Command::PUSH, mksp<DifficultyMenu>()});
+			return;
+		}
+		if (e->forms().RaisedBy->Name == "BUTTON_SKIRMISH")
+		{
+			auto loadedState = mksp<GameState>();
+			loadedState->difficulty = 0;
+			loadedState->skirmishFromMainMenu = true;
+			fw().stageQueueCommand(
+			    {StageCmd::Command::PUSH,
+			     mksp<LoadingScreen>(nullptr, loadSkirmishState(loadedState),
+			                         [loadedState]() { return mksp<Skirmish>(loadedState); })});
 			return;
 		}
 		if (e->forms().RaisedBy->Name == "BUTTON_DEBUG")

--- a/game/ui/skirmish/selectforces.cpp
+++ b/game/ui/skirmish/selectforces.cpp
@@ -308,7 +308,7 @@ SelectForces::SelectForces(sp<GameState> state, Skirmish &skirmish,
 	}
 	else
 	{
-		menuform->findControlTyped<CheckBox>("NUM_CIVILIAN_SLIDER")->setChecked(true);
+		menuform->findControlTyped<CheckBox>("DEFAULT_CIVILIANS")->setChecked(true);
 	}
 }
 

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -308,15 +308,18 @@ void Skirmish::goToBattle(bool customAliens, std::map<StateRef<AgentType>, int> 
 	auto sourceBase = locBase ? locBase : StateRef<Base>(&state, "BASE_1");
 	auto city = sourceBase->building->city;
 
+	// Registered in GameState so the StateRefs below resolve, but deliberately not added
+	// to city->buildings: battle map generation never reads city coordinates, and a
+	// building with default bounds sitting in the city wins Battle::finishBattle's
+	// nearest-building search for retreated aliens.
 	auto newBuilding = mksp<Building>();
-	state.buildings["BUILDING_SKIRMISH"] = newBuilding;
-	city->buildings.emplace_back(&state, "BUILDING_SKIRMISH");
+	state.buildings[Battle::SKIRMISH_BUILDING_ID] = newBuilding;
 
 	auto newBase = mksp<Base>();
-	state.player_bases["BASE_SKIRMISH"] = newBase;
+	state.player_bases[Battle::SKIRMISH_BASE_ID] = newBase;
 
-	StateRef<Building> playerBuilding = {&state, "BUILDING_SKIRMISH"};
-	StateRef<Base> playerBase = {&state, "BASE_SKIRMISH"};
+	StateRef<Building> playerBuilding = {&state, Battle::SKIRMISH_BUILDING_ID};
+	StateRef<Base> playerBase = {&state, Battle::SKIRMISH_BASE_ID};
 
 	playerBuilding->owner = state.getPlayer();
 	playerBuilding->base = playerBase;
@@ -547,7 +550,7 @@ void Skirmish::goToBattle(bool customAliens, std::map<StateRef<AgentType>, int> 
 	sp<Agent> firstAgent;
 	for (auto &a : state.agents)
 	{
-		if (a.second->homeBuilding.id == "BUILDING_SKIRMISH")
+		if (a.second->homeBuilding.id == Battle::SKIRMISH_BUILDING_ID)
 		{
 			firstAgent = a.second;
 			break;

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -478,20 +478,11 @@ void Skirmish::goToBattle(bool customAliens, std::map<StateRef<AgentType>, int> 
 		}
 	}
 
-	LogWarning("Resetting base inventory");
+	LogInfo("Stocking the skirmish base with every available item");
 	playerBase->inventoryAgentEquipment.clear();
+	// Every entry in agent_equipment is offered, so anything a mod adds is available too.
 	for (auto &t : state.agent_equipment)
 	{
-		// Ignore unfinished items
-		if (t.second->type == AEquipmentType::Type::AlienDetector ||
-		    t.second->type == AEquipmentType::Type::DimensionForceField ||
-		    t.second->type == AEquipmentType::Type::MindShield ||
-		    t.second->type == AEquipmentType::Type::MultiTracker ||
-		    t.second->type == AEquipmentType::Type::StructureProbe ||
-		    t.second->type == AEquipmentType::Type::VortexAnalyzer)
-		{
-			// continue;
-		}
 		// Ignore alien builtin weapons
 		if (t.second->store_space == 5 && t.second->manufacturer == state.getAliens())
 		{

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -139,9 +139,10 @@ std::shared_future<void> loadBattleVehicle(bool hotseat, sp<VehicleType> vehicle
 }
 } // namespace
 
-Skirmish::Skirmish(sp<GameState> state) : Stage(), menuform(ui().getForm("skirmish")), state(*state)
+Skirmish::Skirmish(sp<GameState> gameState)
+    : Stage(), menuform(ui().getForm("skirmish")), ownedState(gameState), state(*gameState)
 {
-	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state->getPlayerBalance());
+	menuform->findControlTyped<Label>("TEXT_FUNDS")->setText(state.getPlayerBalance());
 	updateLocationLabel();
 	menuform->findControlTyped<ScrollBar>("NUM_HUMANS_SLIDER")
 	    ->addCallback(

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -60,6 +60,16 @@ std::shared_future<void> loadBattleBuilding(bool hotseat, sp<Building> building,
 		    StateRef<Vehicle> veh = {};
 
 		    const std::map<StateRef<AgentType>, int> *aliensRef = customAliens ? &aliens : nullptr;
+		    if (playerBase->building == building && aliensRef)
+		    {
+			    // Base defence is the one mission type BattleMap::createBattle staffs from
+			    // building->current_crew rather than from the alien list. Passing a list
+			    // sends it down the "enemy raid" branch instead, which spawns guards for
+			    // the alien org - and aliens have none, so nobody deploys. Hand the chosen
+			    // aliens over as the crew and let the crew branch run.
+			    building->current_crew = *aliensRef;
+			    aliensRef = nullptr;
+		    }
 		    const int *guardsRef = customGuards ? &guards : nullptr;
 		    const int *civiliansRef = customCivilians ? &civilians : nullptr;
 
@@ -569,7 +579,7 @@ void Skirmish::customizeForces(bool force)
 		return;
 	}
 	std::map<StateRef<AgentType>, int> *aliens = nullptr;
-	std::map<StateRef<AgentType>, int> aliensNone;
+	std::map<StateRef<AgentType>, int> aliensDefault;
 	if (locVehicle)
 	{
 		aliens = &locVehicle->crew_downed;
@@ -587,7 +597,30 @@ void Skirmish::customizeForces(bool force)
 	}
 	else if (force)
 	{
-		aliens = &aliensNone;
+		// A base has no UFO crew and no preset crew to draw on, so without a default the
+		// roster opens empty, every slider sits at zero, and the battle is won on turn
+		// one. A base assault is delivered by an alien assault ship, so its crew is the
+		// natural default - and a mod that retunes that ship retunes this with it.
+		const auto assaultShip = state.vehicle_types.find("VEHICLETYPE_ALIEN_ASSAULT_SHIP");
+		if (assaultShip != state.vehicle_types.end() && !assaultShip->second->crew_downed.empty())
+		{
+			aliensDefault = assaultShip->second->crew_downed;
+		}
+		else
+		{
+			// No assault ship in this mod set - fall back to the force the campaign
+			// seeds at this difficulty. Entries are a {min, max} range; take the
+			// midpoint so the default is stable rather than re-rolled each time.
+			const auto difficultyAliens = state.initial_aliens.find(state.difficulty);
+			if (difficultyAliens != state.initial_aliens.end())
+			{
+				for (auto &a : difficultyAliens->second)
+				{
+					aliensDefault[a.first] += (a.second.x + a.second.y) / 2;
+				}
+			}
+		}
+		aliens = &aliensDefault;
 	}
 	int guards = -1;
 	if (locBuilding)

--- a/game/ui/skirmish/skirmish.cpp
+++ b/game/ui/skirmish/skirmish.cpp
@@ -202,7 +202,7 @@ Skirmish::Skirmish(sp<GameState> gameState)
 		        menuform->findControlTyped<Label>("PLAYER_TECH")
 		            ->setText(
 		                menuform->findControlTyped<ScrollBar>("PLAYER_TECH_SLIDER")->getValue() == 0
-		                    ? "NO"
+		                    ? "None"
 		                    : format("{0}",
 		                             menuform->findControlTyped<ScrollBar>("PLAYER_TECH_SLIDER")
 		                                 ->getValue()));

--- a/game/ui/skirmish/skirmish.h
+++ b/game/ui/skirmish/skirmish.h
@@ -19,6 +19,9 @@ class Skirmish : public Stage
   private:
 	sp<Form> menuform;
 
+	// Owns the state when Skirmish is the only gameplay stage (main-menu launch).
+	// Campaign launch still has CityView holding a copy; this keeps both paths safe.
+	sp<GameState> ownedState;
 	GameState &state;
 
 	StateRef<Building> locBuilding;


### PR DESCRIPTION
## What

Adds a **Skirmish Mode** button to the main menu, then cleans up the two screens it
leads to. Four commits, each reviewable on its own:

| Commit | |
| --- | --- |
| `feat(ui): add skirmish mode to the main menu` | the button itself |
| `fix(ui): tidy up the skirmish setup and customize-forces screens` | layout and wording |
| `fix(skirmish): stop the customize-forces crash, drop a dead equipment filter` | a null deref and some dead code |
| `refactor(skirmish): keep the synthetic skirmish building out of the cityscape` | the invisible building |
| `fix(skirmish): deploy aliens in a base-defence skirmish` | a base defence with no enemies in it |

## Why

Skirmish was only reachable from cityscape options, so testing a battle meant starting or
loading a campaign first. A main-menu entry is the obvious place for an OpenApoc-added
mode. It loads a disposable campaign `GameState` (same init as a new game), opens the
existing Skirmish setup, and keeps that state alive on the Skirmish stage so it does not
die with no `CityView` underneath. Debrief returns to `MainMenu` rather than building a
`CityView` on a disposable state; campaign-launched skirmish is unchanged
(`skirmishFromMainMenu` stays false).

Commits 2-4 pick up the things @FilmBoy84 flagged in review, done here so they are not
blocking anyone. Details below, and happy to drop any of them if you would rather take
them yourself.

## Formatting

The lint job was failing on a single stray blank line in `mainmenu.cpp` — `.clang-format`
sets `MaxEmptyLinesToKeep: 1`. Fixed, and verified with **clang-format 18.1.3** (the exact
version `ubuntu-latest` installs) read-only across all 502 C/C++ files in the tree: zero
diffs.

Worth flagging for anyone else on a non-Windows machine: CI does not run `tools/lint.sh`,
it runs `format-sources` over the **whole tree** and fails if `git status` is dirty
afterwards. Running that target with a newer clang-format rewrites 9 files that are
already CI-clean on master (`){};` → `) {};`, `operator new[]` spacing, lambda brace
wrapping), so it adds churn *and* still fails. On macOS `uvx --from clang-format==18.1.3
clang-format` gets the right binary without a full LLVM install.

## Screen cleanup

Both skirmish screens declared their sliders as bare `<scroll>` controls.
`ScrollBar::onRender` only ever draws the gripper, and `fundadj.pcx` — the *Adjust
Funding* background these screens borrow — has no slider art painted at those
coordinates, so the grippers floated on bare black. Each slider now sits on a recessed
rail, added as `BUTTON_SLIDER_TRACK` next to the existing `BUTTON_SLIDER_LEFT`/`RIGHT`
aliases.

`skirmish.form` also had roughly a third of its panel empty below the checkbox row, one
header covering three unrelated slider rows, and a `LOCATION` label 42px wider than the
gap before the Select button, so long location strings ran underneath it. The rows are
now spread over the whole panel under four headers — SQUAD, TRAINING AND EQUIPMENT,
DIFFICULTY AND ARMOR, BATTLE OPTIONS — and every slider and checkbox has a tooltip.

`BUTTON_OK` on both screens drew the *tactical* tick sprite stretched to 50x48 from
(602,443), which runs 12px past the right edge and 11px past the bottom of the 640x480
canvas. Every other menu screen uses `BUTTON_OK_DEPRESSED` at its native 35x34, which
lands exactly on the OK button painted into the background art. Both screens now match.

No control ids change — all 25 ids `skirmish.cpp` looks up and all 14 in
`selectforces.cpp` still resolve.

## Mod equipment

Short answer: **weapons added by mods already reach the skirmish pool**, and have all
along.

`Skirmish::goToBattle` walks `state.agent_equipment`, which `GameState::loadMods()` merges
new entries into by key, and stocks 100 of everything. There is no research, tech-level or
manufacturer gate on that loop — and `AEquipmentType::canBeUsed` separately bypasses
`research_dependency` when `current_battle->skirmish`. Only four things can hide an item:

- alien built-in weapons (`store_space == 5 && manufacturer == aliens`)
- `store_space == 0` (special attacks)
- `bioStorage`
- an eight-id manual blacklist (FORCEWEB, ENERGY_POD, DIMENSION_DESTABILISER, ELERIUM,
  PSICLONE, TRACKER_GUN, TRACKER_GUN_CLIP, PSI-GRENADE)

So if a specific modded weapon is missing, one of those four is the place to look first.

One dead filter removed while in there: the "ignore unfinished items" block tested six
`AEquipmentType::Type` values and its only statement was a commented-out `continue`, so it
had never excluded anything. Removed rather than revived — those item types are exactly
what a skirmish is for trying out.

**Vehicle equipment is deliberately not touched.** Skirmish never populates
`inventoryVehicleEquipment`/`inventoryVehicleAmmo` and never opens a vehicle-equip screen,
but the player's craft in `battleInVehicle` is a `VEHICLETYPE_BIOTRANS` that only ferries
agents into the UFO — its weapons never enter the tactical battle. Stocking those maps
would be state nothing reads. Making vehicle loadouts matter in skirmish is a feature, not
a cleanup, so it is left alone.

## The invisible building

A skirmish is staged from a `Building` and `Base` minted at runtime. The building was
pushed into the live `City`'s building vector as well as into `GameState`, but its
`bounds` were never set, so it sat at the map origin occupying no tiles.

Nothing needed it there. `BattleMap::createBattle` reads only `owner`, `base`,
`battle_map`, `preset_crew` and `current_crew`; `generateBase` finds its `Base` by walking
`state.player_bases`, not the city. City membership only ever fed `Battle::finishBattle`,
which houses retreated aliens in whichever building in `city->buildings` is nearest the
battle, by Manhattan distance from `bounds.p0`:

```cpp
for (auto &b : city->buildings)
{
    int distance = std::abs(b->bounds.p0.x - battleLocation.x) + ...
```

A building at the origin is a standing candidate there, and wins outright for base
defence, where `battleLocation` is also the origin. Retreated aliens were being filed into
a building that `exitBattle` deleted a moment later, and were silently lost. It now keeps
its `GameState` entry so the `StateRef`s still resolve, and stays out of the city.

The ids were also spelled out as string literals in three places across two files with
nothing keeping them in step — commit `8a925c6d` had to rename both ends by hand. They now
come from `Battle::SKIRMISH_BUILDING_ID` / `SKIRMISH_BASE_ID`, and the teardown drops the
`city->buildings` erase that no longer has anything to remove.

`Battle::skirmish` stays. Its other two uses are unrelated and load-bearing: agents are not
sent home after the battle, and the research gate on equipment is bypassed.

Still out of scope, noted so it is not mistaken for an oversight: the main-menu path builds
a full campaign (`startGame` + `initState` + `fillPlayerStartingProperty` instantiate a
complete `CITYMAP_HUMAN` with a random alien-infiltrated building) purely to have a city
and a `BASE_1` to graft onto. Decoupling skirmish from that is a larger piece of work.

## Base defence had no aliens in it

Picking a base and clicking through won the battle on turn one - no hostile units were
ever placed. Two things had to line up.

`BattleMap::createBattle` staffs a base defence from `building->current_crew`, not from the
alien list it is handed:

```cpp
if (opponent == state.getAliens() && !aliens)   // crew branch
else                                            // "Enemy raid, spawn guards for them"
```

Skirmish always passes a list, so it always took the `else`, which spawns
`getGuardCount()` guards for the *alien* org - and aliens have no building guards, so it
spawned nobody. The counts picked on the Customize Forces screen never reached a base
defence at all. `loadBattleBuilding` now hands them over as the building's crew and clears
the pointer, so the crew branch runs.

Even then the roster arrived empty: `customizeForces` only has a crew to offer for a UFO
or a preset-crew building, so a base fell through to an empty map and every slider opened
at zero. A base assault is delivered by an alien assault ship, so its `crew_downed` - 6
anthropods, 4 poppers, 4 spitters, 2 chrysalis, 2 skeletoids - is the default now. It reads
from the vehicle table rather than being hardcoded, so a mod that retunes that ship retunes
this with it, and it falls back to the campaign's `initial_aliens` for the difficulty if a
mod set has no assault ship. The sliders still override it.

Both halves predate this PR - `git blame` dates them to Istrebitel, 2017, and no other
commit here touches `battlemap.cpp`.

## Crash fix

`SelectForces` looked up `NUM_CIVILIAN_SLIDER` as a `CheckBox` when no civilian count was
supplied. That id belongs to a `<scroll>`, so `findControlTyped` fails the
`dynamic_pointer_cast`, logs an error and returns `nullptr`, and `setChecked` then
dereferences it. The alien and guard branches beside it already use `DEFAULT_ALIENS` and
`DEFAULT_GUARDS`; this one wanted `DEFAULT_CIVILIANS`.

## Gap matrix

- Row(s): N/A — OpenApoc-added UI, not original-game parity
- Lock test(s): N/A
- Ghidra used: no
- Offsets cited (binary + generation): N/A

## Testing

- [x] `OpenApoc` builds clean
- [x] `ctest --test-dir build --output-on-failure` — 10/10 pass
- [x] clang-format **18.1.3** read-only over all 502 C/C++ files — zero diffs
- [x] Control ids cross-checked against `skirmish.cpp` (25) and `selectforces.cpp` (14) —
      all resolve
- [x] Layout verified by compositing the real sprites over `fundadj.pcx` at the exact form
      coordinates
- [ ] `./tools/check_ignored_binaries.sh` — not required, no ignore-rule changes
- [ ] `python3 tools/regen_compare_report.py` — docs/original-game unchanged
- [x] Manual: main menu → Skirmish Mode → setup screen renders as intended, every control
      resolves (zero `Failed to find control` in the log)
- [x] Manual: base-defence skirmish reaches a live battle on `BATTLEMAP_37base` with aliens
      deployed - 10 anthropod, 4 popper, 4 skeletoid, 4 spitter equip lines in the log,
      matching the assault-ship crew, where the same flow previously won on turn one
- [ ] Manual: `finishBattle` / `exitBattle` after a battle **ends** - not yet exercised, so
      the teardown half of the invisible-building change is still unverified at runtime

## Risks

Commit 4 is still the one to scrutinise. Its construction half is now exercised - a base
defence builds and runs - but the teardown half (`finishBattle` / `exitBattle`) only runs
once a battle actually ends, which has not been tested. Commit 5 changes what deploys in a
base defence, so it is a behaviour change rather than a cleanup, and is worth a look on
that basis. Everything else is data files, a one-line id fix, and dead-code removal. Each
commit reverts independently.

## Links

N/A — no tracker item
