### PR TITLE
Battle: land falling units on the floor they cross and enforce the jump rules (#1581)

### DIFF
--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -4009,6 +4009,84 @@ void BattleUnit::launch(GameState &state, Vec3<float> targetPosition, BodyState 
 	beginBodyStateChange(state, bodyState);
 }
 
+bool BattleUnit::canJumpDown(Vec3<int> target, Vec3<float> &landing)
+{
+	if (!tileObject || isLarge() || canFly() || !isConscious())
+	{
+		return false;
+	}
+	auto &map = tileObject->map;
+	auto *ownTile = tileObject->getOwningTile();
+	Vec3<int> from = ownTile->position;
+	if (target.x == from.x && target.y == from.y)
+	{
+		return false;
+	}
+	if (std::abs(target.x - from.x) > 1 || std::abs(target.y - from.y) > 1)
+	{
+		return false;
+	}
+	if (target.z > from.z || target.z < 0 || !map.tileIsValid({target.x, target.y, from.z}))
+	{
+		return false;
+	}
+	float ownSurface = ownTile->getRestingPosition(false).z;
+	auto *edgeTile = map.getTile(target.x, target.y, from.z);
+	Tile *landingTile = nullptr;
+	for (int z = from.z; z >= 0; z--)
+	{
+		auto *t = map.getTile(target.x, target.y, z);
+		if (!t->getCanStand(false))
+		{
+			continue;
+		}
+		if (t->getRestingPosition(false).z >= ownSurface)
+		{
+			return false;
+		}
+		landingTile = t;
+		break;
+	}
+	if (!landingTile || target.z < landingTile->position.z)
+	{
+		return false;
+	}
+	BattleUnitTileHelper helper(map, *this);
+	if (!helper.canEnterTile(nullptr, landingTile) ||
+	    landingTile->getUnitIfPresent(true, true, false, tileObject))
+	{
+		return false;
+	}
+	BattleUnitTileHelper edgeHelper(map, false, false, true, agent->type->bodyType->maxHeight,
+	                                tileObject);
+	bool jumped = false;
+	bool doorInTheWay = false;
+	float cost = 0.0f;
+	if (!edgeHelper.canEnterTile(ownTile, edgeTile, landingTile != edgeTile, jumped, cost,
+	                             doorInTheWay, true, true, true) ||
+	    doorInTheWay)
+	{
+		return false;
+	}
+	landing = landingTile->getRestingPosition(false);
+	return true;
+}
+
+void BattleUnit::jumpDown(GameState &state, Vec3<float> landing, BodyState bodyState)
+{
+	Vec3<float> targetVectorXY = {landing.x - position.x, landing.y - position.y, 0.0f};
+	if (glm::length(targetVectorXY) == 0.0f)
+	{
+		return;
+	}
+	startFalling(state);
+	launchGoal = landing;
+	launched = true;
+	velocity = glm::normalize(targetVectorXY) * 0.5f * VELOCITY_SCALE_BATTLE;
+	collisionIgnoredTicks = (int)ceilf(36.0f / glm::length(velocity / VELOCITY_SCALE_BATTLE)) + 1;
+	beginBodyStateChange(state, bodyState);
+}
+
 void BattleUnit::startMoving(GameState &state)
 {
 	auto targetMovementMode = missions.empty()

--- a/game/state/battle/battleunit.cpp
+++ b/game/state/battle/battleunit.cpp
@@ -2821,14 +2821,43 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 		}
 	}
 
+	auto &map = tileObject->map;
+	bool descending = newPosition.z < previousPosition.z;
+	bool landedOnFloor = false;
+	bool inGoalColumn = launched && descending && (int)newPosition.x == (int)launchGoal.x &&
+	                    (int)newPosition.y == (int)launchGoal.y;
+	if (descending && (collisionIgnoredTicks == 0 || inGoalColumn) && newPosition.x >= 0.0f &&
+	    newPosition.x < map.size.x && newPosition.y >= 0.0f && newPosition.y < map.size.y)
+	{
+		int topZ = std::min((int)previousPosition.z, map.size.z - 1);
+		int bottomZ = std::max((int)std::floor(newPosition.z), 0);
+		for (int z = topZ; z >= bottomZ && !landedOnFloor; z--)
+		{
+			auto *t = map.getTile((int)newPosition.x, (int)newPosition.y, z);
+			if (!t->getCanStand(isLarge()))
+			{
+				continue;
+			}
+			float surfaceZ = t->getRestingPosition(isLarge()).z;
+			if (surfaceZ <= previousPosition.z && surfaceZ > newPosition.z)
+			{
+				newPosition.z = surfaceZ;
+				landedOnFloor = true;
+			}
+		}
+	}
+
 	// Fell into a unit
 	if (isConscious())
 	{
-		auto presentUnit =
-		    tileObject->map.getTile(newPosition)->getUnitIfPresent(true, true, false, tileObject);
-		if (presentUnit)
+		auto *newTile = map.getTile(newPosition);
+		if (newTile)
 		{
-			updateFallingIntoUnit(state, *presentUnit->getUnit());
+			auto presentUnit = newTile->getUnitIfPresent(true, true, false, tileObject);
+			if (presentUnit)
+			{
+				updateFallingIntoUnit(state, *presentUnit->getUnit());
+			}
 		}
 	}
 
@@ -2890,10 +2919,10 @@ void BattleUnit::updateMovementFalling(GameState &state, unsigned int &moveTicks
 	atGoal = true;
 
 	// Check if reached ground
-	if (collisionIgnoredTicks == 0)
+	if (collisionIgnoredTicks == 0 || landedOnFloor || inGoalColumn)
 	{
 		auto restingPosition = tileObject->getOwningTile()->getRestingPosition(isLarge());
-		if (position.z < restingPosition.z)
+		if (landedOnFloor || position.z < restingPosition.z)
 		{
 			// Stopped falling
 			falling = false;

--- a/game/state/battle/battleunit.h
+++ b/game/state/battle/battleunit.h
@@ -524,6 +524,11 @@ class BattleUnit : public StateObject<BattleUnit>, public std::enable_shared_fro
 	// Launch unit towards target position
 	void launch(GameState &state, Vec3<float> targetPosition,
 	            BodyState bodyState = BodyState::Standing);
+	// Returns whether the unit may step off its ledge into the adjacent tile column "target",
+	// filling "landing" with the resting position it would come down on
+	bool canJumpDown(Vec3<int> target, Vec3<float> &landing);
+	// Step off the ledge towards "landing" at a constant horizontal speed, gravity does the rest
+	void jumpDown(GameState &state, Vec3<float> landing, BodyState bodyState);
 	// Start unit's falling routine
 	void startFalling(GameState &state);
 	// Make unit move

--- a/game/state/battle/battleunitmission.cpp
+++ b/game/state/battle/battleunitmission.cpp
@@ -1577,19 +1577,25 @@ void BattleUnitMission::update(GameState &state, BattleUnit &u, unsigned int tic
 	switch (this->type)
 	{
 		case Type::Jump:
-			if (!jumped && !u.falling && u.atGoal && u.facing == u.goalFacing &&
+			if (!cancelled && !jumped && !u.falling && u.atGoal && u.facing == u.goalFacing &&
 			    u.facing == targetFacing &&
 			    (u.current_body_state == u.target_body_state ||
 			     targetBodyState == BodyState::Jumping) &&
 			    u.target_body_state == targetBodyState)
 			{
-				// Jumping cost assumed same as walking into tile
-				int cost = STANDART_MOVE_TU_COST;
-				if (!spendAgentTUs(state, u, cost, true))
+				if (targetBodyState == BodyState::Jumping)
 				{
-					return;
+					// Jumping cost assumed same as walking into tile
+					if (!spendAgentTUs(state, u, STANDART_MOVE_TU_COST, true))
+					{
+						return;
+					}
+					u.launch(state, jumpTarget, targetBodyState);
 				}
-				u.launch(state, jumpTarget, targetBodyState);
+				else
+				{
+					u.jumpDown(state, jumpTarget, targetBodyState);
+				}
 				jumped = true;
 			}
 			return;
@@ -1975,7 +1981,14 @@ void BattleUnitMission::start(GameState &state, BattleUnit &u)
 			{
 				u.setFacing(state, u.goalFacing);
 			}
-			cancelled = u.isLarge() || !u.canLaunch(jumpTarget);
+			if (targetBodyState == BodyState::Jumping)
+			{
+				cancelled = u.isLarge() || !u.canLaunch(jumpTarget);
+			}
+			else
+			{
+				cancelled = !u.canJumpDown((Vec3<int>)jumpTarget, jumpTarget);
+			}
 			return;
 		case Type::ChangeBodyState:
 		case Type::AcquireTU:

--- a/game/ui/tileview/battleview.cpp
+++ b/game/ui/tileview/battleview.cpp
@@ -2290,7 +2290,17 @@ void BattleView::refreshRangeText()
 
 void BattleView::orderJump(Vec3<int> target, BodyState bodyState)
 {
-	orderJump((Vec3<float>)target + Vec3<float>{0.5f, 0.5f, 0.0f}, bodyState);
+	if (battle.battleViewSelectedUnits.empty())
+	{
+		return;
+	}
+	auto unit = battle.battleViewSelectedUnits.front();
+	Vec3<float> landing;
+	if (!unit->canJumpDown(target, landing))
+	{
+		return;
+	}
+	orderJump(landing, bodyState);
 }
 
 void BattleView::orderJump(Vec3<float> target, BodyState bodyState)
@@ -2300,7 +2310,7 @@ void BattleView::orderJump(Vec3<float> target, BodyState bodyState)
 		return;
 	}
 	auto unit = battle.battleViewSelectedUnits.front();
-	unit->setMission(*state, BattleUnitMission::jump(*unit, target, bodyState));
+	unit->setMission(*state, BattleUnitMission::jump(*unit, target, bodyState, false));
 }
 
 void BattleView::updatePathPreview()


### PR DESCRIPTION
Fixes #1581.
Refs #1057, #1330.

Two commits, reviewable separately: the falling clamp first, the jump rules on top of it.

## Root cause

**Falling.** `BattleUnit::updateMovementFalling` (`battleunit.cpp:2752-2919`) integrates a whole tick batch in one step, never runs a collision check for conscious units, and only lands the unit when the resting surface of the tile it *ends up in* is above it (`:2893-2896`), and only while `collisionIgnoredTicks` is zero. So a drop that in one update exceeds the 0.2 band of the floor it passes goes straight through to the level below. A J jump makes it worse: it sets `collisionIgnoredTicks = 73` for a 72-tick flight (`:3979`) and aims at the target tile's base z (`battleview.cpp:2293`), so the unit is already below the target floor when the first landing test runs. The same block dereferences `getTile(newPosition)` without a null check (`:2824`).

**Jump rules.** The only gate on a manual jump is `canLaunch` (`:3928-3965`): not flying, an adjacent column, and a parabola that exists. Nothing checks that the target is *lower*, that the landing tile is passable or free of units, or that the edge is not a wall or a closed door. On top of that the UI passes `requireFacing = true`, so the unit turns first, and `BattleUnitMission::update` charges 4 TU plus 1 per turn step. A refused jump gets charged too: `start()` sets `cancelled` and `isFinished` and then calls `update()` once more, and the Jump branch never looked at `cancelled`, so it spent the TU and called `launch()`, which silently did nothing. That is the reporter's "TUs are consumed even when no jump happens", and I could not confirm it from reading alone; the harness reproduced it.

## Fix

**Commit 1, `fix(battle): land falling units on the floor they cross`.** A descending unit is clamped to the first standable surface it crosses in its own column, scanning down from its previous z. The clamp and the ordinary owning-tile test are re-enabled inside the collision-ignore window once the unit is over the column it was launched at, so a launch still leaves its own tile unhindered but lands correctly at the far end. `getTile(int,int,int)` returns null for out-of-map x/y, so the scan is safe at the map edge, and the bottom of the range is clamped to level 0 so a z=0 floor is still found. The `getTile` lookup in the "fell into a unit" block is null-checked, the same lookup PR #1664 gated the below-zero kill on.

**Commit 2, `fix(battle): only let agents jump down to a clear adjacent tile`.** A new `canJumpDown` applies the original rules: the target must be an adjacent column; walking down that column from the unit's level, the first standable tile must be strictly below the surface the unit stands on now (so no jumping up a stair step, no jumping across level floor); that landing tile must be passable and free of static units; and the edge to the target column must not be blocked by a wall, a corner wall on a diagonal, or a closed door (via `canEnterTile`, which already encodes all three). `jumpDown` then steps the unit off the ledge at a constant horizontal speed with no vertical throw and lets gravity plus the commit-1 clamp bring it down on whatever floor it reaches, so a drop of any depth works.

The order validates before it creates the mission, asks for no facing change, and costs nothing, and a cancelled mission no longer reaches the code that spends TU. Brainsucker leaps keep `canLaunch`, their own facing and their 4 TU, so AI behaviour is unchanged.

Not adopted, deliberately: fall damage (in the original, not in OpenApoc, existing `FIXME` at `battleunit.cpp:2914`), and the original's "silently try another movement method when the jump is invalid" (a refused jump just does nothing here).

Two open questions for a maintainer, neither blocking: if railings are wall parts with movement cost 255, the edge test refuses jumping over them where the original vaulted, which is a tileset data question I could not settle. And "down a flight of stairs" is implemented as landing on the first lower surface, i.e. the top step; if it should be the bottom of the flight, that needs a definition of "flight" and is a follow-up.

## Verification

Headless harness (`test_jump_rules`, not part of this PR) that boots a base defence battle, switches it to turn based, searches the generated map for the geometry each case needs, and asserts on landing tile, facing and TU. Same harness both ways.

```
                                              9804cfd9              this branch
F0  3.3 tile fall, 4 tick batches (control)   PASS                  PASS
F1  same fall, 16 tick batches                FAIL {50,71,0}        PASS {50,55,1}
F2a jump off a ledge, 4 tick batches          PASS                  PASS
F2b same jump, 16 tick batches                FAIL {2,86,0}         PASS {1,42,1}
J0  own tile / three tiles away refused       FAIL 4 TU charged     PASS TU unchanged
J1  jump up onto a higher surface             FAIL accepted, 4 TU   PASS refused
J2  jump across a blocked edge                FAIL accepted, 4 TU   PASS refused
J3  jump down to a clear ledge                PASS                  PASS
J5  facing unchanged                          PASS                  PASS
J6  no TU for an accepted jump                FAIL 74 -> 70         PASS 72 -> 72
J7  flying unit refused                       FAIL 4 TU charged     PASS TU unchanged
J4  landing tile occupied                     FAIL landed on it     PASS refused
                                              4 pass / 8 fail       12 pass / 0 fail
```

An intermediate run against commit 1 alone gives 6 pass and 6 fail: the four falling cases fixed, every commit-2 case still showing the old behaviour.

F1 and F2b need 16-tick batches because the landing test is sampled once per update; at 4 ticks the per-update drop stays inside the floor's 0.2 band on this map. F2 also needs a ledge above level 0, since `getTile` truncates a z between -1 and 0 back to level 0 and the unit is caught by that floor anyway.

Full ctest green (RelWithDebInfo, Linux); fork CI Lint + CMake green. No save format change: `launched`, `launchGoal`, `collisionIgnoredTicks`, `jumpTarget` and `jumped` are all already serialised.

#755 looks like a duplicate of this and is worth a re-test once this lands.

The harness core is posted as a comment below.
