### PR TITLE
City: deliver combat loot to any owned base with containment (#1471)

### DIFF
--- a/game/state/city/vehicle.cpp
+++ b/game/state/city/vehicle.cpp
@@ -1739,8 +1739,9 @@ StateRef<Building> Vehicle::getServiceDestination(GameState &state)
 	// Step 01: Find first cargo destination and remove arrived cargo
 	for (auto it = cargo.begin(); it != cargo.end();)
 	{
-		if (it->destination == currentBuilding)
+		if (cargoDeliverableAtCurrentBuilding(*it))
 		{
+			it->destination = currentBuilding;
 			// Only add aliens if alien containment is available at base
 			const auto vehicleContainsAlienLoot = cargoContainsAlienLoot();
 			const auto alienContainmentExists =
@@ -2407,7 +2408,7 @@ void Vehicle::updateCargo(GameState &state)
 		// Either this is non-combat loot, or this loot belongs to this building
 		// Don't keep trying to ferry combat loot to other building as we're NOT going to move
 		// when we check it in getServiceDestination method!
-		if (c.originalOwner || c.destination == currentBuilding)
+		if (c.originalOwner || cargoDeliverableAtCurrentBuilding(c))
 		{
 			needFerry = true;
 			break;
@@ -3910,6 +3911,13 @@ const bool Vehicle::cargoContainsAlienLoot() const
 	}
 
 	return false;
+}
+
+bool Vehicle::cargoDeliverableAtCurrentBuilding(const Cargo &c) const
+{
+	return currentBuilding &&
+	       (c.destination == currentBuilding ||
+	        (!c.originalOwner && currentBuilding->base && currentBuilding->owner == owner));
 }
 
 Cargo::Cargo(GameState &state, StateRef<AEquipmentType> equipment, int count, int price,

--- a/game/state/city/vehicle.h
+++ b/game/state/city/vehicle.h
@@ -389,6 +389,7 @@ class Vehicle : public StateObject<Vehicle>,
 	const UString getFormattedVehicleNameForEventMessage(GameState &state) const;
 
 	const bool cargoContainsAlienLoot() const;
+	bool cargoDeliverableAtCurrentBuilding(const Cargo &c) const;
 
 	// Following members are not serialized, but rather setup during game
 


### PR DESCRIPTION
Fixes #1471.

## Root cause

`Battle::exitBattle` stamps every piece of recovered loot with the vehicle's home building as its `Cargo::destination` (`battle.cpp:3334-3335`). The only "we have arrived" test in the cityscape is exact destination equality (`vehicle.cpp:1742` in `getServiceDestination`, `vehicle.cpp:2410` in `updateCargo`), so a craft that lands at any other base is never considered a valid drop-off. The Alien Containment gate lives inside that branch, so it never even gets a chance to run at the second base, and the craft offers no ferry mission either.

## Fix

A single predicate, plus a rebind of the destination on landing:

```cpp
bool Vehicle::cargoDeliverableAtCurrentBuilding(const Cargo &c) const
{
	return currentBuilding && (c.destination == currentBuilding ||
	                           (!c.originalOwner && currentBuilding->base &&
	                            currentBuilding->owner == owner));
}
```

`getServiceDestination` uses it and sets `it->destination = currentBuilding` before the unchanged containment gate and `arrive()` call. The rebind matters: `Cargo::arrive` keys off `destination->base` (`vehicle.cpp:4040-4054`), so without it the loot would leave the vehicle and land in the wrong base's stock. `updateCargo` uses the same predicate when deciding whether a ferry mission is needed, with `c.originalOwner` kept as its own disjunct so transfers and purchases still force a ferry while in flight.

Only combat loot qualifies (`originalOwner == nullptr`), and only at a building that hosts a base owned by the vehicle's owner. Purchases and transfers keep the exact-destination path, and building freight (`Building::cargo`) is a different list that this change never touches.

Ownership is decided via `currentBuilding->owner == owner`, since `Base` has no owner field of its own; that matches the existing convention at `building.cpp:365`.

Loot is redirected to any owned base, not only ones with containment. That is deliberate: it re-triggers the existing "no containment here" dialog at the base the player actually flew to, instead of silently stranding the cargo. No capacity check is added, matching current `Cargo::arrive` behaviour (#1203 territory, out of scope).

## Verification

Headless harness (`test_alien_cargo`, removed after validation): difficulty0 state, a second base B, a Biotrans homed at base A landing at B with one live alien as combat loot.

| case | pre-fix `9804cfd9` | this branch |
|---|---|---|
| B has Alien Containment | no ferry mission, cargo kept aboard | unloaded into B, cargo empty |
| B has no Alien Containment | kept aboard | kept aboard (existing dialog) |
| transfer cargo addressed to A, landed at B | kept aboard | kept aboard |
| loot landed at a building without a player base | kept aboard | kept aboard |

Only the bug case flips; the three controls pass in both legs. Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

Two adjacent one-liners were found while sweeping the cargo consumers and deliberately left out of this diff: `battle.cpp:3354` uses `getMaxCargo()` where `getMaxBio()` looks intended, and `cityview.cpp:4024` is missing an iterator increment. Happy to file them separately.

The harness core is posted as a comment below.
