### PR TITLE
City: land crashing ufos instead of looping when the landing search succeeds (#1666)

### DIFF
--- a/game/state/city/vehiclemission.cpp
+++ b/game/state/city/vehiclemission.cpp
@@ -301,7 +301,7 @@ Vec3<int> FlyingVehicleTileHelper::findTileToLandOn(GameState &, sp<TileObjectVe
 			}
 		}
 	}
-	return startPos;
+	return {-1, -1, -1};
 }
 
 Vec3<float> FlyingVehicleTileHelper::findSidestep(GameState &state, sp<TileObjectVehicle> vTile,
@@ -2045,12 +2045,22 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 			FlyingVehicleTileHelper tileHelper(map, v);
 
 			auto tile = tileHelper.findTileToLandOn(state, vehicleTile);
-			if (tile == vehicleTile->getOwningTile()->position)
+			if (tile == Vec3<int>{-1, -1, -1})
 			{
+				static const unsigned int maxCrashLandAttempts = 10;
+				if (++missionCounter >= maxCrashLandAttempts)
+				{
+					LogWarning("Vehicle mission {0}: Giving up looking for a landing spot after "
+					           "{1} attempts",
+					           getName(), missionCounter);
+					cancelled = true;
+					return;
+				}
+				auto searchOrigin = vehicleTile->getOwningTile()->position;
 				Vec3<int> randomNearbyPos = {
-				    randBoundsInclusive(state.rng, tile.x - 4, tile.x + 4),
-				    randBoundsInclusive(state.rng, tile.y - 4, tile.y + 4),
-				    randBoundsInclusive(state.rng, tile.z - 2, tile.z + 2)};
+				    randBoundsInclusive(state.rng, searchOrigin.x - 4, searchOrigin.x + 4),
+				    randBoundsInclusive(state.rng, searchOrigin.y - 4, searchOrigin.y + 4),
+				    randBoundsInclusive(state.rng, searchOrigin.z - 2, searchOrigin.z + 2)};
 				randomNearbyPos.x = clamp(randomNearbyPos.x, 0, map.size.x - 1);
 				randomNearbyPos.y = clamp(randomNearbyPos.y, 0, map.size.y - 1);
 				randomNearbyPos.z = clamp(randomNearbyPos.z, 0, map.size.z - 1);
@@ -2062,7 +2072,14 @@ void VehicleMission::start(GameState &state, Vehicle &v)
 				return;
 			}
 			this->targetLocation = tile;
-			setPathTo(state, v, tile, getDefaultIterationCount(v));
+			if (tile == vehicleTile->getOwningTile()->position)
+			{
+				currentPlannedPath.clear();
+			}
+			else
+			{
+				setPathTo(state, v, tile, getDefaultIterationCount(v));
+			}
 			return;
 		}
 		case MissionType::FollowVehicle:


### PR DESCRIPTION
`findTileToLandOn` returned the search's own starting tile on failure, which is indistinguishable from a genuine radius-0 success whenever a UFO is above ground it can actually land on. The caller mistook that valid answer for "nothing found" and hopped the UFO to a random nearby tile instead of landing it.

Because `advanceAlongPath` restarts the mission when a path drains to empty, `Crash::start()` re-runs at the exact moment the UFO arrives on its landing tile, where the found tile always equals its own tile. So the collision fires on arrival for every crashing UFO regardless of altitude, and the hop repeats indefinitely.

Before #1654, `addMission` refused a `GotoLocation` for any crashed vehicle, so the bogus hop was dropped and the mission finished correctly on the next check. #1654 relaxed that guard to fix #1653, which exposed this pre-existing defect.

Return an out-of-map sentinel on failure and test for it in the caller. Skip pathfinding when the found tile is the vehicle's own tile, since routing there produced a self-referencing path the mission could never mark finished. The bounded retry into the existing self-destruct handoff stays as a backstop for the case where no landing tile exists at all.

Verified against three source states at two altitudes each: pre-#1654 `727cd974` lands in 240 and 480 ticks, post-#1654 pre-fix `66f5e3a5` never lands at either, and with this change it lands in 240 and 480 ticks again (480 being the 8-tile descent plus one tick). Six terrain configurations at various altitudes all land, a genuine no-landing-spot case gives up and hands off to a self-destruct timer that counts down for real, and `ctest` stays at 11/11.

Fixes #1666
