### PR TITLE
City: end the game on the final victory and the last base lost (#766)

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -3470,7 +3470,7 @@ void Battle::exitBattle(GameState &state)
 
 	if (victory)
 	{
-		LogError("You won, but we have no screen for that yet LOL!");
+		state.eventFromBattle = GameEventType::GameWon;
 	}
 
 	state.current_battle = nullptr;

--- a/game/state/city/base.cpp
+++ b/game/state/city/base.cpp
@@ -144,7 +144,14 @@ void Base::die(GameState &state, bool collapse)
 	state.current_base.clear();
 	if (state.player_bases.empty())
 	{
-		LogError("Player lost, but we have no screen for that yet!");
+		if (state.current_battle)
+		{
+			state.eventFromBattle = GameEventType::GameLost;
+		}
+		else
+		{
+			fw().pushEvent(new GameEvent(GameEventType::GameLost));
+		}
 		return;
 	}
 	else

--- a/game/state/gameevent.cpp
+++ b/game/state/gameevent.cpp
@@ -74,6 +74,11 @@ UString GameEvent::message()
 			return tr("X-COM returning from UFO mission.");
 		case GameEventType::BuildingDisabled:
 			return tr("Building has been disabled");
+		case GameEventType::GameWon:
+			return tr("The link with the Alien dimension is broken forever. The Aliens are "
+			          "vanquished and victory is ours!");
+		case GameEventType::GameLost:
+			return tr("The last X-COM base has fallen. Earth is lost to the Alien invasion.");
 		default:
 			break;
 	}

--- a/game/state/gameeventtypes.h
+++ b/game/state/gameeventtypes.h
@@ -115,6 +115,8 @@ enum class GameEventType
 	BuildingDisabled,
 	MissionCompletedVehicle,
 	MissionCompletedBuildingAlien,
+	GameWon,
+	GameLost,
 
 	None
 };

--- a/game/state/gamestate.cpp
+++ b/game/state/gamestate.cpp
@@ -1780,6 +1780,8 @@ void GameState::updateAfterBattle()
 			break;
 		}
 		case GameEventType::MissionCompletedVehicle:
+		case GameEventType::GameWon:
+		case GameEventType::GameLost:
 		{
 			fw().pushEvent(new GameEvent(eventFromBattle));
 			break;

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -414,6 +414,8 @@
     <value>BuildingDisabled</value>
     <value>MissionCompletedVehicle</value>
     <value>MissionCompletedBuildingAlien</value>
+    <value>GameWon</value>
+    <value>GameLost</value>
     <value>None</value>
   </enum>
   <enum>

--- a/game/ui/tileview/cityview.cpp
+++ b/game/ui/tileview/cityview.cpp
@@ -65,6 +65,7 @@
 #include "game/ui/components/locationscreen.h"
 #include "game/ui/general/aequipscreen.h"
 #include "game/ui/general/ingameoptions.h"
+#include "game/ui/general/mainmenu.h"
 #include "game/ui/general/messagebox.h"
 #include "game/ui/general/messagelogscreen.h"
 #include "game/ui/general/notificationscreen.h"
@@ -4419,6 +4420,24 @@ bool CityView::handleGameStateEvent(Event *e)
 		{
 			setUpdateSpeed(CityUpdateSpeed::Pause);
 			showWeeklyFundingReport();
+		}
+		break;
+		case GameEventType::GameWon:
+		{
+			setUpdateSpeed(CityUpdateSpeed::Pause);
+			auto message_box = mksp<MessageBox>(
+			    tr("VICTORY"), gameEvent->message(), MessageBox::ButtonOptions::Ok, []()
+			    { fw().stageQueueCommand({StageCmd::Command::REPLACEALL, mksp<MainMenu>()}); });
+			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
+		}
+		break;
+		case GameEventType::GameLost:
+		{
+			setUpdateSpeed(CityUpdateSpeed::Pause);
+			auto message_box = mksp<MessageBox>(
+			    tr("DEFEAT"), gameEvent->message(), MessageBox::ButtonOptions::Ok, []()
+			    { fw().stageQueueCommand({StageCmd::Command::REPLACEALL, mksp<MainMenu>()}); });
+			fw().stageQueueCommand({StageCmd::Command::PUSH, message_box});
 		}
 		break;
 		default:


### PR DESCRIPTION
Fixes #766.

## Root cause

`Building::victory` is data-driven and read correctly, but the result never leaves the function. `Battle::exitBattle` sets a local `bool victory` from `building->victory` for `RaidAliens` (`battle.cpp:3400`) and `RaidHumans` (`:3445`), then drops it:

```cpp
LogError("You won, but we have no screen for that yet LOL!");
```

The defeat side is the same stub: `Base::die` logs `Player lost, but we have no screen for that yet!` in the `state.player_bases.empty()` branch and pushes no event. There is no `GameWon` or `GameLost` in `GameEventType`, so `CityView` has nothing to react to and the game simply continues.

## Fix

The minimal slice that makes both outcomes reach the player:

* `gameeventtypes.h`: `GameWon` and `GameLost` appended to the Misc group, no reordering.
* `gameevent.cpp`: two `GameEvent::message()` cases returning `tr(...)` text. No new event subclass, neither carries a payload.
* `battle.cpp:3471`: the `LogError` becomes `state.eventFromBattle = GameEventType::GameWon;` on victory, reusing the already-serialised field the mission-complete events use.
* `gamestate.cpp` `updateAfterBattle()`: a `GameWon` case that pushes the plain event, identical in shape to the existing `MissionCompletedBuildingAlien` case.
* `base.cpp` `Base::die`: the `LogError` becomes a `GameLost` event. When a battle is active the event goes through `eventFromBattle` (`exitBattle` calls `die` before `CityView` exists); otherwise it is pushed directly, which is what `Base::die` already does for `BaseDestroyed`. The `player_bases.empty()` guard means it fires exactly once, whichever caller killed the base.
* `cityview.cpp`: `GameWon` and `GameLost` cases in the unconditional switch, modelled on `FacilityCompleted`: `setUpdateSpeed(Pause)` plus a single-OK `MessageBox` whose callback does `stageQueueCommand({REPLACEALL, mksp<MainMenu>()})` (the `ingameoptions.cpp:212` precedent).
* `gamestate_serialize.xml`: the two names appended to the `GameEventType` list.

Save format is additive. The enum is serialised by name, nothing is removed, renamed or renumbered, and no existing save can contain either value.

## Out of scope, deliberately

* Proper victory and defeat art screens and a final score screen (#264 item 5).
* The ending video: the dev CD image here has no `SMK` directory and I could not confirm a real filename from the extractor sources, so this does not invent one.
* Free play / continue after victory.
* Alien takeover as a second defeat trigger (`organisation.cpp` `takeOver`, structurally a different path, no last-base check) (#264 item 6).

One tradeoff worth naming: on a winning raid, `eventFromBattle` is overwritten, so the player sees the victory box instead of the "Mission completed in Alien building" ticker line for that one mission.

## Verification

Headless harness (`test_endgame`, removed after validation): difficulty0 state, a bare `Battle` driven through `updateBeforeBattle`/`exitBattle`, and the last base killed via `Base::die` with a battle active. Assertions compare `magic_enum::enum_name(eventFromBattle)` to a string so the same source compiles on the base commit.

| case | pre-fix `9804cfd9` | this branch |
|---|---|---|
| won raid on the Dimension Gate Generator | `MissionCompletedBuildingAlien` | `GameWon` |
| won raid on an Alien Farm (control) | `MissionCompletedBuildingAlien` | `MissionCompletedBuildingAlien` |
| last base dies during a battle | `eventFromBattle = None` | `GameLost` |

Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

The `cityview.cpp` switch cases themselves are covered by reading rather than a live run: `Framework`'s event queue is private, draining it needs `Framework::run()`, and `CityView` loads UI forms, so there is no headless precedent in this codebase to copy. If an end-to-end run is wanted, the smallest path is a `UNIT_TEST`-gated queue accessor, which is a larger change than this issue.

The harness core is posted as a comment below.
