### PR TITLE
Battle: guard null tiles when placing hazards (#1064)

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -1295,6 +1295,10 @@ sp<BattleHazard> Battle::placeHazard(GameState &state, StateRef<Organisation> ow
 	if (map)
 	{
 		auto tile = map->getTile(position);
+		if (!tile)
+		{
+			return nullptr;
+		}
 		// Cannot add non-fire hazard if tile is blocked or fire hazard if nothing is there to burn
 		// at
 		if ((!fire && tile->height * 40.0f > 38.0f) || (fire && tile->height * 40.0f < 1.0f))

--- a/game/state/battle/battleexplosion.cpp
+++ b/game/state/battle/battleexplosion.cpp
@@ -261,6 +261,10 @@ void BattleExplosion::expand(GameState &state, const TileMap &map, const Vec3<in
 	{
 		auto pos = pair.first + from;
 		auto tile = map.getTile(pos);
+		if (!tile)
+		{
+			continue;
+		}
 		for (auto &obj : tile->ownedObjects)
 		{
 			if (pair.second.find(obj->getType()) != pair.second.end())

--- a/game/state/battle/battlehazard.cpp
+++ b/game/state/battle/battlehazard.cpp
@@ -178,6 +178,10 @@ bool BattleHazard::expand(GameState &state, const TileMap &map, const Vec3<int> 
 	{
 		auto pos = pair.first + (Vec3<int>)position;
 		auto tile = map.getTile(pos);
+		if (!tile)
+		{
+			continue;
+		}
 		for (auto &obj : tile->ownedObjects)
 		{
 			if (pair.second.find(obj->getType()) != pair.second.end())


### PR DESCRIPTION
Fixes #1064.

## Root cause

`Battle::placeHazard` (`game/state/battle/battle.cpp:1297`) does `auto tile = map->getTile(position);` and dereferences `tile->height` on the next statement with no null check. `TileMap::getTile` (`game/state/tilemap/tilemap.h:114`) returns `nullptr` for any out-of-bounds coordinate and logs `Incorrect tile coordinates {x},{y},{z}`, which is exactly the last line in the issue's log (`8,38,-1`) before the segfault at `battle.cpp:1299`.

The reporter's trigger was collapsing scenery on `47maint_02` falling below z = 0 because the sector had no ground tiles. PR #1230 closed that path (z < 0 guard in `BattleMapPart::updateFalling` plus a resource patch adding the ground layer), so the original save most likely no longer crashes. The unchecked dereference itself was never fixed and is reachable from any other out-of-bounds source (other maps, mods, future callers). The same pattern exists in `BattleHazard::expand` (`battlehazard.cpp:180`) and `BattleExplosion::expand` (`battleexplosion.cpp:263`), where neighbour offsets of an already bounds-checked position are passed to `getTile` unchecked, so edge tiles can hit the same crash. This PR hardens those three sites.

## Fix

- `Battle::placeHazard`: return `nullptr` when `getTile` returns null, matching the early-return already used a few lines below for blocked tiles.
- `BattleHazard::expand` and `BattleExplosion::expand`: `continue` past a null neighbour tile.

Twelve added lines, no signature or behaviour changes on the valid-tile path. A hazard that previously crashed the game now silently fails to place, which is what every other guarded `getTile` caller already does.

## Verification

- Headless harness (difficulty0, real `Battle` via `Battle::beginBattle` base defense on `BATTLEMAP_37base`, `placeHazard` called with `{size.x/2, size.y/2, -1}`):
  - Pre-fix (`3b2b59fe`): SIGSEGV, `gdb` frame `#0 OpenApoc::Battle::placeHazard (...) at game/state/battle/battle.cpp:1300`, line `if ((!fire && tile->height * 40.0f > 38.0f) ...` on a null `tile`, preceded by `Incorrect tile coordinates 64,64,-1`.
  - This branch: returns `nullptr`, exit 0, same `getTile` log line confirming the OOB path was taken.
- Re-validated on current master `3b2b59fe`; full ctest suite green (11/11, RelWithDebInfo, Linux); fork CI Lint + CMake green.

The harness core is posted as a comment below.
