### PR TITLE
Fix CTD when research/manufacture finishes at a non-selected base

### DIFF
--- a/game/ui/base/researchscreen.cpp
+++ b/game/ui/base/researchscreen.cpp
@@ -48,6 +48,31 @@ ResearchScreen::ResearchScreen(sp<GameState> state, sp<Facility> selected_lab) :
 	viewHighlight = BaseGraphics::FacilityHighlight::Labs;
 	if (selected_lab)
 	{
+		// The facility passed in may belong to a base other than the currently
+		// selected one - eg when opened from a "research/manufacture completed"
+		// prompt for a base that isn't the one selected in the cityscape, or from
+		// the cityscape science tabs when the implicitly-selected scientist's base
+		// differs from the current one. Make sure current_base tracks the
+		// facility's actual base, otherwise setCurrentLabInfo() compares agent
+		// counts gathered from the wrong base against this lab's assigned_agents
+		// and asserts.
+		for (auto &base : state->player_bases)
+		{
+			bool found = false;
+			for (auto &facility : base.second->facilities)
+			{
+				if (facility == selected_lab)
+				{
+					found = true;
+					break;
+				}
+			}
+			if (found)
+			{
+				state->current_base = {state.get(), base.second};
+				break;
+			}
+		}
 		state->current_base->selectedLab = viewFacility = selected_lab;
 	}
 	else


### PR DESCRIPTION
Fixes #1577

## Problem

When research or manufacture finishes at a base other than the one currently selected in the cityscape, accepting the results prompt opens `ResearchScreen` for the finished lab while `state->current_base` still points at the selected base. `ResearchScreen::setCurrentLabInfo()` counts assigned agents filtered by `current_base` but asserts that count against the lab's base-independent `assigned_agents` list, so the game crashes with:

`Assertion failed assigned_agent_count == this->viewFacility->lab->assigned_agents.size()` (`game/ui/base/researchscreen.cpp:441`)

The same mismatch is reachable from the cityscape science tabs: with no scientist selected in the active tab, `findCurrentResearchFacility()` falls back to the first suitable facility across all bases without updating `current_base` (second repro in the issue comments).

## Fix

Both paths converge in the `ResearchScreen` constructor, so the fix is applied there: when a `selected_lab` is supplied, look up the base owning that facility and set `state->current_base` to it before anything reads it. This keeps the base tab, lab lists, and agent lists consistent with the displayed lab, and also covers any future caller that forgets to sync the base. Deriving the base only inside `setCurrentLabInfo()` was rejected: it would silence the assert but leave `current_base` wrong, so the lab lists (built from `current_base->facilities`) would not contain the displayed lab.

Covers workshops too - `setCurrentLabInfo()` is shared by all lab types.

## Verification

- Full build clean (cmake + ninja, RelWithDebInfo, `EXTRACT_DATA=OFF`).
- `format-sources` (clang-format-18): no diff on the changed file.
- `tools/lint-tidy.sh` (clang-tidy-18): 0 findings on the changed file.
- `ctest`: the 7 tests that run without game data pass; the 3 needing extracted `cd.iso` data can't run in this environment (pre-existing constraint).
- The two-base savegame from the issue wasn't runnable here (no game data), so the fix is verified by code-path analysis and clean build/lint rather than by reproducing the CTD directly.

## Notes

- No unit test added: exercising the crash path needs a live UI form and extracted game data. Making it testable data-free would need new API surface (e.g. a base back-reference on `Facility`), which felt out of scope for this fix.
- If `selected_lab` is somehow not found in any player base, `current_base` is left unchanged (same as pre-fix behavior).