### PR TITLE
Battle: let a stunned unit rise on an adjacent tile when blocked (#742)

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -4431,7 +4431,39 @@ void BattleUnit::tryToRiseUp(GameState &state)
 {
 	// Do not rise up if unit is standing on us
 	if (tileObject->getOwningTile()->getUnitIfPresent(true, true, false, tileObject))
-		return;
+	{
+		if (isLarge())
+		{
+			return;
+		}
+		auto from = tileObject->getOwningTile();
+		auto helper = BattleUnitTileHelper{tileObject->map, *this};
+		Tile *freeTile = nullptr;
+		for (int dir = 0; dir <= 7 && !freeTile; dir++)
+		{
+			auto heading = dir_facing_map.at(dir);
+			for (int dz : {0, -1, 1})
+			{
+				Vec3<int> pos = {position.x + heading.x, position.y + heading.y, position.z + dz};
+				if (!tileObject->map.isTileInBounds(pos))
+				{
+					continue;
+				}
+				auto to = tileObject->map.getTile(pos);
+				if (helper.canEnterTile(from, to))
+				{
+					freeTile = to;
+					break;
+				}
+			}
+		}
+		if (!freeTile)
+		{
+			return;
+		}
+		setPosition(state, freeTile->getRestingPosition(isLarge()), true);
+		resetGoal();
+	}
 
 	// Find state we can rise into (with animation)
 	auto targetState = BodyState::Standing;


### PR DESCRIPTION
Fixes #742.

## Root cause

`BattleUnit::tryToRiseUp` (`battleunit.cpp:4430-4434`) hard-returns when a conscious unit occupies the downed unit's tile, and does nothing else:

```cpp
// Do not rise up if unit is standing on us
if (tileObject->getOwningTile()->getUnitIfPresent(true, true, false, tileObject))
{
	return;
}
```

`updateRegen` retries this once per game second, so a small unit whose stun has fully decayed stays in the Downed limbo (not conscious, not unconscious, no AI, not selectable) for as long as anyone stands on it, which a player or the AI can keep up indefinitely just by not moving.

## Fix

When the tile is blocked and the unit is not large, walk the eight compass headings (`dir_facing_map`) and for each try the tile at the unit's own z, then z-1, then z+1, taking the first that is in bounds and passes `BattleUnitTileHelper::canEnterTile`. If one is found, `setPosition` the unit to that tile's resting position with `goal = true` and call `resetGoal()`, then fall through into the existing rise-body-state logic unchanged. If no free tile exists, or the unit is large, return exactly as before, so the per-second retry keeps trying.

Large-unit displacement is deliberately out of scope, matching Grichmann's note on the issue.

One thing worth flagging for review: the obvious move is to copy `updateGiveWay`'s `canEnterTile(from, to) && canEnterTile(to, from)` pattern, and that is wrong here. The reverse call swaps the roles, so its "is the target passable" step examines the unit's own tile for a blocking occupant, which in this scenario is occupied by definition. It returns `false` for every candidate, unconditionally. `updateGiveWay` gets away with it because the unit giving way is standing on its own unblocked tile. Only the forward check is used here; the harness caught this immediately, on a hand-picked fully clear 3x3 patch.

## Verification

Headless harness (`test_stunned_rise`, removed after validation): a real base defence battle against the player's own base with zero hostiles, a unit downed and stripped of equipment, a second unit moved onto its tile, the stun cleared, then one game second of ticks.

Pre-fix (`9804cfd9`):

```
FAIL blocked_rise expected=displaced_and_rising got=stuck_or_wrong
PASS control_rise_in_place expected=in_place_and_rising got=in_place_and_rising
PASS large_unit_blocked expected=stayed_down got=stayed_down
```

This branch:

```
PASS blocked_rise expected=displaced_and_rising got=displaced_and_rising
PASS control_rise_in_place expected=in_place_and_rising got=in_place_and_rising
PASS large_unit_blocked expected=stayed_down got=stayed_down
```

Only the blocked case changes; the unblocked control and the large-unit early return are identical in both directions. Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

Separately, ticking this randomly generated base map turns up two latent issues that are present on master, reproduce with this change reverted, and are not touched here: a unit or dropped item occasionally starts falling out of map bounds and one call site segfaults on the resulting null tile, and a freshly relocated unit is occasionally not found by `Tile::getUnitIfPresent` right afterwards even though `occupiedTiles` looks correct. Neither is mentioned in this issue; I can file them separately if that is useful.

The harness core is posted as a comment below.
