### PR TITLE
City: show the real funding adjustment on the weekly funding screen (#1585)

### DIFF
--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1502,6 +1502,7 @@ void GameState::weeklyPlayerUpdate()
 		else
 		{
 			int income = player->income;
+			previousWeekIncome = player->income;
 
 			// Reduce this week's income if government doesn't have enough funds
 			const int availableGovFunds = government->balance / 2;

--- a/game/state/gamestate.h
+++ b/game/state/gamestate.h
@@ -158,6 +158,7 @@ class GameState : public std::enable_shared_from_this<GameState>
 
 	GameScore totalScore = {};
 	GameScore weekScore = {};
+	int previousWeekIncome = 0;
 	int micronoidRainChance = 0;
 
 	// Used to move events from battle to city and remember time

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -42,6 +42,7 @@
     <member>agentEquipmentTemplates</member>
     <member>totalScore</member>
     <member>weekScore</member>
+    <member>previousWeekIncome</member>
     <member>micronoidRainChance</member>
     <member>objectIdCount</member>
     <member type="Section">city_common_image_list</member>

--- a/game/ui/city/weeklyfundingscreen.cpp
+++ b/game/ui/city/weeklyfundingscreen.cpp
@@ -47,7 +47,7 @@ void WeeklyFundingScreen::begin()
 
 	const auto player = state->getPlayer();
 	const auto government = state->getGovernment();
-	int currentIncome = player->income;
+	int currentIncome = state->previousWeekIncome;
 
 	if (government->isRelatedTo(player) == Organisation::Relation::Hostile)
 	{
@@ -105,7 +105,7 @@ void WeeklyFundingScreen::begin()
 		}
 
 		// Income adjustment is still based on base player funding, not current one
-		const int adjustment = (modifier == 0) ? 0 : player->income / modifier;
+		const int adjustment = (modifier == 0) ? 0 : state->previousWeekIncome / modifier;
 
 		labelAdjustment->setText(
 		    format(tr("Funding adjustment> ${0}"), state->formatCurrency(adjustment)));


### PR DESCRIPTION
Fixes #1585.

## Root cause

`GameState::updateEndOfWeek()` pushes the `WeeklyReport` event and then calls `weeklyPlayerUpdate()` synchronously. That function pays this week's income and immediately applies the funding modifier in place: `player->income += player->income / fundingModifier`. The queued event is only dispatched later, when `CityView` opens `WeeklyFundingScreen`, so by the time `begin()` runs `player->income` already holds next week's value. The screen used it both as "current income" and as the base for its own `player->income / modifier` adjustment, so it showed the post-adjustment income as current, an adjustment computed off the already-bumped base, and a next-week figure with the bump counted twice (the reporter's compounding 25% symptom).

PR #1586 already fixed the other half of this report (the `weekScore` reset happening before the screen read it, and the modifier loop breaking early). This is the residual; the values are wrong rather than always zero. #1589 and #1584 are related but separate scoring fixes that feed `weekScore`.

## Fix

* New serialized `GameState::previousWeekIncome`, captured in `weeklyPlayerUpdate()` before `player->income` is mutated.
* `WeeklyFundingScreen::begin()` reads it for the current income and for the adjustment base instead of `player->income`.
* `gamestate_serialize.xml` entry next to `weekScore`. Old saves load with the field at 0.

No change to the money actually paid or to how `player->income` progresses.

## Verification

Headless harness (difficulty0): sets `player->income = 80000` and a `weekScore` that yields modifier 20, runs the real `weeklyPlayerUpdate()`, then constructs the real `WeeklyFundingScreen` without a renderer and reads its three labels.

* master `3b2b59fe`: current `$84,000`, adjustment `$4,200`, next week `$88,200`.
* expected and this branch: `$80,000`, `$4,000`, `$84,000`.
* Re-validated on `3b2b59fe`; full ctest suite green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

The reporter's save is from build 20260123, which predates #1586, so it would help if they could confirm on a current build.

The harness core is posted as a comment below.
