### PR TITLE
Battle: land falling units and items instead of killing them below z=0 (#844)

### DIFF
--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -279,10 +279,14 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 		// Fell below 0???
 		if (newPosition.z < 0)
 		{
-			LogError("Item at {0} {1} fell off the end of the world!?", newPosition.x,
-			         newPosition.y);
-			die(state, false);
-			return;
+			if (!tileObject->map.getTile(newPosition))
+			{
+				LogError("Item at {0} {1} fell off the end of the world!?", newPosition.x,
+				         newPosition.y);
+				die(state, false);
+				return;
+			}
+			collision = true;
 		}
 		setPosition(newPosition);
 	}

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2855,7 +2855,7 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 			newPosition.z = glm::clamp(newPosition.z, 0.0f, mapSize.z - 0.01f);
 		}
 		// Fell below 0???
-		if (newPosition.z < 0)
+		if (newPosition.z < 0 && !tileObject->map.getTile(newPosition))
 		{
 			LogError("Unit at {0} {1} fell off the end of the world!?", newPosition.x,
 			         newPosition.y);


### PR DESCRIPTION
Fixes #844.

## Root cause

`BattleUnit::updateMovementFalling()` and the equivalent block in `BattleItem::update()` integrate a whole batch of ticks of gravity into `newPosition` in one step, more at higher game speed. Before the "reached ground" logic (resting-position snap for units, `findSupport()`/`getSupport()` for items) runs, both check `newPosition.z < 0` and, if true, log `... fell off the end of the world!?` and kill the unit or item.

A unit standing on a z=0 floor tile that starts falling and takes one coarse step overshoots to a small negative z within the same tile. The issue's debug output is exactly this: previous z `0.1218`, new z `-0.0286`, resting height `0.075`. The tile still exists; the check misreads a sub-tile overshoot as "no floor here". #581 noted in 2019 it only reproduced at medium or high speed. PR #1569 clamped x/y at the map edge but left the vertical `z < 0` kill in both files.

## Fix

Gate the kill on tile existence at the overshoot spot via `map.getTile(newPosition)`. `TileMap::getTile(Vec3<float>)` truncates toward zero, so a shallow negative z resolves to the z=0 tile. If it exists, the overshoot is left in place: units land through the existing `position.z < restingPosition.z` snap, and items set `collision = true` so `findSupport()`/`getSupport()` settle them. Death only happens when no tile exists, i.e. the overshoot exceeds a full tile.

## Verification

* Headless harness on a real base-defense battle (difficulty0, fixed RNG seed), three scenarios:
  * (a) standing on the z=0 tile, `startFalling()`, one `battle->update(state, 36)` step; must land.
  * (b) established fall (z velocity -50, 8 ticks); must land at the resting height, not tunnel through.
  * (c) overshoot beyond a full tile, no tile to land on; must still die with the original log line.
* master `3b2b59fe`: (a) fails with `Unit at 69.5 88.5 fell off the end of the world!?`, unit dies.
* This branch: all three pass across three runs.
* Full ctest suite green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

Separately, the "Fell into a unit" check in the same function dereferences `map.getTile(newPosition)` without a null check, so a conscious unit overshooting by more than a full tile segfaults there. Pre-existing on master, left out of scope.

The harness core is posted as a comment below.
