### PR TITLE
Fix crash on out-of-map tile lookup in vehicle recovery reachability checks (#1215)

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -940,6 +940,10 @@ Reachability VehicleTargetHelper::isReachableForRecovery(const Vehicle &v, Vec3<
 
 	auto &map = *v.city->map;
 	auto targetTile = map.getTile(target);
+	if (!targetTile)
+	{
+		return Reachability::BlockedByBuilding;
+	}
 
 	// Check if target tile has no building parts permanently blocking it
 	for (auto &obj : targetTile->ownedObjects)
@@ -960,6 +964,10 @@ Reachability VehicleTargetHelper::isReachableTargetFlying(const Vehicle &v, Vec3
 {
 	auto &map = *v.city->map;
 	auto targetTile = map.getTile(target);
+	if (!targetTile)
+	{
+		return Reachability::BlockedByScenery;
+	}
 
 	// Check if target tile has no scenery permanently blocking it
 	for (auto &obj : targetTile->ownedObjects)


### PR DESCRIPTION
Fixes #1215.

**Root cause:** `VehicleTargetHelper::isReachableForRecovery` and `isReachableTargetFlying` (`game/state/city/vehiclemission.cpp`) dereference `map.getTile(target)` without a null check. `getTile` returns `nullptr` for out-of-map coordinates, and `canRecoverVehicle` feeds them a crashed vehicle's raw `position`, which can sit out of bounds (the turbo-movement path assigns `position = goalPosition` directly, bypassing the clamp in `setPosition`). Same family as #1617.

**Fix:** treat a null tile as permanently blocked: `BlockedByBuilding` in `isReachableForRecovery`, `BlockedByScenery` in `isReachableTargetFlying`, both values the callers already handle. The road/ground variants have the same pattern but are not on this crash path and are left alone.

**Verification**
- Pre-fix headless harness: SIGSEGV at `vehiclemission.cpp:945` (`targetTile->ownedObjects`) with target `{-1,82,12}`.
- Post-fix: same harness passes, including `canRecoverVehicle` with an out-of-bounds crashed target.
- Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

Harness core in the comment below.
