### PR TITLE
Battlescape: optional gravlift line of fire and sight (#1330)

### DIFF
--- a/framework/options.cpp
+++ b/framework/options.cpp
@@ -346,6 +346,9 @@ ConfigOptionBool optionNoScrollSounds("OpenApoc.NewFeature", "NoScrollSounds",
                                       tr("Disable scrolling sounds"), false);
 ConfigOptionBool optionNoInstantThrows("OpenApoc.NewFeature", "NoInstantThrows",
                                        tr("Throwing requires proper facing and pose"), true);
+ConfigOptionBool optionGravliftLineOfFire("OpenApoc.NewFeature", "GravliftLineOfFire",
+                                          tr("Gravlift floors don't block line of fire/sight"),
+                                          true);
 ConfigOptionBool optionFerryChecksRelationshipWhenBuying(
     "OpenApoc.NewFeature", "FerryChecksRelationshipWhenBuying",
     tr("Transtellar checks relationship when buying items"), true);

--- a/framework/options.h
+++ b/framework/options.h
@@ -80,6 +80,7 @@ extern ConfigOptionBool optionInstantExplosionDamage;
 extern ConfigOptionBool optionGravliftSounds;
 extern ConfigOptionBool optionNoScrollSounds;
 extern ConfigOptionBool optionNoInstantThrows;
+extern ConfigOptionBool optionGravliftLineOfFire;
 extern ConfigOptionBool optionFerryChecksRelationshipWhenBuying;
 extern ConfigOptionBool optionAllowManualCityTeleporters;
 extern ConfigOptionBool optionAllowManualCargoFerry;

--- a/game/state/tilemap/tileobject_battlemappart.cpp
+++ b/game/state/tilemap/tileobject_battlemappart.cpp
@@ -1,4 +1,5 @@
 #include "game/state/tilemap/tileobject_battlemappart.h"
+#include "framework/configfile.h"
 #include "framework/image.h"
 #include "framework/renderer.h"
 #include "game/state/battle/battlemappart.h"
@@ -105,21 +106,30 @@ sp<BattleMapPart> TileObjectBattleMapPart::getOwner() const { return map_part; }
 
 sp<VoxelMap> TileObjectBattleMapPart::getVoxelMap(Vec3<int>, bool los) const
 {
+	auto owner = getOwner();
+	// Deliberate deviation from the original: a unit can already walk through a gravlift
+	// floor pad, so letting it block gunfire and vision as well is a design wart, not
+	// something worth preserving for faithfulness.
+	if (config().getBool("OpenApoc.NewFeature.GravliftLineOfFire") && owner->type->floor &&
+	    owner->type->gravlift)
+	{
+		return nullptr;
+	}
 	if (los)
 	{
-		if (getOwner()->falling)
+		if (owner->falling)
 		{
 			// Falling map parts do not break LOS
 			return nullptr;
 		}
 		else
 		{
-			return getOwner()->type->voxelMapLOS;
+			return owner->type->voxelMapLOS;
 		}
 	}
 	else
 	{
-		return getOwner()->type->voxelMapLOF;
+		return owner->type->voxelMapLOF;
 	}
 }
 

--- a/game/ui/general/moreoptions.cpp
+++ b/game/ui/general/moreoptions.cpp
@@ -58,6 +58,7 @@ static const std::list<std::pair<UString, UString>> battlescapeList = {
     {"OpenApoc.NewFeature", "UFODamageModel"},
     {"OpenApoc.NewFeature", "GravliftSounds"},
     {"OpenApoc.NewFeature", "NoInstantThrows"},
+    {"OpenApoc.NewFeature", "GravliftLineOfFire"},
     {"OpenApoc.NewFeature", "PayloadExplosion"},
     {"OpenApoc.NewFeature", "DisplayUnitPaths"},
     {"OpenApoc.NewFeature", "AllowForceFiringParallel"},

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,8 @@
 PROJECT (OpenApoc_Tests CXX C)
 
 set (TEST_LIST test_rect test_voxel test_tilemap test_rng test_images
-		test_unicode test_colour test_backtrace test_strings)
+		test_unicode test_colour test_backtrace test_strings
+		test_gravlift_lineoffire)
 
 foreach(TEST ${TEST_LIST})
 		add_executable(${TEST} ${TEST}.cpp)
@@ -35,3 +36,20 @@ add_test(NAME ${TEST} COMMAND ${TEST}
 		${CMAKE_SOURCE_DIR}/data/mods/base/data/submods/org.openapoc.base/difficulty0
 		${CMAKE_SOURCE_DIR}/data/mods/base/base_gamestate
 		--Framework.CD=${CD_PATH} --Framework.Data=${CMAKE_SOURCE_DIR}/data)
+
+# test_gravlift_lof and test_gravlift_ai_battle are manual investigation
+# harnesses for issue #1330 (grav-lift line-of-fire/sight). They boot a real
+# battle in one of the base game's grav-lift tilesets to exercise the real
+# voxel/AI code paths, which needs the fully extracted tileset/map/gamestate
+# data CI's minimal cd.iso does not provide. They are deliberately not
+# add_test()-ed; build and run them by hand (see the header comment in each
+# .cpp for arguments).
+set(TEST test_gravlift_lof)
+add_executable(${TEST} ${TEST}.cpp)
+target_link_libraries(${TEST} OpenApoc_Library OpenApoc_Framework OpenApoc_GameState)
+target_compile_definitions(${TEST} PRIVATE -DUNIT_TEST)
+
+set(TEST test_gravlift_ai_battle)
+add_executable(${TEST} ${TEST}.cpp)
+target_link_libraries(${TEST} OpenApoc_Library OpenApoc_Framework OpenApoc_GameState)
+target_compile_definitions(${TEST} PRIVATE -DUNIT_TEST)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,12 +38,11 @@ add_test(NAME ${TEST} COMMAND ${TEST}
 		--Framework.CD=${CD_PATH} --Framework.Data=${CMAKE_SOURCE_DIR}/data)
 
 # test_gravlift_lof and test_gravlift_ai_battle are manual investigation
-# harnesses for issue #1330 (grav-lift line-of-fire/sight). They boot a real
-# battle in one of the base game's grav-lift tilesets to exercise the real
-# voxel/AI code paths, which needs the fully extracted tileset/map/gamestate
-# data CI's minimal cd.iso does not provide. They are deliberately not
-# add_test()-ed; build and run them by hand (see the header comment in each
-# .cpp for arguments).
+# harnesses that boot a real battle in one of the base game's grav-lift tilesets
+# to exercise the real voxel/AI code paths, which needs the fully extracted
+# tileset/map/gamestate data CI's minimal cd.iso does not provide. They are
+# deliberately not add_test()-ed; build and run them by hand (see the header
+# comment in each .cpp for arguments).
 set(TEST test_gravlift_lof)
 add_executable(${TEST} ${TEST}.cpp)
 target_link_libraries(${TEST} OpenApoc_Library OpenApoc_Framework OpenApoc_GameState)

--- a/tests/test_gravlift_ai_battle.cpp
+++ b/tests/test_gravlift_ai_battle.cpp
@@ -1,0 +1,367 @@
+// Manual AI-behaviour verification harness for OpenApoc issue #1330.
+// Not part of the committed fix (needs full extracted tileset/gamestate data
+// CI does not provide); build and run exactly like test_gravlift_lof.cpp.
+//
+// Purpose: the GravliftLineOfFire option lets a unit SEE another unit
+// vertically through a lift shaft that it could not see before. That feeds
+// BattleUnit::calculateVisionToUnit -> Battle::visibleUnits per organisation,
+// which drives AI target selection (AIBlockTactical::think, called every
+// Battle::update from battle.cpp) and reaction fire. The hypothesis under
+// test: an AI unit spots a target only reachable/shootable via a path it
+// cannot use, fixates on it, and stalls or loops instead of making progress
+// (the same class of bug as GameState::canTurbo() spinning forever on an
+// unreachable vehicle attack mission).
+//
+// Method: build a real battle in a tileset with grav-lift floor pads (see
+// CANDIDATE_TILESETS), carve a synthetic 2-column lift shaft out of the
+// tileset's real grav-lift pieces (same construction as
+// test_gravlift_lof.cpp), put the player unit at the bottom of the shaft and
+// a hostile org unit at the top (same column, so the only new sightline is
+// the vertical one through the grav-lift floor pads), then drive
+// Battle::update() in RealTime mode for many ticks. Log target selection,
+// position, mission queue and wall-clock time per batch; run once with the
+// flag ON and once OFF (set via config before Framework construction) and
+// diff.
+//
+// Build:
+//   1. Copy into tests/, add to tests/CMakeLists.txt like test_gravlift_lof.
+//   2. flock -w 3600 /tmp/openapoc-build.lock ninja -C build -j2 test_gravlift_ai_battle
+//   3. ./build/bin/test_gravlift_ai_battle <common> <gamestate> [tileset] \
+//        --OpenApoc.NewFeature.GravliftLineOfFire=true|false \
+//        --Framework.CD=data/cd.iso --Framework.Data=data
+#include "framework/configfile.h"
+#include "framework/framework.h"
+#include "framework/logger.h"
+#include "game/state/battle/battle.h"
+#include "game/state/battle/battlemappart.h"
+#include "game/state/battle/battleunit.h"
+#include "game/state/battle/battleunitmission.h"
+#include "game/state/city/building.h"
+#include "game/state/city/vehicle.h"
+#include "game/state/gamestate.h"
+#include "game/state/rules/agenttype.h"
+#include "game/state/rules/battle/battlemap.h"
+#include "game/state/rules/battle/battlemapparttype.h"
+#include "game/state/shared/agent.h"
+#include "game/state/shared/organisation.h"
+#include "game/state/tilemap/tile.h"
+#include "game/state/tilemap/tilemap.h"
+#include "game/state/tilemap/tileobject.h"
+#include "library/voxel.h"
+#include <chrono>
+#include <cstdio>
+#include <glm/glm.hpp>
+#include <iostream>
+#include <list>
+#include <set>
+#include <vector>
+
+using namespace OpenApoc;
+
+namespace
+{
+const std::set<TileObject::Type> mapPartSet = {TileObject::Type::Ground, TileObject::Type::LeftWall,
+                                               TileObject::Type::RightWall,
+                                               TileObject::Type::Feature};
+
+const std::vector<UString> CANDIDATE_TILESETS = {"02police", "12shops", "06office", "07corphq"};
+
+void clearTile(TileMap &map, Vec3<int> tile)
+{
+	auto t = map.getTile(tile);
+	std::vector<sp<TileObject>> toRemove;
+	for (auto &o : t->intersectingObjects)
+	{
+		if (mapPartSet.count(o->getType()))
+		{
+			toRemove.push_back(o);
+		}
+	}
+	for (auto &o : toRemove)
+	{
+		o->removeFromMap();
+	}
+}
+
+sp<BattleMapPart> addPart(GameState &state, TileMap &map, StateRef<BattleMapPartType> type,
+                          Vec3<int> tile)
+{
+	auto part = mksp<BattleMapPart>();
+	part->owner = state.getAliens();
+	part->type = type;
+	part->position = Vec3<float>(tile) + Vec3<float>{0.5f, 0.5f, 0.0f};
+	map.addObjectToMap(part);
+	return part;
+}
+
+UString missionSummary(sp<BattleUnit> u)
+{
+	if (u->missions.empty())
+	{
+		return "idle";
+	}
+	return u->missions.front()->getName();
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+	config().addPositionalArgument("common", "Common gamestate to load");
+	config().addPositionalArgument("gamestate", "Gamestate to load");
+	config().addPositionalArgument("tileset", "Tileset to test (optional)");
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+	auto common_name = config().getString("common");
+	auto gamestate_name = config().getString("gamestate");
+	auto forcedTileset = config().getString("tileset");
+	if (common_name.empty() || gamestate_name.empty())
+	{
+		std::cerr << "Must provide common and gamestate\n";
+		config().showHelp();
+		return EXIT_FAILURE;
+	}
+
+	Framework fw("OpenApoc", false);
+
+	printf("GravliftLineOfFire option = %s\n",
+	       config().getBool("OpenApoc.NewFeature.GravliftLineOfFire") ? "ON" : "OFF");
+
+	auto state = mksp<GameState>();
+	if (!state->loadGame(common_name) || !state->loadGame(gamestate_name))
+	{
+		LogError("Failed to load gamestate");
+		return EXIT_FAILURE;
+	}
+	state->startGame();
+	state->initState();
+	state->fillPlayerStartingProperty();
+	state->fillOrgStartingProperty();
+
+	std::vector<UString> candidates =
+	    forcedTileset.empty() ? CANDIDATE_TILESETS : std::vector<UString>{forcedTileset};
+
+	StateRef<Building> targetBuilding;
+	UString chosenTileset;
+	for (auto &candidate : candidates)
+	{
+		for (auto &p : state->buildings)
+		{
+			auto &b = p.second;
+			if (b->base || !b->battle_map)
+			{
+				continue;
+			}
+			for (auto &ts : b->battle_map->tilesets)
+			{
+				if (ts == candidate)
+				{
+					targetBuilding = {state.get(), p.first};
+					chosenTileset = ts;
+					break;
+				}
+			}
+			if (targetBuilding)
+				break;
+		}
+		if (targetBuilding)
+			break;
+	}
+	if (!targetBuilding)
+	{
+		LogError("No building found using any candidate tileset");
+		return EXIT_FAILURE;
+	}
+	printf("Using building \"%s\" (tileset \"%s\")\n", targetBuilding->name.c_str(),
+	       chosenTileset.c_str());
+
+	std::list<StateRef<Agent>> playerAgents;
+	for (auto &a : state->agents)
+	{
+		if (a.second->type->role == AgentType::Role::Soldier &&
+		    a.second->owner == state->getPlayer())
+		{
+			playerAgents.emplace_back(state.get(), a.first);
+		}
+	}
+	if (playerAgents.empty())
+	{
+		LogError("No player soldier agents available");
+		return EXIT_FAILURE;
+	}
+	StateRef<Vehicle> playerCraft;
+	for (auto &v : state->vehicles)
+	{
+		if (v.second->owner == state->getPlayer())
+		{
+			playerCraft = {state.get(), v.first};
+			break;
+		}
+	}
+	if (!playerCraft)
+	{
+		LogError("No player vehicle available");
+		return EXIT_FAILURE;
+	}
+
+	StateRef<Organisation> opponent = targetBuilding->owner;
+	Battle::beginBattle(*state, false, opponent, playerAgents, nullptr, nullptr, nullptr,
+	                    playerCraft, targetBuilding);
+	if (!state->current_battle)
+	{
+		LogError("Battle::beginBattle failed to create a battle");
+		return EXIT_FAILURE;
+	}
+	auto battle = state->current_battle;
+	Battle::enterBattle(*state);
+	printf("Battle created, map size = {%d,%d,%d}, mode=%s\n", battle->map->size.x,
+	       battle->map->size.y, battle->map->size.z,
+	       battle->mode == Battle::Mode::TurnBased ? "TurnBased" : "RealTime");
+
+	// Find the tileset's most solid grav-lift floor piece, same "worst case"
+	// selection as test_gravlift_lof.cpp, and build a 2-column shaft with it.
+	UString prefix = "BATTLEMAPPART_" + chosenTileset + "_";
+	UString bestFloorId;
+	int bestBits = -1;
+	for (auto &p : state->battleMapTiles)
+	{
+		if (p.first.rfind(prefix, 0) != 0)
+			continue;
+		auto &t = p.second;
+		if (!t->gravlift || !t->floor)
+			continue;
+		int bits = 0;
+		if (t->voxelMapLOF)
+		{
+			for (int z = 0; z < t->voxelMapLOF->size.z; z++)
+				for (int y = 0; y < t->voxelMapLOF->size.y; y++)
+					for (int x = 0; x < t->voxelMapLOF->size.x; x++)
+						if (t->voxelMapLOF->getBit({x, y, z}))
+							bits++;
+		}
+		if (bits > bestBits)
+		{
+			bestBits = bits;
+			bestFloorId = p.first;
+		}
+	}
+	if (bestFloorId.empty())
+	{
+		printf("Tileset \"%s\" has no grav-lift floor pad (control case) - "
+		       "flag must have no effect here.\n",
+		       chosenTileset.c_str());
+	}
+	else
+	{
+		printf("Using grav-lift floor pad \"%s\" (LOF bits=%d)\n", bestFloorId.c_str(), bestBits);
+	}
+
+	const int LEVELS = std::min(4, battle->map->size.z - 1);
+	const int X1 = 1, X2 = 2, Y = 1;
+	if (!bestFloorId.empty())
+	{
+		for (int z = 0; z < LEVELS; z++)
+		{
+			clearTile(*battle->map, {X1, Y, z});
+			clearTile(*battle->map, {X2, Y, z});
+			for (int x : {X1, X2})
+			{
+				addPart(*state, *battle->map, {state.get(), bestFloorId}, {x, Y, z});
+			}
+		}
+	}
+
+	// Grab one real player unit and one real hostile unit.
+	sp<BattleUnit> playerUnit;
+	for (auto &f : battle->forces[state->getPlayer()].squads)
+	{
+		if (f.getNumUnits() > 0)
+		{
+			playerUnit = f.units.front();
+			break;
+		}
+	}
+	sp<BattleUnit> hostileUnit;
+	for (auto &f : battle->forces[opponent].squads)
+	{
+		for (auto &u : f.units)
+		{
+			if (u)
+			{
+				hostileUnit = u;
+				break;
+			}
+		}
+		if (hostileUnit)
+			break;
+	}
+	if (!playerUnit || !hostileUnit)
+	{
+		LogError("Could not find both a player unit and a hostile unit "
+		         "(player=%d, hostile=%d)",
+		         (int)(bool)playerUnit, (int)(bool)hostileUnit);
+		return EXIT_FAILURE;
+	}
+	printf("Player unit: %s (org=%s)\n", playerUnit->id.c_str(), playerUnit->owner->name.c_str());
+	printf("Hostile unit: %s (org=%s)\n", hostileUnit->id.c_str(),
+	       hostileUnit->owner->name.c_str());
+
+	// Place them on different levels of the same shaft column so the only new
+	// sightline exercised is the vertical one through the grav-lift pad(s).
+	playerUnit->setPosition(*state, {X1 + 0.5f, (float)Y, 0.5f});
+	playerUnit->setBodyState(*state, BodyState::Standing);
+	hostileUnit->setPosition(*state, {X1 + 0.5f, (float)Y, (float)(LEVELS - 1) + 0.5f});
+	hostileUnit->setBodyState(*state, BodyState::Standing);
+
+	printf("hasLineToPosition (hostile -> player) at t=0: %s\n",
+	       hostileUnit->hasLineToPosition(playerUnit->position, false) ? "true" : "false");
+
+	// Drive the simulation. Battle::update() calls aiBlock.think() every tick
+	// in RealTime mode (battle.cpp), which is the code path under test.
+	const unsigned TICKS_PER_BATCH = TICKS_PER_SECOND; // ~1 simulated second
+	const int BATCHES = 240;                           // ~1 simulated minute
+	printf("\n%-6s %-9s %-24s %-24s %-10s %-10s %-10s\n", "batch", "ms/batch", "hostile-pos",
+	       "player-pos", "h-mission", "h-target", "visible");
+	double firstBatchMs = -1.0, lastBatchMs = -1.0;
+	Vec3<float> firstHostilePos = hostileUnit->position;
+	for (int batch = 0; batch < BATCHES; batch++)
+	{
+		auto t0 = std::chrono::steady_clock::now();
+		battle->update(*state, TICKS_PER_BATCH);
+		auto t1 = std::chrono::steady_clock::now();
+		double ms = std::chrono::duration<double, std::milli>(t1 - t0).count();
+		if (firstBatchMs < 0)
+			firstBatchMs = ms;
+		lastBatchMs = ms;
+
+		if (batch % 5 == 0 || batch == BATCHES - 1)
+		{
+			auto hp = hostileUnit->position;
+			auto pp = playerUnit->position;
+			UString targetName = hostileUnit->targetUnit ? hostileUnit->targetUnit.id : "(none)";
+			int visible = 0;
+			auto vit = battle->visibleUnits.find(hostileUnit->owner);
+			if (vit != battle->visibleUnits.end())
+				visible = (int)vit->second.size();
+			printf("%-6d %-9.3f (%5.2f,%5.2f,%5.2f)  (%5.2f,%5.2f,%5.2f)  %-10s %-10s %-10d\n",
+			       batch, ms, hp.x, hp.y, hp.z, pp.x, pp.y, pp.z,
+			       missionSummary(hostileUnit).c_str(), targetName.c_str(), visible);
+		}
+		if (hostileUnit->isDead() || playerUnit->isDead())
+		{
+			printf("Unit died at batch %d - ending early (combat resolved)\n", batch);
+			break;
+		}
+	}
+	printf("\nWall-clock ms: first batch=%.3f last batch=%.3f (ratio=%.2fx)\n", firstBatchMs,
+	       lastBatchMs, firstBatchMs > 0 ? lastBatchMs / firstBatchMs : 0.0);
+	printf("Hostile net displacement: %.3f tiles\n",
+	       glm::length(hostileUnit->position - firstHostilePos));
+	printf("Final: hostile alive=%d player alive=%d hostile mission=%s\n", !hostileUnit->isDead(),
+	       !playerUnit->isDead(), missionSummary(hostileUnit).c_str());
+
+	printf("\ntest_gravlift_ai_battle done\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_gravlift_ai_battle.cpp
+++ b/tests/test_gravlift_ai_battle.cpp
@@ -26,9 +26,19 @@
 // Build:
 //   1. Copy into tests/, add to tests/CMakeLists.txt like test_gravlift_lof.
 //   2. flock -w 3600 /tmp/openapoc-build.lock ninja -C build -j2 test_gravlift_ai_battle
-//   3. ./build/bin/test_gravlift_ai_battle <common> <gamestate> [tileset] \
+//   3. ./build/bin/test_gravlift_ai_battle <common> <gamestate> [tileset] [seed] \
 //        --OpenApoc.NewFeature.GravliftLineOfFire=true|false \
 //        --Framework.CD=data/cd.iso --Framework.Data=data
+//
+// [seed] is an optional fixed RNG seed (default 424242) used to make battle
+// map generation reproducible: OpenApoc.NewFeature.SeedRng defaults to true
+// and reseeds GameState::rng from wall-clock time in GameState::startGame(),
+// and BattleMap::generateMap consumes that same rng to decide vertical
+// stacking, sector packing order and sector choice, so without a fixed seed
+// two runs (e.g. flag=false vs flag=true) can silently generate different
+// map geometry and any AI-behaviour comparison between them is not
+// controlled. This harness forces OpenApoc.NewFeature.SeedRng off and pins
+// the seed explicitly so both arms of a comparison run see the same map.
 #include "framework/configfile.h"
 #include "framework/framework.h"
 #include "framework/logger.h"
@@ -49,11 +59,13 @@
 #include "game/state/tilemap/tileobject.h"
 #include "library/voxel.h"
 #include <chrono>
+#include <cstdint>
 #include <cstdio>
 #include <glm/glm.hpp>
 #include <iostream>
 #include <list>
 #include <set>
+#include <string>
 #include <vector>
 
 using namespace OpenApoc;
@@ -110,6 +122,8 @@ int main(int argc, char **argv)
 	config().addPositionalArgument("common", "Common gamestate to load");
 	config().addPositionalArgument("gamestate", "Gamestate to load");
 	config().addPositionalArgument("tileset", "Tileset to test (optional)");
+	config().addPositionalArgument("seed", "Fixed RNG seed for deterministic map generation "
+	                                       "(optional, default 424242)");
 	if (config().parseOptions(argc, argv))
 	{
 		return EXIT_FAILURE;
@@ -117,12 +131,14 @@ int main(int argc, char **argv)
 	auto common_name = config().getString("common");
 	auto gamestate_name = config().getString("gamestate");
 	auto forcedTileset = config().getString("tileset");
+	auto seedArg = config().getString("seed");
 	if (common_name.empty() || gamestate_name.empty())
 	{
 		std::cerr << "Must provide common and gamestate\n";
 		config().showHelp();
 		return EXIT_FAILURE;
 	}
+	const uint64_t rngSeed = seedArg.empty() ? 424242ULL : std::stoull(seedArg);
 
 	Framework fw("OpenApoc", false);
 
@@ -135,6 +151,20 @@ int main(int argc, char **argv)
 		LogError("Failed to load gamestate");
 		return EXIT_FAILURE;
 	}
+
+	// GameState::rng is not part of the save and OpenApoc.NewFeature.SeedRng
+	// defaults to true, which reseeds it from wall-clock time in startGame()
+	// below. That makes battle map generation (BattleMap::generateMap picks
+	// vertical stacking, sector packing order and sector choice off state.rng)
+	// nondeterministic between runs, so comparing flag=false against flag=true
+	// output was actually comparing two different maps. Force the time-based
+	// reseed off and pin the RNG to a fixed, caller-controlled seed instead so
+	// both arms of the comparison see identical map geometry.
+	config().set("OpenApoc.NewFeature.SeedRng", false);
+	state->rng.seed(rngSeed);
+	printf("RNG seed = %llu (OpenApoc.NewFeature.SeedRng forced off)\n",
+	       (unsigned long long)rngSeed);
+
 	state->startGame();
 	state->initState();
 	state->fillPlayerStartingProperty();

--- a/tests/test_gravlift_ai_battle.cpp
+++ b/tests/test_gravlift_ai_battle.cpp
@@ -1,27 +1,6 @@
-// Manual AI-behaviour verification harness for OpenApoc issue #1330.
-// Not part of the committed fix (needs full extracted tileset/gamestate data
-// CI does not provide); build and run exactly like test_gravlift_lof.cpp.
-//
-// Purpose: the GravliftLineOfFire option lets a unit SEE another unit
-// vertically through a lift shaft that it could not see before. That feeds
-// BattleUnit::calculateVisionToUnit -> Battle::visibleUnits per organisation,
-// which drives AI target selection (AIBlockTactical::think, called every
-// Battle::update from battle.cpp) and reaction fire. The hypothesis under
-// test: an AI unit spots a target only reachable/shootable via a path it
-// cannot use, fixates on it, and stalls or loops instead of making progress
-// (the same class of bug as GameState::canTurbo() spinning forever on an
-// unreachable vehicle attack mission).
-//
-// Method: build a real battle in a tileset with grav-lift floor pads (see
-// CANDIDATE_TILESETS), carve a synthetic 2-column lift shaft out of the
-// tileset's real grav-lift pieces (same construction as
-// test_gravlift_lof.cpp), put the player unit at the bottom of the shaft and
-// a hostile org unit at the top (same column, so the only new sightline is
-// the vertical one through the grav-lift floor pads), then drive
-// Battle::update() in RealTime mode for many ticks. Log target selection,
-// position, mission queue and wall-clock time per batch; run once with the
-// flag ON and once OFF (set via config before Framework construction) and
-// diff.
+// Manual AI-behaviour verification harness. Not part of the committed fix
+// (needs full extracted tileset/gamestate data CI does not provide); build
+// and run exactly like test_gravlift_lof.cpp.
 //
 // Build:
 //   1. Copy into tests/, add to tests/CMakeLists.txt like test_gravlift_lof.
@@ -29,16 +8,6 @@
 //   3. ./build/bin/test_gravlift_ai_battle <common> <gamestate> [tileset] [seed] \
 //        --OpenApoc.NewFeature.GravliftLineOfFire=true|false \
 //        --Framework.CD=data/cd.iso --Framework.Data=data
-//
-// [seed] is an optional fixed RNG seed (default 424242) used to make battle
-// map generation reproducible: OpenApoc.NewFeature.SeedRng defaults to true
-// and reseeds GameState::rng from wall-clock time in GameState::startGame(),
-// and BattleMap::generateMap consumes that same rng to decide vertical
-// stacking, sector packing order and sector choice, so without a fixed seed
-// two runs (e.g. flag=false vs flag=true) can silently generate different
-// map geometry and any AI-behaviour comparison between them is not
-// controlled. This harness forces OpenApoc.NewFeature.SeedRng off and pins
-// the seed explicitly so both arms of a comparison run see the same map.
 #include "framework/configfile.h"
 #include "framework/framework.h"
 #include "framework/logger.h"

--- a/tests/test_gravlift_lineoffire.cpp
+++ b/tests/test_gravlift_lineoffire.cpp
@@ -1,7 +1,7 @@
 // Verifies the GravliftLineOfFire option gate on
 // TileObjectBattleMapPart::getVoxelMap. Uses synthetic map part types (no
 // extracted tileset/gamestate data required), so this runs under normal CI
-// unlike the manual full-battle harnesses for issue #1330.
+// unlike the manual full-battle harnesses.
 #include "framework/configfile.h"
 #include "framework/logger.h"
 #include "game/state/battle/battlemappart.h"

--- a/tests/test_gravlift_lineoffire.cpp
+++ b/tests/test_gravlift_lineoffire.cpp
@@ -1,0 +1,124 @@
+// Verifies the GravliftLineOfFire option gate on
+// TileObjectBattleMapPart::getVoxelMap. Uses synthetic map part types (no
+// extracted tileset/gamestate data required), so this runs under normal CI
+// unlike the manual full-battle harnesses for issue #1330.
+#include "framework/configfile.h"
+#include "framework/logger.h"
+#include "game/state/battle/battlemappart.h"
+#include "game/state/gamestate.h"
+#include "game/state/rules/battle/battlemapparttype.h"
+#include "game/state/tilemap/tilemap.h"
+#include "game/state/tilemap/tileobject_battlemappart.h"
+#include "library/voxel.h"
+
+using namespace OpenApoc;
+
+namespace
+{
+
+sp<VoxelMap> makeSolidVoxelMap()
+{
+	auto slice = mksp<VoxelSlice>(Vec2<int>{4, 4});
+	for (int y = 0; y < 4; y++)
+		for (int x = 0; x < 4; x++)
+			slice->setBit({x, y}, true);
+	auto map = mksp<VoxelMap>(Vec3<int>{4, 4, 4});
+	for (int z = 0; z < 4; z++)
+		map->setSlice(z, slice);
+	return map;
+}
+
+StateRef<BattleMapPartType> registerType(GameState &state, const UString &id, bool floor,
+                                         bool gravlift, sp<VoxelMap> voxelMap)
+{
+	auto type = mksp<BattleMapPartType>();
+	type->type = BattleMapPartType::Type::Ground;
+	type->floor = floor;
+	type->gravlift = gravlift;
+	type->voxelMapLOF = voxelMap;
+	type->voxelMapLOS = voxelMap;
+	state.battleMapTiles[id] = type;
+	return {&state, id};
+}
+
+sp<TileObjectBattleMapPart> spawnPart(TileMap &map, StateRef<BattleMapPartType> type,
+                                      Vec3<float> position)
+{
+	auto part = mksp<BattleMapPart>();
+	part->type = type;
+	part->position = position;
+	map.addObjectToMap(part);
+	return part->tileObject;
+}
+
+void expect(bool condition, const UString &message)
+{
+	if (!condition)
+	{
+		LogError("FAILED: {0}", message);
+		exit(EXIT_FAILURE);
+	}
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+
+	auto state = mksp<GameState>();
+	TileMap map{{4, 4, 4}, {1, 1, 1}, {4, 4, 4}, {{TileObject::Type::Ground}}};
+	auto voxelMap = makeSolidVoxelMap();
+
+	auto gravliftFloorType =
+	    registerType(*state, "BATTLEMAPPART_TEST_GRAVLIFT_FLOOR", true, true, voxelMap);
+	auto plainFloorType =
+	    registerType(*state, "BATTLEMAPPART_TEST_PLAIN_FLOOR", true, false, voxelMap);
+	auto gravliftWallType =
+	    registerType(*state, "BATTLEMAPPART_TEST_GRAVLIFT_WALL", false, true, voxelMap);
+
+	auto gravliftFloor = spawnPart(map, gravliftFloorType, {0.5f, 0.5f, 0.5f});
+	auto plainFloor = spawnPart(map, plainFloorType, {1.5f, 0.5f, 0.5f});
+	auto gravliftWall = spawnPart(map, gravliftWallType, {2.5f, 0.5f, 0.5f});
+
+	// Flag OFF must be byte-identical to master: every piece blocks LOS/LOF
+	// regardless of floor/gravlift combination.
+	config().set("OpenApoc.NewFeature.GravliftLineOfFire", false);
+	expect(gravliftFloor->getVoxelMap({}, true) == voxelMap,
+	       "flag off: gravlift floor pad must still block LOS");
+	expect(gravliftFloor->getVoxelMap({}, false) == voxelMap,
+	       "flag off: gravlift floor pad must still block LOF");
+	expect(plainFloor->getVoxelMap({}, true) == voxelMap, "flag off: plain floor must block LOS");
+	expect(gravliftWall->getVoxelMap({}, false) == voxelMap,
+	       "flag off: gravlift wall (non-floor) must block LOF");
+
+	// Flag ON exempts only pieces that are BOTH a floor AND a gravlift.
+	config().set("OpenApoc.NewFeature.GravliftLineOfFire", true);
+	expect(gravliftFloor->getVoxelMap({}, true) == nullptr,
+	       "flag on: gravlift floor pad must not block LOS");
+	expect(gravliftFloor->getVoxelMap({}, false) == nullptr,
+	       "flag on: gravlift floor pad must not block LOF");
+	expect(plainFloor->getVoxelMap({}, true) == voxelMap,
+	       "flag on: non-gravlift floor must still block LOS");
+	expect(plainFloor->getVoxelMap({}, false) == voxelMap,
+	       "flag on: non-gravlift floor must still block LOF");
+	expect(gravliftWall->getVoxelMap({}, true) == voxelMap,
+	       "flag on: gravlift wall (not a floor) must still block LOS");
+	expect(gravliftWall->getVoxelMap({}, false) == voxelMap,
+	       "flag on: gravlift wall (not a floor) must still block LOF");
+
+	// The pre-existing "falling map parts don't break LOS" exemption must
+	// still work independently of this flag.
+	config().set("OpenApoc.NewFeature.GravliftLineOfFire", false);
+	plainFloor->getOwner()->falling = true;
+	expect(plainFloor->getVoxelMap({}, true) == nullptr,
+	       "falling map part must not block LOS regardless of the flag");
+	expect(plainFloor->getVoxelMap({}, false) == voxelMap,
+	       "falling map part must still block LOF (falling only exempts LOS)");
+
+	printf("test_gravlift_lineoffire: all checks passed\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_gravlift_lof.cpp
+++ b/tests/test_gravlift_lof.cpp
@@ -1,0 +1,526 @@
+// Verification harness for OpenApoc issue #1330, sub-problems A and B
+// (line of fire through grav-lift geometry). NOT part of the committed fix:
+// it needs the full extracted tileset/map/gamestate data that CI's minimal
+// cd.iso does not provide, so it is kept out of tests/CMakeLists.txt and run
+// manually from the scratchpad instead.
+//
+// Boots a real battle (common + gamestate, exactly like the other tests in
+// tests/) in a building that actually uses a grav-lift tileset, so every
+// StateRef in the chain (damage types, damage modifiers, agent body types) is
+// resolved through the normal game data pipeline rather than being faked. A
+// real player BattleUnit (real agent, real body type, real getMuzzleLocation)
+// is then moved through a small controlled lift shaft built from the
+// tileset's REAL decoded grav-lift map part types, and
+// BattleUnit::hasLineToPosition is called directly, exactly as the game
+// calls it when resolving a shot.
+//
+// Build (from an OpenApoc worktree with the fix applied or reverted):
+//   1. Temporarily add to tests/CMakeLists.txt:
+//        set(TEST test_gravlift_lof)
+//        add_executable(${TEST} ${TEST}.cpp)
+//        target_link_libraries(${TEST} OpenApoc_Library OpenApoc_Framework OpenApoc_GameState)
+//        target_compile_definitions(${TEST} PRIVATE -DUNIT_TEST)
+//      (copy this file into tests/ first)
+//   2. cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DENABLE_CCACHE=ON
+//   3. flock -w 3600 /tmp/openapoc-build.lock ninja -C build -j2 test_gravlift_lof
+//   4. ./build/bin/test_gravlift_lof <common> <gamestate> [tileset] \
+//        --Framework.CD=data/cd.iso --Framework.Data=data
+//      e.g. common    = data/mods/base/data/submods/org.openapoc.base/difficulty0
+//           gamestate = data/mods/base/base_gamestate
+//           tileset   = 02police | 07corphq | 12shops | 06office (optional;
+//                       defaults to trying them in that order)
+//   Needs data/{tilesets,maps,imagepacks,animationpacks,bulletsprites,cd.iso}
+//   and data/mods/base/{base_gamestate,modinfo.xml,data/submods/.../difficulty*}
+//   populated -- these are gitignored generated artifacts; reference them
+//   read-only from a checkout that already has them extracted (symlink for
+//   tilesets/maps/cd.iso; PhysFS refuses to traverse symlinked directories,
+//   so imagepacks/animationpacks must be real copies, not symlinks).
+#include "framework/configfile.h"
+#include "framework/framework.h"
+#include "framework/logger.h"
+#include "game/state/battle/battle.h"
+#include "game/state/battle/battlemappart.h"
+#include "game/state/battle/battleunit.h"
+#include "game/state/city/building.h"
+#include "game/state/city/vehicle.h"
+#include "game/state/gamestate.h"
+#include "game/state/rules/agenttype.h"
+#include "game/state/rules/battle/battlemap.h"
+#include "game/state/rules/battle/battlemapparttype.h"
+#include "game/state/shared/agent.h"
+#include "game/state/shared/organisation.h"
+#include "game/state/tilemap/collision.h"
+#include "game/state/tilemap/tile.h"
+#include "game/state/tilemap/tilemap.h"
+#include "game/state/tilemap/tileobject.h"
+#include "game/state/tilemap/tileobject_battlemappart.h"
+#include "game/state/tilemap/tileobject_battleunit.h"
+#include "library/voxel.h"
+#include <algorithm>
+#include <cstdio>
+#include <iostream>
+#include <list>
+#include <set>
+#include <vector>
+
+using namespace OpenApoc;
+
+namespace
+{
+const std::set<TileObject::Type> mapPartSet = {TileObject::Type::Ground, TileObject::Type::LeftWall,
+                                               TileObject::Type::RightWall,
+                                               TileObject::Type::Feature};
+
+const std::vector<UString> CANDIDATE_TILESETS = {"02police", "07corphq", "12shops", "06office"};
+
+struct VoxelStats
+{
+	int totalBits = 0;
+	int slicesWithBits = 0;
+	int totalSlices = 0;
+	int minX = -1, maxX = -1, minY = -1, maxY = -1, minZ = -1, maxZ = -1;
+};
+
+VoxelStats analyseVoxelMap(const sp<VoxelMap> &map)
+{
+	VoxelStats stats;
+	if (!map)
+	{
+		return stats;
+	}
+	stats.totalSlices = map->size.z;
+	for (int z = 0; z < map->size.z; z++)
+	{
+		int bitsInSlice = 0;
+		for (int y = 0; y < map->size.y; y++)
+		{
+			for (int x = 0; x < map->size.x; x++)
+			{
+				if (map->getBit({x, y, z}))
+				{
+					bitsInSlice++;
+					if (stats.minX == -1 || x < stats.minX)
+						stats.minX = x;
+					if (x > stats.maxX)
+						stats.maxX = x;
+					if (stats.minY == -1 || y < stats.minY)
+						stats.minY = y;
+					if (y > stats.maxY)
+						stats.maxY = y;
+					if (stats.minZ == -1 || z < stats.minZ)
+						stats.minZ = z;
+					if (z > stats.maxZ)
+						stats.maxZ = z;
+				}
+			}
+		}
+		if (bitsInSlice > 0)
+		{
+			stats.slicesWithBits++;
+		}
+		stats.totalBits += bitsInSlice;
+	}
+	return stats;
+}
+
+void printPieceStats(const UString &id, const sp<BattleMapPartType> &type)
+{
+	auto lof = analyseVoxelMap(type->voxelMapLOF);
+	printf("  %-28s type=%-10s floor=%d gravlift=%d height=%-4d LOF bits=%-4d slices=%d/%d",
+	       id.c_str(),
+	       type->type == BattleMapPartType::Type::Ground     ? "Ground"
+	       : type->type == BattleMapPartType::Type::Feature  ? "Feature"
+	       : type->type == BattleMapPartType::Type::LeftWall ? "LeftWall"
+	                                                         : "RightWall",
+	       (int)type->floor, (int)type->gravlift, type->height, lof.totalBits, lof.slicesWithBits,
+	       lof.totalSlices);
+	if (lof.totalBits > 0)
+	{
+		printf("  bbox x[%d-%d] y[%d-%d] z[%d-%d]", lof.minX, lof.maxX, lof.minY, lof.maxY,
+		       lof.minZ, lof.maxZ);
+	}
+	printf("\n");
+}
+
+// Clears any existing real map content at a tile/z so our synthetic shaft is
+// not confounded by whatever the procedurally-picked building happened to put
+// there.
+void clearTile(TileMap &map, Vec3<int> tile)
+{
+	auto t = map.getTile(tile);
+	std::vector<sp<TileObject>> toRemove;
+	for (auto &o : t->intersectingObjects)
+	{
+		if (mapPartSet.count(o->getType()))
+		{
+			toRemove.push_back(o);
+		}
+	}
+	for (auto &o : toRemove)
+	{
+		o->removeFromMap();
+	}
+}
+
+sp<BattleMapPart> addPart(GameState &state, TileMap &map, StateRef<BattleMapPartType> type,
+                          Vec3<int> tile)
+{
+	auto part = mksp<BattleMapPart>();
+	part->owner = state.getAliens();
+	part->type = type;
+	part->position = Vec3<float>(tile) + Vec3<float>{0.5f, 0.5f, 0.0f};
+	map.addObjectToMap(part);
+	return part;
+}
+
+const char *blockingPieceLabel(const Collision &c)
+{
+	if (!c)
+	{
+		return "NONE (clear)";
+	}
+	auto mp = std::static_pointer_cast<TileObjectBattleMapPart>(c.obj)->getOwner();
+	if (mp->type->floor)
+	{
+		return "floor";
+	}
+	switch (mp->type->type)
+	{
+		case BattleMapPartType::Type::Feature:
+			return "feature/frame";
+		case BattleMapPartType::Type::LeftWall:
+			return "leftwall";
+		case BattleMapPartType::Type::RightWall:
+			return "rightwall";
+		case BattleMapPartType::Type::Ground:
+			return "ground(non-floor)";
+		default:
+			return "other";
+	}
+}
+
+} // namespace
+
+int main(int argc, char **argv)
+{
+	config().addPositionalArgument("common", "Common gamestate to load");
+	config().addPositionalArgument("gamestate", "Gamestate to load");
+	config().addPositionalArgument("tileset", "Tileset to test (optional)");
+	if (config().parseOptions(argc, argv))
+	{
+		return EXIT_FAILURE;
+	}
+	auto common_name = config().getString("common");
+	auto gamestate_name = config().getString("gamestate");
+	auto forcedTileset = config().getString("tileset");
+	if (common_name.empty() || gamestate_name.empty())
+	{
+		std::cerr << "Must provide common and gamestate\n";
+		config().showHelp();
+		return EXIT_FAILURE;
+	}
+
+	Framework fw("OpenApoc", false);
+
+	auto state = mksp<GameState>();
+	LogInfo("Loading common gamestate \"{0}\"", common_name);
+	if (!state->loadGame(common_name))
+	{
+		LogError("Failed to load common gamestate");
+		return EXIT_FAILURE;
+	}
+	LogInfo("Loading gamestate \"{0}\"", gamestate_name);
+	if (!state->loadGame(gamestate_name))
+	{
+		LogError("Failed to load supplied gamestate");
+		return EXIT_FAILURE;
+	}
+
+	state->startGame();
+	state->initState();
+	state->fillPlayerStartingProperty();
+	state->fillOrgStartingProperty();
+
+	std::vector<UString> candidates =
+	    forcedTileset.empty() ? CANDIDATE_TILESETS : std::vector<UString>{forcedTileset};
+
+	// Find a non-base building that uses one of the candidate grav-lift tilesets.
+	StateRef<Building> targetBuilding;
+	UString chosenTileset;
+	for (auto &candidate : candidates)
+	{
+		for (auto &p : state->buildings)
+		{
+			auto &b = p.second;
+			if (b->base || !b->battle_map)
+			{
+				continue;
+			}
+			for (auto &ts : b->battle_map->tilesets)
+			{
+				if (ts == candidate)
+				{
+					targetBuilding = {state.get(), p.first};
+					chosenTileset = ts;
+					break;
+				}
+			}
+			if (targetBuilding)
+			{
+				break;
+			}
+		}
+		if (targetBuilding)
+		{
+			break;
+		}
+	}
+	if (!targetBuilding)
+	{
+		LogError("No building found using any candidate grav-lift tileset");
+		return EXIT_FAILURE;
+	}
+	printf("Using building \"%s\" (tileset \"%s\")\n", targetBuilding->name.c_str(),
+	       chosenTileset.c_str());
+
+	// Gather a player soldier and a player vehicle to run the battle
+	std::list<StateRef<Agent>> playerAgents;
+	for (auto &a : state->agents)
+	{
+		if (a.second->type->role == AgentType::Role::Soldier &&
+		    a.second->owner == state->getPlayer())
+		{
+			playerAgents.emplace_back(state.get(), a.first);
+		}
+	}
+	if (playerAgents.empty())
+	{
+		LogError("No player soldier agents available");
+		return EXIT_FAILURE;
+	}
+	StateRef<Vehicle> playerCraft;
+	for (auto &v : state->vehicles)
+	{
+		if (v.second->owner == state->getPlayer())
+		{
+			playerCraft = {state.get(), v.first};
+			break;
+		}
+	}
+	if (!playerCraft)
+	{
+		LogError("No player vehicle available");
+		return EXIT_FAILURE;
+	}
+
+	StateRef<Organisation> opponent = targetBuilding->owner;
+	Battle::beginBattle(*state, false, opponent, playerAgents, nullptr, nullptr, nullptr,
+	                    playerCraft, targetBuilding);
+	if (!state->current_battle)
+	{
+		LogError("Battle::beginBattle failed to create a battle");
+		return EXIT_FAILURE;
+	}
+	auto battle = state->current_battle;
+	printf("Battle created, map size = {%d,%d,%d}\n", battle->map->size.x, battle->map->size.y,
+	       battle->map->size.z);
+
+	// Spawns real units (including our player soldier) and, crucially, re-runs
+	// Battle::loadResources() afterwards so the now-existing units' image and
+	// animation packs actually get loaded (the earlier loadResources() call
+	// inside createBattle only knows about org guard-type pools, not
+	// yet-to-be-spawned player agents). Without this, setBodyState() below
+	// segfaults on a null animation pack.
+	Battle::enterBattle(*state);
+
+	// Dump EVERY gravlift-flagged map part type in this tileset, not just one
+	// per category: an earlier version of this harness picked the
+	// alphabetically-first id per category via state->battleMapTiles (a
+	// std::map<UString,...>), which for several tilesets happens to be an
+	// empty placeholder variant while OTHER ids in the same category carry
+	// real sliver geometry. Print all of them so nothing is hidden, and for
+	// building the test shaft pick, per category, the id with the largest
+	// LOF bit count (the "worst case" / most solid variant actually used by
+	// the real map).
+	UString prefix = "BATTLEMAPPART_" + chosenTileset + "_";
+	struct Best
+	{
+		UString id;
+		int bits = -1;
+	};
+	Best bestFloor, bestFeature, bestLeftWall, bestRightWall;
+	printf("\nAll grav-lift map part types in tileset \"%s\":\n", chosenTileset.c_str());
+	for (auto &p : state->battleMapTiles)
+	{
+		if (p.first.rfind(prefix, 0) != 0)
+		{
+			continue;
+		}
+		auto &t = p.second;
+		if (!t->gravlift)
+		{
+			continue;
+		}
+		printPieceStats(p.first, t);
+		auto lof = analyseVoxelMap(t->voxelMapLOF);
+		Best *slot = t->floor                                        ? &bestFloor
+		             : t->type == BattleMapPartType::Type::Feature   ? &bestFeature
+		             : t->type == BattleMapPartType::Type::LeftWall  ? &bestLeftWall
+		             : t->type == BattleMapPartType::Type::RightWall ? &bestRightWall
+		                                                             : nullptr;
+		if (slot && lof.totalBits > slot->bits)
+		{
+			slot->id = p.first;
+			slot->bits = lof.totalBits;
+		}
+	}
+	printf("\nRepresentative (largest-LOF-footprint) id chosen per category:\n");
+	printf("  floor     -> %s (bits=%d)\n", bestFloor.id.empty() ? "NONE" : bestFloor.id.c_str(),
+	       bestFloor.bits);
+	printf("  feature   -> %s (bits=%d)\n",
+	       bestFeature.id.empty() ? "NONE" : bestFeature.id.c_str(), bestFeature.bits);
+	printf("  leftwall  -> %s (bits=%d)\n",
+	       bestLeftWall.id.empty() ? "NONE" : bestLeftWall.id.c_str(), bestLeftWall.bits);
+	printf("  rightwall -> %s (bits=%d)\n",
+	       bestRightWall.id.empty() ? "NONE" : bestRightWall.id.c_str(), bestRightWall.bits);
+
+	if (bestFloor.id.empty() && bestFeature.id.empty())
+	{
+		LogError("Tileset \"{0}\" resolved no usable grav-lift pieces", chosenTileset);
+		return EXIT_FAILURE;
+	}
+
+	// Build a controlled 2-column, multi-level lift shaft out of the real
+	// grav-lift pieces (the most solid variant per category), at a spot in
+	// the real battle map cleared of whatever the procedurally-picked
+	// building layout put there.
+	const int LEVELS = std::min(4, battle->map->size.z - 1);
+	const int X1 = 1, X2 = 2, Y = 1;
+	for (int z = 0; z < LEVELS; z++)
+	{
+		clearTile(*battle->map, {X1, Y, z});
+		clearTile(*battle->map, {X2, Y, z});
+		for (int x : {X1, X2})
+		{
+			if (!bestFloor.id.empty())
+				addPart(*state, *battle->map, {state.get(), bestFloor.id}, {x, Y, z});
+			if (!bestFeature.id.empty())
+				addPart(*state, *battle->map, {state.get(), bestFeature.id}, {x, Y, z});
+			if (!bestLeftWall.id.empty())
+				addPart(*state, *battle->map, {state.get(), bestLeftWall.id}, {x, Y, z});
+			if (!bestRightWall.id.empty())
+				addPart(*state, *battle->map, {state.get(), bestRightWall.id}, {x, Y, z});
+		}
+	}
+	auto liftTile = battle->map->getTile(Vec3<int>{X1, Y, 0});
+	printf("\nTile::hasLift at synthetic lift column (%d,%d,0) = %d\n", X1, Y,
+	       (int)liftTile->hasLift);
+
+	// A single real, fully-spawned player unit does all the shooting (same
+	// lookup Battle::enterBattle itself uses to find the first player unit).
+	sp<BattleUnit> unit;
+	for (auto &f : battle->forces[state->getPlayer()].squads)
+	{
+		if (f.getNumUnits() > 0)
+		{
+			unit = f.units.front();
+			break;
+		}
+	}
+	if (!unit)
+	{
+		LogError("No spawned player unit found after Battle::enterBattle");
+		return EXIT_FAILURE;
+	}
+
+	// Record the real per-stance muzzle height (as a fraction of tile height)
+	// so the blocking bands reported below can be related back to it.
+	for (auto stance : {BodyState::Kneeling, BodyState::Standing})
+	{
+		unit->setPosition(*state, {X1 + 0.5f, (float)Y, 0.0f});
+		unit->setBodyState(*state, stance);
+		auto muzzle = unit->getMuzzleLocation();
+		printf("Real muzzle height (%s): z-offset = %.3f (voxel z = %.1f of 20)\n",
+		       stance == BodyState::Kneeling ? "kneeling" : "standing", muzzle.z, muzzle.z * 20.0f);
+	}
+
+	printf("\n=== Sub-problem A: horizontal shot between adjacent lift tiles (x=%d -> x=%d, "
+	       "same level) ===\n",
+	       X1, X2);
+	printf("%-10s %-8s %-8s %-14s\n", "stance", "level", "y-offset", "blocked-by");
+	for (int z = 0; z < LEVELS; z++)
+	{
+		for (auto stance : {BodyState::Kneeling, BodyState::Standing})
+		{
+			const char *stanceName = (stance == BodyState::Kneeling) ? "kneeling" : "standing";
+			for (float yOff : {0.0f, 0.25f, 0.5f})
+			{
+				Vec3<float> pos{X1 + 0.5f, Y + yOff, (float)z};
+				unit->setPosition(*state, pos);
+				unit->setBodyState(*state, stance);
+				auto muzzle = unit->getMuzzleLocation();
+				Vec3<float> target{X2 + 0.5f, Y + yOff, muzzle.z};
+				bool clear = unit->hasLineToPosition(target, false);
+				auto c =
+				    battle->map->findCollision(muzzle, target, mapPartSet, unit->tileObject, false);
+				printf("%-10s %-8d %-8.2f %-14s (hasLineToPosition=%s)\n", stanceName, z, yOff,
+				       blockingPieceLabel(c), clear ? "true" : "false");
+			}
+		}
+	}
+
+	printf("\n=== Sub-problem B: vertical shot down through the shaft (top level -> bottom) "
+	       "===\n");
+	printf("%-10s %-14s %-14s\n", "stance", "from-level", "blocked-by");
+	for (auto stance : {BodyState::Kneeling, BodyState::Standing})
+	{
+		const char *stanceName = (stance == BodyState::Kneeling) ? "kneeling" : "standing";
+		for (int fromLevel = LEVELS - 1; fromLevel >= 1; fromLevel--)
+		{
+			Vec3<float> pos{X1 + 0.5f, (float)Y, (float)fromLevel};
+			unit->setPosition(*state, pos);
+			unit->setBodyState(*state, stance);
+			auto muzzle = unit->getMuzzleLocation();
+			Vec3<float> target{X1 + 0.5f, (float)Y, 0.5f};
+			bool clear = unit->hasLineToPosition(target, false);
+			auto c =
+			    battle->map->findCollision(muzzle, target, mapPartSet, unit->tileObject, false);
+			printf("%-10s %-14d %-14s (hasLineToPosition=%s)\n", stanceName, fromLevel,
+			       blockingPieceLabel(c), clear ? "true" : "false");
+		}
+	}
+
+	// Fine-grained geometry probe: real body stances only tell us whether THAT
+	// specific muzzle height happens to clip something. Sweep raw z-offsets
+	// across the lower part of the tile (where all the non-empty grav-lift
+	// voxel data we decoded above actually sits) so a narrow blocking band
+	// cannot hide between the two stance samples.
+	printf("\n=== Sub-problem A geometry probe: raw z-offset sweep at level 0, x=%d -> x=%d "
+	       "===\n",
+	       X1, X2);
+	printf("%-10s %-14s\n", "z-offset", "blocked-by");
+	for (float zOff = 0.0f; zOff <= 0.5f; zOff += 0.05f)
+	{
+		Vec3<float> start{X1 + 0.5f, (float)Y, zOff};
+		Vec3<float> target{X2 + 0.5f, (float)Y, zOff};
+		auto c = battle->map->findCollision(start, target, mapPartSet, unit->tileObject, false);
+		printf("%-10.2f %-14s\n", zOff, blockingPieceLabel(c));
+	}
+
+	printf("\n=== Sub-problem B geometry probe: raw z-offset sweep, vertical shot per level "
+	       "===\n");
+	printf("%-10s %-8s %-14s\n", "z-offset", "level", "blocked-by");
+	for (float zOff = 0.0f; zOff <= 0.5f; zOff += 0.05f)
+	{
+		for (int fromLevel = LEVELS - 1; fromLevel >= 1; fromLevel--)
+		{
+			Vec3<float> start{X1 + 0.5f, (float)Y, (float)fromLevel + zOff};
+			Vec3<float> target{X1 + 0.5f, (float)Y, 0.5f};
+			auto c = battle->map->findCollision(start, target, mapPartSet, unit->tileObject, false);
+			printf("%-10.2f %-8d %-14s\n", zOff, fromLevel, blockingPieceLabel(c));
+		}
+	}
+
+	printf("\ntest_gravlift_lof done\n");
+	return EXIT_SUCCESS;
+}

--- a/tests/test_gravlift_lof.cpp
+++ b/tests/test_gravlift_lof.cpp
@@ -1,8 +1,8 @@
-// Verification harness for OpenApoc issue #1330, sub-problems A and B
-// (line of fire through grav-lift geometry). NOT part of the committed fix:
-// it needs the full extracted tileset/map/gamestate data that CI's minimal
-// cd.iso does not provide, so it is kept out of tests/CMakeLists.txt and run
-// manually from the scratchpad instead.
+// Verification harness for sub-problems A and B (line of fire through
+// grav-lift geometry). NOT part of the committed fix: it needs the full
+// extracted tileset/map/gamestate data that CI's minimal cd.iso does not
+// provide, so it is kept out of tests/CMakeLists.txt and run manually from
+// the scratchpad instead.
 //
 // Boots a real battle (common + gamestate, exactly like the other tests in
 // tests/) in a building that actually uses a grav-lift tileset, so every


### PR DESCRIPTION
Refs #1330.

**This is a deliberate deviation from the original game, behind an opt-in flag. It is not a bug fix and not a restoration of original behaviour.** Three commits, reviewable separately.

## What the original does

The original blocks these shots too. `TACP.EXE`'s two voxel routines — `FUN_0005bad8` (line-of-sight raycast) and `FUN_0005d25c` (projectile trajectory stepper) — each read exactly one per-tile field per map-part category, offset `+0xf`, `loftemps_lof`. Neither reads `is_floor` (0x47) or `is_gravlift` (0x48). There is no grav-lift special case anywhere in the original's voxel chain, and a grav-lift floor pad assigns LOFTEMPS index 6 to z-slices 0 and 1, which decodes to a fully solid 24x24 plane.

(The original's routines that *do* exempt grav-lifts, `FUN_0004fc38` and `FUN_0004fd1c`, are a movement/reachability constraint with no call edges to or from the voxel chain.)

## Why change it anyway

The original exempts grav-lift floors for **movement** but not for **line of fire**, so a unit can float up through a plate it cannot shoot or see through. That asymmetry is the wart this addresses. OpenApoc already has 44 `OpenApoc.NewFeature.*` options for exactly this kind of deliberate improvement, so this follows that pattern rather than changing behaviour unconditionally.

## The three commits

1. **`add GravliftLineOfFire NewFeature option`** — the option alone, default on, listed in the options UI. No behaviour change.
2. **`exempt gravlift floor pads from line of fire under flag`** — `TileObjectBattleMapPart::getVoxelMap` returns no voxel map for `floor && gravlift` parts, for both LOF and LOS, when the flag is set. With the flag off the behaviour is byte-identical to today.
3. **`add gravlift line-of-fire regression test and manual battle harnesses`**.

## AI behaviour

Exempting LOS feeds `BattleUnit::calculateVisionToUnit` and therefore `visibleUnits`, which drives AI target selection and reaction fire, so the obvious risk was an AI fixating on a unit it can see through a shaft but cannot reach. A harness boots a real battle, places a hostile-organisation unit and a player unit at opposite ends of a grav-lift shaft and drives `Battle::update()` (which calls `aiBlock.think()` every tick) for 8640 ticks:

- Flag off: no line, no engagement decision, both units idle for the whole run.
- Flag on: visibility goes to 1 immediately, exactly **one** attack decision fires at tick ~1, then zero further decisions across the remaining ~8600 ticks. Per-batch wall-clock time fell to 0.29x the first batch rather than growing. Both units alive, positions stable.
- Control, `07corphq` (no grav-lift floor pad): identical decision, displacement and timing with the flag on and off.

## Scope, stated plainly

This only clears shots where a grav-lift **floor pad** is the blocker. In `12shops` and `06office` the same shaft also contains a non-floor grav-lift-flagged piece (a right wall or a frame) which continues to block either way, and `07corphq` has no grav-lift floor pad at all so the flag does nothing there. Those pieces are geometry the original genuinely consults, and exempting them is not proposed.

Sub-problem C of the issue (grenades and units falling off the end of the world down a lift) was already fixed by #1670 and #1676. Sub-problem A (shooting between adjacent lift tiles at the same level) was not reproducible at real muzzle heights in any tileset tested: the only blocking band sits at z 0.00-0.25, well below kneeling (0.55) and standing (0.80).
