### PR TITLE
Battle: do not score picked-up items as lost (#1584)

### DIFF
--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -21,14 +21,15 @@
 namespace OpenApoc
 {
 
-void BattleItem::die(GameState &state, bool violently)
+void BattleItem::die(GameState &state, bool violently, bool scoreAsLost)
 {
 	if (violently)
 	{
 		item->explode(state);
 	}
 	// Lose score if item that dies and it's not a primed grenade
-	if (!item->primed && item->ownerOrganisation && item->ownerOrganisation == state.getPlayer())
+	if (scoreAsLost && !item->primed && item->ownerOrganisation &&
+	    item->ownerOrganisation == state.getPlayer())
 	{
 		state.current_battle->score.equipmentLost -= item->type->score;
 		if (item->payloadType)

--- a/game/state/battle/battleitem.h
+++ b/game/state/battle/battleitem.h
@@ -55,7 +55,7 @@ class BattleItem : public std::enable_shared_from_this<BattleItem>
 	// Returns true if sound and doodad were handled by it
 	bool applyDamage(GameState &state, int power, StateRef<DamageType> damageType);
 
-	void die(GameState &state, bool violently = true);
+	void die(GameState &state, bool violently = true, bool scoreAsLost = true);
 
 	void hopTo(GameState &state, Vec3<float> targetPosition);
 

--- a/game/ui/general/aequipscreen.cpp
+++ b/game/ui/general/aequipscreen.cpp
@@ -1164,7 +1164,7 @@ void AEquipScreen::removeItemFromInventoryBattle(sp<AEquipment> item)
 		LogError("No battle item object in battle inventory?");
 		return;
 	}
-	battleItem->die(*state, false);
+	battleItem->die(*state, false, false);
 }
 
 void AEquipScreen::removeItemFromInventoryBase(sp<AEquipment> item)

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2758,7 +2758,7 @@ void BattleView::orderDrop(bool right)
 		auto item = items.front();
 		unit->agent->addEquipment(
 		    *state, item->item, right ? EquipmentSlotType::RightHand : EquipmentSlotType::LeftHand);
-		item->die(*state, false);
+		item->die(*state, false, false);
 	}
 }
 


### PR DESCRIPTION
Fixes #1584.

## Root cause

`BattleItem::die()` (`game/state/battle/battleitem.cpp`) unconditionally deducts `item->type->score` (plus the payload score) from `battle.score.equipmentLost` for every non-primed, player-owned item that dies, regardless of why it died. The same call is used both for a genuine loss and for removing the ground representation of an item that was just picked back up: the pickup branch of `BattleView::orderDrop()` (`game/ui/tileview/battleview.cpp`, around line 2761) and `AEquipScreen::removeItemFromInventoryBattle()` (`game/ui/general/aequipscreen.cpp`, around line 1167) both call `item->die(*state, false)` right after `agent->addEquipment(...)`. So an item that was dropped and recovered is scored as lost, which is what the debriefing screenshot in the issue shows.

## Fix

`BattleItem::die()` gains a third parameter, `bool scoreAsLost = true`, and the score deduction now also requires it. The two pickup call sites pass `false`. Every other caller is unchanged and keeps the existing scoring behaviour (end-of-mission "left behind" loss in `battle.cpp` still scores; the primed explosive paths in `aequipment.cpp` never scored because of the existing `!item->primed` guard).

## Verification

* Headless harness (difficulty0, real base-defense `Battle`): finds a player unit with scored equipment, drops it through `BattleUnitMission::dropItem`, re-equips it and calls the pickup-shaped `die(*state, false, false)`, then drops it again and calls the two-argument `die(*state, false)` for the genuine-loss shape.
  * master `3b2b59fe`: the harness does not compile, since `die()` only accepted two arguments and the recovery-vs-loss distinction did not exist. The pre-fix behaviour is the unconditional deduction shown above in `battleitem.cpp`.
  * this branch: `equipmentLost` is unchanged after the pickup, and decreases by exactly `item->type->score` on the genuine loss.
* Full ctest suite green (RelWithDebInfo, Linux); fork CI (Lint + CMake) green.

The harness core is posted as a comment below.
