### PR TITLE
Fix hire/fire screen hiding agents aboard a craft landed at their base (#1557, #673)

### DIFF
--- a/game/ui/base/recruitscreen.cpp
+++ b/game/ui/base/recruitscreen.cpp
@@ -14,6 +14,7 @@
 #include "framework/renderer.h"
 #include "game/state/city/base.h"
 #include "game/state/city/building.h"
+#include "game/state/city/vehicle.h"
 #include "game/state/gamestate.h"
 #include "game/state/rules/aequipmenttype.h"
 #include "game/state/shared/aequipment.h"
@@ -159,7 +160,13 @@ void RecruitScreen::populateAgentList()
 		if (a.second->owner == player)
 		{
 			// Need to be able to strip agent
-			if (a.second->currentBuilding == a.second->homeBuilding)
+			auto effectiveBuilding =
+			    a.second->currentBuilding
+			        ? a.second->currentBuilding
+			        : (a.second->currentVehicle && a.second->currentVehicle->currentBuilding
+			               ? a.second->currentVehicle->currentBuilding
+			               : nullptr);
+			if (effectiveBuilding == a.second->homeBuilding)
 			{
 				agentLists[bases[a.second->homeBuilding->base.id]].push_back(
 				    ControlGenerator::createLargeAgentControl(*state, a.second, list->Size.x,


### PR DESCRIPTION
Fixes #1557. Fixes #673.

**Root cause:** `RecruitScreen::populateAgentList()` (`game/ui/base/recruitscreen.cpp`) only lists an agent when `currentBuilding == homeBuilding`. An agent aboard a craft that is landed at that base has `currentBuilding == nullptr`, so it never appears on the hire/fire screen and cannot be fired or transferred without unloading it first. #673 is the multi-base variant of the same filter.

**Fix:** resolve an effective building first: `currentBuilding`, else `currentVehicle->currentBuilding`. Same rule `AEquipScreen::getAgentBuilding` and `Agent::updateHourly` already use. Firing needs no change, `Agent::die` already removes the agent from `currentVehicle->currentAgents`.

**Verification**
- Pre-fix headless harness instantiating `RecruitScreen` against a loaded gamestate: agent aboard a craft landed at its home base not listed; direct-in-building, other-building, and in-flight controls correct.
- Post-fix: all four cases correct.
- Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.
- Rendered under Xvfb: before/after screenshots of the hire/fire screen in the comments below.

Harness core in the comment below.

