### PR TITLE
Fix crash when a battle unit dies mid-update (null owningTile deref) (#1556)

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2033,6 +2033,15 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 			lastHandsTicksRemaining = handsTicksRemaining;
 			lastTurnTicksRemaining = turnTicksRemaining;
 
+			// A unit can also die before this loop is ever entered (e.g. bleeding
+			// out from a fatal wound in updateStateAndStats(), called earlier in
+			// update()). Bail before touching movement/body/hands state, which
+			// assume a live tileObject with a non-null owningTile.
+			if (destroyed || retreated)
+			{
+				break;
+			}
+
 			updateCheckBeginFalling(state);
 			updateBody(state, bodyTicksRemaining);
 			updateHands(state, handsTicksRemaining);

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2039,9 +2039,14 @@ void BattleUnit::update(GameState &state, unsigned int ticks)
 			updateMovement(state, moveTicksRemaining, wasUsingLift);
 			updateTurning(state, turnTicksRemaining, handsTicksRemaining);
 			updateDisplayedItem(state);
+
+			if (destroyed || retreated)
+			{
+				break;
+			}
 		}
 	}
-	if (retreated)
+	if (destroyed || retreated)
 	{
 		return;
 	}
@@ -2636,7 +2641,7 @@ void BattleUnit::updateCrying(GameState &state)
 
 void BattleUnit::updateCheckBeginFalling(GameState &state)
 {
-	if (retreated)
+	if (destroyed || retreated)
 	{
 		return;
 	}
@@ -4873,8 +4878,8 @@ void BattleUnit::die(GameState &state, StateRef<BattleUnit> attacker, bool viole
 		{
 			shadowObject->removeFromMap();
 		}
-		tileObject->removeFromMap();
 		destroyed = true;
+		tileObject->removeFromMap();
 	}
 }
 


### PR DESCRIPTION
Fixes #1556.

## Root cause

A `BattleUnit` that dies with `destroy = true` partway through its own `BattleUnit::update()` tick keeps executing the rest of that tick's movement/falling logic. `die()` calls `tileObject->removeFromMap()`, which nulls the tile object's `owningTile`, but the update path only guarded on `retreated`, never `destroyed`. The movement loop then dereferences the null tile: `Tile::getCanStand(this=0x0)` via `BattleUnit::updateCheckBeginFalling()`, matching the backtrace in the issue (Popper dying mid-tick from its self-destruct).

## Fix

Two commits:

1. Mirror the existing `retreated` guards for `destroyed`: at `updateCheckBeginFalling()` entry, at the movement-loop break, and at the post-loop return. Also set `destroyed = true` before `tileObject->removeFromMap()` in `die()` so the flag is visible to anything that runs during removal.
2. While validating, a second entry point for the same bug class surfaced: a unit that dies before the movement loop is entered (e.g. bleeding out via `updateWoundsAndHealing()` inside `updateStateAndStats()`) crashed in `Tile::getRestingPosition(this=0x0)` via `updateMovementNormal()`. Added the same `destroyed || retreated` guard at the top of the movement-loop body.

## Verification

The issue's attached save no longer loads on current master (it predates 8c5621f0, which moved `SceneryTileType` to a single `StateRefMap` and broke old saves), so verification used a headless harness that recreates the condition: a base-defense battle against a single `AGENTTYPE_POPPER`, killed via a lethal fatal wound resolved inside `updateStateAndStats()` so `die()` runs mid-tick, taking the destroy branch through the Popper's self-destruct.

* With `battleunit.cpp` reverted to pre-fix master: SIGSEGV in `Tile::getCanStand(this=0x0)` from `updateCheckBeginFalling()`, the exact signature from the issue.
* With this branch: clean pass, and a further update tick on the destroyed unit is a safe no-op. Full ctest suite green (RelWithDebInfo, Linux).

The harness code is posted as a comment below for reference.


