### PR TITLE
fix(city): don't restart self-destruct when reload pre-created the smoke doodad

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -2612,11 +2612,7 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 		}
 		case MissionType::SelfDestruct:
 		{
-			if (v.smokeDoodad)
-			{
-				LogError("Restarting self destruct?");
-			}
-			else
+			if (!v.smokeDoodad)
 			{
 				v.setCrashed(state);
 			}


### PR DESCRIPTION
## Root cause

`Vehicle::crashed` is serialized, `Vehicle::smokeDoodad` is not. When a vehicle crashes, `crash()` sets `crashed = true` and queues `Crash` then `SelfDestruct`; `smokeDoodad` is only created once `SelfDestruct` starts. If the player saves before the `Crash` mission finishes, the save holds `crashed=true` with no doodad. On load, `TileMap::addObjectToMap` (`game/state/tilemap/tilemap.cpp:103-109`) sees `crashed` and unconditionally pre-creates a fresh `smokeDoodad`. When `SelfDestruct` later starts, `VehicleMission::start()` found the doodad already set and fired `LogError("Restarting self destruct?")`, which aborts on Windows - the CTD these issues report.

## Fix

A pre-existing `smokeDoodad` after a load is benign (`start()` doesn't touch the self-destruct timer either way), so leave it alone instead of erroring:

```cpp
case MissionType::SelfDestruct:
{
    if (!v.smokeDoodad)
    {
        v.setCrashed(state);
    }
    return;
}
```

`game/state/city/vehiclemission.cpp` only.

## Verification

All three community saves (#1486 x2, #1573) predate the `SceneryTileType` migration (`8c5621f0`) and no longer load on current master at all, independent of this fix, so a full save-load repro wasn't possible. Instead:

1. **Save inspection**: extracted `vehicles.xml` from all three saves; each contains a UFO in exactly the desync window - `crashed=true`, mission queue `[Crash, SelfDestruct]`, no doodad serialized. The #1573 save's Alien Transporter still has 4 unconsumed descent waypoints, i.e. mid-crash-landing at save time.
2. **Direct code-path repro** (throwaway harness, removed before commit): `Vehicle` with `crashed=true` and a non-null `smokeDoodad` (what the load path produces), real `SelfDestruct` mission, `mission.start()`. Unfixed code: `LogError` fires, exit 1. Fixed code: clean, doodad untouched, exit 0.

ctest: all 11 tests pass.

Caveat on #1573: its save matches this bug's precondition exactly, but the reporter uses a weapons mod and the save couldn't be replayed end-to-end here; if it still reproduces after this lands, it should be reopened.

## History

The `LogError` guard dates to `95a0546b` (2017) as a doodad leak-guard; `ff3bad2f` (2018) made `setCrashed()` idempotent and added the load-time pre-creation this bug trips over, leaving the guard obsolete. PR #838 fixed a different trigger of the same error (carried vehicles, issue #364), not this save/load desync.

Fixes #1486, fixes #1613, fixes #1573
