### PR TITLE
Battle: keep large and prone unit footprints on the map (#1007)

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -433,7 +433,7 @@ void Battle::initialMapPartRemoval(GameState &state)
 			for (int y = 0; y < 1; y++)
 			{
 				auto t = map->getTile(u.second->position + Vec3<float>{-x, -y, 1.0f});
-				if (t->solidGround)
+				if (t && t->solidGround)
 				{
 					std::list<sp<TileObjectBattleMapPart>> partsToKill;
 					for (auto &o : t->ownedObjects)
@@ -721,6 +721,12 @@ void Battle::initialUnitSpawn(GameState &state)
 		}
 		auto pos = pickRandom(state.rng, spawnLocations[u.second->agent->type]);
 		spawnLocations[u.second->agent->type].remove(pos);
+		if (u.second->isLarge())
+		{
+			pos.x = std::max(pos.x, 1);
+			pos.y = std::max(pos.y, 1);
+			pos.z = std::min(pos.z, map->size.z - 2);
+		}
 		auto tile = map->getTile(pos.x, pos.y, pos.z);
 		u.second->position = tile->getRestingPosition(u.second->isLarge());
 	}
@@ -1220,6 +1226,12 @@ sp<BattleUnit> Battle::placeUnit(GameState &state, StateRef<Agent> agent)
 sp<BattleUnit> Battle::placeUnit(GameState &state, StateRef<Agent> agent, Vec3<float> position)
 {
 	auto u = placeUnit(state, agent);
+	if (map && u->isLarge())
+	{
+		position.x = std::max(position.x, 1.0f);
+		position.y = std::max(position.y, 1.0f);
+		position.z = std::min(position.z, (float)map->size.z - 2.0f);
+	}
 	u->position = position;
 	if (map)
 	{

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2598,7 +2598,9 @@ void BattleUnit::updateIdling(GameState &state)
 				bool hasSupport = true;
 				for (auto &t : tileObject->occupiedTiles)
 				{
-					if (!tileObject->map.getTile(t)->getCanStand())
+					auto *supportTile =
+					    tileObject->map.isTileInBounds(t) ? tileObject->map.getTile(t) : nullptr;
+					if (!supportTile || !supportTile->getCanStand())
 					{
 						hasSupport = false;
 						break;
@@ -2853,6 +2855,12 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 			newPosition.x = glm::clamp(newPosition.x, 0.0f, mapSize.x - 0.01f);
 			newPosition.y = glm::clamp(newPosition.y, 0.0f, mapSize.y - 0.01f);
 			newPosition.z = glm::clamp(newPosition.z, 0.0f, mapSize.z - 0.01f);
+		}
+		if (isLarge())
+		{
+			newPosition.x = glm::clamp(newPosition.x, 1.0f, mapSize.x - 0.01f);
+			newPosition.y = glm::clamp(newPosition.y, 1.0f, mapSize.y - 0.01f);
+			newPosition.z = glm::clamp(newPosition.z, 0.0f, mapSize.z - 1.01f);
 		}
 		// Fell below 0???
 		if (newPosition.z < 0 && !tileObject->map.getTile(newPosition))

--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -223,7 +223,8 @@ bool BattleUnitTileHelper::canEnterTile(Tile *from, Tile *to, bool allowJumping,
 	if (large)
 	{
 		// Can we fit?
-		if (toPos.x < 1 || toPos.y < 1 || toPos.z + 1 >= map.size.z)
+		if (toPos.x < 1 || toPos.y < 1 || toPos.z + 1 >= map.size.z || fromPos.x < 1 ||
+		    fromPos.y < 1)
 		{
 			return false;
 		}


### PR DESCRIPTION
Fixes #1007.
Fixes #787.

## Root cause

Nothing enforces the invariant "a unit's whole footprint is on the map". A large unit occupies `{x-1..x} x {y-1..y} x {z..z+1}` (`tileobject_battleunit.cpp:279-291`) and a prone unit additionally occupies the legs tile behind it, but `TileObject::setPosition` (`tileobject.cpp:99-141`) only clamps the centre and silently drops footprint tiles that fall off the map. Readers that later walk that footprint then dereference `TileMap::getTile`, which returns `nullptr` and logs `Incorrect tile coordinates ...` for out-of-range coordinates (`tilemap.h:100-118`), without a null check:

* `BattleUnitTileHelper::canEnterTile` guards the TO side (`battleunitmission.cpp:226`) but not the FROM side (`:231-236`). This is the `Incorrect tile coordinates 3,-1,0` crash in the issue, and the mid-mission crash after `findShortestPath`.
* `BattleUnit::updateIdling`'s prone leg-support loop (`battleunit.cpp:2599-2606`) for a prone unit whose legs tile (`pos - facing`) sits off the map. That is the #787 backtrace.
* `Battle::initialMapPartRemoval` (`battle.cpp:435`) dereferencing `getTile(position + {0,0,1})` for a large unit standing at the top z level.

And three places that set a large unit's position never clamped the centre so the footprint stays on the map: `Battle::placeUnit(state, agent, position)`, the `spawnLocations` branch of `Battle::initialUnitSpawn`, and the edge/ceiling clamp in `BattleUnit::updateMovementFalling`. The LOS-block spawn, teleport, give-way and AI random-move paths were already guarded.

## Fix

Four surgical changes in `game/`, no change to `TileMap::getTile`/`isTileInBounds` semantics:

* `canEnterTile` now also rejects `fromPos.x < 1 || fromPos.y < 1` for a large unit, mirroring the existing TO-side fit check (returns `false` silently, same as that check).
* `updateIdling`'s prone-support loop gates the `getTile` call on `isTileInBounds` and treats an out-of-bounds tile as "no support", so the unit kneels up instead of crashing. Same guard style as `updateGiveWay` (`battleunit.cpp:2455`).
* `initialMapPartRemoval` null-checks the tile before reading `solidGround`.
* The three unguarded placement paths clamp a large unit's centre to `x >= 1`, `y >= 1`, `z <= size.z - 2`, so the invariant also holds at the source.

`initialMapPartRemoval` still only checks one of the four footprint tiles; that is pre-existing behaviour, unrelated to the crash, and left alone here.

## Verification

Headless harness (`test_map_bounds`, removed after validation) that builds a real `Battle` via `Battle::beginBattle`/`enterBattle`, places one unit with `Battle::placeUnit` and scripts each edge condition:

| case | pre-fix `9804cfd9` | this branch |
|---|---|---|
| a: large unit, from-side footprint off-map, `canEnterTile` | SIGSEGV at `battleunitmission.cpp:232`, after `Incorrect tile coordinates -1,30,0` | returns `false` |
| b: prone unit, legs tile off-map, `updateIdling` (#787) | SIGSEGV in `Tile::getCanStand(this=0x0)` at `tile.cpp:115`, from `battleunit.cpp:2601` | survives, tile treated as unsupported |
| c: large unit at top z, `initialMapPartRemoval` | SIGSEGV on `t->solidGround` at `battle.cpp:436` | survives |
| d: control, large unit fully in bounds | survives | survives |

Every pre-fix backtrace landed on the predicted line (`gdb -batch -ex run -ex bt`). Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

Related: #1003 is already closed as a duplicate of #1007. #987 (END TURN CTD on a Battleship) matches the same trigger pattern but was not reproduced, so it is not claimed as fixed here.

The harness core is posted as a comment below.
