### PR TITLE
Fix out-of-bounds tile lookups during dogfights near the city border (#1617)

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -288,6 +288,9 @@ class FlyingVehicleMover : public VehicleMover
 				//   Otherwise we think we'll be moving too slow to dodge (basically moving
 				//   backwards into projectile or forwards alongside it and still getting hit)
 				auto point2d = glm::normalize(Vec2<float>{point.x, point.y});
+				// Use the vehicle's owning tile (integer) as the base so offsets don't get
+				// truncated toward zero and collapse onto the vehicle's own tile near 0
+				auto ownTile = vehicle.tileObject->getOwningTile()->position;
 				// Gather all allowed dodge locations according to the rules above
 				std::list<Vec3<int>> possibleDodgeLocations;
 				for (int x = -1; x <= 1; x++)
@@ -314,21 +317,19 @@ class FlyingVehicleMover : public VehicleMover
 								continue;
 							}
 							// Dodging horizontally
-							possibleDodgeLocations.emplace_back(
-							    vehicle.position.x + x, vehicle.position.y + y, vehicle.position.z);
+							possibleDodgeLocations.emplace_back(ownTile.x + x, ownTile.y + y,
+							                                    ownTile.z);
 						}
 						// Dodging vertically
 						if (dodgeUp)
 						{
-							possibleDodgeLocations.emplace_back(vehicle.position.x + x,
-							                                    vehicle.position.y + y,
-							                                    vehicle.position.z + 1.0f);
+							possibleDodgeLocations.emplace_back(ownTile.x + x, ownTile.y + y,
+							                                    ownTile.z + 1);
 						}
 						if (dodgeDown)
 						{
-							possibleDodgeLocations.emplace_back(vehicle.position.x + x,
-							                                    vehicle.position.y + y,
-							                                    vehicle.position.z + -1.0f);
+							possibleDodgeLocations.emplace_back(ownTile.x + x, ownTile.y + y,
+							                                    ownTile.z - 1);
 						}
 					}
 				}

--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -329,6 +329,8 @@ Vec3<float> FlyingVehicleTileHelper::findSidestep(GameState &state, sp<TileObjec
 		{
 			newPosition.z -= 1;
 		}
+		newPosition.x = glm::clamp(newPosition.x, 0.0f, map.size.x - 0.1f);
+		newPosition.y = glm::clamp(newPosition.y, 0.0f, map.size.y - 0.1f);
 		newPosition.z = glm::clamp(newPosition.z, 0.0f, map.size.z - 0.1f);
 
 		if (static_cast<Vec3<int>>(newPosition) != vTile->getOwningTile()->position &&

--- a/game/state/tilemap/tileobject.cpp
+++ b/game/state/tilemap/tileobject.cpp
@@ -96,13 +96,12 @@ void TileObject::setPosition(Vec3<float> newPosition)
 		LogError("This == null");
 	}
 	if (newPosition.x < 0 || newPosition.y < 0 || newPosition.z < 0 ||
-	    newPosition.x > map.size.x + 1 || newPosition.y > map.size.y + 1 ||
-	    newPosition.z > map.size.z + 1)
+	    newPosition.x >= map.size.x || newPosition.y >= map.size.y || newPosition.z >= map.size.z)
 	{
 		LogWarning("Trying to place object at {0} in map of size {1}", newPosition, map.size);
-		newPosition.x = clamp(newPosition.x, 0.0f, (float)map.size.x + 1);
-		newPosition.y = clamp(newPosition.y, 0.0f, (float)map.size.y + 1);
-		newPosition.z = clamp(newPosition.z, 0.0f, (float)map.size.z + 1);
+		newPosition.x = clamp(newPosition.x, 0.0f, map.size.x - 0.1f);
+		newPosition.y = clamp(newPosition.y, 0.0f, map.size.y - 0.1f);
+		newPosition.z = clamp(newPosition.z, 0.0f, map.size.z - 0.1f);
 		LogWarning("Clamped object to {0}", newPosition);
 	}
 	this->removeFromMap();


### PR DESCRIPTION
Refs #1617, complements #1634.

## Root cause

`FlyingVehicleTileHelper::findSidestep` applies a random ±1.0 float offset to x/y but clamps only z, so at the city border `getTile()` gets out-of-map coordinates, producing exactly the issue's `Incorrect tile coordinates` + `No 'to' position supplied` pair. Worse, float→int truncation maps a marginally negative result like `{-0.003, …}` back to tile 0, so it is accepted and the craft sits slightly off-map.

The projectile dodge generator has the same truncation problem: it builds `Vec3<int>` candidates from `vehicle.position + offset` floats, so near the low border a `-1` offset collapses onto the vehicle's own tile (`FromPos == ToPos` error) instead of the intended neighbour.

#1634 covered a third site (`PickNearbyPoint`); this PR covers the remaining two.

## Fix

1. Clamp x/y in `findSidestep` to `[0, size - 0.1]` alongside the existing z clamp; build dodge candidates from the owning tile's integer position instead of truncated float sums.
2. Harden `TileObject::setPosition`: it accepted positions up to a full tile past the map edge and clamped to `size + 1`, itself still invalid, yielding a nullptr tile after the object was already removed from the map. It now clamps anything outside `[0, size)` to `size - 0.1`.

## Verification

Headless harness (core posted as a comment below): a flying vehicle placed at each map corner, seeded RNG, 300 `findSidestep` calls per corner asserting in-bounds results with a valid backing tile.

* Pre-fix `vehiclemission.cpp`: fails on iteration 1 with `out-of-bounds position {-0.0027151704,1.2609513,6.5} from corner {0.3,0.3,6.5}`.
* This branch: clean pass; full ctest suite green (RelWithDebInfo, Linux, extracted CD data).

The dodge generator isn't reachable from a test binary (no header for `FlyingVehicleMover`) and its pre-fix failure is a wrong-but-filtered candidate, so it's fixed by construction. Reporter's save not replayed, hence `Refs` rather than `Fixes`.
