### PR TITLE
fix(framework): iterate a copy of stageCommands in the main loop

### DIFF
--- a/framework/framework.cpp
+++ b/framework/framework.cpp
@@ -353,7 +353,14 @@ void Framework::run(sp<Stage> initialStage)
 			p->ProgramStages.current()->update();
 		}
 
-		for (StageCmd cmd : stageCommands)
+		// Iterate a copy. REPLACEALL and QUIT below clear the stage stack, which destroys
+		// every stage and everything it owns; anything in that teardown that queues another
+		// stage command appends to this very vector mid-iteration and invalidates the
+		// range-for. Copying keeps the existing semantics -- commands raised while processing
+		// this batch are still discarded by the clear() below -- without the undefined
+		// behaviour.
+		const auto commandsThisFrame = stageCommands;
+		for (const StageCmd &cmd : commandsThisFrame)
 		{
 			switch (cmd.cmd)
 			{


### PR DESCRIPTION
## What

`Framework::run()` iterates `stageCommands` with a range-for while the loop body can destroy arbitrary game objects:

```cpp
for (StageCmd cmd : stageCommands)
{
    ...
    case StageCmd::Command::REPLACEALL:
        p->ProgramStages.clear();
    ...
    case StageCmd::Command::QUIT:
        p->ProgramStages.clear();
}
stageCommands.clear();
```

This iterates a local copy instead. One file, +8/−1.

## Why

`ProgramStages.clear()` destroys every stage and everything it owns. Anything in that teardown that reaches `stageQueueCommand()` does `stageCommands.emplace_back()` — appending to the vector currently being iterated, which can reallocate it and invalidate the range-for's iterator.

Copying each `StageCmd` by value, which the loop already does, protects the *element* but not the *iterator*.

Semantics are unchanged: commands raised while processing a batch were already thrown away by the `clear()` below, and still are.

## Testing

- Compiles clean against current `master`.

**Being straight about the evidence:** I have *not* reproduced a crash here. There are ~50 `stageQueueCommand()` call sites and they're overwhelmingly event-handler lambdas, so whether a teardown path actually reaches one is not something I've proven. This is a latent hazard fixed defensively, not a known failure — happy for it to be judged on that basis, or closed if you'd rather only take reproduced bugs.

What makes me think it's worth doing anyway is that it's the same shape as #915 (see #1627): a container iterated while something inside the loop mutates it. That one was real, sat for six years, and cost a `SIGSEGV` on every lost base defence. This one costs eight lines to rule out.

## Risks

Very low. One extra copy of a small vector, once per frame, on a path that is almost always empty.

## Links

- Same defect class as #915 / #1627

## Checklist

- [x] Single-purpose change, one file
- [x] Builds against current `master`
- [x] Existing semantics preserved
- [ ] Not reproduced — defensive fix, see Testing