### PR TITLE
Fix organisation tech level never increasing (#1587)

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1465,6 +1465,22 @@ void GameState::updateEndOfWeek(bool gameStart)
 
 	if (!gameStart)
 	{
+		int maxOrgTechLevel = 1;
+		for (auto &es : equipment_sets)
+		{
+			if (es.second->type == EquipmentSet::Type::Human)
+			{
+				maxOrgTechLevel = std::max(maxOrgTechLevel, es.second->min_score);
+			}
+		}
+		for (auto &[id, org] : organisations)
+		{
+			if (id != player.id && id != aliens.id && id != civilian.id)
+			{
+				org->tech_level = std::min(org->tech_level + 1, maxOrgTechLevel);
+			}
+		}
+
 		for (auto &c : this->cities)
 		{
 			c.second->weeklyLoop(*this);


### PR DESCRIPTION
Fixes #1587.

**Root cause:** `Organisation::tech_level` is set once by the extractor and never changes at runtime. `GameState::updateEndOfWeek` has a per-organisation finance loop but nothing for tech level, so every organisation stays at its starting level for the whole game. The original game raises each organisation's tech level by 1 per week, capped at 12.

**Fix:** in `updateEndOfWeek`, when not `gameStart`, increment `tech_level` for every organisation except `player`, `aliens`, and `civilian`, capped at the highest `min_score` among `Human` `EquipmentSet`s (12 with the shipped data) instead of a hardcoded constant. The separate "+3 on full infiltration" rule is not part of this change.

**Verification**
- Pre-fix headless harness: all 25 non-exempt organisations unchanged after a week (`ORG_CULT_OF_SIRIUS tech_level 2 -> 2, expected 3`).
- Post-fix: weekly +1 with exemptions, cap holds at and beyond the derived value, `gameStart` week leaves levels untouched.
- Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

Harness core in the comment below.
