### PR TITLE
Battle: make the Mind Shield toggle psi defence (#1583)

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -5132,7 +5132,6 @@ bool BattleUnit::useItem(GameState &state, sp<AEquipment> item)
 		case AEquipmentType::Type::DimensionForceField:
 		case AEquipmentType::Type::DisruptorShield:
 		case AEquipmentType::Type::Loot:
-		case AEquipmentType::Type::MindShield:
 		case AEquipmentType::Type::MultiTracker:
 		case AEquipmentType::Type::StructureProbe:
 		case AEquipmentType::Type::VortexAnalyzer:
@@ -5164,6 +5163,10 @@ bool BattleUnit::useItem(GameState &state, sp<AEquipment> item)
 			// Initial use of medikit just brings up interface, action and TU spent happens
 			// when individual body part is clicked
 			item->inUse = !item->inUse;
+			return true;
+		case AEquipmentType::Type::MindShield:
+			item->inUse = !item->inUse;
+			agent->updatePsiDefence();
 			return true;
 		case AEquipmentType::Type::Brainsucker:
 			useBrainsucker(state);

--- a/game/state/shared/aequipment.cpp
+++ b/game/state/shared/aequipment.cpp
@@ -841,6 +841,7 @@ void AEquipment::fire(GameState &state, Vec3<float> targetPosition, StateRef<Bat
 		payloadType.clear();
 		loadAmmo(state);
 		ownerAgent->updateSpeed();
+		ownerAgent->updatePsiDefence();
 	}
 }
 

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -187,6 +187,7 @@ StateRef<Agent> AgentGenerator::createAgent(GameState &state, StateRef<Organisat
 	}
 
 	agent->updateSpeed();
+	agent->updatePsiDefence();
 	agent->modified_stats.restoreTU();
 
 	return {&state, ID};
@@ -780,6 +781,7 @@ void Agent::addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object)
 	}
 	this->equipment.emplace_back(object);
 	updateSpeed();
+	updatePsiDefence();
 	updateIsBrainsucker();
 	if (unit)
 	{
@@ -810,6 +812,7 @@ void Agent::removeEquipment(GameState &state, sp<AEquipment> object)
 	}
 	object->ownerAgent.clear();
 	updateSpeed();
+	updatePsiDefence();
 	updateIsBrainsucker();
 }
 
@@ -839,6 +842,21 @@ void Agent::updateModifiedStats()
 	modified_stats = current_stats;
 	modified_stats.health = health;
 	updateSpeed();
+	updatePsiDefence();
+}
+
+void Agent::updatePsiDefence()
+{
+	int mindShieldsInUse = 0;
+	for (auto &item : equipment)
+	{
+		if (item->type->type == AEquipmentType::Type::MindShield && item->inUse)
+		{
+			mindShieldsInUse++;
+		}
+	}
+	modified_stats.psi_defence =
+	    current_stats.psi_defence + MIND_SHIELD_PSI_DEFENCE_BONUS * mindShieldsInUse;
 }
 
 void Agent::updateIsBrainsucker()

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -19,6 +19,7 @@ namespace OpenApoc
 {
 
 static const unsigned TELEPORT_TICKS_REQUIRED_AGENT = TICKS_PER_SECOND * 30;
+static const int MIND_SHIELD_PSI_DEFENCE_BONUS = 20;
 
 class Organisation;
 class AEquipment;
@@ -172,6 +173,7 @@ class Agent : public StateObject<Agent>,
 	void addEquipment(GameState &state, Vec2<int> pos, sp<AEquipment> object);
 	void removeEquipment(GameState &state, sp<AEquipment> object);
 	void updateSpeed();
+	void updatePsiDefence();
 	// Called when current stats were changed and modified stats need to catch up
 	void updateModifiedStats();
 	bool canRun() { return modified_stats.canRun(); }

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2681,6 +2681,7 @@ void BattleView::orderUse(bool right, bool automatic)
 		// Usable items that have no automatic mode
 		case AEquipmentType::Type::MotionScanner:
 		case AEquipmentType::Type::MediKit:
+		case AEquipmentType::Type::MindShield:
 			if (automatic)
 			{
 				break;
@@ -2701,7 +2702,6 @@ void BattleView::orderUse(bool right, bool automatic)
 		case AEquipmentType::Type::DimensionForceField:
 		case AEquipmentType::Type::DisruptorShield:
 		case AEquipmentType::Type::Loot:
-		case AEquipmentType::Type::MindShield:
 		case AEquipmentType::Type::MultiTracker:
 		case AEquipmentType::Type::StructureProbe:
 		case AEquipmentType::Type::VortexAnalyzer:


### PR DESCRIPTION
Fixes #1583.

## Current behaviour

The Mind Shield is inert. `BattleUnit::useItem()` and the `BattleView::orderUse()` click dispatch both list `MindShield` in their "items that do nothing" case groups, so clicking it in battle is a silent no-op (`useItem` returns `false`). The psi attack chance reads `modified_stats.psi_defence`, which nothing ever updates for this item. In the original game activating it granted +20 psi defence, with a bug that made the bonus permanent after the mission; this is the missing feature without that bug.

## Change

- `Agent::updatePsiDefence()` (new, mirrors `updateSpeed()`): recomputes `modified_stats.psi_defence = current_stats.psi_defence + 20` per equipped Mind Shield with `inUse` set. It always derives from `current_stats` and never mutates it, so unequipping or dropping an active shield clears the bonus and nothing can carry over between missions. The constant `MIND_SHIELD_PSI_DEFENCE_BONUS` sits next to `TELEPORT_TICKS_REQUIRED_AGENT` in `agent.h`.
- Called from every `updateSpeed()` site: `AgentGenerator::createAgent`, `Agent::addEquipment`, `Agent::removeEquipment`, `Agent::updateModifiedStats`, `AEquipment::fire`, plus the new `useItem` case.
- `BattleUnit::useItem`: `MindShield` toggles `item->inUse` like `MotionScanner`, then calls `updatePsiDefence()`.
- `battleview.cpp`: `MindShield` moved to the "usable items with no automatic mode" group so a click reaches `useItem`.
- No load-time hook: `inUse` and `modified_stats` already round-trip through `gamestate_serialize.xml`, so a save made with the shield active restores consistently.

## Open questions

- TU cost for the toggle is currently zero. No original-game source for a cost was found. `MotionScanner` charges 10% of `initialTU` in turn-based mode; happy to match that if preferred.
- The psi-attack consumption path was not exercised live in the harness (needs a MindBender attacker with psi energy and line of sight). Every psi-chance call site reads `modified_stats.psi_defence` directly, so the stat change is what matters.
- Two shields stack by construction (`updatePsiDefence()` counts all in-use shields), matching the reporter's description, but this was not separately tested.

## Verification

- Headless harness (difficulty0 gamestate, base defence battle, shield equipped in the right hand of a player soldier):
  - `3b2b59fe` (master): `useItem(MindShield)` returns `false`, `psi_defence` unchanged.
  - this branch: baseline 28, after activation 48, after deactivation 28, after removing an in-use shield 28 (no leak).
- Full ctest suite green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

The harness core is posted as a comment below.
