### PR TITLE
Battle: handle two brainsuckers attaching to one unit (#1221)

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2928,7 +2928,7 @@ void BattleUnit::updateFallingIntoUnit(GameState &state, BattleUnit &unit)
 			if (position.z < unit.getMuzzleLocation().z)
 			{
 				StateRef<DamageType> brainsucker = {&state, "DAMAGETYPE_BRAINSUCKER"};
-				if (!unit.brainSucker &&
+				if (unit.brainSucker ||
 				    brainsucker->dealDamage(100, unit.agent->type->damage_modifier) == 0)
 				{
 					// Cannot suck this head, get stunned

--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -1862,6 +1862,8 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 			if (targetUnit->brainSucker && targetUnit->brainSucker.id != u.id)
 			{
 				cancelled = true;
+				u.resetGoal();
+				u.startFalling(state);
 				return;
 			}
 			targetUnit->brainSucker = {&state, u.id};


### PR DESCRIPTION
Fixes #1221.

## Root cause

`BattleUnit::updateFallingIntoUnit` (battleunit.cpp:2931) has an inverted eligibility check: a falling Brainsucker only bounces off an already-claimed target when the damage roll also fails (`!unit.brainSucker && dealDamage(...) == 0`), so a second lander always attempts to attach to a unit that already has one attached.

The `Brainsuck` guard in `BattleUnitMission::start` (battleunitmission.cpp:1862) then rejects the second attacher with `cancelled = true` but without the `resetGoal()` / `startFalling()` cleanup that `update()`'s cancel path performs for the same mission type (battleunitmission.cpp:1657-1663). The rejected unit is left hovering with a cancelled mission instead of falling, which matches the "hovers in place forever" observation in the issue thread.

Neither `BattleUnit::useBrainsucker()` nor `UnitAIVanilla::getBrainsuckerDecision()` checks `target->brainSucker`, so two AI Brainsuckers converge on the same nearest victim by design. The reporter's save shows exactly that: three Brainsuckers pick the same soldier and two issue `Brainsuck` starts on it.

## Fix

Three lines in two files:

* `updateFallingIntoUnit`: bounce/stun whenever the target is already claimed, independent of the damage roll (`unit.brainSucker || dealDamage(...) == 0`).
* `BattleUnitMission::start`: the rejection now calls `u.resetGoal(); u.startFalling(state);` alongside `cancelled = true`, symmetric with the `update()` cancel path.

## Verification

The reported crash was not reproduced on Linux: not in RT or TurnBased, not via the direct mission API or a real fall collision, not under ASan+UBSan, and not with the reporter's own save. That save loads and replays the scenario (three Brainsuckers converge on one soldier, two Brainsuck starts on it) through 50 tick blocks with repeated end turn, with no crash before or after this change.

What does change: a headless harness asserting that a rejected second attacher falls (or never queues a Brainsuck mission at all) instead of hovering with a cancelled mission fails on master `3b2b59fe` and passes on this branch, under both plain RelWithDebInfo and ASan+UBSan builds. Full ctest green (Linux); fork CI Lint + CMake green.

@XCOM-HUB, if you still have the setup, a retest on a build with this change would help confirm it covers the crash seen on Windows.

The harness core is posted as a comment below.
