### PR TITLE
Battle: use the original game's combat experience rules (#1665)

### DIFF
--- a/game/state/battle/battle.cpp
+++ b/game/state/battle/battle.cpp
@@ -2423,7 +2423,6 @@ void Battle::giveInterruptChanceToUnit(GameState &state, StateRef<BattleUnit> gi
 				fw().pushEvent(new GameLocationEvent(GameEventType::ZoomView, receiver->position));
 			}
 			interruptQueue.emplace(receiver, receiver->agent->getTULimit(reactionValue));
-			receiver->experiencePoints.reactions++;
 		}
 	}
 }

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -1125,16 +1125,12 @@ bool BattleUnit::startAttackPsiInternal(GameState &state, StateRef<BattleUnit> t
 	}
 	int chance = getPsiChanceForEquipment(target, status, item);
 	int roll = randBoundsExclusive(state.rng, 0, 100);
-	experiencePoints.psi_attack++;
-	experiencePoints.psi_energy++;
 	LogWarning("Psi Attack #{0} Roll {1} Chance {2} {3} Attacker {4} Target {5}", (int)status, roll,
 	           chance, roll < chance ? (UString) "SUCCESS" : (UString) "FAILURE", id, target->id);
 	if (roll >= chance)
 	{
 		return false;
 	}
-	experiencePoints.psi_attack += 2;
-	experiencePoints.psi_energy += 2;
 
 	// Attack hit, apply effects
 
@@ -1939,7 +1935,16 @@ bool BattleUnit::handleCollision(GameState &state, Collision &c)
 			notifyHit(position - glm::normalize(projectile->velocity) * 1.41f);
 			if (projectile->firerUnit)
 			{
-				projectile->firerUnit->experiencePoints.accuracy++;
+				if (projectile->firerUnit->experience.accuracyHits < 40)
+				{
+					projectile->firerUnit->experience.accuracyHits++;
+				}
+				if (state.current_battle->mode == Battle::Mode::TurnBased &&
+				    state.current_battle->interruptUnits.find(projectile->firerUnit) !=
+				        state.current_battle->interruptUnits.end())
+				{
+					projectile->firerUnit->experience.reactionHits++;
+				}
 			}
 			return applyDamage(state, projectile->damage, projectile->damageType, partHit,
 			                   DamageSource::Impact, projectile->firerUnit);
@@ -2208,11 +2213,7 @@ void BattleUnit::updateMorale(GameState &state, unsigned int ticks)
 		{
 			moraleTicksAccumulated -= LOWMORALE_CHECK_INTERVAL;
 
-			if (randBoundsExclusive(state.rng, 0, 100) >= 100 - 2 * agent->modified_stats.morale)
-			{
-				experiencePoints.bravery++;
-			}
-			else
+			if (randBoundsExclusive(state.rng, 0, 100) < 100 - 2 * agent->modified_stats.morale)
 			{
 				moraleStateTicksRemaining = TICKS_PER_LOWMORALE_STATE;
 				moraleState = (MoraleState)(randBoundsInclusive(state.rng, 1, 3));
@@ -2363,6 +2364,7 @@ void BattleUnit::updateRegen(GameState &state, unsigned int ticks)
 					if (agent->modified_stats.stamina > 10)
 					{
 						agent->modified_stats.stamina -= 10;
+						experience.staminaSpent += 10;
 					}
 					else
 					{
@@ -2374,6 +2376,7 @@ void BattleUnit::updateRegen(GameState &state, unsigned int ticks)
 					if (agent->modified_stats.stamina > 30)
 					{
 						agent->modified_stats.stamina -= 30;
+						experience.staminaSpent += 30;
 					}
 					else
 					{
@@ -4131,107 +4134,61 @@ void BattleUnit::sendAgentEvent(GameState &state, GameEventType type, bool check
 	}
 }
 
-int BattleUnit::rollForPrimaryStat(GameState &state, int experience)
-{
-	if (experience > 10)
-	{
-		return randBoundsInclusive(state.rng, 2, 6);
-	}
-	else if (experience > 5)
-	{
-		return randBoundsInclusive(state.rng, 1, 4);
-	}
-	if (experience > 2)
-	{
-		return randBoundsInclusive(state.rng, 1, 3);
-	}
-	if (experience > 0)
-	{
-		return randBoundsInclusive(state.rng, 0, 1);
-	}
-	return 0;
-}
-
-// FIXME: Ensure correct
-// For now, using X-Com 1/2 system of primary/secondary stats,
-// except psi which assumes it's same 3x limit that is applied when using psi gym
 void BattleUnit::processExperience(GameState &state)
 {
-	int secondaryXP = experiencePoints.accuracy + experiencePoints.bravery +
-	                  experiencePoints.psi_attack + experiencePoints.psi_energy +
-	                  experiencePoints.reactions;
-	if (agent->current_stats.accuracy < 100)
+	if (!agent->type->canTrain)
 	{
-		agent->current_stats.accuracy += rollForPrimaryStat(
-		    state, experiencePoints.accuracy * agent->type->improvementPercentagePhysical / 100);
+		return;
 	}
-	if (agent->current_stats.psi_attack < 100 &&
-	    agent->current_stats.psi_attack < agent->initial_stats.psi_attack * 3)
+	if (agent->current_stats.accuracy < 96 && experience.accuracyHits > 0)
 	{
-		agent->current_stats.psi_attack += rollForPrimaryStat(
-		    state, experiencePoints.psi_attack * agent->type->improvementPercentagePsi / 100);
+		int gain = (int)std::ceil((96 - agent->current_stats.accuracy) / 100.0 *
+		                          (experience.accuracyHits / 4));
+		agent->current_stats.accuracy = std::min(96, agent->current_stats.accuracy + gain);
 	}
-	if (agent->current_stats.psi_energy < 100 &&
-	    agent->current_stats.psi_energy < agent->initial_stats.psi_energy * 3)
+	if (agent->current_stats.reactions < 100 && experience.reactionHits > 0 &&
+	    agent->current_stats.reactions > 0)
 	{
-		agent->current_stats.psi_energy += rollForPrimaryStat(
-		    state, experiencePoints.psi_energy * agent->type->improvementPercentagePsi / 100);
+		int gain = std::min(experience.reactionHits / agent->current_stats.reactions, 5);
+		agent->current_stats.reactions = std::min(100, agent->current_stats.reactions + gain);
 	}
-	if (agent->current_stats.reactions < 100)
+	int displayStamina = agent->current_stats.getDisplayStaminaValue();
+	int staminaXP = experience.staminaSpent / 20;
+	if (staminaXP > 0 && displayStamina > 0)
 	{
-		if (state.current_battle->mode == Battle::Mode::TurnBased)
+		int rawGain = staminaXP / displayStamina;
+		if (rawGain > 0)
 		{
-			agent->current_stats.reactions +=
-			    rollForPrimaryStat(state, experiencePoints.reactions *
-			                                  agent->type->improvementPercentagePhysical / 100);
-		}
-		else
-		{
-			agent->current_stats.reactions += rollForPrimaryStat(
-			    state, std::min(3, secondaryXP * agent->type->improvementPercentagePhysical / 100));
+			if (agent->current_stats.speed < 100)
+			{
+				agent->current_stats.speed =
+				    std::min(100, agent->current_stats.speed + std::min(rawGain, 5));
+			}
+			if (agent->current_stats.stamina < 2000)
+			{
+				agent->current_stats.stamina =
+				    std::min(2000, agent->current_stats.stamina + rawGain * 10);
+			}
 		}
 	}
-	if (agent->current_stats.bravery < 100)
-	{
-		agent->current_stats.bravery +=
-		    10 * randBoundsExclusive(state.rng, 0, 99) <
-		    experiencePoints.bravery * 9 * agent->type->improvementPercentagePhysical / 100;
-	}
-	// Units with slower improvement rates need to gain more xp to have a chance to improve
-	// >= 100% improvement rate need just 1 xp
-	// 50% improvement rate needs 2 xp
-	// 10% improvement rate needs 10 xp
-	// ---
-	// Percentile increase also affected (units with 100% improvement gain 10% of their missing
-	// stat, units with 50% gain 5% etc)
-	if (agent->type->improvementPercentagePhysical > 0 &&
-	    secondaryXP > 100 / agent->type->improvementPercentagePhysical)
+	if (experience.killScore > 0)
 	{
 		if (agent->current_stats.health < 100)
 		{
-			int healthBoost = randBoundsInclusive(state.rng, 0, 2) +
-			                  (100 - agent->current_stats.health) / 10 *
-			                      agent->type->improvementPercentagePhysical / 100;
-			agent->current_stats.health += healthBoost;
-			agent->modified_stats.health += healthBoost;
+			int healthGain = experience.killScore >= 30 ? 2 : (experience.killScore >= 15 ? 1 : 0);
+			healthGain = std::min(healthGain, 100 - agent->current_stats.health);
+			agent->current_stats.health += healthGain;
+			agent->modified_stats.health += healthGain;
 		}
-		if (agent->current_stats.speed < 100)
+		if (agent->current_stats.bravery < 100)
 		{
-			agent->current_stats.speed += randBoundsInclusive(state.rng, 0, 2) +
-			                              (100 - agent->current_stats.speed) / 10 *
-			                                  agent->type->improvementPercentagePhysical / 100;
-		}
-		if (agent->current_stats.stamina < 2000)
-		{
-			agent->current_stats.stamina += randBoundsInclusive(state.rng, 0, 2) * 20 +
-			                                (2000 - agent->current_stats.stamina) / 10 *
-			                                    agent->type->improvementPercentagePhysical / 100;
-		}
-		if (agent->current_stats.strength < 100)
-		{
-			agent->current_stats.strength += randBoundsInclusive(state.rng, 0, 2) +
-			                                 (100 - agent->current_stats.strength) / 10 *
-			                                     agent->type->improvementPercentagePhysical / 100;
+			bool gain = agent->current_stats.bravery <= 0
+			                ? true
+			                : experience.killScore * 2 > agent->current_stats.bravery;
+			if (gain)
+			{
+				agent->current_stats.bravery = std::min(100, agent->current_stats.bravery + 10);
+			}
 		}
 	}
 	agent->updateModifiedStats();
@@ -4823,6 +4780,7 @@ void BattleUnit::die(GameState &state, StateRef<BattleUnit> attacker, bool viole
 	         player->isRelatedTo(ourOrg) == Organisation::Relation::Hostile)
 	{
 		attacker->combatRating += agent->type->score;
+		attacker->experience.killScore += agent->type->score;
 		state.current_battle->score.combatRating += agent->type->score;
 	}
 	// Penalty for unit in squad dying

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -136,6 +136,16 @@ enum class MoraleState
 	Berserk
 };
 
+class BattleUnitExperience
+{
+  public:
+	BattleUnitExperience() = default;
+	int accuracyHits = 0;
+	int reactionHits = 0;
+	int staminaSpent = 0;
+	int killScore = 0;
+};
+
 static const std::list<BattleUnitType> BattleUnitTypeList = {
     BattleUnitType::LargeFlyer, BattleUnitType::LargeWalker, BattleUnitType::SmallFlyer,
     BattleUnitType::SmallWalker};
@@ -223,7 +233,7 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	// Stats
 
 	// Accumulated xp points for each stat
-	AgentStats experiencePoints;
+	BattleUnitExperience experience;
 	// Points earned for kills
 	int combatRating = 0;
 	// Fatal wounds for each body part
@@ -618,8 +628,6 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 
 	// Experience
 
-	// Returns a roll for primary state increase based on how much experience was acquired
-	int rollForPrimaryStat(GameState &state, int experience);
 	// Process unit experience into stat increases
 	void processExperience(GameState &state);
 

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -810,6 +810,13 @@
     <member>offset</member>
   </object>
   <object>
+    <name>BattleUnitExperience</name>
+    <member>accuracyHits</member>
+    <member>reactionHits</member>
+    <member>staminaSpent</member>
+    <member>killScore</member>
+  </object>
+  <object>
     <name>BattleUnit</name>
     <member>id</member>
     <member>agent</member>
@@ -830,7 +837,7 @@
     <member>ticksAccumulatedToNextPsiCheck</member>
     <member>psiAttackers</member>
     <member>brainSucker</member>
-    <member>experiencePoints</member>
+    <member>experience</member>
     <member>combatRating</member>
     <member>fatalWounds</member>
     <member>healingBodyPart</member>


### PR DESCRIPTION
Fixes #1665.

## Root cause

`BattleUnit::processExperience` (`battleunit.cpp:4158`) and its helper `rollForPrimaryStat` (`:4134`) are a 2017 placeholder, marked `FIXME ... for now, using X-Com 1/2 system` in the source: random dice rolls instead of Apocalypse's deterministic formulas. The accumulators it reads do not match the original rules either:

* accuracy XP is `+1` per hit, which is right, but uncapped (`battleunit.cpp:1942`);
* reaction XP goes to the interrupt **receiver** just for being offered an interrupt chance (`battle.cpp:2426`), not to the firer for landing a reaction shot;
* bravery XP comes from a per-turn morale-check timer (`battleunit.cpp:2213`), not from kills;
* psi stats accrue XP on psi attempts (`battleunit.cpp:1128-1137`) even though psi never changes from combat;
* there is no kill-score and no stamina-spent tracking at all, so health, bravery, speed and stamina can never move for the right reasons.

## Fix

`processExperience` now implements the documented rules ([ufopaedia: Combat Experience (Apocalypse)](https://www.ufopaedia.org/index.php/Combat_Experience_(Apocalypse))), deterministic, no RNG, gated on `agent->type->canTrain` so androids gain nothing:

| Stat | Trigger | Accrual cap | Gain | Stat cap |
|---|---|---|---|---|
| Accuracy | +1 per hit landed on a living unit | 40 | `ceil((96 - accuracy) / 100 * floor(accXP / 4))` | 96 |
| Reactions | +1 per hit landed by a reaction shot, turn based only | none | `min(floor(reactXP / reactions), 5)` | 100 |
| Speed | stamina spent running | none | `min(floor(stamXP / stamina), 5)` | 100 |
| Stamina | stamina spent running | none | `floor(stamXP / stamina) * 10` internal | 2000 |
| Health | sum of `score` of enemies killed | n/a | `+1` at 15-29, `+2` at 30+ | 100 |
| Bravery | same kill score | n/a | `+10` if `killScore / bravery > 0.5` | 100 |

Strength and every psi stat are never written. Division guards: no reaction gain at `reactions == 0`, no stamina or speed gain at displayed `stamina == 0`, and `bravery == 0` with any kill counts as above the threshold.

`AgentStats experiencePoints` is replaced by a small `BattleUnitExperience` struct holding `accuracyHits`, `reactionHits`, `staminaSpent` and `killScore`, registered in `gamestate_serialize.xml` so mid-battle saves keep working. `rollForPrimaryStat` is removed (no other caller). The accrual sites move accordingly: accuracy hits capped at 40, reaction hits recorded on the firer when it is in `Battle::interruptUnits` in turn-based mode, kill score added next to the existing `combatRating += agent->type->score` on the hostile-kill branch, stamina spend recorded alongside the existing `modified_stats.stamina -=` lines, and the psi, morale-timer and interrupt-receiver increments deleted.

`interruptUnits` membership is used as the "this is a reaction shot" marker because no explicit flag exists on `BattleUnit` or `Projectile`; a unit only enters that map through the interrupt decision flow, so any shot fired while it is there is a reaction shot by construction.

## Assumptions worth a maintainer's eye

* **Stamina XP unit.** The source does not state it. Raw internal spend (10 or 30 per event, matching the existing magnitudes) is accumulated and converted once via `/ 20` at the end, so a per-event `10/20` division does not throw away half an XP on every prone-drag tick.
* **Stamina and speed share one raw term with different caps.** The source gives `min(floor(stamXP/stamina), 5)` for speed and `floor(stamXP/stamina)/2` displayed for stamina. Read literally, only the speed gain carries the per-mission ceiling of 5. Implemented literally; if the intent was for both to share it, that is a one-line change.
* Denominators in the reaction and stamina formulas are the unit's current displayed stat before this mission's gain is applied, matching how the accuracy formula uses live `accuracy`.
* The accuracy ceiling is 96 rather than the general 100, per the source.
* `improvementPercentagePhysical` / `improvementPercentagePsi` are left in place but become unused, per the issue discussion. Androids are excluded via `canTrain`, which is already `false` for them; `improvementPercentagePhysical` is 10 for androids, so comparing it against zero would not have excluded them.

## Verification

Headless harness (`test_battle_experience`, removed after validation): difficulty0 state, real agents from `AgentGenerator`, a bare `BattleUnit` with only `->agent` set, `processExperience` called, assertions on `current_stats`.

```
case                       expected  pre-fix (9804cfd9)       this branch
accuracy 50, 40 hits         55        56                       55
accuracy 96, 40 hits         96        98                       96
reactions 20, 19 r-hits      20        26                       20
reactions 0                   0         3                        0
stamina 400, 2000 spent     450       400                      450
speed 50, 2000 spent         55        50                       55
health 50, killScore 30      52        50                       52
bravery 20, killScore 11     30        20                       30
bravery 0, killScore 1       10         0                       10
android, everything maxed  unchanged  acc+2 rea+2 sta+36 hp+1  unchanged
strength 45                  45        50                       45
```

Pre-fix 19 of 33 cases fail (random rolls, androids training, strength growing from combat, kills doing nothing). This branch: 33 of 33 pass. Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green.

The harness core is posted as a comment below.
