### PR TITLE
fix(city): bounds-check the flying target scan before reading a tile

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -829,6 +829,13 @@ VehicleTargetHelper::adjustTargetToClosestFlying(GameState &state, Vehicle &v, V
 						if (x == midX - i || x == midX + i || y == midY - i || y == midY + i ||
 						    z == midZ - i || z == midZ + i)
 						{
+							// The scan walks outward from the midpoint and can step off the
+							// map, so bounds-check before the lookup - same guard the
+							// Sidestep branch below already applies.
+							if (!map.tileIsValid(x, y, z))
+							{
+								continue;
+							}
 							auto t = map.getTile(x, y, z);
 							if (t->ownedObjects.empty())
 							{


### PR DESCRIPTION
## What

`VehicleTargetHelper::adjustTargetToClosestFlying` has two candidate scans. The `Sidestep` branch bounds-checks before dereferencing:

```cpp
if (!map.tileIsValid(x, y, z))
{
    continue;
}
auto t = map.getTile(x, y, z);
```

The `PickNearbyPoint` branch, thirty lines above it in the same function, does not. This adds the same guard there. +7 lines, one file.

## Why

`PickNearbyPoint`'s loops walk outward from the midpoint — `x` from `midX - i` to `midX + i`, likewise `y` and `z` — so for a target near the edge of the city map they step off it and call `getTile()` with an out-of-range coordinate.

That's the error in #1617:

```
E class OpenApoc::Tile *__cdecl OpenApoc::TileMap::getTile(int,int,int) Incorrect tile coordinates -1,82,12
```

reported when craft fight near the map border and keep getting re-targeted outward.

I'm not proposing anything new here — the project already made this call in the sibling branch; this site was just missed.

## Testing

- Compiles clean against current `master`.
- No behaviour change for in-bounds candidates: the guard only skips coordinates that would have been an invalid lookup.

I have **not** run the reporter's repro, so I'd treat this as fixing the reported error rather than confirmed-closing the issue. #1617 also quotes a second error:

```
canEnterTile ... No 'to' position supplied
```

Skipping out-of-bounds candidates should remove the cause of that too, since the target never gets nominated — but I can't confirm it without the save, so I've said `Refs #1617` rather than `Fixes`.

## Risks

Very low. Pure guard, no logic change. Worst case is that a candidate which previously produced an error log and undefined behaviour is now skipped, and the scan continues to the next one.

## Links

- Refs #1617
- Same defect class as #1627 (a guard applied at one site and missed at its sibling)

## Checklist

- [x] Single-purpose change, one file
- [x] Builds against current `master`
- [x] Matches the existing idiom in the same function
- [ ] Reporter's save not replayed — see Testing