### PR TITLE
Battle: stop falling items dropping through the floor they hit (#1057)

### DIFF
--- a/game/state/battle/battleitem.cpp
+++ b/game/state/battle/battleitem.cpp
@@ -242,9 +242,9 @@ void BattleItem::update(GameState &state, unsigned int ticks)
 			// Intentional fall-through
 			case TileObject::Type::Ground:
 				// Let item fall so that it can collide with scenery or ground if falling on top of
-				// it
+				// it, but never past the surface we just hit
 				newPosition = {previousPosition.x, previousPosition.y,
-				               std::min(newPosition.z, previousPosition.z)};
+				               std::max(std::min(newPosition.z, previousPosition.z), c.position.z)};
 				break;
 			default:
 				LogError("What the hell is this item colliding with? Type is {0}",


### PR DESCRIPTION
Fixes #1057.
Refs #1330.

## Root cause

`BattleItem::update` integrates up to four ticks of gravity into one `newPosition` and then does a single collision check for the whole displacement (`battleitem.cpp:206-220`). The Ground branch of that check throws the collision point away:

```cpp
case TileObject::Type::Ground:
    newPosition = {previousPosition.x, previousPosition.y,
                   std::min(newPosition.z, previousPosition.z)};
    break;
```

It keeps the full pre-collision displacement, clamped only against where the item started this update, and never uses `c.position`, which `findCollision` already set to the voxel-precise collision point in the same tile-space units (`collision.cpp:108-109`, `:164-165`).

A floor's Ground voxels occupy roughly `[k, k+0.1)` of tile level k, so once an item has fallen about 1.6 tiles a single update step crosses the whole band and ends below the floor's tile row. Landing then depends entirely on `findSupport()`, which looks at the owning tile of the already-moved item, i.e. the tile below the floor it just tunnelled through, finds no support, and lets it keep falling. This matches the "must be 3-4 levels up" and "two of three grenades" reports on the issue.

PR #1664's `newPosition.z < 0` gate only protects level 0; an overshoot below a floor at z >= 1 lands on a positive z and never reaches it.

## Fix

One line in the Ground branch: floor the result at the collision surface as well.

```cpp
newPosition = {previousPosition.x, previousPosition.y,
               std::max(std::min(newPosition.z, previousPosition.z), c.position.z)};
```

The existing `min` against `previousPosition.z` stays (`newPosition` may already have been reset by a bounce earlier in the same call), and the item can no longer end below the voxel it just hit. `newPosition`'s owning tile is then the floor's own tile, so `findSupport()`/`getSupport()` snap the item to the resting height as designed. x/y handling, the throw trajectory code and unit falling are untouched. PR #1664's z-below-zero gate is kept as the genuine "no floor anywhere" fallback for items that never register a Ground collision at all.

## Verification

Headless harness (`test_item_fall`, removed after validation): boots a base defence battle from the difficulty0 state, scans the generated map for a column with a floor at a target z and clear tiles above it, drops an AP grenade with `falling = true`, ticks `battle->update(state, 4)` until it settles, and asserts it lands within 0.05 tile of that floor's resting height.

Pre-fix (`9804cfd9`, `battleitem.cpp` restored):

```
PASS item_fall_z0 expected=0.075 got=0.075
FAIL item_fall_z1 expected=1.95 got=0.975
```

This branch:

```
PASS item_fall_z0 expected=0.2 got=0.2
PASS item_fall_z1 expected=1.55 got=1.55
```

The z=0 control passes both ways, confirming PR #1664 is unaffected and isolating the regression to floors at z >= 1. The map is regenerated per run, so the coordinates and heights differ between runs; each case compares its own landing z against its own floor. Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

This closes sub-problem C of #1330; A and B are unrelated code paths and stay open. Unit falling has the same coarse-step problem in `battleunit.cpp` and is handled separately.

The harness core is posted as a comment below.
