### PR TITLE
Launcher: add CD/ISO autodetection

### DIFF
--- a/tools/launcher/CMakeLists.txt
+++ b/tools/launcher/CMakeLists.txt
@@ -12,6 +12,8 @@ qt_standard_project_setup()
 set (LAUNCHER_SOURCE_FILES
 	main.cpp
 	launcherwindow.cpp
+	cddetect.h
+	cddetect.cpp
 	launcherwindow.ui)
 
 set(sources ${sources} "apocicon.rc")

--- a/tools/launcher/cddetect.cpp
+++ b/tools/launcher/cddetect.cpp
@@ -1,0 +1,258 @@
+#include "cddetect.h"
+
+#include <QDir>
+#include <QFile>
+#include <QFileInfo>
+#include <QRegularExpression>
+#include <QSettings>
+#include <QStorageInfo>
+#include <QTextStream>
+
+namespace OpenApoc::CDDetect
+{
+
+// Returns true if `dir` (non-recursively) contains a file named `name`, matched
+// case-insensitively.
+static bool caseInsensitiveFileExists(const QDir &dir, const QString &name)
+{
+	for (const auto &entry : dir.entryList(QDir::Files))
+	{
+		if (entry.compare(name, Qt::CaseInsensitive) == 0)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+bool isPlausibleCDPath(const QString &path)
+{
+	if (path.isEmpty())
+	{
+		return false;
+	}
+
+	const QFileInfo info(path);
+
+	if (info.isFile())
+	{
+		const QString suffix = info.suffix();
+		if (suffix.compare("iso", Qt::CaseInsensitive) == 0)
+		{
+			return true;
+		}
+		if (suffix.compare("cue", Qt::CaseInsensitive) == 0)
+		{
+			const QDir cueDir = info.dir();
+			QFile cueFile(path);
+			if (cueFile.open(QIODevice::ReadOnly | QIODevice::Text))
+			{
+				const QString text = QTextStream(&cueFile).readAll();
+				static const QRegularExpression binRegex(
+				    QStringLiteral("FILE\\s+\"?([^\"\\r\\n]+\\.bin)\"?"),
+				    QRegularExpression::CaseInsensitiveOption);
+				const auto match = binRegex.match(text);
+				if (match.hasMatch())
+				{
+					const QString binName = QFileInfo(match.captured(1)).fileName();
+					if (caseInsensitiveFileExists(cueDir, binName))
+					{
+						return true;
+					}
+				}
+			}
+			// Fall back to the conventional GOG naming if the FILE directive didn't yield a
+			// match (or the referenced .bin doesn't exist alongside the .cue).
+			return caseInsensitiveFileExists(cueDir, QStringLiteral("XCOM.BIN"));
+		}
+		return false;
+	}
+
+	if (info.isDir())
+	{
+		return caseInsensitiveFileExists(QDir(path), QStringLiteral("music"));
+	}
+
+	return false;
+}
+
+// Appends `candidate` to `list` unless an equivalent entry (case-insensitive) is already
+// present.
+static void addUniqueCandidate(QStringList &list, const QString &candidate)
+{
+	for (const auto &existing : list)
+	{
+		if (existing.compare(candidate, Qt::CaseInsensitive) == 0)
+		{
+			return;
+		}
+	}
+	list.append(candidate);
+}
+
+static QStringList steamRoots()
+{
+	QStringList roots;
+#ifdef _WIN32
+	const QString installPath =
+	    QSettings("HKEY_CURRENT_USER\\Software\\Valve\\Steam", QSettings::NativeFormat)
+	        .value("InstallPath")
+	        .toString();
+	if (!installPath.isEmpty() && QDir(installPath).exists())
+	{
+		roots.append(installPath);
+	}
+#else
+	const QString home = QDir::homePath();
+	const QStringList candidates = {
+	    home + "/.steam/steam",
+	    home + "/.local/share/Steam",
+	    home + "/.var/app/com.valvesoftware.Steam/.local/share/Steam",
+	};
+	for (const auto &candidate : candidates)
+	{
+		if (QDir(candidate).exists())
+		{
+			roots.append(candidate);
+		}
+	}
+#endif
+	return roots;
+}
+
+// Extracts all values of `"key"  "value"` pairs from Valve's VDF/ACF text format.
+static QStringList extractQuotedValues(const QString &text, const QString &key)
+{
+	const QRegularExpression regex(
+	    QStringLiteral("\"%1\"\\s*\"([^\"]*)\"").arg(QRegularExpression::escape(key)));
+	QStringList values;
+	auto it = regex.globalMatch(text);
+	while (it.hasNext())
+	{
+		values.append(it.next().captured(1));
+	}
+	return values;
+}
+
+static QString readFile(const QString &path)
+{
+	QFile file(path);
+	if (!file.open(QIODevice::ReadOnly | QIODevice::Text))
+	{
+		return {};
+	}
+	return QTextStream(&file).readAll();
+}
+
+static QStringList steamCandidates()
+{
+	QStringList candidates;
+
+	for (const auto &root : steamRoots())
+	{
+		QStringList libraries = {root};
+
+		const QString vdfPath = root + "/steamapps/libraryfolders.vdf";
+		if (QFileInfo::exists(vdfPath))
+		{
+			const QString vdfText = readFile(vdfPath);
+			for (const auto &path : extractQuotedValues(vdfText, "path"))
+			{
+				addUniqueCandidate(libraries, path);
+			}
+		}
+
+		for (const auto &library : libraries)
+		{
+			const QString manifestPath = library + "/steamapps/appmanifest_7660.acf";
+			if (!QFileInfo::exists(manifestPath))
+			{
+				continue;
+			}
+			const QString manifestText = readFile(manifestPath);
+			const QStringList installDirs = extractQuotedValues(manifestText, "installdir");
+			if (installDirs.isEmpty())
+			{
+				continue;
+			}
+			const QString gameDir = library + "/steamapps/common/" + installDirs.first();
+			const QString candidate = gameDir + "/cd.iso";
+			if (isPlausibleCDPath(candidate))
+			{
+				addUniqueCandidate(candidates, candidate);
+			}
+		}
+	}
+
+	return candidates;
+}
+
+static QStringList gogCandidates()
+{
+	QStringList candidates;
+#ifdef _WIN32
+	const QStringList registryKeys = {
+	    "HKEY_LOCAL_MACHINE\\Software\\GOG.com\\Games\\1445249430",
+	    "HKEY_LOCAL_MACHINE\\Software\\WOW6432Node\\GOG.com\\Games\\1445249430",
+	};
+	for (const auto &key : registryKeys)
+	{
+		const QString installPath =
+		    QSettings(key, QSettings::NativeFormat).value("PATH").toString();
+		if (installPath.isEmpty())
+		{
+			continue;
+		}
+		const QString candidate = installPath + "/CD/XCOM.cue";
+		if (isPlausibleCDPath(candidate))
+		{
+			addUniqueCandidate(candidates, candidate);
+		}
+	}
+#endif
+	return candidates;
+}
+
+static QStringList mountedVolumeCandidates()
+{
+	QStringList candidates;
+	for (const auto &volume : QStorageInfo::mountedVolumes())
+	{
+		if (!volume.isValid() || !volume.isReady())
+		{
+			continue;
+		}
+		const QString rootPath = volume.rootPath();
+		if (isPlausibleCDPath(rootPath))
+		{
+			addUniqueCandidate(candidates, rootPath);
+		}
+	}
+	return candidates;
+}
+
+QStringList detectCandidates()
+{
+	QStringList candidates;
+
+	if (isPlausibleCDPath("./data/cd.iso"))
+	{
+		addUniqueCandidate(candidates, "./data/cd.iso");
+	}
+	for (const auto &candidate : steamCandidates())
+	{
+		addUniqueCandidate(candidates, candidate);
+	}
+	for (const auto &candidate : gogCandidates())
+	{
+		addUniqueCandidate(candidates, candidate);
+	}
+	for (const auto &candidate : mountedVolumeCandidates())
+	{
+		addUniqueCandidate(candidates, candidate);
+	}
+
+	return candidates;
+}
+
+} // namespace OpenApoc::CDDetect

--- a/tools/launcher/cddetect.h
+++ b/tools/launcher/cddetect.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <QString>
+#include <QStringList>
+
+namespace OpenApoc::CDDetect
+{
+
+// Lightweight plausibility check (existence + extension/marker only, no PhysFS mounting).
+// Used both to decide whether the current CD path needs (re)detection and to validate
+// scan-produced candidates.
+bool isPlausibleCDPath(const QString &path);
+
+// Scans known locations (local ./data/cd.iso, Steam appid 7660, GOG registry entry,
+// mounted/extracted volumes) for a plausible X-COM: Apocalypse data source.
+QStringList detectCandidates();
+
+} // namespace OpenApoc::CDDetect

--- a/tools/launcher/launcherwindow.cpp
+++ b/tools/launcher/launcherwindow.cpp
@@ -1,11 +1,13 @@
 #include <QApplication>
 #include <QFileDialog>
+#include <QInputDialog>
 #include <QProcess>
 #include <QSize>
 #include <array>
 #include <string_view>
 #include <utility>
 
+#include "cddetect.h"
 #include "launcherwindow.h"
 #include "ui_launcherwindow.h"
 
@@ -17,6 +19,29 @@
 #include "framework/options.h"
 
 using namespace OpenApoc;
+
+// Runs the shared candidate scan + picker flow. Kept as a file-local free function (not a
+// LauncherWindow member) so it can safely be called before `ui` exists, in the ctor's startup
+// detection path.
+static QString resolveCDPath(QWidget *dialogParent, bool forceChooser)
+{
+	QStringList candidates = OpenApoc::CDDetect::detectCandidates();
+	if (candidates.isEmpty())
+	{
+		LogInfo("CD autodetect: no candidates found");
+		return {};
+	}
+	if (!forceChooser && candidates.size() == 1)
+	{
+		return candidates.first();
+	}
+	bool ok = false;
+	QString choice = QInputDialog::getItem(
+	    dialogParent, "Select X-COM: Apocalypse data source",
+	    "Found possible data source(s), pick one (Cancel to leave unchanged):", candidates, 0,
+	    false, &ok);
+	return (ok && !choice.isEmpty()) ? choice : QString();
+}
 
 static std::list<std::pair<UString, ModInfo>> enumerateMods()
 {
@@ -61,6 +86,18 @@ LauncherWindow::LauncherWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui
 
 	config().parseOptions(1, &fake_argv);
 
+	// `ui` does not exist yet at this point in construction, so read/write the CD path option
+	// directly rather than through `ui->cdPath`.
+	const QString currentCD = QString::fromStdString(OpenApoc::Options::cdPathOption.get());
+	if (!OpenApoc::CDDetect::isPlausibleCDPath(currentCD))
+	{
+		const QString detected = resolveCDPath(this, /*forceChooser=*/false);
+		if (!detected.isEmpty())
+		{
+			OpenApoc::Options::cdPathOption.set(detected.toStdString());
+		}
+	}
+
 	this->currentFramework = mkup<OpenApoc::Framework>("OpenApoc_Launcher", false);
 	ui->setupUi(this);
 
@@ -73,6 +110,7 @@ LauncherWindow::LauncherWindow(QWidget *parent) : QMainWindow(parent), ui(new Ui
 	connect(ui->browseCDFile, &QPushButton::clicked, this, &LauncherWindow::browseCDFile);
 	connect(ui->browseCDDir, &QPushButton::clicked, this, &LauncherWindow::browseCDDir);
 	connect(ui->browseDataDir, &QPushButton::clicked, this, &LauncherWindow::browseDataDir);
+	connect(ui->autodetectButton, &QPushButton::clicked, this, &LauncherWindow::onAutodetect);
 	connect(ui->resolutionBox, static_cast<void (QComboBox::*)(int)>(&QComboBox::activated), this,
 	        &LauncherWindow::setResolutionSelection);
 
@@ -416,6 +454,17 @@ void LauncherWindow::browseDataDir()
 	}
 
 	ui->dataPath->setText(newPath);
+}
+
+void LauncherWindow::onAutodetect()
+{
+	// Always show the picker, even for a single candidate, since this is a deliberate,
+	// user-initiated rerun (unlike the silent startup autodetect).
+	const QString detected = resolveCDPath(this, /*forceChooser=*/true);
+	if (!detected.isEmpty())
+	{
+		ui->cdPath->setText(detected);
+	}
 }
 
 void LauncherWindow::exit()

--- a/tools/launcher/launcherwindow.h
+++ b/tools/launcher/launcherwindow.h
@@ -32,6 +32,7 @@ class LauncherWindow : public QMainWindow
 	void browseCDFile();
 	void browseCDDir();
 	void browseDataDir();
+	void onAutodetect();
 
 	void enabledModSelected(const QString &modName);
 	void disabledModSelected(const QString &modName);

--- a/tools/launcher/launcherwindow.ui
+++ b/tools/launcher/launcherwindow.ui
@@ -176,6 +176,13 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout">
+       <item row="0" column="4">
+        <widget class="QPushButton" name="autodetectButton">
+         <property name="text">
+          <string>Autodetect</string>
+         </property>
+        </widget>
+       </item>
        <item row="2" column="1">
         <widget class="QLineEdit" name="dataPath"/>
        </item>


### PR DESCRIPTION
## Summary

Closes #1645.

On launcher startup, if the configured CD path (`Framework.CD`, default `./data/cd.iso`) is missing or doesn't look like a valid X-COM: Apocalypse data source, the launcher now scans a small set of known locations for one:

- local `./data/cd.iso`
- Steam library folders (appid 7660, `steamapps/common/<installdir>/cd.iso`, parsed from `libraryfolders.vdf` / `appmanifest_7660.acf`)
- GOG's registry install path (product 1445249430, `CD/XCOM.cue`, Windows only)
- mounted/extracted volumes (via `QStorageInfo::mountedVolumes()`, looking for a top-level `music` entry)

If exactly one plausible candidate is found, it's silently written to the CD path option. If several are found, a modal picker lets the user choose (Cancel leaves the value unchanged). If none are found, the field is left as-is and no dialog appears.

A new "Autodetect" button was added to the Paths tab (next to the existing browse buttons) that reruns the same scan on demand, always showing the picker even for a single match, since that's a deliberate user action.

This is detection/UX sugar only: no game data is bundled, downloaded, or imaged; no new config key was introduced (`Framework.CD` is reused); and full validation still happens where it already did (the `music` probe in `Framework`'s constructor). Candidate checks are lightweight plausibility checks (existence + extension, `.cue` needs an adjacent `.bin`, a directory needs a case-insensitive `music` entry) with no PhysFS mounting during detection.

The detection logic lives in new files `tools/launcher/cddetect.h`/`.cpp`, exposing two free functions (`isPlausibleCDPath`, `detectCandidates`); no new detector class hierarchy, no async/background scanning, no third-party VDF parsing library.

## Test plan

Manual test matrix run in isolated scratch directories (via `portable.txt`, with `HOME` overridden to fake scratch homes so no real user config or Steam install was touched):

- [x] No-config first run, no candidates present: CD path field stays at the default, no dialog, no crash.
- [x] Valid existing CD path (directory containing a `music` marker file) is left unchanged, no detection scan runs.
- [x] Fake Steam library fixture (`libraryfolders.vdf` + `appmanifest_7660.acf` + placeholder `cd.iso`, matching the real Steam appid 7660 `installdir` of `XCom Apocalypse`): exactly one candidate found, silently prefilled.
- [x] Two candidates present (local `./data/cd.iso` + Steam fixture): the modal picker is shown (confirmed the launcher blocks before Framework/logging init starts, i.e. before reaching the picker's result); interactive confirm/cancel of the picker itself isn't automatable headless (no synthetic Qt input injection available in this environment).
- [ ] Autodetect button rerun with 1 candidate still showing the picker: verified by code inspection only (`forceChooser=true` unconditionally skips the single-candidate shortcut) — not automatable headless since it requires clicking a button in the running GUI.

Build: `cmake --build build --target OpenApoc_Launcher` succeeds cleanly on Linux (Qt 6.10.2) with no new compiler warnings from `cddetect.cpp`/`launcherwindow.cpp`/`.h`.

**Not verified**: Windows registry paths (Steam `HKEY_CURRENT_USER\Software\Valve\Steam`, GOG `HKEY_LOCAL_MACHINE\Software\GOG.com\Games\1445249430` and its `WOW6432Node` fallback) are implemented per the existing NSIS installer's `ScanSteamLibrary`/`ScanGOG` logic but untested on a real Windows machine — flagging for reviewers with Windows access to spot-check, along with the "Autodetect" button's placement/visibility in the Paths tab grid (verified analytically via widget minimum-width sums given no screenshot tooling was available in this environment; not screenshotted).