### PR TITLE
Agents: award medals from victory points on the history sheet (#1212)

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -1620,6 +1620,10 @@ void BattleUnit::applyDamageDirect(GameState &state, int damage, bool generateFa
 	else
 	{
 		bool lessThanOneThird = agent->modified_stats.health * 3 / agent->current_stats.health == 0;
+		if (agent->owner == state.getPlayer())
+		{
+			agent->recordHealthLost(std::min(damage, std::max(0, agent->modified_stats.health)));
+		}
 		agent->modified_stats.health -= damage;
 		agent->modified_stats.loseMorale(damage * 50 * (15 - agent->modified_stats.bravery / 10) /
 		                                 agent->current_stats.health / 100);
@@ -2283,6 +2287,11 @@ void BattleUnit::updateWoundsAndHealing(GameState &state, unsigned int ticks)
 		{
 			if (w.second > 0)
 			{
+				if (agent->owner == state.getPlayer())
+				{
+					agent->recordHealthLost(
+					    std::min(w.second, std::max(0, agent->modified_stats.health)));
+				}
 				agent->modified_stats.health -= w.second;
 				if (isHealing && healingBodyPart == w.first)
 				{
@@ -4708,11 +4717,12 @@ bool BattleUnit::useSpawner(GameState &state, const AEquipmentType &item)
 void BattleUnit::die(GameState &state, StateRef<BattleUnit> attacker, bool violently)
 {
 	auto attackerOrg = attacker ? attacker->agent->owner : nullptr;
-	if (attacker)
+	auto ourOrg = agent->owner;
+	if (attacker && attackerOrg == state.getPlayer() &&
+	    attackerOrg->isRelatedTo(ourOrg) == Organisation::Relation::Hostile)
 	{
 		attacker->recordKill();
 	}
-	auto ourOrg = agent->owner;
 	bool destroy = false;
 	// Violent deaths (spawn stuff, blow up)
 	if (violently)

--- a/game/state/gamestate_serialize.xml
+++ b/game/state/gamestate_serialize.xml
@@ -269,6 +269,7 @@
     <member>hiredOn</member>
     <member>killCount</member>
     <member>missionCount</member>
+    <member>victoryPoints</member>
   </object>
   <object>
     <name>AgentPortrait</name>

--- a/game/state/shared/agent.cpp
+++ b/game/state/shared/agent.cpp
@@ -1494,10 +1494,38 @@ unsigned int Agent::getKills() const { return killCount; }
 
 unsigned int Agent::getMissions() const { return missionCount; }
 
-unsigned int Agent::getMedalTier() const { return 0; }
+unsigned int Agent::getVictoryPoints(const GameState &state) const
+{
+	return std::max(victoryPoints, missionCount * 10 + killCount) + getDaysInService(state);
+}
 
-void Agent::incrementMissionCount() { missionCount++; }
+unsigned int Agent::getMedalTier(const GameState &state) const
+{
+	static const unsigned int thresholds[] = {200, 400, 700, 1000, 1500};
+	const auto points = getVictoryPoints(state);
+	unsigned int tier = 0;
+	for (const auto &threshold : thresholds)
+	{
+		if (points >= threshold)
+		{
+			tier++;
+		}
+	}
+	return tier;
+}
 
-void Agent::incrementKillCount() { killCount++; }
+void Agent::incrementMissionCount()
+{
+	missionCount++;
+	victoryPoints += 10;
+}
+
+void Agent::incrementKillCount()
+{
+	killCount++;
+	victoryPoints++;
+}
+
+void Agent::recordHealthLost(int amount) { victoryPoints += std::max(0, amount); }
 
 } // namespace OpenApoc

--- a/game/state/shared/agent.h
+++ b/game/state/shared/agent.h
@@ -88,6 +88,7 @@ class Agent : public StateObject<Agent>,
 	GameTime hiredOn;
 	unsigned int missionCount = 0;
 	unsigned int killCount = 0;
+	unsigned int victoryPoints = 0;
 
 	unsigned int teleportTicksAccumulated = 0;
 	bool canTeleport() const;
@@ -240,10 +241,12 @@ class Agent : public StateObject<Agent>,
 	unsigned int getDaysInService(const GameState &state) const;
 	unsigned int getKills() const;
 	unsigned int getMissions() const;
-	unsigned int getMedalTier() const;
+	unsigned int getVictoryPoints(const GameState &state) const;
+	unsigned int getMedalTier(const GameState &state) const;
 
 	void incrementMissionCount();
 	void incrementKillCount();
+	void recordHealthLost(int amount);
 
 	void destroy() override;
 };

--- a/game/ui/general/agentsheet.cpp
+++ b/game/ui/general/agentsheet.cpp
@@ -72,11 +72,12 @@ void AgentSheet::displayHistory(const Agent &item)
 	killCount << item.getKills();
 	historyForm->findControlTyped<Label>("VALUE_KILL_COUNT")->setText(killCount.str());
 
-	for (unsigned int i = 5; i > item.getMedalTier(); i--)
+	const auto medalTier = item.getMedalTier(*state);
+	for (unsigned int i = 1; i <= 5; i++)
 	{
 		auto formLabel = format("MEDAL_{0}", i);
 		auto medalFormElement = historyForm->findControlTyped<Graphic>(formLabel);
-		medalFormElement->setVisible(false);
+		medalFormElement->setVisible(i <= medalTier);
 	}
 }
 


### PR DESCRIPTION
Fixes #1212.

Completes item 10 of #264, which PR #1236 (the history screen) and PR #1248 (the medal graphics) left half done.

## Root cause

PR #1248 shipped the five medal graphics with `Agent::getMedalTier()` hardcoded to `return 0;` (`agent.cpp:1488-1501`), described at the time as a precursor to a wider agent-experience change that never followed. The agent carries `hiredOn`, `missionCount` and `killCount`, but there is no health-lost input, no victory-point total and no threshold table, so no agent can ever earn a medal.

Two smaller problems sit on top of it:

* `AgentSheet::displayHistory` (`agentsheet.cpp:57-80`) only ever hides medals, looping `MEDAL_5` down to `MEDAL_(tier+1)`. The history page is a single shared subform (`aequipscreen.form:130`), reused for every agent hovered, so once a low-ranked agent has been shown the medals stay hidden for everyone after it.
* `recordKill` is called before the teamkill / hostile split in `BattleUnit::die` (`battleunit.cpp:4707-4713`), so teamkills and civilian kills inflate the displayed kill count.

## Fix

Rules from [ufopaedia: Agents Medals (Apocalypse)](https://www.ufopaedia.org/index.php/Agents_Medals_(Apocalypse)): thresholds at 200, 400, 700, 1000 and 1500 victory points, earned at 1 per day in service, 10 per completed mission, 1 per health point lost and 1 per hostile kill.

* A new `unsigned int victoryPoints` on `Agent` accumulates only the battle-derived inputs: `+10` in `incrementMissionCount`, `+1` in `incrementKillCount`, and `recordHealthLost(amount)` for damage taken.
* Days are added at read time, `getVictoryPoints(state) = victoryPoints + getDaysInService(state)`. The rule is linear, so lazy and accumulated give the same number, and this needs no daily hook and gives existing saves the correct day component immediately.
* `getMedalTier(state)` counts thresholds at or below the total. It gains a `const GameState &` like `getDaysInService`; the only caller already holds `state`.
* Health lost is recorded on the direct-damage path and on fatal-wound bleeding, clamped to the health actually present so overkill does not inflate the total, and only for player-owned agents. Medikit heals do not subtract.
* `recordKill` moves inside the existing hostile branch, guarded on `attacker->agent->owner` rather than the unit's owner, so a mind-controlled alien does not credit the player and a mind-controlled X-COM agent killing an alien still gets its kill.
* `displayHistory` now sets the visibility of all five medals on every call instead of only hiding them.

Save format is additive: one new `unsigned int` member. Old saves read it as 0, and the getter floors the total at `missionCount * 10 + killCount` to backfill them. The health component cannot be recovered for saves made before this change.

Two behaviour changes worth calling out: the displayed kill count no longer includes teamkills and civilian kills, which matches the original rule; and if you would rather keep the broad count, `recordKill` can stay where it is with a separate hostile-only victory-point increment instead.

## Verification

Headless harness (`test_agent_medals`, removed after validation), one source driving both legs, run against `9804cfd9` and this branch:

| case | pre-fix | this branch |
|---|---|---|
| tier table at 0/199/200/399/400/699/700/999/1000/1499/1500/2000 | tier 0 for every input (10 fail) | matches the table |
| 200 days served alone earns the first medal | fail | pass |
| backfill: 20 missions and 5 kills read as 205 points, tier 1 | fail | pass |
| increments: 2 missions + 3 kills + 17 health = 40 points | n/a | pass |
| an agent on 199 points that loses 1 health tips to tier 1 | fail | pass |
| stun damage records no points | n/a | pass |
| display: tier 3 shows `MEDAL_1..3`, tier 0 hides all five, tier 5 re-shows all five on the same form | 8 fail (hide-only loop) | pass |

Pre-fix 21 failures; this branch 51 passes, 0 failures. Full ctest green both ways (`test_serialize` covers the new member's round trip); fork CI Lint + CMake green.

Two sub-cases could not be driven headlessly, both because `BattleUnit::die` needs a live battle map (it touches `current_battle->currentPlayer`, `removeFromSquad` and `dropDown`/`tileObject->removeFromMap()`): the overkill clamp, which by definition only fires on a lethal hit, and the kill-filter branch itself. The harness asserts the relations that filter keys on instead (the player is Hostile to the aliens and is not Hostile to itself or to civilians).

The harness core is posted as a comment below.
