### PR TITLE
framework: a localhost command socket for driving the game programmat…

### DIFF
--- a/forms/CMakeLists.txt
+++ b/forms/CMakeLists.txt
@@ -8,6 +8,8 @@ set (FORMS_SOURCE_FILES
 	checkbox.cpp
 	control.cpp
 	form.cpp
+	harness_ui.cpp
+	harness_actions.cpp
 	graphicbutton.cpp
 	graphic.cpp
 	label.cpp
@@ -26,6 +28,8 @@ set (FORMS_HEADER_FILES
 	checkbox.h
 	control.h
 	form.h
+	harness_ui.h
+	harness_actions.h
 	forms_enums.h
 	forms.h
 	graphicbutton.h

--- a/forms/control.h
+++ b/forms/control.h
@@ -143,6 +143,8 @@ class Control : public std::enable_shared_from_this<Control>
 	sp<Control> getAncestor(sp<Control> Parent);
 
 	Vec2<int> getLocationOnScreen() const { return resolvedLocation; }
+	// UI-space position, so a harness can address a control without pixel maths.
+	Vec2<int> getLocationInUi() const { return resolvedLocation; }
 
 	void setRelativeWidth(float widthPercent);
 	void setRelativeHeight(float widthPercent);

--- a/forms/form.cpp
+++ b/forms/form.cpp
@@ -1,4 +1,5 @@
 #include "form.h"
+#include "forms/harness_actions.h"
 #include "dependencies/pugixml/src/pugixml.hpp"
 #include "framework/data.h"
 #include "framework/framework.h"
@@ -6,9 +7,26 @@
 namespace OpenApoc
 {
 
-Form::Form() : Control() {}
+namespace
+{
+// Forms register themselves on construction so the harness can enumerate what is on screen.
+std::vector<Form *> g_liveForms;
+} // namespace
 
-Form::~Form() = default;
+const std::vector<Form *> &Form::liveForms() { return g_liveForms; }
+
+Form::Form() : Control()
+{
+	g_liveForms.push_back(this);
+	// Installed from here rather than at startup so the action handler exists as soon as there is
+	// any form to act on. Without it CONTROL/ACTION/HELP answer "no action handler".
+	installFormsHarnessActions();
+}
+
+Form::~Form()
+{
+	g_liveForms.erase(std::remove(g_liveForms.begin(), g_liveForms.end(), this), g_liveForms.end());
+}
 
 void Form::readFormStyle(pugi::xml_node *node)
 {
@@ -33,10 +51,24 @@ void Form::readFormStyle(pugi::xml_node *node)
 
 void Form::eventOccured(Event *e) { Control::eventOccured(e); }
 
-void Form::onRender() { Control::onRender(); }
+void Form::onRender()
+{
+	// A form that renders or updates is on screen. That is what the harness means by "visible" --
+	// liveForms() knows every constructed form, but only these are actually being shown, and an
+	// automated driver must not click a control belonging to a screen nobody can see.
+	if (auto self = std::dynamic_pointer_cast<Form>(weak_from_this().lock()))
+	{
+		notifyVisibleForm(self);
+	}
+	Control::onRender();
+}
 
 void Form::update()
 {
+	if (auto self = std::dynamic_pointer_cast<Form>(weak_from_this().lock()))
+	{
+		notifyVisibleForm(self);
+	}
 	Control::update();
 	resolveLocation();
 }

--- a/forms/form.h
+++ b/forms/form.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <vector>
+
 #include "control.h"
 
 namespace OpenApoc
@@ -7,6 +9,11 @@ namespace OpenApoc
 
 class Form : public Control
 {
+  public:
+	// Every Form currently constructed, in creation order. Registered here because there is no
+	// other way for a test harness to find the controls that are actually on screen -- with a
+	// resizable viewport and UI scaling, computing rects from the .form XML is not reliable.
+	static const std::vector<Form *> &liveForms();
 
   protected:
 	void onRender() override;

--- a/forms/harness_actions.cpp
+++ b/forms/harness_actions.cpp
@@ -1,0 +1,558 @@
+#include "forms/harness_actions.h"
+#include "forms/checkbox.h"
+#include "forms/control.h"
+#include "forms/form.h"
+#include "forms/graphicbutton.h"
+#include "forms/label.h"
+#include "forms/listbox.h"
+#include "forms/radiobutton.h"
+#include "forms/scrollbar.h"
+#include "forms/textbutton.h"
+#include "forms/textedit.h"
+#include "framework/framework.h"
+#include "framework/harness.h"
+#include "library/strings.h"
+#include "library/strings_format.h"
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <set>
+#include <vector>
+
+namespace OpenApoc
+{
+namespace
+{
+
+uint64_t formsFrame = 0;
+std::vector<wp<Form>> visibleForms;
+
+uint64_t currentFrame()
+{
+	if (auto *instance = Framework::tryGetInstance())
+	{
+		return instance->getFrameNumber();
+	}
+	return 0;
+}
+
+UString controlTypeName(Control *control)
+{
+	if (dynamic_cast<TextButton *>(control))
+	{
+		return "TextButton";
+	}
+	if (dynamic_cast<GraphicButton *>(control))
+	{
+		return "GraphicButton";
+	}
+	if (dynamic_cast<RadioButton *>(control))
+	{
+		return "RadioButton";
+	}
+	if (dynamic_cast<CheckBox *>(control))
+	{
+		return "CheckBox";
+	}
+	if (dynamic_cast<ScrollBar *>(control))
+	{
+		return "ScrollBar";
+	}
+	if (dynamic_cast<ListBox *>(control))
+	{
+		return "ListBox";
+	}
+	if (dynamic_cast<TextEdit *>(control))
+	{
+		return "TextEdit";
+	}
+	if (dynamic_cast<Label *>(control))
+	{
+		return "Label";
+	}
+	if (dynamic_cast<Form *>(control))
+	{
+		return "Form";
+	}
+	return "Control";
+}
+
+std::vector<sp<Form>> liveForms()
+{
+	std::vector<sp<Form>> out;
+	std::set<Form *> seen;
+	for (auto &weak : visibleForms)
+	{
+		auto form = weak.lock();
+		if (!form || !seen.insert(form.get()).second)
+		{
+			continue;
+		}
+		out.push_back(form);
+	}
+	return out;
+}
+
+sp<Control> findNamedControl(const UString &id)
+{
+	for (auto &form : liveForms())
+	{
+		if (form->Name == id)
+		{
+			return form;
+		}
+		if (auto found = form->findControl(id))
+		{
+			return found;
+		}
+	}
+	return nullptr;
+}
+
+void collectNamed(const sp<Control> &control, std::vector<UString> &out)
+{
+	if (!control)
+	{
+		return;
+	}
+	if (!control->Name.empty() && control->Name != "Control")
+	{
+		out.push_back(format("{0}:{1}:visible={2}:enabled={3}", control->Name,
+		                     controlTypeName(control.get()), control->isVisible() ? 1 : 0,
+		                     control->Enabled ? 1 : 0));
+	}
+	for (auto &child : control->Controls)
+	{
+		collectNamed(child, out);
+	}
+}
+
+bool parseBoolValue(const UString &value, bool &out)
+{
+	const auto lowered = to_lower(value);
+	if (lowered == "1" || lowered == "true" || lowered == "on" || lowered == "yes")
+	{
+		out = true;
+		return true;
+	}
+	if (lowered == "0" || lowered == "false" || lowered == "off" || lowered == "no")
+	{
+		out = false;
+		return true;
+	}
+	return false;
+}
+
+bool parseIntValue(const UString &value, int &out)
+{
+	if (value.empty())
+	{
+		return false;
+	}
+	char *end = nullptr;
+	const long parsed = std::strtol(value.c_str(), &end, 10);
+	if (!end || *end != '\0')
+	{
+		return false;
+	}
+	out = static_cast<int>(parsed);
+	return true;
+}
+
+// The gap the named-action layer leaves is runtime widgets with no ids: purchase rows, lab
+// entries, agent rows. They are real controls in the tree, they simply were never given a Name,
+// so the only handle on them is their position in their parent. These two helpers turn that
+// position into an address, which keeps the driver operating the actual UI rather than reaching
+// past it into GameState.
+
+// Nth child of a control, skipping nothing -- index is the raw child order the engine built.
+sp<Control> itemAt(const sp<Control> &parent, int index)
+{
+	if (!parent || index < 0 || index >= static_cast<int>(parent->Controls.size()))
+	{
+		return nullptr;
+	}
+	return parent->Controls[static_cast<size_t>(index)];
+}
+
+// First descendant that "set" knows how to drive. A purchase row is a bare Control whose
+// quantity is an unnamed ScrollBar child (transactioncontrol.cpp:702), so setting the row means
+// setting that scrollbar.
+sp<Control> firstSettableDescendant(const sp<Control> &root, int depth = 0)
+{
+	if (!root || depth > 8)
+	{
+		return nullptr;
+	}
+	for (auto &child : root->Controls)
+	{
+		if (!child)
+		{
+			continue;
+		}
+		if (dynamic_cast<ScrollBar *>(child.get()) || dynamic_cast<CheckBox *>(child.get()) ||
+		    dynamic_cast<TextEdit *>(child.get()))
+		{
+			return child;
+		}
+	}
+	for (auto &child : root->Controls)
+	{
+		if (auto found = firstSettableDescendant(child, depth + 1))
+		{
+			return found;
+		}
+	}
+	return nullptr;
+}
+
+// First label text anywhere under a control. Runtime list rows carry their identity only as a
+// child Label -- a purchase row's item name, a lab's facility name -- so without this a driver
+// can address rows by position but has no idea which row is which, and ends up buying whatever
+// happens to be in slot 3.
+UString firstLabelText(const sp<Control> &root, int depth = 0)
+{
+	if (!root || depth > 8)
+	{
+		return "";
+	}
+	for (auto &child : root->Controls)
+	{
+		if (auto *lbl = dynamic_cast<Label *>(child.get()))
+		{
+			const auto t = lbl->getText();
+			if (!t.empty())
+			{
+				return t;
+			}
+		}
+	}
+	for (auto &child : root->Controls)
+	{
+		const auto found = firstLabelText(child, depth + 1);
+		if (!found.empty())
+		{
+			return found;
+		}
+	}
+	return "";
+}
+
+UString applyToControl(const sp<Control> &control, const UString &label, const UString &op,
+                       const UString &value);
+
+UString applyControl(const UString &id, const UString &op, const UString &value)
+{
+	auto control = findNamedControl(id);
+	if (!control)
+	{
+		return format("ERR unknown control \"{0}\"", id);
+	}
+	return applyToControl(control, id, op, value);
+}
+
+UString applyToControl(const sp<Control> &control, const UString &id, const UString &op,
+                       const UString &value)
+{
+	if (op == "click" || op.empty())
+	{
+		if (!control->click())
+		{
+			return format("ERR control \"{0}\" not clickable (visible={1} enabled={2})", id,
+			              control->isVisible() ? 1 : 0, control->Enabled ? 1 : 0);
+		}
+		return format("OK clicked {0}", id);
+	}
+	if (op == "toggle")
+	{
+		if (auto *box = dynamic_cast<CheckBox *>(control.get()))
+		{
+			box->setChecked(!box->isChecked());
+			return format("OK {0} checked={1}", id, box->isChecked() ? 1 : 0);
+		}
+		if (!control->click())
+		{
+			return format("ERR control \"{0}\" cannot toggle", id);
+		}
+		return format("OK toggled {0}", id);
+	}
+	// Reading a widget's current value matters as much as writing it: a transaction row's
+	// quantity is a balance, so setting it *below* what the base already holds sells the
+	// difference. A driver that cannot read the current value ends up selling the squad's
+	// weapons while believing it is buying them.
+	if (op == "get")
+	{
+		if (auto *box = dynamic_cast<CheckBox *>(control.get()))
+		{
+			return format("OK {0} checked={1}", id, box->isChecked() ? 1 : 0);
+		}
+		if (auto *bar = dynamic_cast<ScrollBar *>(control.get()))
+		{
+			return format("OK {0} value={1} min={2} max={3}", id, bar->getValue(),
+			              bar->getMinimum(), bar->getMaximum());
+		}
+		if (auto *list = dynamic_cast<ListBox *>(control.get()))
+		{
+			return format("OK {0} items={1}", id, static_cast<int>(list->Controls.size()));
+		}
+		if (auto *lbl = dynamic_cast<Label *>(control.get()))
+		{
+			auto t = lbl->getText();
+			std::replace(t.begin(), t.end(), ' ', '_');
+			return format("OK {0} text={1}", id, t.empty() ? UString("-") : t);
+		}
+		if (auto inner = firstSettableDescendant(control))
+		{
+			return applyToControl(inner, format("{0}/inner", id), "get", "");
+		}
+		return format("ERR control \"{0}\" ({1}) has no readable value", id,
+		              controlTypeName(control.get()));
+	}
+	if (op == "set")
+	{
+		if (auto *box = dynamic_cast<CheckBox *>(control.get()))
+		{
+			bool checked = false;
+			if (!parseBoolValue(value, checked))
+			{
+				return format("ERR set {0} needs true/false", id);
+			}
+			box->setChecked(checked);
+			return format("OK {0} checked={1}", id, box->isChecked() ? 1 : 0);
+		}
+		if (auto *bar = dynamic_cast<ScrollBar *>(control.get()))
+		{
+			int parsed = 0;
+			if (!parseIntValue(value, parsed))
+			{
+				return format("ERR set {0} needs an integer", id);
+			}
+			if (!bar->setValue(parsed))
+			{
+				return format("ERR set {0} rejected value {1} (min={2} max={3})", id, parsed,
+				              bar->getMinimum(), bar->getMaximum());
+			}
+			return format("OK {0} value={1}", id, bar->getValue());
+		}
+		if (auto *edit = dynamic_cast<TextEdit *>(control.get()))
+		{
+			edit->setText(value);
+			return format("OK {0} text set", id);
+		}
+		if (auto *list = dynamic_cast<ListBox *>(control.get()))
+		{
+			int index = 0;
+			if (!parseIntValue(value, index) || index < 0 ||
+			    index >= static_cast<int>(list->Controls.size()))
+			{
+				return format("ERR set {0} needs an item index 0..{1}", id,
+				              static_cast<int>(list->Controls.size()) - 1);
+			}
+			// Neither Control::click() nor setSelected() actually selects a list item: the
+			// first raises MouseClick, which ListBox ignores for selection, and the second
+			// raises nothing at all. Both would report success while the screen behind the list
+			// never changed.
+			if (!list->selectItemByIndex(static_cast<size_t>(index)))
+			{
+				return format("ERR set {0} could not select item {1}", id, index);
+			}
+			return format("OK {0} selected {1}", id, index);
+		}
+		// Rows in a runtime-built list are plain Controls whose editable part is an unnamed
+		// child -- the purchase quantity is a ScrollBar inside the row. Reach it rather than
+		// refusing.
+		if (auto inner = firstSettableDescendant(control))
+		{
+			return applyToControl(inner, format("{0}/inner", id), "set", value);
+		}
+		return format("ERR control \"{0}\" ({1}) does not support set", id,
+		              controlTypeName(control.get()));
+	}
+	return format("ERR unknown control op \"{0}\"", op);
+}
+
+UString handleFormAction(const UString &verb, const std::vector<UString> &args)
+{
+	const auto action = to_lower(verb);
+	if (action == "help")
+	{
+		return "OK verbs=help,controls,control,click,set,get,toggle,item "
+		       "usage=CONTROL <id> [click|toggle|set <value>|item <N> [op] [value]] "
+		       "CONTROLS [<id>] lists children of <id> by position";
+	}
+	if (action == "controls")
+	{
+		// With an id, enumerate that control's immediate children by position, including the
+		// unnamed ones. A driver cannot address what it cannot see, and the rows that matter --
+		// purchase lines, lab entries -- have no names to list.
+		if (!args.empty())
+		{
+			auto parent = findNamedControl(args[0]);
+			if (!parent)
+			{
+				return format("ERR unknown control \"{0}\"", args[0]);
+			}
+			UString reply = format("OK parent={0} items={1}", args[0], parent->Controls.size());
+			for (size_t i = 0; i < parent->Controls.size(); i++)
+			{
+				const auto &child = parent->Controls[i];
+				if (!child)
+				{
+					continue;
+				}
+				const auto inner = firstSettableDescendant(child);
+				auto text = firstLabelText(child);
+				std::replace(text.begin(), text.end(), ' ', '_');
+				reply += format(" {0}:{1}:{2}:visible={3}:settable={4}:text={5}", i,
+				                child->Name.empty() ? UString("-") : child->Name,
+				                controlTypeName(child.get()), child->isVisible() ? 1 : 0,
+				                inner ? controlTypeName(inner.get()) : UString("-"),
+				                text.empty() ? UString("-") : text);
+			}
+			return reply;
+		}
+		std::vector<UString> names;
+		for (auto &form : liveForms())
+		{
+			collectNamed(form, names);
+		}
+		UString reply = format("OK count={0}", names.size());
+		for (auto &name : names)
+		{
+			reply += " ";
+			reply += name;
+		}
+		return reply;
+	}
+	if (action == "click")
+	{
+		if (args.empty())
+		{
+			return "ERR click needs a control id";
+		}
+		return applyControl(args[0], "click", "");
+	}
+	if (action == "toggle")
+	{
+		if (args.empty())
+		{
+			return "ERR toggle needs a control id";
+		}
+		return applyControl(args[0], "toggle", "");
+	}
+	if (action == "set")
+	{
+		if (args.size() < 2)
+		{
+			return "ERR set needs a control id and a value";
+		}
+		UString value;
+		for (size_t i = 1; i < args.size(); i++)
+		{
+			if (i > 1)
+			{
+				value += " ";
+			}
+			value += args[i];
+		}
+		return applyControl(args[0], "set", value);
+	}
+	if (action == "control")
+	{
+		if (args.empty())
+		{
+			return "ERR CONTROL needs a control id";
+		}
+		auto control = findNamedControl(args[0]);
+		if (!control)
+		{
+			return format("ERR unknown control \"{0}\"", args[0]);
+		}
+		UString label = args[0];
+		size_t i = 1;
+		// Walk any number of "item <N>" hops before the terminal operation. One level covers a
+		// plain list row; some widgets need more. MapSelector's map rows are the case that
+		// forced this: the row itself is an inert Control with no click handler at all, and the
+		// button that actually picks the map (calling Skirmish::setLocation) is a *second-level*
+		// child of that row -- not the row itself, and not something ListBox selection reaches
+		// either, since MapSelector never listens for ListBoxChangeSelected. Only
+		// `item <N> item 1 click` reaches it without pixel geometry.
+		while (i + 1 < args.size() && to_lower(args[i]) == "item")
+		{
+			int index = 0;
+			if (!parseIntValue(args[i + 1], index))
+			{
+				return format("ERR item index \"{0}\" is not a number", args[i + 1]);
+			}
+			auto next = itemAt(control, index);
+			if (!next)
+			{
+				return format("ERR {0} has no item {1} (items={2})", label, index,
+				              static_cast<int>(control->Controls.size()));
+			}
+			control = next;
+			label = format("{0}[{1}]", label, index);
+			i += 2;
+		}
+		UString op = i < args.size() ? to_lower(args[i]) : UString("click");
+		UString value;
+		if (op == "set")
+		{
+			for (size_t j = i + 1; j < args.size(); j++)
+			{
+				if (j > i + 1)
+				{
+					value += " ";
+				}
+				value += args[j];
+			}
+		}
+		return applyToControl(control, label, op, value);
+	}
+	return "";
+}
+
+} // namespace
+
+void notifyVisibleForm(const sp<Form> &form)
+{
+	if (!form)
+	{
+		return;
+	}
+	installFormsHarnessActions();
+	const auto frame = currentFrame();
+	if (frame != formsFrame)
+	{
+		visibleForms.clear();
+		formsFrame = frame;
+	}
+	visibleForms.emplace_back(form);
+}
+
+void installFormsHarnessActions()
+{
+	static bool installed = false;
+	if (installed)
+	{
+		return;
+	}
+	installed = true;
+	auto previous = getHarnessActionHandler();
+	setHarnessActionHandler(
+	    [previous](const UString &verb, const std::vector<UString> &args) -> UString
+	    {
+		    auto reply = handleFormAction(verb, args);
+		    if (!reply.empty())
+		    {
+			    return reply;
+		    }
+		    if (previous)
+		    {
+			    return previous(verb, args);
+		    }
+		    return "";
+	    });
+}
+
+} // namespace OpenApoc

--- a/forms/harness_actions.h
+++ b/forms/harness_actions.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include "library/sp.h"
+
+namespace OpenApoc
+{
+
+class Form;
+
+void notifyVisibleForm(const sp<Form> &form);
+void installFormsHarnessActions();
+
+} // namespace OpenApoc

--- a/forms/harness_ui.cpp
+++ b/forms/harness_ui.cpp
@@ -1,0 +1,94 @@
+// Live UI introspection for the test harness.
+//
+// The harness used to locate controls by parsing data/forms/**.form and recomputing the layout
+// itself. That only worked while the viewport was a fixed size and the UI was unscaled. With a
+// resizable display and a UI scale factor, the only trustworthy source of a control's position is
+// the control itself, after the engine has resolved it.
+//
+// framework/ cannot name Control (OpenApoc_Forms links OpenApoc_Framework, never the reverse), so
+// this lives here and installs itself into the framework's UI hook.
+
+#include "forms/control.h"
+#include "forms/form.h"
+#include "forms/harness_ui.h"
+#include "framework/harness.h"
+#include "library/strings_format.h"
+#include <algorithm>
+#include <set>
+
+namespace OpenApoc
+{
+namespace
+{
+
+// One control per record: id, class, resolved screen rect, visibility. Tab separated inside a
+// record, semicolon between records, so the whole dump stays on the harness's single reply line.
+void dumpControl(const sp<Control> &c, const UString &filter, UString &out, int &count, int depth,
+                 std::set<UString> &seen)
+{
+	if (!c || depth > 12)
+	{
+		return;
+	}
+	const auto name = c->Name;
+	const bool named = !name.empty() && name != "Control";
+	if (named && (filter.empty() || to_lower(name).find(to_lower(filter)) != UString::npos))
+	{
+		const auto pos = c->getLocationInUi();
+		// ui().getForm() caches a template and hands out a copy, so both are live and identical.
+		// Collapse exact duplicates rather than reporting every control twice.
+		const auto key = format("{0},{1},{2},{3},{4}", name, pos.x, pos.y, c->Size.x, c->Size.y);
+		if (seen.insert(key).second)
+		{
+			if (count++ > 0)
+			{
+				out += ";";
+			}
+			out += format("{0},{1}", key, c->isVisible() ? 1 : 0);
+		}
+	}
+	for (const auto &child : c->Controls)
+	{
+		dumpControl(child, filter, out, count, depth + 1, seen);
+	}
+}
+
+UString dumpLiveUI(const UString &filter)
+{
+	UString out;
+	int count = 0;
+	std::set<UString> seen;
+	for (auto *form : Form::liveForms())
+	{
+		if (!form || !form->isVisible())
+		{
+			continue;
+		}
+		// Walk from the form itself so the root's own rect is reported too.
+		for (const auto &child : form->Controls)
+		{
+			dumpControl(child, filter, out, count, 1, seen);
+		}
+		const auto pos = form->getLocationInUi();
+		if (filter.empty() || to_lower(form->Name).find(to_lower(filter)) != UString::npos)
+		{
+			const auto key = format("{0},{1},{2},{3},{4}", form->Name, pos.x, pos.y, form->Size.x,
+			                        form->Size.y);
+			if (seen.insert(key).second)
+			{
+				if (count++ > 0)
+				{
+					out += ";";
+				}
+				out += format("{0},1", key);
+			}
+		}
+	}
+	return format("count={0} at={1}", count, out.empty() ? UString("-") : out);
+}
+
+} // namespace
+
+void registerFormsHarnessUI() { setHarnessUIHandler(dumpLiveUI); }
+
+} // namespace OpenApoc

--- a/forms/harness_ui.h
+++ b/forms/harness_ui.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace OpenApoc
+{
+
+// Installs the live-UI dump behind the harness UI command. Call once at startup; the forms layer
+// answers it, because framework/ cannot name Control.
+void registerFormsHarnessUI();
+
+} // namespace OpenApoc

--- a/forms/listbox.cpp
+++ b/forms/listbox.cpp
@@ -482,6 +482,31 @@ void ListBox::setSelected(sp<Control> c)
 	this->setDirty();
 }
 
+bool ListBox::selectItemByIndex(size_t index)
+{
+	// Selection is only half of what a click does. A real MouseDown sets `selected` *and* raises
+	// ListBoxChangeSelected, which is what screens actually listen to -- ResearchScreen swaps the
+	// active lab on it, for one. setSelected() raises nothing, and Control::click() on the item
+	// raises MouseClick, which ListBox does not treat as selection at all. A harness "set" built
+	// on either reports success and changes nothing.
+	if (index >= this->Controls.size())
+	{
+		return false;
+	}
+	auto item = this->Controls[index];
+	if (!item)
+	{
+		return false;
+	}
+	if (selected != item)
+	{
+		selected = item;
+		this->pushFormEvent(FormEventType::ListBoxChangeSelected, nullptr);
+	}
+	this->setDirty();
+	return true;
+}
+
 sp<Control> ListBox::getSelectedItem() { return selected; }
 
 sp<Control> ListBox::getHoveredItem() { return hovered; }

--- a/forms/listbox.h
+++ b/forms/listbox.h
@@ -45,6 +45,10 @@ class ListBox : public Control
 	void unloadResources() override;
 
 	void setSelected(sp<Control> c);
+	// Select the item at `index` the way a mouse click does, raising ListBoxChangeSelected.
+	// setSelected() only assigns and marks dirty, so screens that react to selection never
+	// hear about it -- see the comment on the definition.
+	bool selectItemByIndex(size_t index);
 	sp<Control> getSelectedItem();
 	sp<Control> getHoveredItem();
 

--- a/framework/CMakeLists.txt
+++ b/framework/CMakeLists.txt
@@ -6,6 +6,7 @@ option(DIALOG_ON_ERROR "Pop up a dialog box showing errors" ON)
 
 set (FRAMEWORK_SOURCE_FILES
 	configfile.cpp
+	harness.cpp
 	data.cpp
 	event.cpp
 	font.cpp
@@ -32,6 +33,7 @@ list(APPEND ALL_SOURCE_FILES ${FRAMEWORK_SOURCE_FILES})
 
 set (FRAMEWORK_HEADER_FILES
 	configfile.h
+	harness.h
 	data.h
 	event.h
 	font.h

--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -1,4 +1,5 @@
 #include "framework/framework.h"
+#include "framework/harness.h"
 #include "framework/ThreadPool/ThreadPool.h"
 #include "framework/apocresources/cursor.h"
 #include "framework/configfile.h"
@@ -80,6 +81,8 @@ class FrameworkPrivate
 
 	sp<Surface> scaleSurface;
 	up<ThreadPool> threadPool;
+	// Localhost command socket for automated play. Null unless Framework.Harness.Enable=1.
+	up<Harness> harness;
 
 	std::atomic<int> toolTipTimerId = 0;
 	up<Event> toolTipTimerEvent;
@@ -256,9 +259,36 @@ Framework::Framework(const UString programName, bool createWindow)
 	if (createWindow)
 	{
 		displayInitialise();
-		enableSDLDialogLogger(p->window);
+		// SDL_ShowSimpleMessageBox is modal and blocks the thread that calls it until somebody
+		// dismisses it, and Logger.dialogLevel defaults to Error -- so under the harness a single
+		// LogError deadlocks the main loop forever, taking the harness (which is polled from that
+		// same loop) down with it. Nobody is there to click OK on an automated run.
+		if (Options::harnessEnable.get())
+		{
+			LogInfo("Harness enabled: not installing the modal SDL dialog logger");
+		}
+		else
+		{
+			enableSDLDialogLogger(p->window);
+		}
 	}
 	audioInitialise(!createWindow);
+
+#if defined(__APPLE__) && TARGET_OS_IPHONE
+	if (Options::harnessEnable.get())
+	{
+		LogWarning("Framework.Harness is disabled on iOS");
+	}
+#else
+	if (Options::harnessEnable.get())
+	{
+		p->harness.reset(new Harness(Options::harnessPort.get()));
+		if (!p->harness->listening())
+		{
+			p->harness.reset();
+		}
+	}
+#endif
 }
 
 Framework::~Framework()
@@ -343,6 +373,11 @@ void Framework::run(sp<Stage> initialStage)
 			LogWarning("Over 5 frames behind - likely vsync limited?");
 		}
 
+		frameNumber++;
+		if (p->harness)
+		{
+			p->harness->poll(*this);
+		}
 		processEvents();
 
 		if (p->ProgramStages.isEmpty())
@@ -975,6 +1010,42 @@ bool Framework::displayHasWindow() const
 		return false;
 	if (!p->window)
 		return false;
+	return true;
+}
+
+void Framework::displaySetSize(Vec2<int> size)
+{
+	if (!p->window)
+	{
+		return;
+	}
+	// 640x480 is the game's own native resolution and the floor everything else is scaled from.
+	SDL_SetWindowSize(p->window, std::max(640, size.x), std::max(480, size.y));
+	// The OS window resizes; the render surface does not follow it yet, because that needs the
+	// resizable-viewport work which is a separate change. The harness RESIZE reply reports the
+	// dimensions actually in effect rather than the ones asked for, so a driver reading the reply
+	// sees the truth instead of a success that did nothing.
+}
+
+bool Framework::writeScreenshot(const UString &path)
+{
+	if (!p->defaultSurface || !p->defaultSurface->rendererPrivateData)
+	{
+		LogWarning("Screenshot requested before anything was drawn");
+		return false;
+	}
+	auto img = p->defaultSurface->rendererPrivateData->readBack();
+	if (!img)
+	{
+		LogWarning("Screenshot readBack returned no image");
+		return false;
+	}
+	if (!this->data->writeImage(path, img))
+	{
+		LogWarning("Failed to write screenshot \"{0}\"", path);
+		return false;
+	}
+	LogInfo("Wrote screenshot to \"{0}\"", path);
 	return true;
 }
 

--- a/framework/framework.h
+++ b/framework/framework.h
@@ -29,6 +29,10 @@ class RGBImage;
 class Framework
 {
   private:
+	// Monotonic frame counter, exposed through getFrameNumber() so an automated driver can
+	// wait a definite number of frames rather than sleeping and hoping.
+	uint64_t frameNumber = 0;
+
 	up<FrameworkPrivate> p;
 	UString programName;
 	bool createWindow;
@@ -71,6 +75,12 @@ class Framework
 	int displayGetWidth();
 	int displayGetHeight();
 	Vec2<int> displayGetSize();
+	// Resize the window as if the user dragged it. Automation hook: the harness RESIZE command
+	// needs a deterministic display size, since a driver reasoning about screen coordinates
+	// cannot depend on whatever size the window happened to open at.
+	void displaySetSize(Vec2<int> size);
+	// Read the last rendered frame back and write it to disk. Automation hook for SCREENSHOT.
+	bool writeScreenshot(const UString &path);
 	void displaySetTitle(UString NewTitle);
 	void displaySetIcon(sp<RGBImage> icon);
 	bool displayHasWindow() const;
@@ -80,6 +90,10 @@ class Framework
 	int coordWindowToDisplayX(int x) const;
 	int coordWindowToDisplayY(int y) const;
 	Vec2<int> coordWindowsToDisplay(const Vec2<int> &coord) const;
+
+	// Frame counter, so an automated driver can wait a definite number of frames rather than
+	// sleeping and hoping.
+	uint64_t getFrameNumber() const { return frameNumber; }
 
 	bool isSlowMode();
 	void setSlowMode(bool SlowEnabled);

--- a/framework/harness.cpp
+++ b/framework/harness.cpp
@@ -1,0 +1,817 @@
+#include "framework/harness.h"
+#include "framework/event.h"
+#include "framework/framework.h"
+#include "framework/logger.h"
+#include "framework/options.h"
+#include "framework/stage.h"
+#include "library/strings_format.h"
+#include <SDL_keyboard.h>
+#include <SDL_mouse.h>
+#include <SDL_video.h>
+#include <algorithm>
+#include <cstdint>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <typeinfo>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <winsock2.h>
+#include <ws2tcpip.h>
+using HarnessSocket = SOCKET;
+static const HarnessSocket HARNESS_INVALID = INVALID_SOCKET;
+#define harnessCloseSocket closesocket
+#else
+#include <arpa/inet.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <sys/select.h>
+#include <sys/socket.h>
+#include <unistd.h>
+using HarnessSocket = int;
+static const HarnessSocket HARNESS_INVALID = -1;
+#define harnessCloseSocket close
+#endif
+
+#ifdef __GNUG__
+#include <cxxabi.h>
+#include <memory>
+#endif
+
+namespace OpenApoc
+{
+namespace
+{
+
+UString demangleStage(const Stage *stage)
+{
+	if (!stage)
+	{
+		return "none";
+	}
+	const char *raw = typeid(*stage).name();
+#ifdef __GNUG__
+	int status = 0;
+	std::unique_ptr<char, void (*)(void *)> demangled(
+	    abi::__cxa_demangle(raw, nullptr, nullptr, &status), std::free);
+	if (status == 0 && demangled)
+	{
+		UString name = demangled.get();
+		const UString prefix = "OpenApoc::";
+		if (name.rfind(prefix, 0) == 0)
+		{
+			name = name.substr(prefix.size());
+		}
+		return name;
+	}
+#endif
+	return raw;
+}
+
+int sdlButtonFromName(const UString &name)
+{
+	const auto n = to_lower(name);
+	if (n == "right")
+	{
+		return SDL_BUTTON_RIGHT;
+	}
+	if (n == "middle")
+	{
+		return SDL_BUTTON_MIDDLE;
+	}
+	return SDL_BUTTON_LEFT;
+}
+
+bool parseIntToken(const UString &tok, int &out)
+{
+	if (tok.empty())
+	{
+		return false;
+	}
+	char *end = nullptr;
+	const long v = std::strtol(tok.c_str(), &end, 10);
+	if (!end || *end != '\0')
+	{
+		return false;
+	}
+	out = static_cast<int>(v);
+	return true;
+}
+
+bool parseKeyName(const UString &name, int &keyCode, int &scanCode)
+{
+	const SDL_Keycode key = SDL_GetKeyFromName(name.c_str());
+	if (key == SDLK_UNKNOWN)
+	{
+		return false;
+	}
+	keyCode = static_cast<int>(key);
+	scanCode = static_cast<int>(SDL_GetScancodeFromKey(key));
+	return true;
+}
+
+void setNonBlocking(HarnessSocket fd)
+{
+#ifdef _WIN32
+	u_long mode = 1;
+	ioctlsocket(fd, FIONBIO, &mode);
+#else
+	const int flags = fcntl(fd, F_GETFL, 0);
+	fcntl(fd, F_SETFL, flags | O_NONBLOCK);
+#endif
+}
+
+void sendAll(HarnessSocket fd, const UString &text)
+{
+	const char *p = text.c_str();
+	size_t left = text.size();
+	while (left > 0)
+	{
+#ifdef _WIN32
+		const int n = send(fd, p, static_cast<int>(left), 0);
+#elif defined(MSG_NOSIGNAL)
+		const ssize_t n = send(fd, p, left, MSG_NOSIGNAL);
+#else
+		const ssize_t n = send(fd, p, left, 0);
+#endif
+		if (n <= 0)
+		{
+			return;
+		}
+		p += n;
+		left -= static_cast<size_t>(n);
+	}
+}
+
+HarnessQueryFunction harnessQueryHandler;
+HarnessActionFunction harnessActionHandler;
+HarnessUIFunction harnessUIHandler;
+
+} // namespace
+
+void setHarnessQueryHandler(HarnessQueryFunction function)
+{
+	harnessQueryHandler = std::move(function);
+}
+
+HarnessQueryFunction getHarnessQueryHandler() { return harnessQueryHandler; }
+
+void setHarnessActionHandler(HarnessActionFunction function)
+{
+	harnessActionHandler = std::move(function);
+}
+
+HarnessActionFunction getHarnessActionHandler() { return harnessActionHandler; }
+
+void setHarnessUIHandler(HarnessUIFunction function) { harnessUIHandler = std::move(function); }
+
+HarnessUIFunction getHarnessUIHandler() { return harnessUIHandler; }
+
+bool parseHarnessCommand(const UString &line, HarnessCommand &out)
+{
+	out = {};
+	UString trimmed = line;
+	while (!trimmed.empty() && (trimmed.back() == '\r' || trimmed.back() == '\n' ||
+	                            trimmed.back() == ' ' || trimmed.back() == '\t'))
+	{
+		trimmed.pop_back();
+	}
+	size_t start = 0;
+	while (start < trimmed.size() && (trimmed[start] == ' ' || trimmed[start] == '\t'))
+	{
+		start++;
+	}
+	if (start > 0)
+	{
+		trimmed = trimmed.substr(start);
+	}
+	if (trimmed.empty())
+	{
+		out.type = HarnessCommand::Type::Unknown;
+		out.error = "empty";
+		return false;
+	}
+
+	auto parts = split(trimmed, " \t");
+	if (parts.empty())
+	{
+		out.type = HarnessCommand::Type::Unknown;
+		out.error = "empty";
+		return false;
+	}
+	const auto verb = to_upper(parts[0]);
+
+	auto restAfter = [&](size_t index) -> UString
+	{
+		size_t pos = 0;
+		for (size_t i = 0; i <= index && pos < trimmed.size(); i++)
+		{
+			while (pos < trimmed.size() && (trimmed[pos] == ' ' || trimmed[pos] == '\t'))
+			{
+				pos++;
+			}
+			while (pos < trimmed.size() && trimmed[pos] != ' ' && trimmed[pos] != '\t')
+			{
+				pos++;
+			}
+		}
+		while (pos < trimmed.size() && (trimmed[pos] == ' ' || trimmed[pos] == '\t'))
+		{
+			pos++;
+		}
+		return pos < trimmed.size() ? trimmed.substr(pos) : "";
+	};
+
+	if (verb == "STATUS")
+	{
+		out.type = HarnessCommand::Type::Status;
+		return true;
+	}
+	if (verb == "QUIT")
+	{
+		out.type = HarnessCommand::Type::Quit;
+		return true;
+	}
+	if (verb == "TEXT")
+	{
+		out.type = HarnessCommand::Type::Text;
+		out.text = restAfter(0);
+		if (out.text.empty())
+		{
+			out.type = HarnessCommand::Type::Unknown;
+			out.error = "TEXT needs a string";
+			return false;
+		}
+		return true;
+	}
+	if (verb == "GS")
+	{
+		out.type = HarnessCommand::Type::Query;
+		out.text = restAfter(0);
+		if (out.text.empty())
+		{
+			out.type = HarnessCommand::Type::Unknown;
+			out.error = "GS needs a query";
+			return false;
+		}
+		return true;
+	}
+	if (verb == "UI")
+	{
+		out.type = HarnessCommand::Type::UiDump;
+		out.text = restAfter(0);
+		return true;
+	}
+	if (verb == "SAVE")
+	{
+		out.type = HarnessCommand::Type::Save;
+		out.path = restAfter(0);
+		if (out.path.empty())
+		{
+			out.type = HarnessCommand::Type::Unknown;
+			out.error = "SAVE needs a path";
+			return false;
+		}
+		return true;
+	}
+	if (verb == "SCREENSHOT")
+	{
+		out.type = HarnessCommand::Type::Screenshot;
+		out.path = restAfter(0);
+		if (out.path.empty())
+		{
+			out.type = HarnessCommand::Type::Unknown;
+			out.error = "SCREENSHOT needs a path";
+			return false;
+		}
+		return true;
+	}
+	if (verb == "KEY" || verb == "KEYDOWN" || verb == "KEYUP")
+	{
+		if (parts.size() < 2)
+		{
+			out.error = "KEY needs a name";
+			return false;
+		}
+		// SDL key names can contain spaces ("Left Shift", "Page Down"), so take the whole
+		// remainder of the line rather than just the next token.
+		const UString keyName = restAfter(0);
+		if (!parseKeyName(keyName, out.keyCode, out.scanCode))
+		{
+			out.error = format("unknown key \"{0}\"", keyName);
+			return false;
+		}
+		if (verb == "KEY")
+		{
+			out.type = HarnessCommand::Type::Key;
+		}
+		else if (verb == "KEYDOWN")
+		{
+			out.type = HarnessCommand::Type::KeyDown;
+		}
+		else
+		{
+			out.type = HarnessCommand::Type::KeyUp;
+		}
+		return true;
+	}
+	if (verb == "RESIZE")
+	{
+		if (parts.size() < 3 || !parseIntToken(parts[1], out.x) || !parseIntToken(parts[2], out.y))
+		{
+			out.error = "RESIZE width height";
+			return false;
+		}
+		out.type = HarnessCommand::Type::Resize;
+		return true;
+	}
+	if (verb == "MOVE")
+	{
+		if (parts.size() < 3 || !parseIntToken(parts[1], out.x) || !parseIntToken(parts[2], out.y))
+		{
+			out.error = "MOVE x y";
+			return false;
+		}
+		out.type = HarnessCommand::Type::Move;
+		return true;
+	}
+	if (verb == "CLICK" || verb == "DOWN" || verb == "UP")
+	{
+		if (parts.size() < 3 || !parseIntToken(parts[1], out.x) || !parseIntToken(parts[2], out.y))
+		{
+			out.error = format("{0} x y [button]", parts[0]);
+			return false;
+		}
+		if (parts.size() >= 4)
+		{
+			out.sdlButton = sdlButtonFromName(parts[3]);
+		}
+		if (verb == "CLICK")
+		{
+			out.type = HarnessCommand::Type::Click;
+		}
+		else if (verb == "DOWN")
+		{
+			out.type = HarnessCommand::Type::Down;
+		}
+		else
+		{
+			out.type = HarnessCommand::Type::Up;
+		}
+		return true;
+	}
+	if (verb == "SCROLL")
+	{
+		if (parts.size() < 4 || !parseIntToken(parts[1], out.x) ||
+		    !parseIntToken(parts[2], out.y) || !parseIntToken(parts[3], out.wheelVertical))
+		{
+			out.error = "SCROLL x y dy [dx]";
+			return false;
+		}
+		if (parts.size() >= 5)
+		{
+			parseIntToken(parts[4], out.wheelHorizontal);
+		}
+		out.type = HarnessCommand::Type::Scroll;
+		return true;
+	}
+
+	if (verb == "CONTROLS" || verb == "HELP")
+	{
+		out.type = HarnessCommand::Type::Action;
+		out.text = to_lower(verb);
+		// CONTROLS takes an optional control id, to enumerate that control's children by
+		// position -- the only way to address runtime list rows, which have no names.
+		for (size_t i = 1; i < parts.size(); i++)
+		{
+			out.args.push_back(parts[i]);
+		}
+		return true;
+	}
+	if (verb == "CONTROL")
+	{
+		if (parts.size() < 2)
+		{
+			out.error = "CONTROL needs a control id";
+			return false;
+		}
+		out.type = HarnessCommand::Type::Action;
+		out.text = "control";
+		for (size_t i = 1; i < parts.size(); i++)
+		{
+			out.args.push_back(parts[i]);
+		}
+		return true;
+	}
+	if (verb == "ACTION")
+	{
+		if (parts.size() < 2)
+		{
+			out.error = "ACTION needs a verb";
+			return false;
+		}
+		out.type = HarnessCommand::Type::Action;
+		out.text = to_lower(parts[1]);
+		for (size_t i = 2; i < parts.size(); i++)
+		{
+			out.args.push_back(parts[i]);
+		}
+		return true;
+	}
+
+	out.error = format("unknown command \"{0}\"", parts[0]);
+	return false;
+}
+
+Harness::Harness(int port)
+{
+#ifdef _WIN32
+	WSADATA wsa;
+	if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+	{
+		LogError("Harness WSAStartup failed");
+		return;
+	}
+#endif
+	if (!bindListen(port))
+	{
+		LogError("Harness failed to listen on 127.0.0.1:{0}", port);
+		return;
+	}
+	LogInfo("Harness listening on 127.0.0.1:{0}", port);
+}
+
+Harness::~Harness()
+{
+	for (auto &c : clients)
+	{
+		if (c.fd != static_cast<int>(HARNESS_INVALID))
+		{
+			harnessCloseSocket(static_cast<HarnessSocket>(c.fd));
+		}
+	}
+	if (listenFd != static_cast<int>(HARNESS_INVALID) && listenFd >= 0)
+	{
+		harnessCloseSocket(static_cast<HarnessSocket>(listenFd));
+	}
+#ifdef _WIN32
+	WSACleanup();
+#endif
+}
+
+bool Harness::listening() const { return listenFd >= 0; }
+
+bool Harness::bindListen(int port)
+{
+	const HarnessSocket fd = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
+	if (fd == HARNESS_INVALID)
+	{
+		return false;
+	}
+	int yes = 1;
+	setsockopt(fd, SOL_SOCKET, SO_REUSEADDR, reinterpret_cast<const char *>(&yes), sizeof(yes));
+	sockaddr_in addr{};
+	addr.sin_family = AF_INET;
+	addr.sin_port = htons(static_cast<uint16_t>(port));
+	addr.sin_addr.s_addr = htonl(INADDR_LOOPBACK);
+	if (bind(fd, reinterpret_cast<sockaddr *>(&addr), sizeof(addr)) != 0)
+	{
+		harnessCloseSocket(fd);
+		return false;
+	}
+	if (listen(fd, 4) != 0)
+	{
+		harnessCloseSocket(fd);
+		return false;
+	}
+	setNonBlocking(fd);
+	listenFd = static_cast<int>(fd);
+	listenPort = port;
+	return true;
+}
+
+void Harness::poll(Framework &fw)
+{
+	if (listenFd < 0)
+	{
+		return;
+	}
+	fd_set rfds;
+	FD_ZERO(&rfds);
+	FD_SET(static_cast<HarnessSocket>(listenFd), &rfds);
+	int maxFd = listenFd;
+	for (auto &c : clients)
+	{
+		if (c.fd >= 0)
+		{
+			FD_SET(static_cast<HarnessSocket>(c.fd), &rfds);
+			maxFd = std::max(maxFd, c.fd);
+		}
+	}
+	timeval tv{};
+	tv.tv_sec = 0;
+	tv.tv_usec = 0;
+	const int n = select(maxFd + 1, &rfds, nullptr, nullptr, &tv);
+	if (n <= 0)
+	{
+		return;
+	}
+	if (FD_ISSET(static_cast<HarnessSocket>(listenFd), &rfds))
+	{
+		acceptReady();
+	}
+	for (auto &c : clients)
+	{
+		if (c.fd >= 0 && FD_ISSET(static_cast<HarnessSocket>(c.fd), &rfds))
+		{
+			readClient(c, fw);
+		}
+	}
+	clients.erase(
+	    std::remove_if(clients.begin(), clients.end(), [](const Client &c) { return c.fd < 0; }),
+	    clients.end());
+}
+
+void Harness::acceptReady()
+{
+	sockaddr_in addr{};
+	socklen_t len = sizeof(addr);
+	const HarnessSocket fd =
+	    accept(static_cast<HarnessSocket>(listenFd), reinterpret_cast<sockaddr *>(&addr), &len);
+	if (fd == HARNESS_INVALID)
+	{
+		return;
+	}
+	if (addr.sin_addr.s_addr != htonl(INADDR_LOOPBACK))
+	{
+		harnessCloseSocket(fd);
+		return;
+	}
+	setNonBlocking(fd);
+#ifdef SO_NOSIGPIPE
+	int nosig = 1;
+	setsockopt(fd, SOL_SOCKET, SO_NOSIGPIPE, reinterpret_cast<const char *>(&nosig), sizeof(nosig));
+#endif
+	clients.push_back(Client{static_cast<int>(fd), ""});
+}
+
+void Harness::readClient(Client &c, Framework &fw)
+{
+	char buf[1024];
+#ifdef _WIN32
+	const int n = recv(static_cast<HarnessSocket>(c.fd), buf, sizeof(buf), 0);
+#else
+	const ssize_t n = recv(static_cast<HarnessSocket>(c.fd), buf, sizeof(buf), 0);
+#endif
+	if (n <= 0)
+	{
+		closeClient(c);
+		return;
+	}
+	c.buffer.append(buf, static_cast<size_t>(n));
+	size_t nl;
+	while ((nl = c.buffer.find('\n')) != UString::npos)
+	{
+		UString line = c.buffer.substr(0, nl);
+		c.buffer.erase(0, nl + 1);
+		HarnessCommand cmd;
+		UString reply;
+		if (!parseHarnessCommand(line, cmd))
+		{
+			reply = format("ERR {0}\n", cmd.error.empty() ? "parse" : cmd.error);
+		}
+		else
+		{
+			reply = execute(cmd, fw);
+			if (reply.empty() || reply.back() != '\n')
+			{
+				reply += "\n";
+			}
+		}
+		sendAll(static_cast<HarnessSocket>(c.fd), reply);
+	}
+}
+
+void Harness::closeClient(Client &c)
+{
+	if (c.fd >= 0)
+	{
+		harnessCloseSocket(static_cast<HarnessSocket>(c.fd));
+		c.fd = -1;
+	}
+}
+
+void Harness::injectMove(Framework &fw, int x, int y, int buttonMask)
+{
+	auto *e = new MouseEvent(EVENT_MOUSE_MOVE);
+	e->mouse().X = x;
+	e->mouse().Y = y;
+	e->mouse().DeltaX = x - lastX;
+	e->mouse().DeltaY = y - lastY;
+	e->mouse().Button = buttonMask;
+	e->mouse().WheelVertical = 0;
+	e->mouse().WheelHorizontal = 0;
+	lastX = x;
+	lastY = y;
+	fw.pushEvent(e);
+	warpCursor(fw, x, y);
+}
+
+void Harness::injectButton(Framework &fw, int x, int y, int sdlButton, bool down)
+{
+	auto *e = new MouseEvent(down ? EVENT_MOUSE_DOWN : EVENT_MOUSE_UP);
+	e->mouse().X = x;
+	e->mouse().Y = y;
+	e->mouse().DeltaX = 0;
+	e->mouse().DeltaY = 0;
+	e->mouse().WheelVertical = 0;
+	e->mouse().WheelHorizontal = 0;
+	e->mouse().Button = SDL_BUTTON(sdlButton);
+	lastX = x;
+	lastY = y;
+	fw.pushEvent(e);
+}
+
+void Harness::injectKey(Framework &fw, int keyCode, int scanCode, bool down)
+{
+	auto *e = new KeyboardEvent(down ? EVENT_KEY_DOWN : EVENT_KEY_UP);
+	e->keyboard().KeyCode = keyCode;
+	e->keyboard().ScanCode = scanCode;
+	e->keyboard().Modifiers = 0;
+	fw.pushEvent(e);
+}
+
+void Harness::warpCursor(Framework &fw, int x, int y)
+{
+	// The engine tracks the cursor from the injected event itself (ApocCursor::eventOccured), so
+	// warping the OS pointer is purely cosmetic -- and it steals the physical mouse from whoever is
+	// using the machine during a long automated run. Opt-in only.
+	if (!Options::harnessWarpCursor.get())
+	{
+		return;
+	}
+	auto *window = static_cast<SDL_Window *>(fw.getWindowHandle());
+	if (!window)
+	{
+		return;
+	}
+	int ww = 0;
+	int wh = 0;
+	SDL_GetWindowSize(window, &ww, &wh);
+	const auto size = fw.displayGetSize();
+	int wx = x;
+	int wy = y;
+	if (size.x > 0 && size.y > 0 && ww > 0 && wh > 0)
+	{
+		wx = x * ww / size.x;
+		wy = y * wh / size.y;
+	}
+	SDL_WarpMouseInWindow(window, wx, wy);
+}
+
+UString Harness::execute(const HarnessCommand &cmd, Framework &fw)
+{
+	switch (cmd.type)
+	{
+		case HarnessCommand::Type::Move:
+			injectMove(fw, cmd.x, cmd.y, 0);
+			return "OK";
+		case HarnessCommand::Type::Down:
+			injectMove(fw, cmd.x, cmd.y, 0);
+			injectButton(fw, cmd.x, cmd.y, cmd.sdlButton, true);
+			return "OK";
+		case HarnessCommand::Type::Up:
+			injectButton(fw, cmd.x, cmd.y, cmd.sdlButton, false);
+			return "OK";
+		case HarnessCommand::Type::Click:
+			injectMove(fw, cmd.x, cmd.y, 0);
+			injectButton(fw, cmd.x, cmd.y, cmd.sdlButton, true);
+			injectButton(fw, cmd.x, cmd.y, cmd.sdlButton, false);
+			return "OK";
+		case HarnessCommand::Type::Scroll:
+		{
+			auto *e = new MouseEvent(EVENT_MOUSE_SCROLL);
+			e->mouse().X = cmd.x;
+			e->mouse().Y = cmd.y;
+			e->mouse().DeltaX = 0;
+			e->mouse().DeltaY = 0;
+			e->mouse().Button = 0;
+			e->mouse().WheelVertical = cmd.wheelVertical;
+			e->mouse().WheelHorizontal = cmd.wheelHorizontal;
+			fw.pushEvent(e);
+			return "OK";
+		}
+		case HarnessCommand::Type::Key:
+			injectKey(fw, cmd.keyCode, cmd.scanCode, true);
+			injectKey(fw, cmd.keyCode, cmd.scanCode, false);
+			return "OK";
+		case HarnessCommand::Type::KeyDown:
+			injectKey(fw, cmd.keyCode, cmd.scanCode, true);
+			return "OK";
+		case HarnessCommand::Type::KeyUp:
+			injectKey(fw, cmd.keyCode, cmd.scanCode, false);
+			return "OK";
+		case HarnessCommand::Type::Text:
+		{
+			auto *e = new TextEvent();
+			e->text().Input = cmd.text;
+			fw.pushEvent(e);
+			return "OK";
+		}
+		case HarnessCommand::Type::Screenshot:
+			if (!fw.writeScreenshot(cmd.path))
+			{
+				return format("ERR screenshot failed ({0})", cmd.path);
+			}
+			return format("OK {0}", cmd.path);
+		case HarnessCommand::Type::Status:
+		{
+			const auto stage = fw.stageGetCurrent();
+			const auto size = fw.displayGetSize();
+			auto detail = stage ? stage->harnessDetail() : UString("");
+			std::replace(detail.begin(), detail.end(), ' ', '_');
+			return format("OK stage={0} w={1} h={2} mouse={3},{4} port={5} detail={6}",
+			              demangleStage(stage.get()), size.x, size.y, lastX, lastY, listenPort,
+			              detail.empty() ? UString("-") : detail);
+		}
+		case HarnessCommand::Type::Query:
+		{
+			const auto handler = getHarnessQueryHandler();
+			if (!handler)
+			{
+				return "ERR no gamestate (query handler not installed yet)";
+			}
+			UString reply = handler(cmd.text);
+			if (reply.empty())
+			{
+				return format("ERR unknown query \"{0}\"", cmd.text);
+			}
+			// The reply protocol is strictly one line per command.
+			std::replace(reply.begin(), reply.end(), '\n', ' ');
+			return format("OK {0}", reply);
+		}
+		case HarnessCommand::Type::Save:
+		{
+			// Routed through the same game-layer hook as GS: framework cannot see GameState.
+			const auto handler = getHarnessQueryHandler();
+			if (!handler)
+			{
+				return "ERR no gamestate (query handler not installed yet)";
+			}
+			UString reply = handler("save " + cmd.path);
+			if (reply.empty())
+			{
+				return "ERR save failed";
+			}
+			std::replace(reply.begin(), reply.end(), '\n', ' ');
+			return format("OK {0}", reply);
+		}
+		case HarnessCommand::Type::UiDump:
+		{
+			const auto handler = getHarnessUIHandler();
+			if (!handler)
+			{
+				return "ERR no ui handler installed";
+			}
+			UString reply = handler(cmd.text);
+			if (reply.empty())
+			{
+				return "OK count=0";
+			}
+			std::replace(reply.begin(), reply.end(), '\n', ' ');
+			return format("OK {0}", reply);
+		}
+		case HarnessCommand::Type::Resize:
+		{
+			fw.displaySetSize({cmd.x, cmd.y});
+			const auto size = fw.displayGetSize();
+			return format("OK resized w={0} h={1}", size.x, size.y);
+		}
+		case HarnessCommand::Type::Action:
+		{
+			const auto handler = getHarnessActionHandler();
+			if (!handler)
+			{
+				return "ERR no action handler (forms not loaded yet)";
+			}
+			UString reply = handler(cmd.text, cmd.args);
+			if (reply.empty())
+			{
+				return format("ERR unknown action \"{0}\"", cmd.text);
+			}
+			std::replace(reply.begin(), reply.end(), '\n', ' ');
+			return reply;
+		}
+		case HarnessCommand::Type::Quit:
+			fw.stageQueueCommand({StageCmd::Command::QUIT});
+			return "OK quitting";
+		case HarnessCommand::Type::Unknown:
+			break;
+	}
+	return format("ERR {0}", cmd.error.empty() ? "unknown" : cmd.error);
+}
+
+} // namespace OpenApoc

--- a/framework/harness.h
+++ b/framework/harness.h
@@ -1,0 +1,137 @@
+#pragma once
+
+#include "library/strings.h"
+#include <functional>
+#include <vector>
+
+namespace OpenApoc
+{
+
+class Framework;
+
+// Line protocol on 127.0.0.1 (off unless Framework.Harness.Enable=1).
+//
+//   CLICK <x> <y> [left|right|middle]
+//   MOVE <x> <y>
+//   DOWN <x> <y> [left|right|middle]
+//   UP <x> <y> [left|right|middle]
+//   SCROLL <x> <y> <dy> [dx]
+//   KEY <name>
+//   KEYDOWN <name>
+//   KEYUP <name>
+//   TEXT <string>
+//   SCREENSHOT <path>
+//   RESIZE <width> <height>
+//   STATUS
+//   GS <query>
+//   SAVE <path>
+//   CONTROLS
+//   CONTROL <id> [click|toggle|set <value>]
+//   ACTION <verb> [args...]
+//   HELP
+//   UI [filter]
+//   QUIT
+//
+// Replies are one line: "OK ..." or "ERR ...".
+// CONTROL/ACTION invoke live form widgets by id (no pixel math). CLICK x y remains
+// for nameless widgets (map tiles, list rows). Screens still render as usual.
+
+// GS is answered by the game layer. framework/ sits below game/state/ in the link graph
+// (OpenApoc_GameState links OpenApoc_Framework, never the reverse), so the harness cannot name a
+// GameState type. The game layer installs a handler instead, mirroring how logger.h takes a
+// LogFunction. Returns a single line with no trailing newline; an empty return means "no answer".
+using HarnessQueryFunction = std::function<UString(const UString &query)>;
+void setHarnessQueryHandler(HarnessQueryFunction function);
+HarnessQueryFunction getHarnessQueryHandler();
+
+// Named UI / game actions. forms/ installs a handler that walks the currently
+// visible forms. Returns a full "OK ..." / "ERR ..." line, or empty for unknown.
+using HarnessActionFunction =
+    std::function<UString(const UString &verb, const std::vector<UString> &args)>;
+void setHarnessActionHandler(HarnessActionFunction function);
+HarnessActionFunction getHarnessActionHandler();
+
+// UI is answered by the forms layer, which framework also cannot name (OpenApoc_Forms links
+// OpenApoc_Framework, never the reverse). Kept separate from the GameState hook because the two
+// have different owners and lifetimes: this one is installed once at startup and never chained.
+using HarnessUIFunction = std::function<UString(const UString &filter)>;
+void setHarnessUIHandler(HarnessUIFunction function);
+HarnessUIFunction getHarnessUIHandler();
+
+struct HarnessCommand
+{
+	enum class Type
+	{
+		Click,
+		Move,
+		Down,
+		Up,
+		Scroll,
+		Key,
+		KeyDown,
+		KeyUp,
+		Text,
+		Screenshot,
+		Status,
+		Query,
+		Save,
+		Resize,
+		UiDump,
+		Action,
+		Quit,
+		Unknown
+	};
+	Type type = Type::Unknown;
+	int x = 0;
+	int y = 0;
+	int wheelVertical = 0;
+	int wheelHorizontal = 0;
+	int sdlButton = 1;
+	int keyCode = 0;
+	int scanCode = 0;
+	UString text;
+	UString path;
+	UString error;
+	std::vector<UString> args;
+};
+
+bool parseHarnessCommand(const UString &line, HarnessCommand &out);
+
+class Harness
+{
+  public:
+	explicit Harness(int port);
+	~Harness();
+
+	Harness(const Harness &) = delete;
+	Harness &operator=(const Harness &) = delete;
+
+	bool listening() const;
+	int port() const { return listenPort; }
+	void poll(Framework &fw);
+
+  private:
+	int listenFd = -1;
+	int listenPort = 0;
+	int lastX = 0;
+	int lastY = 0;
+
+	struct Client
+	{
+		int fd = -1;
+		UString buffer;
+	};
+	std::vector<Client> clients;
+
+	bool bindListen(int port);
+	void acceptReady();
+	void readClient(Client &c, Framework &fw);
+	void closeClient(Client &c);
+	UString execute(const HarnessCommand &cmd, Framework &fw);
+	void injectMove(Framework &fw, int x, int y, int buttonMask);
+	void injectButton(Framework &fw, int x, int y, int sdlButton, bool down);
+	void injectKey(Framework &fw, int keyCode, int scanCode, bool down);
+	void warpCursor(Framework &fw, int x, int y);
+};
+
+} // namespace OpenApoc

--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -174,6 +174,9 @@ void dumpOptionsToLog()
 
 	dumpOption(skipIntroOption);
 	dumpOption(loadGameOption);
+	dumpOption(harnessEnable);
+	dumpOption(harnessPort);
+	dumpOption(harnessWarpCursor);
 
 	dumpOption(modList);
 	dumpOption(modPath);
@@ -517,6 +520,15 @@ ConfigOptionBool packSaveOption("Game.Save", "Pack", tr("Pack saved games into a
 
 ConfigOptionBool skipIntroOption("Game", "SkipIntro", tr("Skip intro video"), false);
 ConfigOptionString loadGameOption("Game", "Load", tr("Path to save game to load at startup"), "");
+
+ConfigOptionBool harnessEnable("Framework.Harness", "Enable",
+                               "Listen on 127.0.0.1 for click/key/screenshot commands", false);
+ConfigOptionInt harnessPort("Framework.Harness", "Port", "Harness TCP port (localhost only)",
+                            17321);
+ConfigOptionBool harnessWarpCursor("Framework.Harness", "WarpCursor",
+                                   "Move the OS cursor to follow injected harness input. Off by "
+                                   "default so automated runs do not hijack the physical mouse.",
+                                   false);
 
 ConfigOptionString modList("Game", "Mods",
                            tr("A colon-separated list of mods to load (relative to mod directory)"),

--- a/framework/options.h
+++ b/framework/options.h
@@ -153,6 +153,11 @@ extern ConfigOptionBool packSaveOption;
 extern ConfigOptionBool skipIntroOption;
 extern ConfigOptionString loadGameOption;
 
+// Test harness: a localhost line protocol for driving the game programmatically.
+extern ConfigOptionBool harnessEnable;
+extern ConfigOptionInt harnessPort;
+extern ConfigOptionBool harnessWarpCursor;
+
 extern ConfigOptionString modList;
 extern ConfigOptionString modPath;
 

--- a/framework/stage.h
+++ b/framework/stage.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "library/strings.h"
+
 #include "framework/logger.h"
 #include "library/sp.h"
 
@@ -104,6 +106,15 @@ class Stage : public std::enable_shared_from_this<Stage>
 	    This function is called when the screen needs to be redrawn
 	*/
 	virtual void render() = 0;
+
+	/*
+	    Function: HarnessDetail
+	    Extra identification for the test harness, for stages whose C++ type does not say which
+	    screen this actually is. The ending cutscenes are the motivating case: victory and defeat
+	    are both a VideoScreen and differ only by which video is playing, so a driver watching
+	    stage names alone cannot tell a won campaign from a lost one.
+	*/
+	virtual UString harnessDetail() const { return ""; }
 
 	/*
 	    Function: IsTransition

--- a/game/main.cpp
+++ b/game/main.cpp
@@ -1,3 +1,4 @@
+#include "forms/harness_ui.h"
 #include "forms/ui.h"
 #include "framework/configfile.h"
 #include "framework/framework.h"
@@ -18,6 +19,9 @@ int main(int argc, char *argv[])
 
 	{
 		up<Framework> fw(new Framework(UString(argv[0]), true));
+
+		// Let the harness see the live control tree rather than guessing layout from XML.
+		registerFormsHarnessUI();
 
 		fw->run(mksp<BootUp>());
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 PROJECT (OpenApoc_Tests CXX C)
 
 set (TEST_LIST test_rect test_voxel test_tilemap test_rng test_images
-		test_unicode test_colour test_backtrace)
+		test_unicode test_colour test_backtrace test_harness)
 
 foreach(TEST ${TEST_LIST})
 		add_executable(${TEST} ${TEST}.cpp)

--- a/tests/test_harness.cpp
+++ b/tests/test_harness.cpp
@@ -1,0 +1,94 @@
+#include "framework/configfile.h"
+#include "framework/harness.h"
+#include "tests/test_helpers.h"
+
+using namespace OpenApoc;
+using namespace OpenApoc::TestHelpers;
+
+static bool test_parse_click()
+{
+	HarnessCommand cmd;
+	TEST_REQUIRE(parseHarnessCommand("CLICK 10 20", cmd), "parse click");
+	TEST_REQUIRE(cmd.type == HarnessCommand::Type::Click, "type");
+	TEST_REQUIRE(cmd.x == 10 && cmd.y == 20, "xy");
+	TEST_REQUIRE(cmd.sdlButton == 1, "default left");
+	TEST_REQUIRE(parseHarnessCommand("CLICK 3 4 right", cmd), "parse right");
+	TEST_REQUIRE(cmd.sdlButton == 3, "right button");
+	return true;
+}
+
+static bool test_parse_key_and_text()
+{
+	HarnessCommand cmd;
+	TEST_REQUIRE(parseHarnessCommand("KEY Escape", cmd), "parse escape");
+	TEST_REQUIRE(cmd.type == HarnessCommand::Type::Key, "key type");
+	TEST_REQUIRE(cmd.keyCode != 0, "keycode");
+	TEST_REQUIRE(parseHarnessCommand("KEY Left Shift", cmd), "parse multi-word key name");
+	TEST_REQUIRE(cmd.type == HarnessCommand::Type::Key, "multi-word key type");
+	TEST_REQUIRE(cmd.keyCode != 0, "multi-word keycode");
+	TEST_REQUIRE(parseHarnessCommand("TEXT hello world", cmd), "parse text");
+	TEST_REQUIRE(cmd.type == HarnessCommand::Type::Text, "text type");
+	TEST_REQUIRE(cmd.text == "hello world", "text rest");
+	return true;
+}
+
+static bool test_parse_status_quit_shot()
+{
+	HarnessCommand cmd;
+	TEST_REQUIRE(parseHarnessCommand("STATUS", cmd) && cmd.type == HarnessCommand::Type::Status,
+	             "status");
+	TEST_REQUIRE(parseHarnessCommand("QUIT", cmd) && cmd.type == HarnessCommand::Type::Quit,
+	             "quit");
+	TEST_REQUIRE(parseHarnessCommand("SCREENSHOT /tmp/oa.png", cmd), "shot");
+	TEST_REQUIRE(cmd.type == HarnessCommand::Type::Screenshot && cmd.path == "/tmp/oa.png", "path");
+	return true;
+}
+
+static bool test_parse_errors()
+{
+	HarnessCommand cmd;
+	TEST_REQUIRE(!parseHarnessCommand("CLICK no", cmd), "bad click");
+	TEST_REQUIRE(!parseHarnessCommand("NOTACOMMAND", cmd), "unknown");
+	TEST_REQUIRE(!parseHarnessCommand("GS", cmd), "GS needs a query");
+	TEST_REQUIRE(parseHarnessCommand("GS all", cmd) && cmd.type == HarnessCommand::Type::Query,
+	             "GS query");
+	TEST_REQUIRE(cmd.text == "all", "GS query text");
+	TEST_REQUIRE(!parseHarnessCommand("", cmd), "empty");
+	return true;
+}
+
+static bool test_parse_named_actions()
+{
+	HarnessCommand cmd;
+	TEST_REQUIRE(parseHarnessCommand("CONTROLS", cmd) && cmd.type == HarnessCommand::Type::Action,
+	             "controls");
+	TEST_REQUIRE(cmd.text == "controls", "controls verb");
+	TEST_REQUIRE(parseHarnessCommand("CONTROL BUTTON_NEWGAME", cmd), "control id");
+	TEST_REQUIRE(cmd.type == HarnessCommand::Type::Action && cmd.text == "control", "control verb");
+	TEST_REQUIRE(cmd.args.size() == 1 && cmd.args[0] == "BUTTON_NEWGAME", "control id arg");
+	TEST_REQUIRE(parseHarnessCommand("CONTROL NUM_HUMANS_SLIDER set 8", cmd), "control set");
+	TEST_REQUIRE(cmd.args.size() == 3 && cmd.args[1] == "set" && cmd.args[2] == "8", "set args");
+	TEST_REQUIRE(parseHarnessCommand("ACTION click BUTTON_NEWGAME", cmd), "action click");
+	TEST_REQUIRE(cmd.text == "click" && cmd.args.size() == 1 && cmd.args[0] == "BUTTON_NEWGAME",
+	             "action click args");
+	TEST_REQUIRE(parseHarnessCommand("HELP", cmd) && cmd.text == "help", "help");
+	TEST_REQUIRE(!parseHarnessCommand("CONTROL", cmd), "control needs id");
+	TEST_REQUIRE(!parseHarnessCommand("ACTION", cmd), "action needs verb");
+	return true;
+}
+
+int main(int argc, char **argv)
+{
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+	applyDeterministicTestConfig();
+	return runTestSuite({
+	    {"parse_click", test_parse_click},
+	    {"parse_key_and_text", test_parse_key_and_text},
+	    {"parse_status_quit_shot", test_parse_status_quit_shot},
+	    {"parse_errors", test_parse_errors},
+    {"parse_named_actions", test_parse_named_actions},
+	});
+}

--- a/tests/test_helpers.h
+++ b/tests/test_helpers.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include "framework/configfile.h"
+#include "framework/logger.h"
+#include "game/state/gamestate.h"
+#include "library/strings.h"
+#include <cstdlib>
+#include <utility>
+#include <vector>
+
+namespace OpenApoc
+{
+namespace TestHelpers
+{
+
+inline thread_local bool testCheckFailed = false;
+
+#define TEST_CHECK(cond, ...)                                                                      \
+	do                                                                                             \
+	{                                                                                              \
+		if (!(cond))                                                                               \
+		{                                                                                          \
+			LogError(__VA_ARGS__);                                                                 \
+			::OpenApoc::TestHelpers::testCheckFailed = true;                                       \
+		}                                                                                          \
+	} while (0)
+
+#define TEST_REQUIRE(cond, ...)                                                                    \
+	do                                                                                             \
+	{                                                                                              \
+		if (!(cond))                                                                               \
+		{                                                                                          \
+			LogError(__VA_ARGS__);                                                                 \
+			return false;                                                                          \
+		}                                                                                          \
+	} while (0)
+
+inline void applyDeterministicTestConfig()
+{
+	config().set("OpenApoc.NewFeature.SeedRng", false);
+	config().set("Config.Save", false);
+	config().set("OpenApoc.NewFeature.FerryChecksRelationshipWhenBuying", true);
+	config().set("OpenApoc.NewFeature.CallExistingFerry", true);
+}
+
+// NOTE: loadStartedGameState() lives with the gamestate work, not here. This branch carries only
+// the harness, and the loader depends on extracted-table members that arrive with it.
+
+inline int runTestSuite(const std::vector<std::pair<const char *, bool (*)()>> &tests)
+{
+	bool anyFailed = false;
+	for (const auto &t : tests)
+	{
+		testCheckFailed = false;
+		LogInfo("Running {0}", t.first);
+		const bool ok = t.second();
+		if (!ok || testCheckFailed)
+		{
+			LogError("FAILED {0}", t.first);
+			anyFailed = true;
+		}
+		else
+		{
+			LogInfo("PASSED {0}", t.first);
+		}
+	}
+	return anyFailed ? EXIT_FAILURE : EXIT_SUCCESS;
+}
+
+} // namespace TestHelpers
+} // namespace OpenApoc


### PR DESCRIPTION
…ically

Adds a line protocol on 127.0.0.1, off unless Framework.Harness.Enable=1, that lets code play the game the way a person does: by naming controls, not by computing pixels.

    STATUS                              stage, size, mouse, port
    CONTROLS / CONTROL <id> [click|toggle|set <v>|item <N>]
    UI [filter]                         live control tree with resolved rects
    CLICK/MOVE/DOWN/UP/SCROLL/KEY/TEXT  raw input for nameless widgets
    SCREENSHOT <path>, GS <query>, ACTION <verb>, SAVE, RESIZE, HELP, QUIT

Replies are one line, "OK ..." or "ERR ...".

WHY BY NAME. Computing a control's rect from the .form XML stops being reliable the moment the UI scales or the viewport changes, and a driver that clicks coordinates silently clicks the wrong thing instead of failing. CONTROL addresses the live widget, so a miss is an error rather than a wrong action.

LAYERING. framework/ sits below game/ and forms/ in the link graph and cannot name their types, so it exposes three handler hooks instead -- query, action, UI -- in the same shape logger.h takes a LogFunction. game/ and forms/ install their own; framework only carries the socket. That is why this change adds no game-layer knowledge to framework.

Supporting pieces, each existing because the protocol needs it:

  * Form::liveForms() -- forms register on construction; the only way to find what is on screen.
  * notifyVisibleForm() from onRender/update -- distinguishes "constructed" from "actually shown", so a driver cannot act on a screen nobody can see.
  * Control::getLocationInUi(), ListBox::selectItemByIndex() -- address widgets without pixels. selectItemByIndex raises ListBoxChangeSelected, which setSelected() does not; screens listen to the event, so a "set" built on setSelected reports success and changes nothing.
  * Framework::getFrameNumber(), writeScreenshot(), displaySetSize().
  * Stage::harnessDetail() -- victory and defeat are both a VideoScreen, and a driver watching stage names alone cannot tell a won campaign from a lost one.
  * Under the harness the modal SDL dialog logger is not installed: it blocks the thread that raises it, and that is the same thread the socket is polled from, so one LogError would deadlock an automated run with nobody there to click OK.

Verified against a running game, not just compiled:

    CONTROLS                     -> OK count=8 FORM_MAINMENU:Form:visible=1 BUTTON_NEWGAME:TextButton...
    CONTROL BUTTON_NEWGAME click -> OK clicked BUTTON_NEWGAME
    STATUS                       -> OK stage=DifficultyMenu

11/11 tests pass, including test_harness over the command parser.

KNOWN LIMIT: RESIZE moves the OS window but the render surface does not follow, which needs the resizable-viewport work and is deliberately not in this change. The reply reports the dimensions actually in effect rather than the ones requested, so a driver reading it sees the truth.