### PR TITLE
Fix agents keeping lab and craft assignments when fired or transferred

### DIFF
--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -7,6 +7,7 @@
 #include "game/state/city/building.h"
 #include "game/state/city/city.h"
 #include "game/state/city/facility.h"
+#include "game/state/city/research.h"
 #include "game/state/city/vehicle.h"
 #include "game/state/gameevent.h"
 #include "game/state/gamestate.h"
@@ -410,13 +411,22 @@ void Agent::transfer(GameState &state, StateRef<Building> newHome)
 	homeBuilding = newHome;
 	recentlyHired = false;
 	recentlyTransferred = true;
+	leaveLabAndCraft(state);
+	setMission(state, AgentMission::gotoBuilding(state, *this, newHome, false, true));
+}
+
+void Agent::leaveLabAndCraft(GameState &state)
+{
+	auto thisRef = StateRef<Agent>{&state, shared_from_this()};
 	if (lab_assigned)
 	{
-		auto thisRef = StateRef<Agent>{&state, shared_from_this()};
-		lab_assigned->assigned_agents.remove(thisRef);
-		lab_assigned = nullptr;
+		Lab::removeAgent(lab_assigned, thisRef);
 	}
-	setMission(state, AgentMission::gotoBuilding(state, *this, newHome, false, true));
+	if (currentVehicle)
+	{
+		currentVehicle->currentAgents.erase(thisRef);
+		currentVehicle = nullptr;
+	}
 }
 
 sp<AEquipment> Agent::getArmor(BodyPart bodyPart) const
@@ -952,12 +962,9 @@ void Agent::die(GameState &state, bool silent)
 	// Set health to zero so agent will die on next update
 	modified_stats.health = 0;
 
-	// Remove from vehicle
-	if (currentVehicle)
-	{
-		currentVehicle->currentAgents.erase(thisRef);
-		currentVehicle = nullptr;
-	}
+	// Remove from lab and any craft roster
+	leaveLabAndCraft(state);
+
 	// Remove from building
 	if (currentBuilding)
 	{
@@ -968,13 +975,6 @@ void Agent::die(GameState &state, bool silent)
 	if (currentBuilding)
 	{
 		homeBuilding = nullptr;
-	}
-
-	// Remove from lab
-	if (lab_assigned)
-	{
-		lab_assigned->assigned_agents.remove(thisRef);
-		lab_assigned = nullptr;
 	}
 
 	// In city (if not died in a vehicle) we make an event

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -143,6 +143,8 @@ class Agent : public StateObject<Agent>,
 
 	StateRef<Lab> lab_assigned = nullptr;
 	bool isAssignedToLab() const { return lab_assigned != nullptr; }
+	/* Clear lab assignment and vehicle roster membership - used before transfer or removal */
+	void leaveLabAndCraft(GameState &state);
 
 	StateRef<BattleUnit> unit;
 

--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -514,26 +514,7 @@ void RecruitScreen::executeOrders()
 				}
 				else
 				{
-					switch (agent->type->role)
-					{
-						case AgentType::Role::Physicist:
-						case AgentType::Role::BioChemist:
-						case AgentType::Role::Engineer:
-						{
-							if (agent->lab_assigned)
-							{
-								StateRef<Lab> lab{state.get(), agent->lab_assigned};
-								agent->lab_assigned->removeAgent(lab, agent);
-							}
-							agent->transfer(*state, bases[i]->building);
-							break;
-						}
-						case AgentType::Role::Soldier:
-						{
-							agent->transfer(*state, bases[i]->building);
-							break;
-						}
-					}
+					agent->transfer(*state, bases[i]->building);
 				}
 			}
 		}

--- a/game/ui/base/transferscreen.cpp
+++ b/game/ui/base/transferscreen.cpp
@@ -508,16 +508,6 @@ void TransferScreen::executeOrders()
 					case TransactionControl::Type::BioChemist:
 					case TransactionControl::Type::Engineer:
 					case TransactionControl::Type::Physicist:
-					{
-						StateRef<Agent> agent{state.get(), c->itemId};
-						if (agent->lab_assigned)
-						{
-							StateRef<Lab> lab{state.get(), agent->lab_assigned};
-							agent->lab_assigned->removeAgent(lab, agent);
-						}
-						agent->transfer(*state, newBase->building);
-						break;
-					}
 					case TransactionControl::Type::Soldier:
 					{
 						StateRef<Agent> agent{state.get(), c->itemId};

--- a/tests/test_lab_assignment.cpp
+++ b/tests/test_lab_assignment.cpp
@@ -7,8 +7,10 @@
 #include "game/state/city/city.h"
 #include "game/state/city/facility.h"
 #include "game/state/city/research.h"
+#include "game/state/city/vehicle.h"
 #include "game/state/gamestate.h"
 #include "game/state/gamestate_serialize.h"
+#include "game/state/rules/city/vehicletype.h"
 #include "game/state/shared/agent.h"
 #include "library/strings.h"
 #include <iostream>
@@ -28,6 +30,22 @@ static OpenApoc::StateRef<OpenApoc::Agent> findScientist(OpenApoc::sp<OpenApoc::
 		}
 	}
 	LogWarning("No scientist found");
+	return {};
+}
+
+// Find a soldier agent owned by the player that isn't currently in a vehicle
+static OpenApoc::StateRef<OpenApoc::Agent> findFreeSoldier(OpenApoc::sp<OpenApoc::GameState> state)
+{
+	for (auto &agent : state->agents)
+	{
+		if (agent.second->owner == state->getPlayer() &&
+		    agent.second->type->role == OpenApoc::AgentType::Role::Soldier &&
+		    !agent.second->currentVehicle)
+		{
+			return {state.get(), agent.first};
+		}
+	}
+	LogWarning("No free soldier found");
 	return {};
 }
 
@@ -257,6 +275,70 @@ static bool test_transfer_removes_from_lab(OpenApoc::sp<OpenApoc::GameState> sta
 	return true;
 }
 
+// Test that transfer removes an agent from a vehicle's crew roster
+static bool test_transfer_removes_from_vehicle(OpenApoc::sp<OpenApoc::GameState> state)
+{
+	LogInfo("Testing transfer removes from vehicle...");
+
+	auto soldier = findFreeSoldier(state);
+	if (!soldier)
+	{
+		LogError("No free soldier found, skipping transfer-from-vehicle test");
+		return true;
+	}
+
+	auto targetBuilding = ensureSecondBase(state);
+	if (!targetBuilding)
+	{
+		LogError("Failed to create or find second base for transfer-from-vehicle test");
+		return false;
+	}
+
+	if (targetBuilding == soldier->homeBuilding)
+	{
+		LogError("Target building should be different from soldier's home building");
+		return false;
+	}
+
+	auto vehicle = OpenApoc::mksp<OpenApoc::Vehicle>();
+	auto vehicleId = OpenApoc::Vehicle::generateObjectID(*state);
+	if (state->vehicle_types.empty())
+	{
+		LogWarning("No vehicle types found, skipping transfer-from-vehicle test");
+		return true;
+	}
+	vehicle->type = {state.get(), state->vehicle_types.begin()->second};
+	vehicle->owner = state->getPlayer();
+	state->vehicles[vehicleId] = vehicle;
+	OpenApoc::StateRef<OpenApoc::Vehicle> vehicleRef = {state.get(), vehicleId};
+
+	soldier->currentVehicle = vehicleRef;
+	vehicleRef->currentAgents.insert(soldier);
+
+	if (soldier->currentVehicle != vehicleRef)
+	{
+		LogError("Soldier's currentVehicle should point to the vehicle before transfer");
+		return false;
+	}
+
+	soldier->transfer(*state, targetBuilding);
+
+	if (soldier->currentVehicle != nullptr)
+	{
+		LogError("Soldier's currentVehicle should be nullptr after transfer");
+		return false;
+	}
+
+	if (vehicleRef->currentAgents.find(soldier) != vehicleRef->currentAgents.end())
+	{
+		LogError("Soldier should not be in vehicle's currentAgents after transfer");
+		return false;
+	}
+
+	LogInfo("Transfer removes from vehicle test passed");
+	return true;
+}
+
 // Test that death removes agent from any assgigned lab
 static bool test_die_removes_from_lab(OpenApoc::sp<OpenApoc::GameState> state)
 {
@@ -467,6 +549,12 @@ int main(int argc, char **argv)
 	if (!test_transfer_removes_from_lab(state))
 	{
 		LogError("Transfer removes from lab test failed");
+		return EXIT_FAILURE;
+	}
+
+	if (!test_transfer_removes_from_vehicle(state))
+	{
+		LogError("Transfer removes from vehicle test failed");
 		return EXIT_FAILURE;
 	}
 


### PR DESCRIPTION
Fixes #1559

## Problem

Firing or transferring an agent left their lab assignment (and craft roster membership) intact. Saves then contained dangling agent references in `research.xml` and `buildings.xml`, which made them fail to load with errors like `AGENT_245` not found. The fire path relied on UI-side cleanup duplicated across screens, and `Agent::transfer()` only cleared the lab assignment, never the vehicle roster.

## Fix

- New shared `Agent::leaveLabAndCraft()` clears the lab assignment and vehicle roster membership in one place; called from `Agent::transfer()` and `Agent::die()` (the fire path).
- Removed the now-redundant inline lab-removal logic from `RecruitScreen` and `TransferScreen`.
- Added `test_transfer_removes_from_vehicle()` to `tests/test_lab_assignment.cpp`.

## Verification

- `OpenApoc_GameState` and `OpenApoc_GameUI` build clean (cmake + ninja), no new warnings.
- clang-format clean.
- New test compiles; it needs extracted game data to run, so it relies on CI for execution.

## Notes

- Scope is limited to the fire/transfer paths from the issue; other agent-removal paths (capture, base loss) are untouched.