### PR TITLE
Fix UFO deleted by deadlock guard when shot down over unlandable terrain (#1653)

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -3172,11 +3172,15 @@ Vehicle::addMission(GameState &state, VehicleMission mission, bool toBack)
 		// - Can place on carrying vehicles
 		case VehicleMission::MissionType::GotoLocation:
 		case VehicleMission::MissionType::Land:
-			if (crashed || sliding || falling)
+		{
+			bool executingCrashMission =
+			    !missions.empty() && missions.front().type == VehicleMission::MissionType::Crash;
+			if ((crashed && !executingCrashMission) || sliding || falling)
 			{
 				return missions.end();
 			}
 			break;
+		}
 		// - Cannot place in front
 		// - Cannot place on crashed vehicles
 		// - Cannot place on carrying vehicles


### PR DESCRIPTION
Fixes #1653.

## Root cause

`Vehicle::crash()` sets `crashed = true` and then queues the `Crash` mission. When `Crash::start()` cannot find a landing tile (`FlyingVehicleTileHelper::findTileToLandOn()` returns the vehicle's own position) it falls back to `addMission(gotoLocation(random nearby tile))` so the UFO drifts and retries from a new spot. `Vehicle::addMission()` refuses `GotoLocation` for any vehicle with `crashed` set, so that hop is silently dropped (return value unused) and the `Crash` mission keeps an empty path.

`getNewGoal()` then hits `advanceAlongPath()` with the empty path, which pushes `RestartNextMission`; that is popped immediately, `Crash::start()` runs again, and the loop repeats until the 1000-iteration guard fires: error dialog `Vehicle ... deadlocked, please send log to developers. Vehicle will self-destruct now...` and the UFO is deleted instead of crash-landing (no crash site, no recovery). The hop dates from 2016 (`e1018579`), the `crashed` guard from 2017 (`5f19916d`), so this has been broken for any UFO shot down over dense scenery since then.

## Fix

In `Vehicle::addMission()`, only reject `GotoLocation`/`Land` for a crashed vehicle when it is not currently executing its `Crash` mission (`missions.front().type == Crash`). A UFO between `crash()` and touchdown is `crashed` but still airborne and driven by that mission, so its own hop request is legitimate. Grounded crashed vehicles never have `Crash` at the front (it is popped on landing), so player orders on wrecks are still refused as before.

## Verification

* Reproduced from the issue's log: ~660 `RestartNextMission finished` / `Crash landing {0,0,0} starting` / `Can't find place to land` triplets, then the deadlock error, with no `GotoLocation` mission ever appearing in between.
* Headless harness (difficulty0, alien UFO spawned at a tile where `findTileToLandOn()` returns its own position, then `crash()` + `getNewGoal()`, three rng seeds):
  * master `727cd974`: `getNewGoal()` returns false after the guard, logs the `deadlocked` error, vehicle dead, for all three seeds.
  * this branch: `getNewGoal()` returns true, front mission is the `GotoLocation` hop, vehicle alive, all three seeds.
* Full ctest suite green (RelWithDebInfo, Linux), fork CI (Lint + CMake) green.

The harness core is posted as a comment below.
